### PR TITLE
Import 'B' response type (Hz) and converted it to 'A' (Laplace)

### DIFF
--- a/misc/docs/source/credits/CONTRIBUTORS.txt
+++ b/misc/docs/source/credits/CONTRIBUTORS.txt
@@ -9,6 +9,7 @@ Peter Danecek
 Martin van Driel
 Fabian Engels
 Sven Egdorf
+Marc Grunberg
 Conny Hammer
 Sebastian Heimann
 Lukas Heiniger

--- a/obspy/arclink/client.py
+++ b/obspy/arclink/client.py
@@ -1316,13 +1316,12 @@ class Client(object):
 
                         # convert from Hz (Analog) to rad/s (Laplace)
                         if paz['response_type'] == "B":
-                            warnings.warn("Converting from Hz to Laplace.", UserWarning)
                             x2pi = lambda x: (x * 2 * pi)
                             paz['poles'] = list(map(x2pi, paz['poles']))
                             paz['zeros'] = list(map(x2pi, paz['zeros']))
-                            paz['normalization_factor'] = paz['normalization_factor'] * \
-                                            (2 * pi) ** \
-                                            (len(paz['poles']) - len(paz['zeros']))
+                            paz['normalization_factor'] = \
+                                paz['normalization_factor'] * (2 * pi) ** \
+                                (len(paz['poles']) - len(paz['zeros']))
                             paz['gain'] = paz['normalization_factor']
                             paz['response_type'] = "A"
 

--- a/obspy/arclink/client.py
+++ b/obspy/arclink/client.py
@@ -21,6 +21,7 @@ from fnmatch import fnmatch
 import io
 from lxml import objectify, etree
 from telnetlib import Telnet
+from numpy import pi
 import os
 import time
 import warnings
@@ -833,6 +834,13 @@ class Client(object):
         paz = AttribDict()
         # instrument name
         paz['name'] = xml_doc.get('name', '')
+
+        # Response type: A=Laplace(rad/s), B=Analog(Hz), C, D
+        try:
+            paz['response_type'] = xml_doc.get('type')
+        except:
+            paz['response_type'] = None
+
         # normalization factor
         try:
             if xml_ns == _INVENTORY_NS_1_0:
@@ -1305,6 +1313,19 @@ class Client(object):
                             continue
                         # parse PAZ
                         paz = self.__parsePAZ(xml_paz[0], xml_ns)
+
+                        # convert from Hz (Analog) to rad/s (Laplace)
+                        if paz['response_type'] == "B":
+                            warnings.warn("Converting from Hz to Laplace.", UserWarning)
+                            x2pi = lambda x: (x * 2 * pi)
+                            paz['poles'] = list(map(x2pi, paz['poles']))
+                            paz['zeros'] = list(map(x2pi, paz['zeros']))
+                            paz['normalization_factor'] = paz['normalization_factor'] * \
+                                            (2 * pi) ** \
+                                            (len(paz['poles']) - len(paz['zeros']))
+                            paz['gain'] = paz['normalization_factor']
+                            paz['response_type'] = "A"
+
                         # sensitivity
                         paz['sensitivity'] = temp['sensitivity']
                         paz['sensitivity_frequency'] = \

--- a/obspy/xseed/parser.py
+++ b/obspy/xseed/parser.py
@@ -540,12 +540,12 @@ class Parser(object):
                     data['zeros'].append(z)
                 # force conversion from Hz to Laplace
                 if getattr(resp, label) == "B":
-                    warnings.warn("Converting from Hz to Laplace.", UserWarning)
                     x2pi = lambda x: (x * 2 * np.pi)
                     data['poles'] = list(map(x2pi, data['poles']))
                     data['zeros'] = list(map(x2pi, data['zeros']))
-                    data['gain'] =  resp.A0_normalization_factor * \
-                                    (2 * np.pi) ** (len(data['poles']) - len(data['zeros']))
+                    data['gain'] = resp.A0_normalization_factor * \
+                        (2 * np.pi) ** \
+                        (len(data['poles']) - len(data['zeros']))
         return data
 
     def getCoordinates(self, seed_id, datetime=None):

