### PR TITLE
Added BoundedValueType metaclass and tests

### DIFF
--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -34,6 +34,6 @@ from obspy.core.util.geodetics import calcVincentyInverse, gps2DistAzimuth, \
 from obspy.core.util.misc import BAND_CODE, complexifyString, guessDelta, \
     scoreatpercentile, toIntOrZero, loadtxt, CatchOutput
 from obspy.core.util.obspy_types import OrderedDict, Enum, \
-    ComplexWithUncertainties, FloatWithUncertainties
+    ComplexWithUncertainties, FloatWithUncertainties, BoundedValueType
 from obspy.core.util.xmlwrapper import XMLParser, tostring, register_namespace
 from obspy.core.util.version import get_git_version as _getVersionString


### PR DESCRIPTION
@krischer Here is the metaclass I was talking about, added and tested but not implemented into any types yet.

Implementation would be like this:

``` python
# Takes the _minimum, _maximum
class Latitude(FloatWithUncertainties):
    __metaclass__ = BoundedValueType
    _maximum = 90.
    _minimum = -90.

# or can set those from the metaclass itself
class Longitude(FloatWithUncertainties):
    __metaclass__ = BoundedValueType.set_bounds(-180.,180.)
```

...and enforces on class construction.

``` python
In [3]: Latitude(34)
Out[3]: 34.0

In [4]: Latitude(100)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-90970f217309> in <module>()
----> 1 Latitude(100)

/srv/net/home/markwill/Code/python/obspy/obspy/core/util/obspy_types.py in __call__(self, *args, **kwargs)
    310                                                      self._minimum,
    311                                                      self._maximum)
--> 312             raise ValueError(msg)
    313         return obj
    314 

ValueError: Latitude must be in [-90.0, 90.0]
```

This would also work if you wanted to enforce positive values on `plusError` and `minusError` uncertainties or something in the future. @megies feel free to reject or kick down the road if you're getting too close to a release to refactor stuff.
