### PR TITLE
temporary files in obspy.arclink are not removed if download failed

### DIFF
--- a/obspy/arclink/client.py
+++ b/obspy/arclink/client.py
@@ -305,22 +305,24 @@ class Client(object):
             msg = "Uncovered status message - contact a developer to fix this"
             raise ArcLinkException(msg)
         self._writeln('DOWNLOAD %d' % req_id)
-        fd = self._client.get_socket().makefile('rb+')
-        length = int(fd.readline(100).strip())
-        data = ''
-        while len(data) < length:
-            buf = fd.read(min(4096, length - len(data)))
-            data += buf
-        buf = fd.readline(100).strip()
-        if buf != "END" or len(data) != length:
-            raise Exception('Wrong length!')
-        if self.debug:
-            if data.startswith('<?xml'):
-                print(data)
-            else:
-                print("%d bytes of data read" % len(data))
-        self._writeln('PURGE %d' % req_id)
-        self._bye()
+        try:
+            fd = self._client.get_socket().makefile('rb+')
+            length = int(fd.readline(100).strip())
+            data = ''
+            while len(data) < length:
+                buf = fd.read(min(4096, length - len(data)))
+                data += buf
+            buf = fd.readline(100).strip()
+            if buf != "END" or len(data) != length:
+                raise Exception('Wrong length!')
+            if self.debug:
+                if data.startswith('<?xml'):
+                    print(data)
+                else:
+                    print("%d bytes of data read" % len(data))
+        finally:
+            self._writeln('PURGE %d' % req_id)
+            self._bye()
         # check for encryption
         if 'encrypted="true"' in xml_doc:
             # extract dcid


### PR DESCRIPTION
whenever a download request by e.g. client.getWaveform in obspy.arclink fails, the temporary file created in /var/tmp or /tmp or whatever temporary folder is defined by environment variable TMPDIR, remains allocated on the disk, though with size 0.

we ran now into an issue that millions of those dead files had accumulated on our disk. The quick fix on our side was to remove those files manually but I'd like to ask whether this could be fixed at the source?

Thanks,
Christian
