### PR TITLE
PPSD: add a switch for hydrophone data

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -85,6 +85,11 @@ master:
      - new option `PPSD.plot(..., cumulative=True)` for a cumulative plot of
        the histogram, i.e. a non-exceedence percentage visualization, similar
        to the `percentile` option.
+     - changes to special handling of rotational: now handled by kwarg
+       `special_handling="ringlaser"` (kwarg `is_rotational_data` is
+       deprecated, see #916)
+     - special handling option for hydrophone data (no differentiation, see
+       #916)
  - obspy.taup
    * Added support for nd file format for input velocity models. Allows for 
      named discontinuities at arbitrary depths allowing for less Earth like


### PR DESCRIPTION
... and unify with special handling of rotational data (from ringlaser).

I was asked whether we could add support for hydrophones (omitting the differentiation in processing), so here goes. There could be better / more canonical ways to do this.. any other suggestions welcome. One downside of unifying the handling of ring laser data could be problems when loading an old pickle. I'm trying to avoid those problems but this should be tested..