--- a/obspy/xseed/parser.py
+++ b/obspy/xseed/parser.py
@@ -514,9 +514,10 @@ class Parser(object):
                     resp = blkt
                     label = 'transfer_function_types'
                 # Check if Laplace transform
-                if getattr(resp, label) != "A":
-                    msg = 'Only supporting Laplace transform response ' + \
-                          'type. Skipping other response information.'
+                if getattr(resp, label) not in ["A", "B"]:
+                    msg = 'Only supporting Laplace (rad/sec) or Analog (Hz)' + \
+                          'transform response type. ' + \
+                          'Skipping other response information.'
                     warnings.warn(msg, UserWarning)
                     continue
                 # A0_normalization_factor
@@ -537,6 +538,14 @@ class Parser(object):
                     except TypeError:
                         z = complex(resp.real_zero, resp.imaginary_zero)
                     data['zeros'].append(z)
+                # force conversion from Hz to Laplace
+                if getattr(resp, label) == "B":
+                    warnings.warn("Converting from Hz to Laplace.", UserWarning)
+                    x2pi = lambda x: (x * 2 * np.pi)
+                    data['poles'] = list(map(x2pi, data['poles']))
+                    data['zeros'] = list(map(x2pi, data['zeros']))
+                    data['gain'] =  resp.A0_normalization_factor * \
+                                    (2 * np.pi) ** (len(data['poles']) - len(data['zeros']))
         return data
 
     def getCoordinates(self, seed_id, datetime=None):

--- a/obspy/xseed/tests/test_parser.py
+++ b/obspy/xseed/tests/test_parser.py
@@ -64,11 +64,6 @@ class ParserTestCase(unittest.TestCase):
                       'seismometer_gain': 1.01885, 'sensitivity': 427336.0,
                       'zeros': []}
             self.assertEqual(paz, result)
-            # triggers a UserWarning but still returns some results
-            paz = parser.getPAZ("NZ.DCZ.10.HHZ", t)
-            result = {'sensitivity': 838861000.0, 'seismometer_gain': 2000.0,
-                      'digitizer_gain': 419430.0}
-            self.assertEqual(paz, result)
 
     def test_invalidStartHeader(self):
         """
@@ -644,17 +639,13 @@ class ParserTestCase(unittest.TestCase):
         filename = os.path.join(self.path, 'G.SPB.dataless')
         parser = Parser()
         parser.read(filename)
-        # 1 - G.SPB..BHZ - raises UserWarning - no Laplace transform
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", UserWarning)
-            self.assertRaises(UserWarning, parser.getPAZ, 'G.SPB..BHZ')
+        # 1 - G.SPB..BHZ - no Laplace transform - works
+        parser.getPAZ('G.SPB..BHZ')
         # 2 - G.SPB.00.BHZ - raises exception because of multiple results
         self.assertRaises(SEEDParserException, parser.getPAZ, 'G.SPB.00.BHZ')
-        # 3 - G.SPB.00.BHZ with datetime - again no Laplace transform
+        # 3 - G.SPB.00.BHZ with datetime - no Laplace transform - works
         dt = UTCDateTime('2007-01-01')
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("error", UserWarning)
-            self.assertRaises(UserWarning, parser.getPAZ, 'G.SPB.00.BHZ', dt)
+        parser.getPAZ('G.SPB.00.BHZ', dt)
         # 4 - G.SPB.00.BHZ with later datetime works
         dt = UTCDateTime('2012-01-01')
         parser.getPAZ('G.SPB.00.BHZ', dt)


### PR DESCRIPTION
Using this patch permits to work with Poles and Zeros given in Hz (B response type in Seed documentation).

* The poles, zeros  are converted in Laplace (rad/s) - seems to be de default behavior of rdseed - 
* The normalisation factor is also scaled. 
* It applies to Parser and also to the arclink client.
* paz['response_type'] was added in the arclink client.