### PR TITLE
Could not find PAZ

### DIFF
--- a/obspy/arclink/client.py
+++ b/obspy/arclink/client.py
@@ -1183,23 +1183,23 @@ class Client(object):
                 # instruments
                 for stream in station.xpath('ns:' + stream_ns,
                                             namespaces={'ns': xml_ns}):
-                    # date / times
-                    try:
-                        start = UTCDateTime(stream.get('start'))
-                    except:
-                        start = None
-                    try:
-                        end = UTCDateTime(stream.get('end'))
-                    except:
-                        end = None
-                    # check date/time boundaries
-                    if start > endtime:
-                        continue
-                    if end and starttime > end:
-                        continue
                     # fetch component
                     for comp in stream.xpath('ns:' + component_ns,
                                              namespaces={'ns': xml_ns}):
+                        # date / times
+                        try:
+                            start = UTCDateTime(comp.get('start'))
+                        except:
+                            start = None
+                        try:
+                            end = UTCDateTime(comp.get('end'))
+                        except:
+                            end = None
+                        # check date/time boundaries
+                        if start > endtime:
+                            continue
+                        if end and starttime > end:
+                            continue
                         if xml_ns == _INVENTORY_NS_0_2:
                             seismometer_id = stream.get(seismometer_ns, None)
                         else:


### PR DESCRIPTION
I have a problem with getPAZ,  on macos 10.6.8 using Python 2.7.5 and the latest dev  with the following code

``` python
#!/usr/bin/env python

from obspy.core import UTCDateTime
from obspy.arclink import Client


client = Client(user="bonaime@obspy")
station = 'SSB'
channel = 'BHZ'
network = 'G'
loc = '00'

time = UTCDateTime("2011-10-12")
paz = client.getPAZ(network, station, loc, channel, time)

print 'PAZ from:'+str(time)+'is downloaded\n\n'

time = UTCDateTime("2012-10-13")
paz = client.getPAZ(network, station, loc, channel, time)
```

the first getPAZ is working but not the second. Between the "2011-10-12" and "2011-10-13" dataless has changed. 

in obspy.arclink.client I put a 

``` python
print result
```

in the getInventory function, just before 

``` python
  xml_doc = etree.fromstring(result)
```

Here is the xml I have for the firt getPAZ

