### PR TITLE
Added the ability to interpolate in the frequency domain to Trace.resample(). Should fix issue #857

### DIFF
--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1580,73 +1580,92 @@ class TraceTestCase(unittest.TestCase):
         resolved.
         """
         starttime = UTCDateTime("1970-01-01T00:00:00.000000Z")
+        tr0 = Trace(np.sin(np.linspace(0, 2*np.pi, 10)),
+                    {'sampling_rate': 1.0,
+                     'starttime': starttime})
         # downsample
-        tr = Trace(np.sin(np.linspace(0,2*np.pi,10)), 
-                   {'sampling_rate':1.0,
-                    'starttime':starttime})
+        tr = tr0.copy()
         tr.resample(0.5, window='hanning', no_filter=True)
-        expected = np.array([ 0.19478735,  0.83618307,  0.32200221, 
-                             -0.7794053 , -0.57356732])
-        assert len(tr.data) == 5
-        assert np.all(np.abs(tr.data - expected) < 1e-7)
-        assert tr.stats.sampling_rate == 0.5
-        assert tr.stats.delta == 2.0
-        assert tr.stats.npts == 5
-        assert tr.stats.starttime == starttime
-        assert tr.stats.endtime == starttime + tr.stats.delta * (tr.stats.npts-1)
-        assert tr.stats.processing == ['resample:0:hanning']
-        
+        self.assertEqual(len(tr.data), 5)
+        expected = np.array([0.19478735, 0.83618307, 0.32200221,
+                             -0.7794053, -0.57356732])
+        self.assertTrue(np.all(np.abs(tr.data - expected) < 1e-7))
+        self.assertEqual(tr.stats.sampling_rate, 0.5)
+        self.assertEqual(tr.stats.delta, 2.0)
+        self.assertEqual(tr.stats.npts, 5)
+        self.assertEqual(tr.stats.starttime, starttime)
+        self.assertEqual(tr.stats.endtime,
+                         starttime + tr.stats.delta * (tr.stats.npts-1))
+        self.assertEqual(tr.stats.processing, ['resample:0:hanning'])
+
         # upsample
-        tr = Trace(np.sin(np.linspace(0,2*np.pi,10)), 
-                   {'sampling_rate':1.0,
-                    'starttime':starttime})
+        tr = tr0.copy()
         tr.resample(2.0, window='hanning', no_filter=True)
-        assert len(tr.data) == 20
-        assert tr.stats.sampling_rate == 2.0
-        assert tr.stats.delta == 0.5
-        assert tr.stats.npts == 20
-        assert tr.stats.starttime == starttime
-        assert tr.stats.endtime == starttime + tr.stats.delta * (tr.stats.npts-1)
-        assert tr.stats.processing == ['resample:2:hanning']
-        
+        self.assertEqual(len(tr.data), 20)
+        self.assertEqual(tr.stats.sampling_rate, 2.0)
+        self.assertEqual(tr.stats.delta, 0.5)
+        self.assertEqual(tr.stats.npts, 20)
+        self.assertEqual(tr.stats.starttime, starttime)
+        self.assertEqual(tr.stats.endtime,
+                         starttime + tr.stats.delta * (tr.stats.npts-1))
+        self.assertEqual(tr.stats.processing, ['resample:2:hanning'])
+
         # downsample with non integer ratio
-        tr = Trace(np.sin(np.linspace(0,2*np.pi,10)), 
-                   {'sampling_rate':1.0,
-                    'starttime':starttime})
+        tr = tr0.copy()
         tr.resample(0.75, window='hanning', no_filter=True)
-        assert len(tr.data) == int(10*.75)
-        assert tr.stats.sampling_rate == 0.75
-        assert tr.stats.delta == 1/0.75
-        assert tr.stats.npts == int(10*.75)
-        assert tr.stats.starttime == starttime
-        assert tr.stats.endtime == starttime + tr.stats.delta * (tr.stats.npts-1)
-        assert tr.stats.processing == ['resample:0:hanning']
-        
+        self.assertEqual(len(tr.data), int(10*.75))
+        expected = np.array([0.15425413, 0.66991128, 0.74610418, 0.11960477,
+                             -0.60644662, -0.77403839, -0.30938935])
+        self.assertTrue(np.all(np.abs(tr.data - expected) < 1e-7))
+        self.assertEqual(tr.stats.sampling_rate, 0.75)
+        self.assertEqual(tr.stats.delta, 1/0.75)
+        self.assertEqual(tr.stats.npts, int(10*.75))
+        self.assertEqual(tr.stats.starttime, starttime)
+        self.assertEqual(tr.stats.endtime,
+                         starttime + tr.stats.delta * (tr.stats.npts-1))
+        self.assertEqual(tr.stats.processing, ['resample:0:hanning'])
+
         # downsample without window
-        tr = Trace(np.sin(np.linspace(0,2*np.pi,10)), 
-                   {'sampling_rate':1.0,
-                    'starttime':starttime})
+        tr = tr0.copy()
         tr.resample(0.5, window=None, no_filter=True)
-        assert len(tr.data) == 5
-        assert tr.stats.sampling_rate == 0.5
-        assert tr.stats.delta == 2.0
-        assert tr.stats.npts == 5
-        assert tr.stats.starttime == starttime
-        assert tr.stats.endtime == starttime + tr.stats.delta * (tr.stats.npts-1)
-        assert tr.stats.processing == ['resample:0:None']
-        
+        self.assertEqual(len(tr.data), 5)
+        self.assertEqual(tr.stats.sampling_rate, 0.5)
+        self.assertEqual(tr.stats.delta, 2.0)
+        self.assertEqual(tr.stats.npts, 5)
+        self.assertEqual(tr.stats.starttime, starttime)
+        self.assertEqual(tr.stats.endtime,
+                         starttime + tr.stats.delta * (tr.stats.npts-1))
+        self.assertEqual(tr.stats.processing, ['resample:0:None'])
+
         # downsample with window and automatic filtering
-        tr = Trace(np.sin(np.linspace(0,2*np.pi,10)), 
-                   {'sampling_rate':1.0,
-                    'starttime':starttime})
+        tr = tr0.copy()
         tr.resample(0.5, window='hanning', no_filter=False)
-        assert len(tr.data) == 5
-        assert tr.stats.sampling_rate == 0.5
-        assert tr.stats.delta == 2.0
-        assert tr.stats.npts == 5
-        assert tr.stats.starttime == starttime
-        assert tr.stats.endtime == starttime + tr.stats.delta * (tr.stats.npts-1)
-        assert tr.stats.processing == ["filter:lowpasscheby2:{'freq': 0.25, 'maxorder': 12}", 'resample:0:hanning']
+        self.assertEqual(len(tr.data), 5)
+        self.assertEqual(tr.stats.sampling_rate, 0.5)
+        self.assertEqual(tr.stats.delta, 2.0)
+        self.assertEqual(tr.stats.npts, 5)
+        self.assertEqual(tr.stats.starttime, starttime)
+        self.assertEqual(tr.stats.endtime,
+                         starttime + tr.stats.delta * (tr.stats.npts-1))
+        self.assertEqual(tr.stats.processing,
+                         ["filter:lowpasscheby2:" +
+                          "{'freq': 0.25, 'maxorder': 12}",
+                          "resample:0:hanning"])
+
+        # downsample with custom window
+        tr = tr0.copy()
+        window = np.ones((tr.stats.npts))
+        tr.resample(0.5, window=window, no_filter=True)
+        self.assertEqual(tr.stats.processing,
+                         ["resample:0:" +
+                          "[ 1.  1.  1.  1.  1.  1.  1.  1.  1.  1.]"])
+
+        # downsample with bad window
+        tr = tr0.copy()
+        window = np.array([0, 1, 2, 3])
+        self.assertRaises(ValueError, tr.resample,
+                          sampling_rate=0.5, window=window, no_filter=True)
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1403,8 +1403,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
     def resample(self, sampling_rate, window='hanning', no_filter=True,
                  strict_length=False):
         """
