### PR TITLE
iris.client.getWaveform: use station WS + location code wildcard handling

### DIFF
--- a/obspy/iris/client.py
+++ b/obspy/iris/client.py
@@ -189,6 +189,12 @@ class Client(object):
             TA.A25A..BHN | 2010-03-25T00:00:00... | 40.0 Hz, 72001 samples
             TA.A25A..BHZ | 2010-03-25T00:00:00... | 40.0 Hz, 72001 samples
         """
+        # XXX changes to be made: see #486
+        # XXX  - prevent handling of "  " and "--" in location code as
+        # XXX    wildcards. only "*" and "?" should be wildcards.
+        # XXX  - use station WS to determine channels to be fetched in
+        # XXX    wildcarded requests. availability WS is not suited for this
+        # XXX    task.
         kwargs = {}
         kwargs['network'] = str(network)[0:2]
         kwargs['station'] = str(station)[0:5]


### PR DESCRIPTION
Hi,

This issue was revealed by one of our product specialists, who was attempting to retrieve recent data from a series of stations; one of which contained a "  " for its location code.

_The issue(s):_
1. Obspy treats location codes of "--" or "  " as though they were wildcards, forcing a call to the IRIS availability service.
2. The IRIS availability service lags behind the real-time data, so requests for recent data may not include all stations for which data exists.  The station service, however, should contain a better approximation for data that may be retrievable from IRIS.

ObsPy checks to see if there are wildcards by looking for alphanumeric values in all the net/sta/loc/cha fields.  Unfortunately, neither "  " or "--" pass the `.isalnum()` test.  This means that channels with "  " or "--" locations will be treated as though they were wildcarded, and then force an (unneccesary) call to the availability service.

One possible fix is that within Obspy.iris.client.py, the `Client.getWaveform` , the following `if` statement could be changed from:

``` python

if all([val.isalnum() for val in (kwargs['network'],
                                  kwargs['station'],
                                  kwargs['location'],
                                  kwargs['channel'])]):
```

to:

``` python
if all([val.isalnum() for val in (kwargs['network'],
                                  kwargs['station'],
                                  kwargs['location'].replace('--','xx'),  
                                  kwargs['channel'])]):
```

This change shouldn't affect kwargs but helps keep availability from being called unnecessarily.

The availability service may not reflect the most recent data, so a good test for this is to retrieve recent data from a single station that has a location of "  " .

IRIS's station service might be provide better first cut for retrieving the lists of stations/channels that match the criteria.  Calling station with the desired net/sta/loc/cha/times with output=text and level=channel will retrieve a table (well, a pipe-separated list) that can then be parsed without too much effort into lists that are suitable for bulkdataselect.

I should not forget to mention: we would like to collaborate with whomever is doing the updates, if possible, to help find the best way for ObsPy to interact with IRIS services.

Cheers!
Celso
IRIS DMC Web Services Team
