### PR TITLE
awkward behavior of Event's preferred IDs

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -2527,7 +2527,11 @@ __Event = _eventTypeClassFactory(
     class_attributes=[("resource_id", ResourceIdentifier),
                       ("event_type", EventType),
                       ("event_type_certainty", EventTypeCertainty),
-                      ("creation_info", CreationInfo)],
+                      ("creation_info", CreationInfo),
+                      ("preferred_origin_id", ResourceIdentifier),
+                      ("preferred_magnitude_id", ResourceIdentifier),
+                      ("preferred_focal_mechanism_id", ResourceIdentifier),
+                      ],
     class_contains=['event_descriptions', 'comments', 'picks', 'amplitudes',
                     'focal_mechanisms', 'origins', 'magnitudes',
                     'station_magnitudes'])
@@ -2627,6 +2631,14 @@ class Event(__Event):
     :type station_magnitudes: list of
         :class:`~obspy.core.event.StationMagnitude`
     :param station_magnitudes: Station magnitudes associated with the event.
+    :type preferred_origin_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :param preferred_origin_id: Resource identifier of preferred Origin.
+    :type preferred_magnitude_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :param preferred_magnitude_id: Resource identifier of preferred Magnitude.
+    :type preferred_focal_mechanism_id:
+        :class:`~obspy.core.event.ResourceIdentifier`
+    :param preferred_focal_mechanism_id: Resource identifier of preferred
+        Focal Mechanism.
 
     .. note::
 
@@ -2672,31 +2684,19 @@ class Event(__Event):
         """
         Returns the preferred origin
         """
-        try:
-            return ResourceIdentifier(self.preferred_origin_id).\
-                getReferredObject()
-        except AttributeError:
-            return None
+        return self.preferred_origin_id.getReferredObject()
 
     def preferred_magnitude(self):
         """
         Returns the preferred magnitude
         """
-        try:
-            return ResourceIdentifier(self.preferred_magnitude_id).\
-                getReferredObject()
-        except AttributeError:
-            return None
+        return self.preferred_magnitude_id.getReferredObject()
 
     def preferred_focal_mechanism(self):
         """
         Returns the preferred focal mechanism
         """
-        try:
-            return ResourceIdentifier(self.preferred_focal_mechanism_id).\
-                getReferredObject()
-        except AttributeError:
-            return None
+        return self.preferred_focal_mechanism_id.getReferredObject()
 
 
 class Catalog(object):


### PR DESCRIPTION
`Event` has three `ResourceIdentifier`s referencing other objects..
- `preferred_origin_id`
- `preferred_magnitude_id`
- `preferred_focal_mechanism_id`

Right now their handling is pretty strange and also awkward.
- they are not cleanly defined with the `Event` class but handled/documented somewhat implicitly only through the getter methods for the object they refer to
- it seems these attributes are expected to be set with strings (of the `ResourceIdentifier`)... why not just use the `ResourceIdentifier` itself?
- in principle I'd rather make the respective getter methods (e.g. `Event.preferred_origin()`) into property/setter pairs, that would be much more convenient to use if one could get/set like..

``` python
old_preferred_origin = event.preferred_origin
event.preferred_origin = some_other_origin
```

However, the last part is probably not doable with staying backwards compatible and not breaking old cold... :(

Ideas? Opinions?
