### PR TITLE
obspy-scan cannot handle channels with multiple sampling rate epochs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,8 @@ dev:
      most operating systems
  - obspy.imaging:
    * more options to customize day plots
+   * obspy-scan can be provided metadata to support changing sampling
+     rates
  - obspy.realtime:
    * two new processing plugins (offset, kurtosis)
  - obspy.seg2:


### PR DESCRIPTION
We have some channels where the sampling rate was changed from e.g. 500sps to 250sps doe to memory restrictions at some point in time, meaning that we have two different epochs. When running obspy-scan on this data, a gap between every border between two files shows up in the epoch with the lower sampling rate although there is no gap in reality. I have found out the issue is in scan.py, line 287:
gaps = startend[diffs > 1.8 \* samp_int[_id], 1]

samp_int only contains one sampling rate value per channel, even if there are multiple sampling rate epochs. If we reduce the sampling rate from 500sps to 250sps the difference will be 2*samp_int[_id] meaning a gap is detected where there is no gap in reality. To me, this looks like a more complex data structure (taking into account different epochs) would be needed to handle this correctly than just a dictionary with one entry per channel.
