### PR TITLE
Fix CatchOutput context manager, take 2

### DIFF
--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2
 
 from ctypes import CDLL
 from ctypes.util import find_library
@@ -61,29 +60,23 @@ class UtilMiscTestCase(unittest.TestCase):
         with CatchOutput() as out:
             os.system('echo "abc"')
             libc.printf(b"def\n")
+            # This flush is necessary for Python 3, which uses different
+            # buffering modes. Fortunately, in practice, we do not mix Python
+            # and C writes to stdout. This can also be fixed by setting the
+            # PYTHONUNBUFFERED environment variable, but this must be done
+            # externally, and cannot be done by the script.
+            libc.fflush(None)
             print("ghi")
             print("jkl", file=sys.stdout)
             os.system('echo "123" 1>&2')
             print("456", file=sys.stderr)
 
-        if PY2:
-            if platform.system() == "Windows":
-                self.assertEqual(out.stdout, b'"abc"\ndef\nghi\njkl\n')
-                self.assertEqual(out.stderr, b'"123" \n456\n')
-            else:
-                self.assertEqual(out.stdout, b"abc\ndef\nghi\njkl\n")
-                self.assertEqual(out.stderr, b"123\n456\n")
+        if platform.system() == "Windows":
+            self.assertEqual(out.stdout, b'"abc"\ndef\nghi\njkl\n')
+            self.assertEqual(out.stderr, b'"123" \n456\n')
         else:
-            # XXX: cannot catch the printf call to def in Py3k
-            # XXX: Introduces special characters on MAC OSX which
-            #      avoid test report to be sent (see #743). Therefore
-            #      test is skipped
-            if platform.system() == "Windows":
-                self.assertEqual(out.stdout, b'"abc"\nghi\njkl\n')
-                self.assertEqual(out.stderr, b'"123" \n456\n')
-            else:
-                self.assertEqual(out.stdout, b"abc\nghi\njkl\n")
-                self.assertEqual(out.stderr, b"123\n456\n")
+            self.assertEqual(out.stdout, b"abc\ndef\nghi\njkl\n")
+            self.assertEqual(out.stderr, b"123\n456\n")
 
     def test_CatchOutput_IO(self):
         """


### PR DESCRIPTION
I simplified `CatchOutput` by using `tempfile.TemporaryFile` instead of manual file management based on http://bugs.python.org/msg184312. Also should have sort-of fixed the bug with `def` disappearing on Python 3. The real fix is to use `PYTHONUNBUFFERED`, but that's external and cannot be tweaked in a script.

This works on Linux, obviously. But I guess we should see what's up with OSX and Windows, this time.