### PR TITLE
Docs: Linked Anchors Hidden Behind Navbar

### DIFF
--- a/misc/docs/source/_static/css/custom.css
+++ b/misc/docs/source/_static/css/custom.css
@@ -187,3 +187,13 @@ dd p {
   color: #843534;
   font-weight: 700;
 }
+
+/* force the anchor links below the nav bar */
+div.section h1:before, div.section h2:before, div.section h3:before,
+div.section h4:before, div.section h5:before, div.section h6:before {
+  display: block;
+  content: " ";
+  margin-top: -60px;
+  height: 60px;
+  visibility: hidden;
+}*/


### PR DESCRIPTION
In the new bootstrap theme links to headings / anchors open with the heading hidden behind the fixed navbar.

Example: http://docs.obspy.org/master/tutorial/code_snippets/reading_seismograms.html#accessing-meta-data

This problem is discussed in [this Bootstrap ticket](https://github.com/twbs/bootstrap/issues/1768), but none of the proposed solutions works perfectly.

I have implemented the solution of [this comment](https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033). With it the anchor link displays as expected.

See here for the fixed version: http://bmorg.github.io/obspy/doc-anchorfix/tutorial/code_snippets/reading_seismograms.html#accessing-meta-data

However, this introduces a new (less severe) bug: when clicking on an unselected anchor link on the page:

![anchorfix-link](https://cloud.githubusercontent.com/assets/842699/4154410/78a5fb7e-3461-11e4-9d06-e42056a0c017.png)

it is displayed with a margin at the top:

![anchorfix-margin](https://cloud.githubusercontent.com/assets/842699/4154433/aadde2fa-3461-11e4-9cac-1f16712b7345.png)

When it is clicked a second time, the page jumps up and the margin disappears.

(This does not happen in Safari.)

So this fix isn't perfect, but I wasn't able to come up with a better solution for now, and I think the new behavior is preferable to the current behavior. But hopefully someone has a better idea?
