### PR TITLE
Fix cfrequency refactoring

### DIFF
--- a/obspy/signal/freqattributes.py
+++ b/obspy/signal/freqattributes.py
@@ -112,7 +112,7 @@ def cfrequency(data, fs, smoothie, fk):
         cfreq = np.zeros(data.shape[0])
         i = 0
         for row in data:
-            cfreq[i] = cfrequency_unwindowed(row,fs)
+            cfreq[i] = cfrequency_unwindowed(row, fs)
             i = i + 1
         cfreq = util.smooth(cfreq, smoothie)
         #cfreq_add = \
@@ -129,8 +129,9 @@ def cfrequency(data, fs, smoothie, fk):
         return cfreq, dcfreq
     # for unwindowed data
     else:
-        cfreq=cfrequency_unwindowed(data, fs)
+        cfreq = cfrequency_unwindowed(data, fs)
         return cfreq
+
 
 def cfrequency_unwindowed(data, fs):
     """
@@ -148,14 +149,13 @@ def cfrequency_unwindowed(data, fs):
     :param fs: Sampling frequency in Hz.
     :return: **cfreq** - Central frequency in Hz
     """
-    nfft=util.nextpow2(len(data))
+    nfft = util.nextpow2(len(data))
     freq = np.linspace(0, fs, nfft + 1)
     freqaxis = freq[0:nfft / 2]
     Px_wm = welch(data, np.hamming(len(data)), nfft)
     Px = Px_wm[0:len(Px_wm) / 2]
     cfreq = np.sqrt(np.sum(freqaxis ** 2 * Px) / (sum(Px)))
     return cfreq
- 
 
 
 def bwith(data, fs, smoothie, fk):

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -92,7 +92,8 @@ class FreqTraceTestCase(unittest.TestCase):
     def test_cfrequency(self):
         """
         """
-        cfreq = freqattributes.cfrequency(self.data_win_bc, self.fs, self.smoothie, self.fk)
+        cfreq = freqattributes.cfrequency(self.data_win_bc, self.fs,
+                                          self.smoothie, self.fk)
         rms = np.sqrt(np.sum((cfreq[0] - self.res[:, 18]) ** 2) /
                       np.sum(self.res[:, 18] ** 2))
         self.assertEqual(rms < 1.0e-5, True)
@@ -101,8 +102,9 @@ class FreqTraceTestCase(unittest.TestCase):
         self.assertEqual(rms < 1.0e-5, True)
 
     def test_cfrequency_no_win(self):
-        cfreq = freqattributes.cfrequency(self.data_win_bc[0], self.fs, self.smoothie, self.fk)
-        rms = (cfreq - self.res[0,18])/self.res[0,18]
+        cfreq = freqattributes.cfrequency(self.data_win_bc[0], self.fs,
+                                          self.smoothie, self.fk)
+        rms = (cfreq - self.res[0, 18]) / self.res[0, 18]
         self.assertTrue(rms < 1.0e-5)
 
     def test_bwith(self):


### PR DESCRIPTION
Here is an attempt at refactoring one of the signal.freqattributes routines, as per issue #532. 

It may not be the most elegant way of refactoring the code, but it allows the calculation of the central frequency for a single trace. Tests all passed ok, including new test for the single trace case.
