### PR TITLE
Stream.select() with empty values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,7 +28,9 @@ dev:
      either a file-like object with RESP information or an obspy.xseed.Parser
      object (e.g. created reading a dataless SEED file).
    * fix Stream.select() when using values like "" or 0, e.g.
-     Stream.select(location="").
+     Stream.select(location="") or when filtering by component with a channel
+     code less than 3 characters long (now these traces will be omitted from
+     the result when filtering by component).
    * fix a bug when merging valid data into a masked trace (see #638)
    * event.ResourceIdentifier objects are now initialized with a QuakeML
      conform string by default, i.e. if no custom prefix is provided during

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1611,10 +1611,12 @@ class Stream(object):
                     continue
             if npts is not None and int(npts) != trace.stats.npts:
                 continue
-            if component is not None and \
-                    not fnmatch.fnmatch(trace.stats.channel[-1].upper(),
-                                        component.upper()):
-                continue
+            if component is not None:
+                if len(trace.stats.channel) < 3:
+                    continue
+                if not fnmatch.fnmatch(trace.stats.channel[-1].upper(),
+                                       component.upper()):
+                    continue
             traces.append(trace)
         return self.__class__(traces=traces)
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2060,6 +2060,22 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(st.select(channel=""), st2)
         self.assertEqual(st.select(npts=0), st2)
 
+    def test_select_short_channel_code(self):
+        """
+        Test that select by component only checks channel codes longer than two
+        characters.
+        """
+        st = Stream([Trace(), Trace(), Trace(), Trace(), Trace(), Trace()])
+        st[0].stats.channel = "EHZ"
+        st[1].stats.channel = "HZ"
+        st[2].stats.channel = "Z"
+        st[3].stats.channel = "E"
+        st[4].stats.channel = "N"
+        st[5].stats.channel = "EHN"
+        self.assertEqual(len(st.select(component="Z")), 1)
+        self.assertEqual(len(st.select(component="N")), 1)
+        self.assertEqual(len(st.select(component="E")), 0)
+
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')


### PR DESCRIPTION
Fixes a bug when selecting for e.g. `location=""` which was not doing anything.
