### PR TITLE
higher image test tolerances for matplotlib versions != 1.3.1

### DIFF
--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -136,6 +136,9 @@ class ImageComparison(NamedTemporaryFile):
     """
     Handles the comparison against a baseline image in an image test.
 
+    .. note::
+        Baseline images are created using matplotlib version `1.3.1`.
+
     :type image_path: str
     :param image_path: Path to directory where the baseline image is located
     :type image_name: str


### PR DESCRIPTION
I would propose to give any mpl versions that do not match the version the baseline images were created with a high tolerance. We so often see failing image tests on non 1.3.1 mpl versions that show diff images with slightly shifted axes and labels and texts...

I think rigorous testing on mpl 1.3.1 is enough, other versions get higher tolerance but we still see if the plot can be executed with the respective mpl API.
