### PR TITLE
Filter in obspy.signal.cross_correlation.xcorrPickCorrection silently modifies arguments

### DIFF
--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -286,6 +286,10 @@ def xcorrPickCorrection(pick1, trace1, pick2, trace2, t_before, t_after,
         msg = "Trace ids do not match: %s != %s" % (trace1.id, trace2.id)
         warnings.warn(msg)
     samp_rate = trace1.stats.sampling_rate
+    # don't modify existing traces with filters
+    if filter:
+        trace1 = trace1.copy()
+        trace2 = trace2.copy()
     # check data, apply filter and take correct slice of traces
     slices = []
     for _i, (t, tr) in enumerate(((pick1, trace1), (pick2, trace2))):

--- a/obspy/signal/tests/test_cross_correlation.py
+++ b/obspy/signal/tests/test_cross_correlation.py
@@ -32,6 +32,8 @@ class CrossCorrelationTestCase(unittest.TestCase):
 
         tr1 = st1.select(component="Z")[0]
         tr2 = st2.select(component="Z")[0]
+        tr1_copy = tr1.copy()
+        tr2_copy = tr2.copy()
         t1 = UTCDateTime("2010-05-27T16:24:33.315000Z")
         t2 = UTCDateTime("2010-05-27T16:27:30.585000Z")
 
@@ -46,6 +48,8 @@ class CrossCorrelationTestCase(unittest.TestCase):
             filter_options={'freqmin': 1, 'freqmax': 10})
         self.assertAlmostEqual(dt, -0.013025086360067755)
         self.assertAlmostEqual(coeff, 0.98279277273758803)
+        self.assertEqual(tr1, tr1_copy)
+        self.assertEqual(tr2, tr2_copy)
 
 
 def suite():


### PR DESCRIPTION
The documentation for `obspy.signal.cross_correlation.xcorrPickCorrection` indicates that one might use the `filter` argument to change the processing slightly. What's _not_ mentioned is that this filtering is done on the input traces themselves.

Personally, I think `xcorrPickCorrection` should filter on a copy, but if this is intended, it should be documented as it's not something one would expect.
