### PR TITLE
Trace.split() should return Stream object

### DIFF
--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1826,7 +1826,7 @@ class Trace(object):
             # no gaps
             return [self]
         slices = flatnotmaskedContiguous(self.data)
-        trace_list = []
+        split_stream = Stream()
         for slice in slices:
             if slice.step:
                 raise NotImplementedError("step not supported")
@@ -1834,8 +1834,8 @@ class Trace(object):
             tr = Trace(header=stats)
             tr.stats.starttime += (stats.delta * slice.start)
             tr.data = self.data[slice.start:slice.stop]
-            trace_list.append(tr)
-        return trace_list
+            split_stream.append(tr)
+        return split_stream
 
     def times(self):
         """


### PR DESCRIPTION
In my opinion Trace.split() should return a Stream object. I do not see any advantage of returning a list of Traces here and it is not in line with Stream.split(). I am aware that this is not ideal theoretically as Stream is based on Trace and this is a step in the direction of circular imports. However, actually there are a lot of places in Trace methods were Stream gets imported.