-        Resample trace data using Fourier method.
- 
+        Resample trace data using Fourier method. Spectra are linearly
+        interpolated if required.
+
         :type sampling_rate: float
         :param sampling_rate: The sampling rate of the resampled signal.
         :type window: array_like, callable, string, float, or tuple, optional
@@ -1417,21 +1418,21 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type strict_length: bool, optional
         :param strict_length: Leave traces unchanged for which endtime of trace
             would change. Defaults to ``False``.
- 
+
         .. note::
- 
+
             This operation is performed in place on the actual data arrays. The
             raw data is not accessible anymore afterwards. To keep your
             original data, use :meth:`~obspy.core.trace.Trace.copy` to create
             a copy of your trace object.
             This also makes an entry with information on the applied processing
             in ``stats.processing`` of this trace.
- 
+
         Uses :func:`scipy.signal.resample`. Because a Fourier method is used,
         the signal is assumed to be periodic.
- 
+
         .. rubric:: Example
- 
+
         >>> tr = Trace(data=np.array([0.5, 0, 0.5, 1, 0.5, 0, 0.5, 1]))
         >>> len(tr)
         8
@@ -1447,11 +1448,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         array([ 0.5       ,  0.40432914,  0.3232233 ,  0.26903012,  0.25 ...
         """
         from scipy.signal.windows import get_window
+        from scipy.fftpack import rfft, irfft
         factor = self.stats.sampling_rate / float(sampling_rate)
         # check if endtime changes and this is not explicitly allowed
-        if strict_length and len(self.data) % factor != 0.0:
-            msg = "Endtime of trace would change and strict_length=True."
-            raise ValueError(msg)
+        if strict_length:
+            if len(self.data) % factor != 0.0:
+                msg = "Endtime of trace would change and strict_length=True."
+                raise ValueError(msg)
         # do automatic lowpass filtering
         if not no_filter:
             # be sure filter still behaves good
@@ -1462,28 +1465,46 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 raise ArithmeticError(msg)
             freq = self.stats.sampling_rate * 0.5 / float(factor)
             self.filter('lowpassCheby2', freq=freq, maxorder=12)
-         
+
         # resample in the frequency domain
-        num = int(self.stats.npts / factor)
-        
-        X = np.fft.fft(self.data)
+        X = rfft(self.data)
+        X = np.insert(X, 1, 0)
+        if self.stats.npts % 2 == 0:
+            X = np.append(X, [0])
+        Xr = X[::2]
+        Xi = X[1::2]
+
         if window is not None:
             if callable(window):
                 W = window(np.fft.fftfreq(self.stats.npts))
-            elif isinstance(window, np.ndarray) and window.shape == (self.stats.npts,):
+            elif isinstance(window, np.ndarray):
+                if window.shape != (self.stats.npts,):
+                    msg = "Window has the wrong shape. Window length must " + \
+                          "equal the number of points."
+                    raise ValueError(msg)
                 W = window
             else:
                 W = np.fft.ifftshift(get_window(window, self.stats.npts))
-            X = X * W         
-            
-        X = np.fft.fftshift(X)
-        f = np.fft.fftshift(np.fft.fftfreq(self.stats.npts, self.stats.delta))
-        F = np.fft.fftshift(np.fft.fftfreq(num, 1./sampling_rate))
-        Y = np.interp(F, f, X.real) + 1j*np.interp(F, f, X.imag)
-        y = np.fft.ifft(np.fft.ifftshift(Y)) * (float(num) / float(self.stats.npts))
-        self.data = y.real
+            Xr *= W[:self.stats.npts//2+1]
+            Xi *= W[:self.stats.npts//2+1]
+
+        # interpolate
+        num = int(self.stats.npts / factor)
+        df = 1.0 / (self.stats.npts * self.stats.delta)
+        dF = 1.0 / num * sampling_rate
+        f = df * np.arange(0, self.stats.npts // 2 + 1, dtype=int)
+        nF = num // 2 + 1
+        F = dF * np.arange(0, nF, dtype=int)
+        Y = np.zeros((2*nF))
+        Y[::2] = np.interp(F, f, Xr)
+        Y[1::2] = np.interp(F, f, Xi)
+
+        Y = np.delete(Y, 1)
+        if num % 2 == 0:
+            Y = np.delete(Y, -1)
+        self.data = irfft(Y) * (float(num) / float(self.stats.npts))
         self.stats.sampling_rate = sampling_rate
-         
+
         # add processing information to the stats dictionary
         proc_info = "resample:%d:%s" % (sampling_rate, window)
         self._addProcessingInfo(proc_info)


### PR DESCRIPTION
Ok, so now here's the promised pull request. The new code uses the numpy.interp() function to interpolate the spectra in the frequency domain. I guess that's roughly what you were suggesting, Lion, right?

A few (in fact two) more thoughts:
1) I'm not sure to what extent the strict_length option makes sense. The endtime of a trace may also change if len(self.data) % factor == 0.0 holds, since the endtime is calculated based on (npts - 1)*delta. 
2) I've seen that in the current master branch there's a new signal.interpolation module, which also contains a weighted_average_slopes() function, of which I'm assuming that it does something similar to SAC's "interpolate" command. Maybe this would in general be the better solution for resample(), since this windowing + filtering business seems a little messy to me. On the other hand the "weighted average slopes" method might be messy too, so not sure...
