### PR TITLE
Minor change to setup.py (0.8.4 release)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ from distutils.errors import DistutilsExecError, CompileError
 from distutils.unixccompiler import UnixCCompiler
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
-import distribute_setup
 import glob
 import os
 import platform
@@ -629,8 +628,6 @@ def setupLibTauP():
 
 
 def setupPackage(gfortran=True, ccompiler=True):
-    # automatically install distribute if the user does not have it installed
-    distribute_setup.use_setuptools()
     # use lib2to3 for Python 3.x
     if sys.version_info[0] == 3:
         convert2to3()


### PR DESCRIPTION
This removes some some (apparently) `distribute` specific stuff. 

Background:
The python packages `setuptools` and `distribute` re-merged, and `distribute` seems to disappear from standard environments and package managers. The removed code causes the installation script to fail in such environments.

I guess this issue will disappear in a future 0.9.x release, as it uses a different (f2py based) setup.py script. Not sure what is the planing for _possible_ 0.8.x bug fix releases. If such a release would use the _traditional_ `setup.py` this fix might become relevant.
