### PR TITLE
fixed error - timeout object has no attribute value

### DIFF
--- a/obspy/seedlink/client/seedlinkconnection.py
+++ b/obspy/seedlink/client/seedlinkconnection.py
@@ -811,10 +811,7 @@ class SeedLinkConnection(object):
                     self.connect()
                     self.state.state = SLState.SL_UP
                 except Exception as e:
-                    try:
-                    	logger.error(e.value)
-                    except AttributeError:
-                    	logger.error("timeout object has no attribute value")
+                    logger.error(str(e))
                     #traceback.print_exc()
                 self.state.netto_trig = -1
                 self.state.netdly_trig = -1


### PR DESCRIPTION
I've solved this error with the approach "easier to ask for forgiveness than permission" EAFP.

/obspy/seedlink/client/seedlinkconnection.py", line 814, in collect
    logger.error(e.value)
AttributeError: 'timeout' object has no attribute 'value'
