### PR TITLE
Two small improvements for event.py

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -322,9 +322,11 @@ def _eventTypeClassFactory(class_name, class_attributes=[], class_contains=[]):
                 if hasattr(self, error_key) and\
                    _bool(getattr(self, error_key)):
                     err_items = getattr(self, error_key).items()
-                    err_items.sort()
-                    repr_str += " [%s]" % ', '.join(
-                        [str(k) + "=" + str(v) for k, v in err_items])
+                    _err_items = [(k, v) for k, v in err_items if _bool(v)]
+                    _err_items.sort()
+                    if _err_items:
+                        repr_str += " [%s]" % ', '.join(
+                            [str(k) + "=" + str(v) for k, v in _err_items])
                 return repr_str
 
             # Case 2: Short representation for small objects. Will just print a
@@ -639,9 +641,10 @@ class ResourceIdentifier(object):
         # the referred object.
         if ResourceIdentifier.__resource_id_weak_dict[self] is referred_object:
             return
-        msg = "The resource identifier already exists and points to " + \
+        msg = "The resource identifier '%s' already exists and points to " + \
               "another object. It will now point to the object " + \
               "referred to by the new resource identifier."
+        msg = msg % referred_object.resource_id.resource_id
         # Always raise the warning!
         warnings.warn_explicit(msg, UserWarning, __file__,
                                inspect.currentframe().f_back.f_lineno)


### PR DESCRIPTION
- Do not print error fields set to 'None';
- More informative message for already existing
  resource_ids.

The first modification fixes the following behavior:

``` python
In [1]: from obspy.core.event import Origin

In [2]: origin = Origin()

In [3]: origin.latitude = 10.1

In [4]: origin.latitude_errors['uncertainty'] = 0.1

In [5]: origin.latitude_errors['other uncertainty'] = None

In [6]: print origin
Origin(latitude=10.1 [other uncertainty=None, uncertainty=0.1])
```

And corrects it to:

``` python
In [6]: print origin
Origin(latitude=10.1 [uncertainty=0.1])
```

Warning: The second modification currently makes `obspy.core.tests.test_event.ResourceIdentifierTestCase` fail, since this test compares two `UTCDateTime()` objects which do not have a `resource_id` attribute.

Why are we using `UTCDateTime()` for this test?
