### PR TITLE
Saving and Loading of compressed PPSD files

### DIFF
--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -11,6 +11,7 @@ import numpy as np
 import os
 import unittest
 import warnings
+import tempfile
 
 
 class PsdTestCase(unittest.TestCase):
@@ -132,6 +133,35 @@ class PsdTestCase(unittest.TestCase):
         binning = np.load(file_binning)
         np.testing.assert_array_equal(ppsd.spec_bins, binning['spec_bins'])
         np.testing.assert_array_equal(ppsd.period_bins, binning['period_bins'])
+
+        # test saving and loading of the PPSD (using a temporary file)
+        file_ = tempfile.NamedTemporaryFile(delete=False)
+        file_.close()
+        filename = file_.name
+        # test saving and loading an uncompressed file
+        ppsd.save(filename, compress=False)
+        ppsd_loaded = PPSD.load(filename)
+        self.assertEqual(len(ppsd_loaded.times), 4)
+        self.assertEqual(ppsd_loaded.nfft, 65536)
+        self.assertEqual(ppsd_loaded.nlap, 49152)
+        np.testing.assert_array_equal(ppsd_loaded.hist_stack, result_hist)
+        np.testing.assert_array_equal(ppsd_loaded.spec_bins,
+                                      binning['spec_bins'])
+        np.testing.assert_array_equal(ppsd_loaded.period_bins,
+                                      binning['period_bins'])
+        # test saving and loading a compressed file
+        ppsd.save(filename, compress=True)
+        ppsd_loaded = PPSD.load(filename)
+        self.assertEqual(len(ppsd_loaded.times), 4)
+        self.assertEqual(ppsd_loaded.nfft, 65536)
+        self.assertEqual(ppsd_loaded.nlap, 49152)
+        np.testing.assert_array_equal(ppsd_loaded.hist_stack, result_hist)
+        np.testing.assert_array_equal(ppsd_loaded.spec_bins,
+                                      binning['spec_bins'])
+        np.testing.assert_array_equal(ppsd_loaded.period_bins,
+                                      binning['period_bins'])
+        # remove the temporary file
+        os.unlink(filename)
 
 
 def suite():


### PR DESCRIPTION
I extended the PPSD object's `save()` method to support saving of compressed files. I also added a `PPSD.load()` to seamlessly load pickled PPSD objects, both compressed and uncompressed.

While the saving of a compressed file takes significantly longer, the resulting file size for the data I tested was about 15% of the uncompressed file.

I tested this on Debian and Windows 7.

I also updated the documentation and the unit test.

I did, however, not get the doc builder to run, so I was unable to check if I got the doc syntax right. Especially this reference to the static method:

```
    The :func:`~obspy.signal.spectral_estimation.PPSD.load` method detects
    compression automatically.
```
