### PR TITLE
Increase speed of Python STA/LTA by about 8 times

### DIFF
--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -221,8 +221,7 @@ def classicSTALTAPy(a, nsta, nlta):
     sta = np.cumsum(a ** 2)
 
     # Convert to float
-    if sta.dtype in ['int32', 'int64']:
-        sta = sta.astype('float')
+    sta = sta.astype(np.float, copy=False)
 
     # Copy for LTA
     lta = sta.copy()


### PR DESCRIPTION
This patch increases the speed of the Python implementation of STA/LTA from about **20** times the duration of the C implementation to about **2.5** times the duration of the C implementation:

``` python
In [68]: tr = read()[0]

In [75]: %timeit classicSTALTA(tr.data, 5, 60)
10000 loops, best of 3: 44 µs per loop

In [76]: %timeit classicSTALTAPy_old(tr.data, 5, 60)
1000 loops, best of 3: 842 µs per loop

In [77]: %timeit classicSTALTAPy_new(tr.data, 5, 60)
10000 loops, best of 3: 110 µs per loop
```

The result stays the same:

``` python
In [69]: stalta1 = classicSTALTA(tr.data, 5, 60)

In [70]: stalta2 = classicSTALTAPy_old(tr.data, 5, 60)

In [71]: stalta3 = classicSTALTAPy_new(tr.data, 5, 60)

In [72]: np.allclose(stalta1, stalta2)
Out[72]: True

In [73]: np.allclose(stalta1, stalta3)
Out[73]: True

In [74]: np.allclose(stalta2, stalta3)
Out[74]: True
```

Since the old function contiained a comment about improving the speed of the function, I figured I might just as well submit this. :-)
