### PR TITLE
readSEGY and handling ambiguous SEG Y files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,9 @@ dev:
  - obspy.seg2:
    * adding read support for SEG2 data format code 1 and 2
      (signed 16bit/32bit integer)
+ - obspy.segy:
+   * fixes handling of files in IEEE floating point format with Rev 0
+     binary header table codes (see #610)
  - obspy.signal:
    * adding cross correlation single-station similarity checking with
      master event templates to coincidence trigger


### PR DESCRIPTION
I've recently encountered a SEGY that had its data in IEEE floating point format, but still adhered to the Rev 0 binary header table codes.

Rev 0 is apparently agnostic to floating point format.  When `readSEGY` is called, all files are assumed to be of SEG Y rev 1.0.  This causes files marked 'floating point' in rev 0.0 to be read in as IBM format, when the true format is ambiguous.  

This is perhaps a sensible default (and has served me correctly in the past), but for these edge cases, it would be very useful if there was a way to force the floating point format ("data sample format code") at the call to `segy.read(...)` in the same way it can be specified during a call to `segy.write(...)`.
