### PR TITLE
Fix calc of centre of "local" station/event plots.

### DIFF
--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -153,8 +153,8 @@ def plot_basemap(lons, lats, size, color, labels=None,
         else:
             max_lons = max(lons)
             min_lons = min(lons)
-        lat_0 = (max(lats) + min(lats)) / 2.
-        lon_0 = (max_lons + min_lons) / 2.
+        lat_0 = max(lats) / 2. + min(lats) / 2.
+        lon_0 = max_lons / 2. + min_lons / 2.
         if lon_0 > 180:
             lon_0 -= 360
         deg2m_lat = 2 * np.pi * 6371 * 1000 / 360


### PR DESCRIPTION
When the centre of the station/event plot is outside ±90, the sum of the
min&max are greater than ±180. The Longitude class does not like this
value, but this can be fixed by halving both before the addition.
