### PR TITLE
Bug in in array_processing, modul get_spoint

### DIFF
--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -703,33 +703,27 @@ def get_timeshift(geometry, sll_x, sll_y, sl_s, grdpts_x, grdpts_y):
 
 def get_spoint(stream, stime, etime):
     """
+    Calculates start and end offsets relative to stime and etime for each
+    trace in stream in samples.
+
     :param stime: UTCDateTime to start
     :param etime: UTCDateTime to end
+    :returns: start and end sample offset arrays
     """
-    slatest = stream[0].stats.starttime
-    eearliest = stream[0].stats.endtime
-    for tr in stream:
-        if tr.stats.starttime >= slatest:
-            slatest = tr.stats.starttime
-        if tr.stats.endtime <= eearliest:
-            eearliest = tr.stats.endtime
-
-    if slatest > stime:
-        msg = "Specified start-time is smaller than starttime in stream"
-        raise ValueError(msg)
-    if eearliest < etime:
-        msg = "Specified end-time bigger is than endtime in stream"
-        raise ValueError(msg)
-
     spoint = np.empty(len(stream), dtype="int32", order="C")
     epoint = np.empty(len(stream), dtype="int32", order="C")
-    # now we have to adjust to the beginning of real start time
     for i, tr in enumerate(stream):
+        if tr.stats.starttime > stime:
+            msg = "Specified stime %s is smaller than starttime %s in stream"
+            raise ValueError(msg % (stime, tr.stats.starttime))
+        if tr.stats.endtime < etime:
+            msg = "Specified etime %s is bigger than endtime %s in stream"
+            raise ValueError(msg % (etime, tr.stats.endtime))
+        # now we have to adjust to the beginning of real start time
         spoint[i] = int((stime - tr.stats.starttime) *
-                        tr.stats.sampling_rate + 1)
+                        tr.stats.sampling_rate + .5)
         epoint[i] = int((tr.stats.endtime - etime) *
-                        tr.stats.sampling_rate + 1)
-
+                        tr.stats.sampling_rate + .5)
     return spoint, epoint
 
 
@@ -761,8 +755,8 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     else:
         raise TypeError('klim must either be a float or a tuple of length 4')
 
-    nkx = np.ceil((kxmax + kstep / 10. - kxmin) / kstep)
-    nky = np.ceil((kymax + kstep / 10. - kymin) / kstep)
+    nkx = int(np.ceil((kxmax + kstep / 10. - kxmin) / kstep))
+    nky = int(np.ceil((kymax + kstep / 10. - kymin) / kstep))
 
     transff = np.empty((nkx, nky))
 
@@ -814,9 +808,9 @@ def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
     else:
         raise TypeError('slim must either be a float or a tuple of length 4')
 
-    nsx = np.ceil((sxmax + sstep / 10. - sxmin) / sstep)
-    nsy = np.ceil((symax + sstep / 10. - symin) / sstep)
-    nf = np.ceil((fmax + fstep / 10. - fmin) / fstep)
+    nsx = int(np.ceil((sxmax + sstep / 10. - sxmin) / sstep))
+    nsy = int(np.ceil((symax + sstep / 10. - symin) / sstep))
+    nf = int(np.ceil((fmax + fstep / 10. - fmin) / fstep))
 
     transff = np.empty((nsx, nsy))
     buff = np.zeros(nf)

--- a/obspy/signal/tests/test_sonic.py
+++ b/obspy/signal/tests/test_sonic.py
@@ -3,8 +3,7 @@
 from obspy import Trace, Stream, UTCDateTime
 from obspy.core.util import AttribDict
 from obspy.signal.array_analysis import array_transff_freqslowness, \
-    array_processing
-from obspy.signal.array_analysis import array_transff_wavenumber
+    array_processing, array_transff_wavenumber, get_spoint
 from obspy.signal.util import utlLonLat
 import numpy as np
 import unittest
@@ -84,19 +83,19 @@ class SonicTestCase(unittest.TestCase):
         kwargs = dict(prewhiten=prewhiten, coordsys='xy', verbose=False,
                       method=method)
         out = array_processing(*args, **kwargs)
