### PR TITLE
FloatingPointError: invalid value encountered in ...

### DIFF
--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -31,6 +31,8 @@ from obspy.signal.util import prevpow2
 
 MATPLOTLIB_VERSION = getMatplotlibVersion()
 
+dtiny = np.finfo(0.0).tiny
+
 
 if MATPLOTLIB_VERSION is None:
     # if matplotlib is not present be silent about it and only raise the
@@ -614,6 +616,10 @@ class PPSD():
 
         # working with the periods not frequencies later so reverse spectrum
         spec = spec[::-1]
+
+        # avoid calculating log of zero
+        idx = spec < dtiny
+        spec[idx] = dtiny
 
         # go to dB
         spec = np.log10(spec)

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -237,6 +237,7 @@ def classicSTALTAPy(a, nsta, nlta):
     # pad zeros of length nlta to avoid overfit and
     # return STA/LTA ratio
     sta[0:nlta_1] = 0
+    lta[0:nlta_1] = 1  # avoid devision by zero
     return sta / lta
 
 
@@ -266,6 +267,7 @@ def delayedSTALTA(a, nsta, nlta):
         lta[i] = (a[i - nsta - 1] ** 2 + a[i - nsta - nlta - 1] ** 2) / \
                  nlta + lta[i - 1]
     sta[0:nlta + nsta + 50] = 0
+    lta[0:nlta + nsta + 50] = 1  # avoid division by zero
     return sta / lta
 
 


### PR DESCRIPTION
from http://tests.obspy.org/?id=2598

``` python
Traceback (most recent call last):
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/core/tests/test_trace.py", line 1024, in test_taper
    tr.taper()
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/core/trace.py", line 1760, in taper
    self.data = self.data * func(self.stats.npts, *args, **kwargs)
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/invsim.py", line 113, in cosTaper
    (np.arange(idx1, idx2 + 1) - idx1) / (idx2 - idx1))))
FloatingPointError: invalid value encountered in divide
```

``` python
Traceback (most recent call last):
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tests/test_tf_misfit.py", line 207, in test_envelope_gof
    TFEG = tfeg(S1(t), S1(t), dt=dt, fmin=fmin, fmax=fmax, nf=nf)
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tf_misfit.py", line 607, in tfeg
    st2_isref=st2_isref)
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tf_misfit.py", line 100, in tfem
    W1 = np.empty((1, nf, st1.shape[0])) * 0j
FloatingPointError: invalid value encountered in multiply
```

``` python
Traceback (most recent call last):
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tests/test_tf_misfit.py", line 153, in test_envelope_misfit
    TFEM_11a = tfem(S1a(t), S1(t), dt=dt, fmin=fmin, fmax=fmax, nf=nf)
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tf_misfit.py", line 100, in tfem
    W1 = np.empty((1, nf, st1.shape[0])) * 0j
FloatingPointError: invalid value encountered in multiply
```

``` python
Traceback (most recent call last):
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tests/test_tf_misfit.py", line 92, in test_phase_misfit
    TFEM_11p = tfem(s1p, S1(t), dt=dt, fmin=fmin, fmax=fmax, nf=nf)
  File "/tmp/tmp.jLYqwDasQO/lib/python2.7/site-packages/obspy-tar_zipball.dev-py2.7-linux-x86_64.egg/obspy/signal/tf_misfit.py", line 100, in tfem
    W1 = np.empty((1, nf, st1.shape[0])) * 0j
FloatingPointError: invalid value encountered in multiply
```

Any ideas?
