### PR TITLE
fixing version number on py3.x

### DIFF
--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -58,8 +58,7 @@ def call_git_describe(abbrev=4):
         p.stdout.close()
     except:
         return None
-    path = os.path.normpath(path)
-    if path != OBSPY_ROOT:
+    if os.path.normpath(path) != OBSPY_ROOT:
         return None
     try:
         p = Popen(['git', 'describe', '--dirty', '--abbrev=%d' % abbrev,
@@ -82,7 +81,7 @@ def call_git_describe(abbrev=4):
 def read_release_version():
     try:
         with io.open(VERSION_FILE, "rt") as fh:
-            version = fh.readlines()[0]
+            version = fh.readline()
         return version.strip()
     except:
         return None


### PR DESCRIPTION
After some deep digging I've finally been able to fix the mysteriously failing version numbers on Travis Python 3.x reports.

A comparison of two file paths wasn't reporting equality anymore due to one being a bytearray and one a decoded string in Python 3.

This is introducing an ugly `if` switch and fixes this issue for Python 3.x, any more elegant solutions are welcome.