-        if 0:  # 1 for debugging
+        if False:  # 1 for debugging
             print '\n', out[:, 1:]
         return out
 
     def test_sonicBf(self):
         out = self.arrayProcessing(prewhiten=0, method=0)
         raw = """
-9.69515476e-01 1.95237117e-05 1.84349488e+01 1.26491106e+00
-9.59920378e-01 1.68637467e-05 1.84349488e+01 1.26491106e+00
-9.63367672e-01 1.36251275e-05 1.84349488e+01 1.26491106e+00
-9.65265591e-01 1.35077292e-05 1.84349488e+01 1.26491106e+00
-9.56276421e-01 1.15114010e-05 1.84349488e+01 1.26491106e+00
-9.49731735e-01 9.66531018e-06 1.84349488e+01 1.26491106e+00
+9.68742255e-01 1.95739086e-05 1.84349488e+01 1.26491106e+00
+9.60822403e-01 1.70468277e-05 1.84349488e+01 1.26491106e+00
+9.61689241e-01 1.35971034e-05 1.84349488e+01 1.26491106e+00
+9.64670470e-01 1.35565806e-05 1.84349488e+01 1.26491106e+00
+9.56880885e-01 1.16028992e-05 1.84349488e+01 1.26491106e+00
+9.49584782e-01 9.67131311e-06 1.84349488e+01 1.26491106e+00
         """
         ref = np.loadtxt(StringIO(raw), dtype='f4')
         self.assertTrue(np.allclose(ref, out[:, 1:], rtol=1e-6))
@@ -104,12 +103,12 @@ class SonicTestCase(unittest.TestCase):
     def test_sonicBfPrew(self):
         out = self.arrayProcessing(prewhiten=1, method=0)
         raw = """
-1.41116437e-01 1.95237117e-05 1.84349488e+01 1.26491106e+00
-1.28633209e-01 1.68637467e-05 1.84349488e+01 1.26491106e+00
-1.30422122e-01 1.36251275e-05 1.84349488e+01 1.26491106e+00
-1.33438392e-01 1.35077292e-05 1.84349488e+01 1.26491106e+00
-1.32708065e-01 1.15114010e-05 1.84349488e+01 1.26491106e+00
-1.31982873e-01 9.66531018e-06 1.84349488e+01 1.26491106e+00
+1.40997967e-01 1.95739086e-05 1.84349488e+01 1.26491106e+00
+1.28566503e-01 1.70468277e-05 1.84349488e+01 1.26491106e+00
+1.30517975e-01 1.35971034e-05 1.84349488e+01 1.26491106e+00
+1.34614854e-01 1.35565806e-05 1.84349488e+01 1.26491106e+00
+1.33609938e-01 1.16028992e-05 1.84349488e+01 1.26491106e+00
+1.32638966e-01 9.67131311e-06 1.84349488e+01 1.26491106e+00
         """
         ref = np.loadtxt(StringIO(raw), dtype='f4')
         self.assertTrue(np.allclose(ref, out[:, 1:]))
@@ -117,12 +116,12 @@ class SonicTestCase(unittest.TestCase):
     def test_sonicCapon(self):
         out = self.arrayProcessing(prewhiten=0, method=1)
         raw = """
-8.57600009e-01 8.57600009e-01  1.49314172e+01 1.55241747e+00
-1.72793618e+04 1.72793618e+04 -1.48240520e+02 2.46981781e+00
-4.58603016e+02 4.58603016e+02  1.54653824e+02 2.10237960e+00
-7.28814121e+02 7.28814121e+02  1.58198591e+02 1.07703296e+00
-9.43803974e+02 9.43803974e+02 -9.78533133e+01 2.92745623e+00
-2.04031354e+02 2.04031354e+02 -7.50685828e+01 1.55241747e+00
+9.06938200e-01 9.06938200e-01  1.49314172e+01  1.55241747e+00
+8.90494375e+02 8.90494375e+02 -9.46232221e+00  1.21655251e+00
+3.07129784e+03 3.07129784e+03 -4.95739213e+01  3.54682957e+00
+5.00019137e+03 5.00019137e+03 -1.35000000e+02  1.41421356e-01
+7.94530414e+02 7.94530414e+02 -1.65963757e+02  2.06155281e+00
+6.08349575e+03 6.08349575e+03  1.77709390e+02  2.50199920e+00
         """
         ref = np.loadtxt(StringIO(raw), dtype='f4')
         # XXX relative tolerance should be lower!
