### PR TITLE
Debian packaging broken in master

### DIFF
--- a/misc/debian/deb__build_debs.sh
+++ b/misc/debian/deb__build_debs.sh
@@ -104,6 +104,8 @@ elif [ $CODENAME = "squeeze" ]
     echo "8" > ./debian/compat
 fi
 # build the package
+export FFLAGS="$FFLAGS -fPIC"  # needed for gfortran
+export LDFLAGS="$LDFLAGS -shared"  # needed for gfortran
 fakeroot ./debian/rules clean build binary
 # generate changes file
 DEBARCH=`dpkg-architecture -qDEB_HOST_ARCH`


### PR DESCRIPTION
Debian packaging does not work in current master. It seems during linking the Python and Numpy headers are not found. [See build log here.](https://gist.github.com/megies/42e3c69cd88a09e76c6f)
