### PR TITLE
IPython print integration

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -370,6 +370,9 @@ def _eventTypeClassFactory(class_name, class_attributes=[], class_contains=[]):
                          for _i in containers])
             return ret_str
 
+        def _repr_pretty_(self, p, cycle):
+            p.text(str(self))
+
         def copy(self):
             return copy.deepcopy(self)
 
@@ -837,6 +840,9 @@ class ResourceIdentifier(object):
 
     def __str__(self):
         return self.id
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     def __repr__(self):
         return 'ResourceIdentifier(id="%s")' % self.id
@@ -2665,6 +2671,9 @@ class Event(__Event):
             self.short_str(),
             "\n".join(super(Event, self).__str__().split("\n")[1:]))
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def __repr__(self):
         return super(Event, self).__str__(force_one_line=True)
 
@@ -2912,6 +2921,9 @@ class Catalog(object):
             out += "\nTo see all events call " + \
                    "'print(CatalogObject.__str__(print_all=True))'"
         return out
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.__str__(print_all=p.verbose))
 
     def append(self, event):
         """

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -549,6 +549,9 @@ class Stream(object):
                 'Stream.__str__(extended=True))" to print all Traces]'
         return out
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.__str__(extended=p.verbose))
+
     def __eq__(self, other):
         """
         Implements rich comparison of Stream objects for "==" operator.

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -198,6 +198,9 @@ class Stats(AttribDict):
                           'npts', 'calib']
         return self._pretty_str(priorized_keys)
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
 
 def _add_processing_info(func):
     """
@@ -388,6 +391,9 @@ class Trace(object):
         if np.ma.count_masked(self.data):
             out += ' (masked)'
         return trace_id + out % (self.stats)
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     def __len__(self):
         """

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -902,6 +902,9 @@ class UTCDateTime(object):
         return "%s%sZ" % (self.strftime('%Y-%m-%dT%H:%M:%S'),
                           (self.__ms_pattern % (abs(self.timestamp % 1)))[1:])
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def __unicode__(self):
         """
         Returns ISO8601 unicode representation from current UTCDateTime object.

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -136,6 +136,9 @@ class Enum(object):
         keys = list(self.__enums.keys())
         return "Enum([%s])" % ", ".join(['"%s"' % _i for _i in keys])
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
 
 class CustomComplex(complex):
     """

--- a/obspy/fdsn/client.py
+++ b/obspy/fdsn/client.py
@@ -1048,6 +1048,9 @@ class Client(object):
                                          services=services_string))
         return ret
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def help(self, service=None):
         """
         Print a more extensive help for a given service.

--- a/obspy/mseed/scripts/recordanalyzer.py
+++ b/obspy/mseed/scripts/recordanalyzer.py
@@ -282,6 +282,9 @@ class RecordAnalyser(object):
         ret_val += '\tCorrected Starttime: %s\n' % self.corrected_starttime
         return ret_val
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
 
 def main(argv=None):
     """

--- a/obspy/segy/segy.py
+++ b/obspy/segy/segy.py
@@ -123,6 +123,9 @@ class SEGYFile(object):
         """
         return '%i traces in the SEG Y structure.' % len(self.traces)
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def _autodetectEndianness(self):
         """
         Tries to automatically determine the endianness of the file at hand.
@@ -387,6 +390,9 @@ class SEGYBinaryFileHeader(object):
                                            str(getattr(self, item[1]))))
         return "\n".join(final_str)
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def write(self, file, endian=None):
         """
         Writes the header to an open file like object.
@@ -589,6 +595,9 @@ class SEGYTrace(object):
                 float(1E6)))
         return ret_val
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def __getattr__(self, name):
         """
         This method is only called if the attribute is not found in the usual
@@ -734,6 +743,9 @@ class SEGYTraceHeader(object):
             retval += '%s: %i\n' % (name, getattr(self, name))
         return retval
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def _createEmptyTraceHeader(self):
         """
         Init the trace header with zeros.
@@ -874,6 +886,9 @@ class SUFile(object):
         Prints some information about the SU file.
         """
         return '%i traces in the SU structure.' % len(self.traces)
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     def _readTraces(self, unpack_headers=False, headonly=False):
         """

--- a/obspy/station/channel.py
+++ b/obspy/station/channel.py
@@ -194,6 +194,9 @@ class Channel(BaseNode):
                           if self.response else ""))
         return ret
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     @property
     def location_code(self):
         return self._location_code

--- a/obspy/station/channel.py
+++ b/obspy/station/channel.py
@@ -186,9 +186,9 @@ class Channel(BaseNode):
                      self.dip if self.dip is not None else ""),
                 channel_types=("\tChannel types: %s\n" % ", ".join(self.types)
                                if self.types else ""),
-                sampling_rate=("\tSampling Rate: {sampling_rate:.2f} Hz\n" %
+                sampling_rate=("\tSampling Rate: %.2f Hz\n" %
                                self.sample_rate if self.sample_rate else ""),
-                sensor=("\tSensor: {sensor}\n" % self.sensor.type
+                sensor=("\tSensor: %s\n" % self.sensor.type
                         if self.sensor else ""),
                 response=("\tResponse information available"
                           if self.response else ""))

--- a/obspy/station/inventory.py
+++ b/obspy/station/inventory.py
@@ -204,6 +204,9 @@ class Inventory(ComparingObject):
             subsequent_indent="\t\t\t", expand_tabs=False))
         return ret_str
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def write(self, path_or_file_object, format, **kwargs):
         """
         Writes the inventory object to a file or file-like object in

