### PR TITLE
seismicportal.eu FDSN WADL files cannot be read

### DIFF
--- a/obspy/fdsn/header.py
+++ b/obspy/fdsn/header.py
@@ -24,6 +24,7 @@ URL_MAPPINGS = {"IRIS": "http://service.iris.edu",
                 "NCEDC": "http://service.ncedc.org",
                 "USP": "http://sismo.iag.usp.br",
                 "GFZ": "http://geofon.gfz-potsdam.de",
+                "NERIES": "http://www.seismicportal.eu",
                 }
 
 FDSNWS = ("dataselect", "event", "station")


### PR DESCRIPTION
ObsPy cannot read the WADL files from www.seismicportal.eu.

See here:
http://lists.swapbytes.de/archives/obspy-users/2014-January/001188.html

The issue appears to be that the WADLs have documentation tags with no information in them. Currently the WADL parser assumes that if a doc tag is present it will also contain some information.
