### PR TITLE
Trace.remove_response() without nfft_pow2 option slow for certain npts

### DIFF
--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2179,15 +2179,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if taper:
             data *= cosTaper(npts, taper_fraction,
                              sactaper=True, halfcosine=False)
-        # The number of points for the FFT has to be at least 2 * npts (in
-        # order to prohibit wrap around effects during convolution) cf.
-        # evalresp scales directly with nfft, therefore taking the next power
-        # of two has a greater negative performance impact than the slow down
-        # of a not power of two in the FFT
-        if npts & 0x1:  # check if uneven
-            nfft = 2 * (npts + 1)
-        else:
-            nfft = 2 * npts
+        # smart calculation of nfft dodging large primes
+        from obspy.signal.util import _npts2nfft
+        nfft = _npts2nfft(npts)
         # Transform data to Frequency domain
         data = np.fft.rfft(data, n=nfft)
         # calculate and apply frequency response,

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -17,6 +17,7 @@ import warnings
 import itertools
 import tempfile
 import numpy as np
+import math
 
 
 # The following dictionary maps the first character of the channel_id to the
@@ -439,6 +440,33 @@ def CatchOutput():
             os.remove(stderr_filename)
         except OSError:
             pass
+
+
+def factorize_int(x):
+    """
+    Calculate prime factorization of integer.
+
+    Could be done faster but faster algorithm have much more lines of code and
+    this is fast enough for our purposes.
+
+    http://stackoverflow.com/questions/14550794/\
+    python-integer-factorization-into-primes
+
+    >>> factorize_int(1800004)
+    [2, 2, 450001]
+    >>> factorize_int(1800003)
+    [3, 19, 23, 1373]
+    """
+    if x == 1:
+        return [1]
+    factors, limit, check, num = [], int(math.sqrt(x)) + 1, 2, x
+    for check in xrange(2, limit):
+        while num % check == 0:
+            factors.append(check)
+            num /= check
+    if num > 1:
+        factors.append(num)
+    return factors
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear developers,

when working with large traces (say, nb of data ~ 1,000,000), the rfft inside 'remove_response' method hangs (on my computer at least).

In 'simulate' method there is an option nfft_pow2, which I always use to get away with this.

Is it possible to add this option to remove_response?

Thanks
BG