@@ -131,19 +130,32 @@ class SonicTestCase(unittest.TestCase):
     def test_sonicCaponPrew(self):
         out = self.arrayProcessing(prewhiten=1, method=1)
         raw = """
-1.28958194e-01 8.57600009e-01 1.49314172e+01 1.55241747e+00
-8.67841733e-03 2.46878767e+00 6.11550357e+00 2.81602557e+00
-1.62662506e-02 1.01472317e+02 3.55376778e+01 8.60232527e-01
-1.16868438e-02 2.58679345e+01 2.65650512e+01 8.94427191e-01
-1.78311467e-02 3.35905434e+01 1.97988764e+01 2.65706605e+00
-2.39100818e-02 1.87168023e+02 1.68690068e+02 1.52970585e+00
+1.30482688e-01 9.06938200e-01  1.49314172e+01  1.55241747e+00
+8.93029978e-03 8.90494375e+02 -9.46232221e+00  1.21655251e+00
+9.55393634e-03 1.50655072e+01  1.42594643e+02  2.14009346e+00
+8.85762420e-03 7.27883670e+01  1.84349488e+01  1.26491106e+00
+1.51510617e-02 6.54541771e-01  6.81985905e+01  2.15406592e+00
+3.10761699e-02 7.38667657e+00  1.13099325e+01  1.52970585e+00
         """
         ref = np.loadtxt(StringIO(raw), dtype='f4')
         # XXX relative tolerance should be lower!
         self.assertTrue(np.allclose(ref, out[:, 1:], rtol=4e-5))
 
-    def test_array_transff_freqslowness(self):
+    def test_getSpoint(self):
+        stime = UTCDateTime(1970, 1, 1, 0, 0)
+        etime = UTCDateTime(1970, 1, 1, 0, 0) + 10
+        data = np.empty(20)
+        # sampling rate defaults to 1 Hz
+        st = Stream([
+            Trace(data, {'starttime': stime - 1}),
+            Trace(data, {'starttime': stime - 4}),
+            Trace(data, {'starttime': stime - 2}),
+        ])
+        spoint, epoint = get_spoint(st, stime, etime)
+        self.assertTrue(np.allclose([1, 4, 2], spoint))
+        self.assertTrue(np.allclose([8, 5, 7], epoint))
 
+    def test_array_transff_freqslowness(self):
         coords = np.array([[10., 60., 0.],
                            [200., 50., 0.],
                            [-120., 170., 0.],
@@ -181,7 +193,6 @@ class SonicTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(transffll, transffth, decimal=6)
 
     def test_array_transff_wavenumber(self):
-
         coords = np.array([[10., 60., 0.],
                            [200., 50., 0.],
                            [-120., 170., 0.],


### PR DESCRIPTION
In modul get_spoint, `spoint[i]` (unit is sample) is set to a variable with unit time. I think instead it must be:

```
    ...
    #diffstart = (slatest - stream[i].stats.starttime)
    diffstart = (slatest - stream[i].stats.starttime) / stream[i].stats.delta
    frac, ddummy = math.modf(diffstart)
    spoint[i] = int(ddummy)
    ...
```

 Same for epoint:

```
   ...
    #diffend = stream[i].stats.endtime - eearliest
    diffend = stream[i].stats.endtime - eearliest / stream[i].stats.delta
    frac, ddummy = math.modf(diffend)
    epoint[i] = int(ddummy)
    ...
```

If the start time of all traces are the same, then this bug does not have an effect.
