### PR TITLE
Adding salt formula for current obspy release 0.9.2

### DIFF
--- a/misc/installer/salt-formula/README.md
+++ b/misc/installer/salt-formula/README.md
@@ -1,0 +1,43 @@
+Salt formula for ObsPy
+======================
+Contains a salt state file for installing obspy. The default is to install the latest stable release using the supported methods, and packages from official operating system repositories whenever possible.
+
+
+Debian/Ubuntu install
+---------------------
+Adds deb repo with gpg key, and installs package automatically
+
+
+Red Hat/CentOS/Scientific Linux
+-------------------------------
+The current behavior is to fall back to a PIP install. The package dependencies will be installed via yum. This assumes you have already set up the EPEL repo, and does not check for this. The salt program is found in EPEL, so if you installed from there, or used the bootstrap salt script, this should already be set up.
+
+
+Arch Linux
+----------
+Experimental PIP install, same as RHEL, install dependencies from package, then use PIP for the rest. This is currently set up to install the latest ObsPy release, which is not yet Python 3, so the dependencies and pip install all use the `python2` Arch packages (The python (3) deps are stubbed out in `map.jinja` in anticipation of this release).
+
+
+Examples
+--------
+Assuming this is installed in base path (e.g. '/srv/salt/obspy')
+
+Using top file:
+```
+# Example top.sls file snippet
+# Installs obspy on all Linux machines.
+base:
+    'G@kernel:Linux':
+        - match: compound
+        - obspy
+```
+Using shell (dry run):
+From salt master
+```shell
+$ sudo salt -G 'kernel:Linux' state.sls obspy test=True
+```
+
+Local or masterless minion
+```shell
+$ sudo salt-call --local state.sls obspy test=True
+```

--- a/misc/installer/salt-formula/obspy/dependencies.sls
+++ b/misc/installer/salt-formula/obspy/dependencies.sls
@@ -1,0 +1,12 @@
+#
+# Salt state for dependecies available in package repos
+#
+{% from "obspy/map.jinja" import pkg_deps with context %}
+
+obspy_pkg_dependencies:
+    pkg.installed:
+        - pkgs:
+        {% for pkg_dep in pkg_deps %}
+            - {{ pkg_dep }}
+        {% endfor %}
+

--- a/misc/installer/salt-formula/obspy/git.sls
+++ b/misc/installer/salt-formula/obspy/git.sls
@@ -1,0 +1,12 @@
+#
+#
+#
+include:
+    - obspy.dependencies
+
+obspy:
+    pip.installed:
+        - name : git+https://github.com/obspy/obspy.git@master#egg=obspy
+        - require:
+            - pkg: obspy_pkg_dependencies
+

--- a/misc/installer/salt-formula/obspy/init.sls
+++ b/misc/installer/salt-formula/obspy/init.sls
@@ -1,0 +1,35 @@
+#
+# Salt - ObsPy install
+# Only supported obspy install methods are used (deb + pip)
+#
+# Use the native package management system for dependencies
+# whenever possible. Use pip for everything else.
+#
+#######################################################################
+# REPOSITORY INSTALL
+#######################################################################
+
+#- Debian/Ubuntu
+#
+{% if grains['os_family'] == 'Debian' %}
+
+obspy:
+    pkgrepo.managed:
+        - humanname: ObsPy - Python framework for seismology
+        - name: deb http://deb.obspy.org {{ grains['oscodename'] }} main
+        - file: /etc/apt/sources.list.d/obspy.list
+        - key_url: https://raw.github.com/obspy/obspy/master/misc/debian/public.key
+
+    pkg.installed:
+        - name: python-obspy
+        - refresh: True
+
+#######################################################################
+# PIP INSTALL
+#######################################################################
+{% else %}
+
+include:
+    - obspy.pip
+
+{% endif %}

--- a/misc/installer/salt-formula/obspy/map.jinja
+++ b/misc/installer/salt-formula/obspy/map.jinja
@@ -1,0 +1,23 @@
+#
+# Package dependencies for pip install
+#
+{% set pkg_deps = salt['grains.filter_by']({
+    'RedHat': ['python-pip', 'python-devel', 'python-setuptools', 'numpy', 
+               'scipy', 'python-matplotlib', 'python-lxml', 'python-suds', 
+               'python-sqlalchemy', 'python-tornado', 'gcc-gfortran', 'gcc'],
+
+    'Arch': ['python2-pip', 'python2-setuptools', 'python2-numpy', 'python2-scipy',
+             'python2-matplotlib', 'python2-lxml', 'python2-sqlalchemy', 
+             'python2-suds', 'python2-tornado', 'gcc-fortran', 'gcc'],
+
+    'Debian': ['python-pip', 'python-dev', 'python-numpy', 'python-setuptools', 
+               'python-lxml', 'python-matplotlib', 'python-scipy', 'python-sqlalchemy',
+               'python-suds', 'python-tornado', 'gcc', 'gfortran'],
+
+}, default='Debian') %}
+
+# Python 3 (Arch default)
+#    'Arch': ['python-pip', 'python-setuptools', 'python-numpy', 'python-scipy',
+#             'python-matplotlib', 'python-lxml', 'python-sqlalchemy', 
+#             'python-tornado', 'gcc-fortran', 'gcc'],
+

--- a/misc/installer/salt-formula/obspy/pip.sls
+++ b/misc/installer/salt-formula/obspy/pip.sls
@@ -1,0 +1,14 @@
+#
+# Salt state for a pip install of ObsPy (from PyPI)
+#
+include:
+    - obspy.dependencies
+
+obspy:
+    pip.installed:
+        {% if grains['os_family'] == 'Arch' %}
+        - bin_env: /usr/sbin/pip2
+        {% endif %}
+        - require:
+            - pkg: obspy_pkg_dependencies
+

--- a/misc/installer/salt-formula/obspy/testing.sls
+++ b/misc/installer/salt-formula/obspy/testing.sls
@@ -1,0 +1,16 @@
+#
+# Example for obspy dev, MUST have all dependecies installed already
+#
+
+# This forces an upgrade, which must be done with no dep installs, b/c
+# otherwise pip will try and build a new numpy/scipy/matplotlib, etc.
+# which is probably not what we want.
+
+obspy:
+    pip.installed:
+        - name : git+https://github.com/obspy/obspy.git@master#egg=obspy
+        - activate: True
+        - upgrade: True
+        - no_deps: True
+        - bin_env: /opt/virtualenv/testpy
+


### PR DESCRIPTION
Adding per earlier discussion, the salt formula is the only one I have somewhat tested, so it's the only one I'll add for now.

I broke out the install of various parts, so one could use these states as blocks for alternate installs (like installing from the git master branch for testing), but the default is installing the latest release from the deb or PyPI repos.
