### PR TITLE
add a check for the station id to Network.get_response()

### DIFF
--- a/obspy/station/network.py
+++ b/obspy/station/network.py
@@ -155,7 +155,8 @@ class Network(BaseNode):
             responses = []
         else:
             channels = [cha for sta in self.stations for cha in sta.channels
-                        if cha.code == channel
+                        if sta.code == station
+                        and cha.code == channel
                         and cha.location_code == location
                         and (cha.start_date is None
                              or cha.start_date <= datetime)


### PR DESCRIPTION
obspy.station.network.Network.get_response() doesn't currently take the station id contained in seed_id into account. Instead it collects all responses that match the given channel. This results in a warning "Found more than one matching response. Returning first." and the wrong response being attached to a trace when used with Trace.attach_response(), if the corresponding inventory contains more than one station.

Sorry, for not providing a test case... however, there is no test_network.py yet and I didn't feel like spending too much time on it now ... :-)
