### PR TITLE
Version information broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -433,7 +433,7 @@ def add_data_files(config):
     # python files are included per default, we only include data files
     # here
     EXCLUDE_WILDCARDS = ['*.py', '*.pyc', '*.pyo', '*.pdf']
-    EXCLUDE_DIRS = ['src', 'docs', '__pycache__']
+    EXCLUDE_DIRS = ['src', '__pycache__']
     common_prefix = SETUP_DIRECTORY + os.path.sep
     for root, dirs, files in os.walk(os.path.join(SETUP_DIRECTORY, 'obspy')):
         root = root.replace(common_prefix, '')


### PR DESCRIPTION
After a few hours of bug tracking (why version information in travis was not working anymore), I found that merging #431 completely broke our version information routine. It happened in this commit (64c54ff) which inadequately replaced the MANIFEST.in with a function in setup.py that adds directories to the installation of the package. The problem is that RELEASE-VERSION generated during installation does not get included. Actually the very general wildcard recursive include (that was introduced at some point 225c46f2 because of similar problems with missing files -- it is just not feasible / too error prone to assume that everybody remembers adding new files in the MANIFEST as well) was replaced by an (older MANIFEST file version?!) include of only some directories, which is missing vital files.

 I understand this was necessary because numpy.distutils does not use the MANIFEST file. However it feels much less clean to have this list of includes hidden in the depths of the setup.py. In any case RELEASE-VERSION has to be included and I am pretty sure that other files might get missed through this, too. This needs thorough checking.
