### PR TITLE
Add support to MiniSEED sequence count

### DIFF
--- a/obspy/mseed/core.py
+++ b/obspy/mseed/core.py
@@ -437,7 +437,7 @@ def readMSEED(mseed_object, starttime=None, endtime=None, headonly=False,
 
 
 def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
-               flush=True, verbose=0, **_kwargs):
+               sequence_number=None, flush=True, verbose=0, **_kwargs):
     """
     Write Mini-SEED file from a Stream object.
 
@@ -467,6 +467,10 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
         little-endian, ``1`` or ``'>'`` for MBF or big-endian. ``'='`` is the
         native byte order. If ``-1`` it will be passed directly to libmseed
         which will also default it to big endian. Defaults to big endian.
+    :type sequence_number: int, optional
+    :param sequence_number: Must be an integer ranging between 1 and 999999.
+        Represents the sequence count of the first record of each Trace.
+        Defaults to 1.
     :type flush: bool, optional
     :param flush: If ``True``, all data will be packed into records. If
         ``False`` new records will only be created when there is enough data to
@@ -477,10 +481,13 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
         diagnostic output.
 
     .. note::
-        The ``reclen``, ``encoding`` and ``byteorder`` keyword arguments can be
-        set in the ``stats.mseed`` of each :class:`~obspy.core.trace.Trace` as
-        well as ``kwargs`` of this function. If both are given the ``kwargs``
-        will be used.
+        The ``reclen``, ``encoding``, ``byteorder`` and ``sequence_count``
+        keyword arguments can be set in the ``stats.mseed`` of
+        each :class:`~obspy.core.trace.Trace` as well as ``kwargs`` of this
+        function. If both are given the ``kwargs`` will be used.
+
+        The ``stats.mseed.blkt1001.timing_quality`` value will also be written
+        if it is set.
 
         The ``stats.mseed.blkt1001.timing_quality`` value will also be written
         if it is set.
@@ -522,6 +529,19 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
 
     if encoding is not None:
         encoding = util._convert_and_check_encoding_for_writing(encoding)
+
+    if sequence_number is not None:
+        # Check sequence number type
+        try:
+            sequence_number = int(sequence_number)
+            # Check sequence number value
+            if sequence_number < 1 or sequence_number > 999999:
+                raise ValueError("Sequence number out of range. It must be " +
+                                 " between 1 and 999999.")
+        except (TypeError, ValueError):
+            msg = "Invalid sequence number. It must be an integer ranging " +\
+                  "from 1 to 999999."
+            raise ValueError(msg)
 
     trace_attributes = []
     use_blkt_1001 = False
@@ -577,19 +597,24 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
         else:
             use_blkt_100 = False
 
-        if hasattr(trace.stats, 'mseed') and \
-            hasattr(trace.stats['mseed'], 'sequence_number'):
+        if sequence_number is not None:
+            trace_attr['sequence_number'] = sequence_number
+        elif hasattr(trace.stats, 'mseed') and \
+                hasattr(trace.stats['mseed'], 'sequence_number'):
+
             sequence_number = trace.stats['mseed']['sequence_number']
             # Check sequence number type
             try:
                 sequence_number = int(sequence_number)
+                # Check sequence number value
                 if sequence_number < 1 or sequence_number > 999999:
-                    raise ValueError("Sequence number out of range. It must" +\
-                                     " be between 1 and 999999.")
-            except ValueError:
-                msg = "Invalid sequence number in Stream[%i].stats." % _i + \
-                      "mseed.sequence_number. It must be an integer ranging" + \
-                      " from 1 to 999999"
+                    raise ValueError("Sequence number out of range in " +
+                                     "Stream[%i].stats. It must be between " +
+                                     "1 and 999999.")
+            except (TypeError, ValueError):
+                msg = "Invalid sequence number in Stream[%i].stats." % _i +\
+                      "mseed.sequence_number. It must be an integer ranging" +\
+                      " from 1 to 999999."
                 raise ValueError(msg)
             trace_attr['sequence_number'] = sequence_number
         else:

--- a/obspy/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/mseed/tests/test_mseed_reading_and_writing.py
@@ -416,13 +416,12 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         Tests Mini-SEED writing with an sequence number starting at something
         different than 1.
         """
-        
-        npts = 2200 # At least 3 records of 512 bytes
-        np.random.seed(815)  # make test reproducable
+        npts = 2200  # At least 3 records of 512 bytes
+        np.random.seed(815)  # make test reproducible
         numPyData = np.random.randint(-1000, 1000, npts).astype(np.int32)
         starttime = UTCDateTime(2008, 1, 1, 0, 0, 10)
         header = {'network': "NE", 'station': "STATI", 'location': "LO",
-                  'channel': "CHA", 'npts': npts, 'sampling_rate':1,
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
                   'starttime': starttime,
                   'mseed': {'dataquality': "D", "sequence_number": "str"}}
 