--- a/obspy/station/network.py
+++ b/obspy/station/network.py
@@ -107,6 +107,9 @@ class Network(BaseNode):
             subsequent_indent="\t\t\t", expand_tabs=False))
         return ret
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def get_contents(self):
         """
         Returns a dictionary containing the contents of the object.

--- a/obspy/station/response.py
+++ b/obspy/station/response.py
@@ -164,6 +164,9 @@ class ResponseStage(ComparingObject):
                 if self.decimation_input_sample_rate is not None else ""))
         return ret.strip()
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
 
 class PolesZerosResponseStage(ResponseStage):
     """
@@ -244,6 +247,9 @@ class PolesZerosResponseStage(ResponseStage):
             zeros=", ".join(map(str, self.zeros)),
             )
         return ret
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     @property
     def zeros(self):
@@ -365,6 +371,9 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 transfer_fct_type=self.cf_transfer_function_type,
                 num_count=len(self.numerator), den_count=len(self.denominator))
         return ret
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     @property
     def numerator(self):
@@ -1135,6 +1144,9 @@ class Response(ComparingObject):
                      ("%g" % i.stage_gain) if i.stage_gain else "UNKNOWN")
                  for i in self.response_stages]))
         return ret
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
     def plot(self, min_freq, output="VEL", start_stage=None,
              end_stage=None, label=None, axes=None, sampling_rate=None,

--- a/obspy/station/station.py
+++ b/obspy/station/station.py
@@ -141,6 +141,9 @@ class Station(BaseNode):
             subsequent_indent="\t\t", expand_tabs=False))
         return ret
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def __getitem__(self, index):
         return self.channels[index]
 

--- a/obspy/station/util.py
+++ b/obspy/station/util.py
@@ -199,6 +199,9 @@ class DataAvailability(ComparingObject):
         return "Data Availability from %s to %s." % (str(self.start),
                                                      str(self.end))
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
 
 class Equipment(ComparingObject):
     """
@@ -565,6 +568,9 @@ class Site(ComparingObject):
             town=self.town, county=self.county, region=self.region,
             country=self.country)
         return ret
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
 
 
 class Latitude(FloatWithUncertaintiesFixedUnit):

--- a/obspy/xseed/blockette/blockette.py
+++ b/obspy/xseed/blockette/blockette.py
@@ -70,6 +70,9 @@ class Blockette(object):
             temp += os.linesep
         return temp.strip()
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def getFields(self, xseed_version=DEFAULT_XSEED_VERSION):
         fields = []
         for field in self.fields:

--- a/obspy/xseed/fields.py
+++ b/obspy/xseed/fields.py
@@ -56,6 +56,9 @@ class Field(object):
         if self.id:
             return "F%02d" % self.id
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def convert(self, value):
         return value
 

--- a/obspy/xseed/parser.py
+++ b/obspy/xseed/parser.py
@@ -139,6 +139,9 @@ class Parser(object):
                  channel["latitude"], channel["longitude"])
         return ret_str.strip()
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     @map_example_filename("data")
     def read(self, data):
         """


### PR DESCRIPTION
This adds a pretty printing method to all objects that already implement `__str__`. I was lazy, and didn't want to re-write the same stuff, so the new method just calls `__str__` in almost all cases. So it probably won't wrap as nicely as it should. It enables you to do something like:
```
In [3]: st
Out[3]:
3 Trace(s) in Stream:
BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHN | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples

In [4]: UTCDateTime()
Out[4]: 2015-01-24T07:27:03.943735Z
```
instead of
```
In [5]: print(st)
3 Trace(s) in Stream:
BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHN | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
In [6]: print(UTCDateTime())
2015-01-24T07:27:03.943735Z
```

I am aware that @krischer started some other IPython stuff, but that's a much larger scope with full maps and such. This PR is essentially because I'm too lazy to type out `print(st)` in IPython. ;)