### PR TITLE
Correct string representation of long event types.

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -285,7 +285,7 @@ def _eventTypeClassFactory(class_name, class_attributes=[], class_contains=[]):
             super(AbstractEventType, self).clear()
             self.__init__()
 
-        def __str__(self):
+        def __str__(self, force_one_line=False):
             """
             Fairly extensive in an attempt to cover several use cases. It is
             always possible to change it in the child class.
@@ -328,7 +328,8 @@ def _eventTypeClassFactory(class_name, class_attributes=[], class_contains=[]):
 
             # Case 2: Short representation for small objects. Will just print a
             # single line.
-            if len(attributes) <= 3 and not containers:
+            if len(attributes) <= 3 and not containers or\
+               force_one_line:
                 att_strs = ["%s=%s" % (_i, get_value_repr(_i))
                             for _i in attributes if _bool(getattr(self, _i))]
                 ret_str += "(%s)" % ", ".join(att_strs)
@@ -357,7 +358,7 @@ def _eventTypeClassFactory(class_name, class_attributes=[], class_contains=[]):
             return copy.deepcopy(self)
 
         def __repr__(self):
-            return self.__str__()
+            return self.__str__(force_one_line=True)
 
         def __nonzero__(self):
             # We use custom _bool() for testing getattr() since we want


### PR DESCRIPTION
This is done by:
1. Introducing a `force_one_line` option for `AbstractEventType.__str__()`
2. Calling `self.__str__()` with that option in `AbstractEventType.__repr__()`

So that:

``` python
In [1]: from obspy.core.event import WaveformStreamID

In [2]: wid = WaveformStreamID(network_code='BW', station_code='FUR', location_code='', channel_code='EHZ')

In [3]: print wid.__str__()
WaveformStreamID
      network_code: 'BW'
      station_code: 'FUR'
      channel_code: 'EHZ'
     location_code: ''

In [4]: print wid.__str__(force_one_line=True)
WaveformStreamID(network_code='BW', station_code='FUR', channel_code='EHZ', location_code='')

In [5]: print wid.__repr__()
WaveformStreamID(network_code='BW', station_code='FUR', channel_code='EHZ', location_code='')

In [6]: print str(wid)
WaveformStreamID
      network_code: 'BW'
      station_code: 'FUR'
      channel_code: 'EHZ'
     location_code: ''

In [7]: print repr(wid)
WaveformStreamID(network_code='BW', station_code='FUR', channel_code='EHZ', location_code='')
```