@@ -431,35 +430,35 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         dataStream = Stream([dataTrace])
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            self.assertRaises(ValueError, dataStream.write, tempfile, 
+            self.assertRaises(ValueError, dataStream.write, tempfile,
                               format="MSEED", encoding=11, reclen=512)
 
-        # Seq num out of range
+        # Seq num out of range #1
         header = {'network': "NE", 'station': "STATI", 'location': "LO",
-                  'channel': "CHA", 'npts': npts, 'sampling_rate':1,
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
                   'starttime': starttime,
                   'mseed': {'dataquality': "D", "sequence_number": -1}}
         dataTrace = Trace(data=numPyData, header=header)
         dataStream = Stream([dataTrace])
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            self.assertRaises(ValueError, dataStream.write, tempfile, 
+            self.assertRaises(ValueError, dataStream.write, tempfile,
                               format="MSEED", encoding=11, reclen=512)
         # Seq num out of range #2
         header = {'network': "NE", 'station': "STATI", 'location': "LO",
-                  'channel': "CHA", 'npts': npts, 'sampling_rate':1,
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
                   'starttime': starttime,
                   'mseed': {'dataquality': "D", "sequence_number": 1000001}}
         dataTrace = Trace(data=numPyData, header=header)
         dataStream = Stream([dataTrace])
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            self.assertRaises(ValueError, dataStream.write, tempfile, 
+            self.assertRaises(ValueError, dataStream.write, tempfile,
                               format="MSEED", encoding=11, reclen=512)
 
         # Seq num missing, defaults to 1
         header = {'network': "NE", 'station': "STATI", 'location': "LO",
-                  'channel': "CHA", 'npts': npts, 'sampling_rate':1,
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
                   'starttime': starttime,
                   'mseed': {'dataquality': "D"}}
         dataTrace = Trace(data=numPyData, header=header)
@@ -468,11 +467,11 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
             tempfile = tf.name
             dataStream.write(tempfile, format="MSEED", encoding=11, reclen=512)
             tf.seek(0, os.SEEK_SET)
-            self.assertEqual(tf.read(6), native_str("000001"))
+            self.assertEqual(tf.read(6), b"000001")
 
         # Seq num changed to 999998, expecting rollover
         header = {'network': "NE", 'station': "STATI", 'location': "LO",
-                  'channel': "CHA", 'npts': npts, 'sampling_rate':1,
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
                   'starttime': starttime,
                   'mseed': {'dataquality': "D", "sequence_number": 999998}}
         dataTrace = Trace(data=numPyData, header=header)
@@ -481,11 +480,24 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
             tempfile = tf.name
             dataStream.write(tempfile, format="MSEED", encoding=11, reclen=512)
             tf.seek(0, os.SEEK_SET)
-            seq_counts = [native_str("999998"), native_str("999999"), 
-                          native_str("000001")]
-            for _i in range(0, 3):
-                self.assertEqual(tf.read(6), seq_counts[_i])
+            seq_counts = [b"999998", b"999999", b"000001"]
+            for count in seq_counts:
+                self.assertEqual(tf.read(6), count)
                 tf.seek(506, os.SEEK_CUR)
+
+        # Setting sequence number as kwarg argument of write
+        header = {'network': "NE", 'station': "STATI", 'location': "LO",
+                  'channel': "CHA", 'npts': npts, 'sampling_rate': 1,
+                  'starttime': starttime,
+                  'mseed': {'dataquality': "D"}}
+        dataTrace = Trace(data=numPyData, header=header)
+        dataStream = Stream([dataTrace])
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            dataStream.write(tempfile, format="MSEED", encoding=11, reclen=512,
+                             sequence_number=42)
+            tf.seek(0, os.SEEK_SET)
+            self.assertEqual(tf.read(6), b"000042")
 
     def test_writeAndReadDifferentRecordLengths(self):
         """


### PR DESCRIPTION
Hello,

I have to create one miniSEED file from data that may have gaps in it. The best way I've found to achieve this is to use obspy to create one MiniSEED files for each part of continuous data, and then merge them to have one single file.

Therefore I need a method to merge MiniSEED files. Additional treatment is needed to rewrite the sequence number of the records, since each input file starts over at 1.

I haven't seen anything about it in obspy (maybe I've missed it?) but I can code it. My question is: would it have a sense to add it to obspy? If no, I'll just create it for myself. Otherwise, I'll make a pull request to obspy. In that case, I will add support for multi-traces MiniSEED files (probably sorting them by trace and by date).

Cheers,

SF
