### PR TITLE
Deprecate wrap_long_string utility function.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,8 @@
      provided by the future package.
    * new plugins for NonLinLoc formats for readEvents() and
      Catalog/Event.write() (see obspy.nlloc and #900)
+   * The wrap_long_string utility function is deprecated. Users may use the
+     textwrap module which provides similar functionality.
  - obspy.css:
    * Support for little-endian binary and ASCII files (see #881).
    * Support exporting Inventory objects to CSS relations.

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -288,6 +288,10 @@ def wrap_long_string(string, line_length=79, prefix="",
         line to be longer than the specified line length. If set to True,
         Long words will be force-hyphenated to fit the line.
 
+    .. deprecated:: 0.10.0
+        The wrap_long_string function is deprecated. Please use the textwrap
+        module from the standard library instead.
+
     .. rubric:: Examples
 
     >>> string = ("Retrieve an event based on the unique origin "
@@ -323,6 +327,11 @@ def wrap_long_string(string, line_length=79, prefix="",
                     ID numbers assigned by
                     the IRIS DMC
     """
+
+    warnings.warn('The wrap_long_string function is deprecated. Please use '
+                  'the textwrap module from the standard library instead.',
+                  DeprecationWarning)
+
     def text_width_for_prefix(line_length, prefix):
         text_width = line_length - len(prefix) - \
             (assumed_tab_width - 1) * prefix.count("\t")

--- a/obspy/fdsn/client.py
+++ b/obspy/fdsn/client.py
@@ -27,11 +27,11 @@ from obspy.fdsn.wadl_parser import WADLParser
 from obspy.fdsn.header import DEFAULT_USER_AGENT, \
     URL_MAPPINGS, DEFAULT_PARAMETERS, PARAMETER_ALIASES, \
     WADL_PARAMETERS_NOT_TO_BE_PARSED, FDSNException, FDSNWS
-from obspy.core.util.misc import wrap_long_string
 
 import collections
 import io
 from lxml import etree
+import textwrap
 import threading
 import warnings
 import os
@@ -1113,8 +1113,10 @@ class Client(object):
                 if req_def:
                     req_def = ", %s" % req_def
                 if param["doc_title"]:
-                    doc_title = wrap_long_string(param["doc_title"],
-                                                 prefix="        ")
+                    doc_title = textwrap.fill(param["doc_title"], width=79,
+                                              initial_indent="        ",
+                                              subsequent_indent="        ",
+                                              break_long_words=False)
                     doc_title = "\n" + doc_title
                 else:
                     doc_title = ""


### PR DESCRIPTION
It's used in only one place, and can be replaced by the `textwrap` module in the standard library.