### PR TITLE
More informative message for existing resource_ids

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -2334,7 +2334,7 @@ class Event(__Event):
             "\n".join(super(Event, self).__str__().split("\n")[1:]))
 
     def __repr__(self):
-        return 'Event(resource_id="%s")' % self.resource_id
+        return super(Event, self).__str__(force_one_line=True)
 
     def preferred_origin(self):
         """


### PR DESCRIPTION
~~Warning: This currently makes `obspy.core.tests.test_event.ResourceIdentifierTestCase` fail, since this test compares two `UTCDateTime()` objects which do not have a `resource_id` attribute.~~

~~Why are we using `UTCDateTime()` for this test?~~
