### PR TITLE
Throw verbose exception if no data has been added before plotting

### DIFF
--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -731,6 +731,11 @@ class PPSD():
         :type show: bool (optional)
         :param show: Enable/disable immediately showing the plot.
         """
+        # check if any data has been added yet
+        if self.hist_stack is None:
+            msg = 'No data to plot'
+            raise Exception(msg)
+
         X, Y = np.meshgrid(self.xedges, self.yedges)
         hist_stack = self.hist_stack * 100.0 / len(self.times_used)
 


### PR DESCRIPTION
Trying to plot a PPSD() without adding data beforehand throws an exception that isn't necessarily self-explanatory:

``` python
>>> ppsd = PPSD(stats, stats['paz'])
>>> ppsd.plot(fn)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/[...]/obspy/signal/spectral_estimation.py", line 734, in plot
    X, Y = np.meshgrid(self.xedges, self.yedges)
AttributeError: PPSD instance has no attribute 'xedges'
```

After applying this patch, the exception is slightly more helpful:

``` python
>>> ppsd = PPSD(stats, stats['paz'])
>>> ppsd.plot(fn)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/[...]/obspy/signal/spectral_estimation.py", line 737, in plot
    raise Exception(msg)
Exception: No data to plot
```
