### PR TITLE
Testing font fixes

### DIFF
--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -308,7 +308,7 @@ class ImageComparison(NamedTemporaryFile):
         """
         Set matplotlib defaults.
         """
-        from matplotlib import get_backend, rcParams, rcdefaults
+        from matplotlib import font_manager, get_backend, rcParams, rcdefaults
         import locale
 
         try:
@@ -333,6 +333,12 @@ class ImageComparison(NamedTemporaryFile):
         # set matplotlib builtin default settings for testing
         rcdefaults()
         rcParams['font.family'] = 'Bitstream Vera Sans'
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', 'findfont:.*')
+            font_manager.findfont('Bitstream Vera Sans')
+        if w:
+            warnings.warn('Unable to find the Bitstream Vera Sans font. '
+                          'Plotting tests will likely fail.')
         try:
             rcParams['text.hinting'] = False
         except KeyError:

--- a/obspy/imaging/tests/test_mopad.py
+++ b/obspy/imaging/tests/test_mopad.py
@@ -52,26 +52,28 @@ class MopadTestCase(unittest.TestCase):
               [-2.39, 1.04, 1.35, 0.57, -2.94, -0.94],
               [150, 87, 1]]
 
-        # Initialize figure
-        fig = plt.figure(figsize=(6, 6), dpi=300)
-        ax = fig.add_subplot(111, aspect='equal')
-
-        # Plot the stations or borders
-        ax.plot([-100, -100, 100, 100], [-100, 100, -100, 100], 'rv')
-
-        x = -100
-        y = -100
-        for i, t in enumerate(mt):
-            # add the beachball (a collection of two patches) to the axis
-            ax.add_collection(Beach(t, width=30, xy=(x, y), linewidth=.6))
-            x += 50
-            if (i + 1) % 5 == 0:
-                x = -100
-                y += 50
-        # set the x and y limits and save the output
-        ax.axis([-120, 120, -120, 120])
-        # create and compare image
         with ImageComparison(self.path, 'mopad_collection.png') as ic:
+            # Initialize figure
+            fig = plt.figure(figsize=(6, 6), dpi=300)
+            ax = fig.add_subplot(111, aspect='equal')
+
+            # Plot the stations or borders
+            ax.plot([-100, -100, 100, 100], [-100, 100, -100, 100], 'rv')
+
+            x = -100
+            y = -100
+            for i, t in enumerate(mt):
+                # add the beachball (a collection of two patches) to the axis
+                ax.add_collection(Beach(t, width=30, xy=(x, y), linewidth=.6))
+                x += 50
+                if (i + 1) % 5 == 0:
+                    x = -100
+                    y += 50
+
+            # set the x and y limits
+            ax.axis([-120, 120, -120, 120])
+
+            # create and compare image
             fig.savefig(ic.name)
 
 


### PR DESCRIPTION
Add a warning for when Bitstream Vera Sans is unavailable (that's really a packaging bug though, since matplotlib uses it as the default font). Also, fix MoPaD test which didn't correctly set up the figure with the default font.