### PR TITLE
Fix CatchOutput context manager

### DIFF
--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -11,6 +11,7 @@ from obspy.core.util.decorator import skipIf
 import os
 import platform
 import sys
+import tempfile
 import unittest
 
 
@@ -84,6 +85,18 @@ class UtilMiscTestCase(unittest.TestCase):
             else:
                 self.assertEqual(out.stdout, b"abc\nghi\njkl\n")
                 self.assertEqual(out.stderr, b"123\n456\n")
+
+    def test_CatchOutput_IO(self):
+        with CatchOutput() as out:
+            fn = tempfile.TemporaryFile(prefix='obspy')
+
+        try:
+            fn.write(b'abc')
+            fn.seek(0)
+            fn.read(3)
+            fn.close()
+        except OSError as e:
+            self.fail('CatchOutput has broken file I/O!\n' + str(e))
 
     def test_no_obspy_imports(self):
         """

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -7,7 +7,6 @@ from future.utils import PY2
 from ctypes import CDLL
 from ctypes.util import find_library
 from obspy.core.util.misc import wrap_long_string, CatchOutput
-from obspy.core.util.decorator import skipIf
 import os
 import platform
 import sys
@@ -53,9 +52,9 @@ class UtilMiscTestCase(unittest.TestCase):
                     "\t\tID numbers assigned by\n"
                     "\t\tthe IRIS DMC")
 
-    @skipIf(not PY2, 'Solely test related Py3k issue')
     def test_CatchOutput(self):
         """
+        Tests for CatchOutput context manager.
         """
         libc = CDLL(find_library("c"))
 
@@ -87,7 +86,10 @@ class UtilMiscTestCase(unittest.TestCase):
                 self.assertEqual(out.stderr, b"123\n456\n")
 
     def test_CatchOutput_IO(self):
-        with CatchOutput() as out:
+        """
+        Tests that CatchOutput context manager does not break I/O.
+        """
+        with CatchOutput():
             fn = tempfile.TemporaryFile(prefix='obspy')
 
         try:

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -408,9 +408,6 @@ def CatchOutput():
                 os.dup2(stdout_file, fd_stdout)
                 os.dup2(stderr_file, fd_stderr)
 
-                os.close(stdout_file)
-                os.close(stderr_file)
-
                 try:
                     raised = False
                     yield out


### PR DESCRIPTION
`CatchOutput` corrupts some file I/O. This didn't seem to be a problem before, but matplotlib 1.4.2 changed the way they did I/O to fonts, and it seems to have triggered this bug. I have added a test case that should work similarly to what matplotlib does.

As far as I can tell, this change works just fine. Because of the `finally` clause, I _think_ there shouldn't be any new leaks. Please test though.