### PR TITLE
Numpy 1.8.0 compatibility.

### DIFF
--- a/obspy/core/preview.py
+++ b/obspy/core/preview.py
@@ -41,7 +41,7 @@ def createPreview(trace, delta=60):
     if samples_per_slice < 1:
         raise ValueError('samples_per_slice is less than 0 - skipping')
     # minimum and maximum of samples before a static time marker
-    start = (delta - start_time % delta) * int(trace.stats.sampling_rate)
+    start = int((delta - start_time % delta) * int(trace.stats.sampling_rate))
     start_time = start_time - start_time % delta
     if start > (delta / 2) and data[0:start].size:
         first_diff = [data[0:start].max() - data[0:start].min()]

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -36,9 +36,9 @@ class WaveformTestCase(unittest.TestCase):
         :return: Stream object
         """
         time_delta = endtime - starttime
-        number_of_samples = time_delta * sampling_rate + 1
+        number_of_samples = int(time_delta * sampling_rate) + 1
         # Calculate first sine wave.
-        curve = np.linspace(0, 2 * np.pi, int(number_of_samples // 2))
+        curve = np.linspace(0, 2 * np.pi, number_of_samples // 2)
         # Superimpose it with a smaller but shorter wavelength sine wave.
         curve = np.sin(curve) + 0.2 * np.sin(10 * curve)
         # To get a thick curve alternate between two curves.

--- a/obspy/signal/calibration.py
+++ b/obspy/signal/calibration.py
@@ -208,7 +208,7 @@ def spectral_helper(x, y, NFFT=256, Fs=2, noverlap=0, pad_to=None,
     windowVals = np.hanning(NFFT)
 
     step = NFFT - noverlap
-    ind = np.arange(0, len(x) - NFFT + 1, step)
+    ind = np.arange(0, len(x) - NFFT + 1, step, dtype=np.int32)
     n = len(ind)
     Pxy = np.zeros((numFreqs, n), np.complex_)
 

--- a/obspy/signal/freqattributes.py
+++ b/obspy/signal/freqattributes.py
@@ -287,11 +287,11 @@ def logbankm(p, n, fs, w):
     lr = np.log((fh) / (fl)) / (p + 1)
     bl = n * ((fl) *
               np.exp(np.array([0, 1, p, p + 1]) * float(lr)) / float(fs))
-    b2 = np.ceil(bl[1])
-    b3 = np.floor(bl[2])
-    b1 = np.floor(bl[0]) + 1
-    b4 = min(fn2, np.ceil(bl[3])) - 1
-    pf = np.log(((np.arange(b1 - 1, b4 + 1) / n) * fs) / (fl)) / lr
+    b2 = int(np.ceil(bl[1]))
+    b3 = int(np.floor(bl[2]))
+    b1 = int(np.floor(bl[0])) + 1
+    b4 = int(min(fn2, np.ceil(bl[3]))) - 1
+    pf = np.log(((np.arange(b1 - 1, b4 + 1, dtype=np.float) / n) * fs) / (fl)) / lr
     fp = np.floor(pf)
     pm = pf - fp
     k2 = b2 - b1 + 1
@@ -304,7 +304,6 @@ def logbankm(p, n, fs, w):
     mx = b4 + 1
     #x = np.array([[c],[r]], dtype=[('x', 'float'), ('y', 'float')])
     #ind=np.argsort(x, order=('x','y'))
-    help = np.append([c], [r], axis=0)
     if (w == 'Hann'):
         v = 1. - [np.cos([v * float(np.pi / 2.)])]
     elif (w == 'Hamming'):
@@ -312,7 +311,7 @@ def logbankm(p, n, fs, w):
     # bugfix for #70 - scipy.sparse.csr_matrix() delivers sometimes a
     # transposed matrix depending on the installed NumPy version - using
     # scipy.sparse.coo_matrix() ensures compatibility with old NumPy versions
-    xx = sparse.coo_matrix((v, help)).transpose().todense()
+    xx = sparse.coo_matrix((v, (c,r))).transpose().todense()
     return xx, mn - 1, mx - 1
 
 


### PR DESCRIPTION
NumPy 1.8.0 has deprecated use of non-integer integers (e.g., 1.0 instead of 1) in places where integers are expected, such as array indices. This change fixes any non-integer usage so that the tests all pass.

I did not audit every single place a non-integer integer may occur (I'm not sure there would be a simple way to find them anyway), so if a test didn't trigger it, it might not have been fixed.
