### PR TITLE
files missing in tarball/eggs distributed via pypi (src traball canot be built with easy_install, pip etc)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 recursive-include obspy *
 global-exclude *.pyc *.pdf
+include README.md
+include CONTRIBUTING.md
+include CHANGELOG.txt
+include distribute_setup.py


### PR DESCRIPTION
The distributed src tarball does not include any .def files (e.g. obspy/mseed/src/libmseed/libmseed.def).

These are called in setup.py  
e.g   setup.py 421:    lines = open(src + 'libmseed.def', 'r').readlines()[2:]

Ergo, setup.py fails.
