### PR TITLE
test_stream.py: Use float64 array as test stream

### DIFF
--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -23,25 +23,28 @@ class StreamTestCase(unittest.TestCase):
                   'starttime': UTCDateTime(2007, 12, 31, 23, 59, 59, 915000),
                   'npts': 412, 'sampling_rate': 200.0,
                   'channel': 'EHE'}
-        trace1 = Trace(data=np.random.randint(0, 1000, 412).view('float64'),
+        trace1 = Trace(data=np.random.randint(0, 1000, 412).astype('float64'),
                        header=deepcopy(header))
         header['starttime'] = UTCDateTime(2008, 1, 1, 0, 0, 4, 35000)
         header['npts'] = 824
-        trace2 = Trace(data=np.random.randint(0, 1000, 824).view('float64'),
+        trace2 = Trace(data=np.random.randint(0, 1000, 824).astype('float64'),
                        header=deepcopy(header))
         header['starttime'] = UTCDateTime(2008, 1, 1, 0, 0, 10, 215000)
-        trace3 = Trace(data=np.random.randint(0, 1000, 824).view('float64'),
+        trace3 = Trace(data=np.random.randint(0, 1000, 824).astype('float64'),
                        header=deepcopy(header))
         header['starttime'] = UTCDateTime(2008, 1, 1, 0, 0, 18, 455000)
         header['npts'] = 50668
-        trace4 = Trace(data=np.random.randint(0, 1000, 50668).view('float64'),
-                       header=deepcopy(header))
+        trace4 = Trace(
+            data=np.random.randint(0, 1000, 50668).astype('float64'),
+           header=deepcopy(header))
         self.mseed_stream = Stream(traces=[trace1, trace2, trace3, trace4])
         header = {'network': '', 'station': 'RNON ', 'location': '',
                   'starttime': UTCDateTime(2004, 6, 9, 20, 5, 59, 849998),
                   'sampling_rate': 200.0, 'npts': 12000,
                   'channel': '  Z'}
-        trace = Trace(data=np.random.randint(0, 1000, 12000).view('float64'), header=header)
+        trace = Trace(
+            data=np.random.randint(0, 1000, 12000).astype('float64'),
+            header=header)
         self.gse2_stream = Stream(traces=[trace])
 
     def test_setitem(self):


### PR DESCRIPTION
Using randint as source of test stream conflicts with simple casting
when multiplying with calibration constant. And consequently tests fail.
Casting / viewing array as 'float64' fixes this.