``` xml
<?xml version="1.0" encoding="utf-8"?>
<ns0:inventory xmlns:ns0="http://geofon.gfz-potsdam.de/ns/Inventory/1.0/">
    <ns0:network archive="IPGP" code="G" description="GEOSCOPE" end="" institutions="" netClass="p" publicID="Network/G" region="" restricted="false" shared="true" start="1980-01-01T00:00:00.0000Z" type="BB">
        <ns0:remark />
        <ns0:station affiliation="GEOSCOPE" archive="IPGP" archiveNetworkCode="" code="SSB" country=" France" description="Tunnel de Badole - Saint Sauveur en Rue, France" elevation="700.0" end="" latitude="45.279" longitude="4.542" place="Tunnel de Badole - Saint Sauveur en Rue" publicID="Station/G/SSB/1982-05-02T00:00:00.0000Z" restricted="false" shared="true" start="1982-05-02T00:00:00.0000Z" type="">
            <ns0:remark />
            <ns0:sensorLocation code="00" elevation="700.0" end="2011-10-12T11:00:00.0000Z" latitude="45.279" longitude="4.542" publicID="SensorLocation#20121008113208.1972.737" start="1982-05-02T00:00:00.0000Z">
                <ns0:stream azimuth="0.0" clockSerialNumber="" code="BHZ" datalogger="Datalogger#20121008134151.262036.4553" dataloggerChannel="0" dataloggerSerialNumber="xxxx" depth="0.0" dip="-90.0" end="2011-10-12T11:00:00.0000Z" flags="CG" format="Steim2" gain="6012950000.0" gainFrequency="0.02" gainUnit="M/S" restricted="false" sampleRateDenominator="1" sampleRateNumerator="20" sensor="Sensor#20121008134151.279347.4593" sensorChannel="0" sensorSerialNumber="yyyy" shared="false" start="2009-02-16T00:00:00.0000Z" />
            </ns0:sensorLocation>
        </ns0:station>
    </ns0:network>
    <ns0:datalogger clockManufacturer="" clockModel="" clockType="" description="SSB.2009.047.H00" digitizerManufacturer="" digitizerModel="" gain="1677720.0" maxClockDrift="0.00019531" name="SSB.2009.047.H00" publicID="Datalogger#20121008134151.262036.4553" recorderManufacturer="" recorderModel="">
        <ns0:remark />
        <ns0:decimation sampleRateDenominator="1" sampleRateNumerator="20">
            <ns0:analogueFilterChain />
            <ns0:digitalFilterChain>ResponseFIR#20121008134151.278971.4592</ns0:digitalFilterChain>
        </ns0:decimation>
        <ns0:calibration channel="0" end="2011-10-12T11:00:00.0000Z" gain="1677720.0" gainFrequency="0.0" serialNumber="xxxx" start="2009-02-16T00:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
        <ns0:calibration channel="1" end="" gain="1677720.0" gainFrequency="0.0" serialNumber="xxxx" start="2009-02-16T00:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
        <ns0:calibration channel="2" end="" gain="1677720.0" gainFrequency="0.0" serialNumber="xxxx" start="2009-02-16T00:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
    </ns0:datalogger>
    <ns0:sensor description="STS1" highFrequency="" lowFrequency="" manufacturer="STRECKEISEN" model="STS1" name="SSB.2009.047.HZ00" publicID="Sensor#20121008134151.279347.4593" response="ResponsePAZ#20121008134151.279455.4594" type="" unit="M/S">
        <ns0:remark />
        <ns0:calibration channel="0" end="2011-10-12T11:00:00.0000Z" gain="3584.0" gainFrequency="0.02" serialNumber="yyyy" start="2009-02-16T00:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
    </ns0:sensor>
    <ns0:responseFIR correction="34.0" decimationFactor="1" delay="34.0" gain="1.0" name="SSB.00.BHZ.2009.047.stage_3" numberOfCoefficients="67" publicID="ResponseFIR#20121008134151.278971.4592" symmetry="A">
        <ns0:coefficients>3.77162e-17 -1.69713e-10 1.71838e-08 -2.43964e-07 2.58252e-07 1.5609e-06 -1.81704e-06 2.41376e-06 -3.70491e-06 8.73276e-07 3.64235e-05 -0.000246833 -0.000393599 0.000655961 -0.00102025 0.00123051 -0.00106043 0.000288613 0.00122683 -0.00345855 0.00614628 -0.00875821 0.0105179 -0.0104955 0.00776882 -0.0016282 -0.00764096 0.0198944 -0.0387619 0.0551044 -0.0713696 0.0833036 -0.0867195 0.0628769 0.889951 0.167002 -0.128687 0.100726 -0.0755007 0.0515952 -0.0311146 0.011006 0.000476173 -0.00823882 0.0124211 -0.0131333 0.0114417 -0.00845235 0.00513644 -0.00220567 6.47577e-05 0.00117235 -0.00160962 0.00148359 -0.00106529 0.000590532 -0.000273576 -0.000321484 3.98515e-05 1.0833e-06 -4.64297e-06 2.88448e-06 -1.62081e-06 1.31617e-06 4.72519e-07 -3.29637e-07 2.71423e-08</ns0:coefficients>
        <ns0:remark />
    </ns0:responseFIR>
    <ns0:responsePAZ gain="3584.0" gainFrequency="0.02" name="SSB.2009.047.HZ00" normalizationFactor="4893.58" normalizationFrequency="0.02" numberOfPoles="4" numberOfZeros="2" publicID="ResponsePAZ#20121008134151.279455.4594" type="A">
        <ns0:zeros>(0.0,0.0) (0.0,0.0)</ns0:zeros>
        <ns0:poles>(-0.0121536,0.0121339) (-0.0121536,-0.0121339) (-32.4261,61.9769) (-32.4261,-61.9769)</ns0:poles>
        <ns0:remark />
    </ns0:responsePAZ>
</ns0:inventory>
```

and for the second one

