### PR TITLE
arclink: fix problem with routing after server side software update

### DIFF
--- a/obspy/arclink/client.py
+++ b/obspy/arclink/client.py
@@ -595,7 +595,7 @@ class Client(object):
         if modified_after:
             rtype += 'modified_after=%s ' % modified_after.formatArcLink()
         # request data
-        rdata = [starttime, endtime, network, station]
+        rdata = [starttime, endtime, network, station, "*", "*"]
         # fetch plain XML document
         result = self._fetch(rtype, rdata, route=False)
         # parse XML document


### PR DESCRIPTION
Currently at the default arclink node at GFZ a software update causes problems for our routing requests in some special cases. I believe this change fixes it (tests run OK, so it should work with older arclink nodes). However, this will most likely be fixed at server side within the next weeks and this change would not reach end user until the next release. So, probably it is useless to merge this change into master..
