### PR TITLE
tr.detrend not respecting masked arrays

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -14,7 +14,7 @@ from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, getExampleFile
 from obspy.core.util.base import ENTRY_POINTS, _readFromPlugin, \
     _getFunctionFromEntryPoint
-from obspy.core.util.decorator import uncompressFile
+from obspy.core.util.decorator import uncompressFile, raiseIfMasked
 from pkg_resources import load_entry_point
 import cPickle
 import copy
@@ -2071,6 +2071,7 @@ class Stream(object):
         for tr in self:
             tr.integrate(type=type)
 
+    @raiseIfMasked
     def detrend(self, type='simple'):
         """
         Method to remove a linear trend from all traces.

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1117,6 +1117,15 @@ class TraceTestCase(unittest.TestCase):
         tr.stats.sampling_rate = 20
         tr.spectrogram(show=False)
 
+    def test_raiseMasked(self):
+        """
+        Tests that detrend() raises in case of a masked array. (see #498)
+        """
+        x = np.arange(10)
+        x = np.ma.masked_inside(x, 3, 4)
+        tr = Trace(x)
+        self.assertRaises(NotImplementedError, tr.detrend)
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -13,6 +13,7 @@ from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict, createEmptyDataChunk
 from obspy.core.util.base import _getFunctionFromEntryPoint
 from obspy.core.util.misc import flatnotmaskedContiguous
+from obspy.core.util.decorator import raiseIfMasked
 import math
 import numpy as np
 import warnings
@@ -1583,6 +1584,7 @@ class Trace(object):
         proc_info = "integrate:%s" % (type)
         self._addProcessingInfo(proc_info)
 
+    @raiseIfMasked
     def detrend(self, type='simple', **options):
         """
         Method to remove a linear trend from the trace.


### PR DESCRIPTION
Using tr.detrend with masked Traces gives wrong results (due to underlying routines not respecting masked arrays), e.g.:

``` python
import numpy as np
from obspy import Trace
x = np.arange(10)
x = np.ma.masked_greater(x, 3)
tr = Trace(x)
print tr.data
tr.detrend("demean")
print tr.data
```

results in

```
masked_array(data = [0 1 2 3 -- -- -- -- -- --],
             mask = [False False False False  True  True  True  True  True  True],
       fill_value = 999999)
array([-4.5, -3.5, -2.5, -1.5, -0.5,  0.5,  1.5,  2.5,  3.5,  4.5])
```
