### PR TITLE
numpy array from bytearray (in obspy.seedlink)

### DIFF
--- a/obspy/seedlink/slpacket.py
+++ b/obspy/seedlink/slpacket.py
@@ -109,7 +109,7 @@ class SLPacket(object):
     def getMSRecord(self):
         # following from  obspy.mseed.tests.test_libmseed.py -> test_msrParse
         msr = clibmseed.msr_init(C.POINTER(MSRecord)())
-        pyobj = np.array(self.msrecord)
+        pyobj = np.frombuffer(self.msrecord, dtype=np.uint8)
         errcode = \
                 clibmseed.msr_parse(pyobj.ctypes.data_as(C.POINTER(C.c_char)),
                 len(pyobj), C.pointer(msr), -1, 1, 1)


### PR DESCRIPTION
I experience segmentation faults on certain systems when constructing a numpy array from a bytearray (see numpy/numpy#3175). This is used in obspy.seedlink. It seems we should move from `np.array()` to `np.frombuffer()` in this specific case.