``` xml
<?xml version="1.0" encoding="utf-8"?>
<ns0:inventory xmlns:ns0="http://geofon.gfz-potsdam.de/ns/Inventory/1.0/">
    <ns0:network archive="IPGP" code="G" description="GEOSCOPE" end="" institutions="" netClass="p" publicID="Network/G" region="" restricted="false" shared="true" start="1980-01-01T00:00:00.0000Z" type="BB">
        <ns0:remark />
        <ns0:station affiliation="GEOSCOPE" archive="IPGP" archiveNetworkCode="" code="SSB" country=" France" description="Tunnel de Badole - Saint Sauveur en Rue, France" elevation="700.0" end="" latitude="45.279" longitude="4.542" place="Tunnel de Badole - Saint Sauveur en Rue" publicID="Station/G/SSB/1982-05-02T00:00:00.0000Z" restricted="false" shared="true" start="1982-05-02T00:00:00.0000Z" type="">
            <ns0:remark />
            <ns0:sensorLocation code="00" elevation="700.0" end="2011-10-12T11:00:00.0000Z" latitude="45.279" longitude="4.542" publicID="SensorLocation#20121008113208.1972.737" start="1982-05-02T00:00:00.0000Z">
                <ns0:stream azimuth="0.0" clockSerialNumber="" code="BHZ" datalogger="Datalogger#20121008134151.27981.4595" dataloggerChannel="0" dataloggerSerialNumber="xxxx" depth="0.0" dip="-90.0" end="" flags="CG" format="Steim2" gain="5536540000.0" gainFrequency="0.02" gainUnit="M/S" restricted="false" sampleRateDenominator="1" sampleRateNumerator="20" sensor="Sensor#20121008134151.280342.4597" sensorChannel="0" sensorSerialNumber="yyyy" shared="false" start="2011-10-12T11:00:00.0000Z" />
            </ns0:sensorLocation>
        </ns0:station>
    </ns0:network>
    <ns0:datalogger clockManufacturer="" clockModel="" clockType="" description="SSB.2011.285.H00" digitizerManufacturer="" digitizerModel="" gain="1677720.0" maxClockDrift="0.00019531" name="SSB.2011.285.H00" publicID="Datalogger#20121008134151.27981.4595" recorderManufacturer="" recorderModel="">
        <ns0:remark />
        <ns0:decimation sampleRateDenominator="1" sampleRateNumerator="20">
            <ns0:analogueFilterChain />
            <ns0:digitalFilterChain>ResponseFIR#20121008134151.279962.4596</ns0:digitalFilterChain>
        </ns0:decimation>
        <ns0:calibration channel="0" end="" gain="1677720.0" gainFrequency="0.0" serialNumber="xxxx" start="2011-10-12T11:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
    </ns0:datalogger>
    <ns0:sensor description="STS1" highFrequency="" lowFrequency="" manufacturer="STRECKEISEN" model="STS1" name="SSB.2011.285.HZ00" publicID="Sensor#20121008134151.280342.4597" response="ResponsePAZ#20121008134151.28046.4598" type="" unit="M/S">
        <ns0:remark />
        <ns0:calibration channel="0" end="" gain="3300.0" gainFrequency="0.02" serialNumber="yyyy" start="2011-10-12T11:00:00.0000Z">
            <ns0:remark />
        </ns0:calibration>
    </ns0:sensor>
    <ns0:responseFIR correction="34.0" decimationFactor="1" delay="34.0" gain="1.0" name="SSB.00.BHZ.2011.285.stage_3" numberOfCoefficients="67" publicID="ResponseFIR#20121008134151.279962.4596" symmetry="A">
        <ns0:coefficients>3.77162e-17 -1.69713e-10 1.71838e-08 -2.43964e-07 2.58252e-07 1.5609e-06 -1.81704e-06 2.41376e-06 -3.70491e-06 8.73276e-07 3.64235e-05 -0.000246833 -0.000393599 0.000655961 -0.00102025 0.00123051 -0.00106043 0.000288613 0.00122683 -0.00345855 0.00614628 -0.00875821 0.0105179 -0.0104955 0.00776882 -0.0016282 -0.00764096 0.0198944 -0.0387619 0.0551044 -0.0713696 0.0833036 -0.0867195 0.0628769 0.889951 0.167002 -0.128687 0.100726 -0.0755007 0.0515952 -0.0311146 0.011006 0.000476173 -0.00823882 0.0124211 -0.0131333 0.0114417 -0.00845235 0.00513644 -0.00220567 6.47577e-05 0.00117235 -0.00160962 0.00148359 -0.00106529 0.000590532 -0.000273576 -0.000321484 3.98515e-05 1.0833e-06 -4.64297e-06 2.88448e-06 -1.62081e-06 1.31617e-06 4.72519e-07 -3.29637e-07 2.71423e-08</ns0:coefficients>
        <ns0:remark />
    </ns0:responseFIR>
    <ns0:responsePAZ gain="3300.0" gainFrequency="0.02" name="SSB.2011.285.HZ00" normalizationFactor="5451.0" normalizationFrequency="0.02" numberOfPoles="4" numberOfZeros="2" publicID="ResponsePAZ#20121008134151.28046.4598" type="A">
        <ns0:zeros>(0.0,0.0) (0.0,0.0)</ns0:zeros>
        <ns0:poles>(-0.01234,0.01234) (-0.01234,-0.01234) (-35.0,65.0) (-35.0,-65.0)</ns0:poles>
        <ns0:remark />
    </ns0:responsePAZ>
</ns0:inventory>
```

We can see some responses in  both 'result'

Then I followed the code until

``` python
 # instruments
                for stream in station.xpath('ns:' + stream_ns,
                                            namespaces={'ns': xml_ns}):
                    # date / times
                    try:
                        start = UTCDateTime(stream.get('start'))
                    except:
                        start = None
                    try:
                        end = UTCDateTime(stream.get('end'))
                    except:
                        end = None
                     print 'start '+str(start)+ 'end '+str(end)
```

In this 'for loop', as I understand, we are looking at the different 'streams' in result. But the 'start' and 'end' are, I think, not the right ones. I don't really understand the xpath, but, I think, we are not looking at the right elements. Here is the output of the print for the two getPAZ 

``` log
start 1982-05-02T00:00:00.000000Zend 2011-10-12T11:00:00.000000Z
start 1982-05-02T00:00:00.000000Zend 2011-10-12T11:00:00.000000Z
```

We have the same start and end with two different streams.
if we look in the xml data we have for the first getPAZ
end="2011-10-12T11:00:00.0000Z"
start="2009-02-16T00:00:00.0000Z"

and for the second one
start="2011-10-12T11:00:00.0000Z
and no end because the channel is still open
