### PR TITLE
sac read/write fixes: swapping bytes, missing header field. (cleanup)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -80,6 +80,8 @@
      Catalog/Event objects. (see #900)
  - obspy.pdas:
    * read support for PDAS waveform files
+ - obspy.sac:
+   * New `byteorder` option for writing sac files to disk.
  - obspy.seedlink:
    * bugfix: INFO responses from the IRIS ringserver are now parsed
      correctly (see #807)

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -118,7 +118,8 @@ class WaveformPluginsTestCase(unittest.TestCase):
                     # check byte order
                     if format == 'SAC':
                         # SAC format preserves byteorder on writing
-                        self.assertIn(st[0].data.dtype.byteorder, ('=', byteorder))
+                        self.assertTrue(st[0].data.dtype.byteorder
+                                        in ('=', byteorder))
                     else:
                         self.assertEqual(st[0].data.dtype.byteorder, '=')
                     # check meta data

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -54,6 +54,10 @@ class WaveformPluginsTestCase(unittest.TestCase):
                 continue
             for native_byteorder in ['<', '>']:
                 for byteorder in ['<', '>', '=']:
+                    if format == 'SAC' and byteorder == '=':
+                        # SAC file format enforces '<' or '>'
+                        # byteorder on writing
+                        continue
                     # new trace object in native byte order
                     dt = np.dtype(np.int_).newbyteorder(native_byteorder)
                     if format in ('MSEED', 'GSE2'):
@@ -112,7 +116,11 @@ class WaveformPluginsTestCase(unittest.TestCase):
                             os.remove(outfile[:-4] + '.QBN')
                             os.remove(outfile[:-4] + '.QHD')
                     # check byte order
-                    self.assertEqual(st[0].data.dtype.byteorder, '=')
+                    if format == 'SAC':
+                        # SAC format preserves byteorder on writing
+                        self.assertIn(st[0].data.dtype.byteorder, ('=', byteorder))
+                    else:
+                        self.assertEqual(st[0].data.dtype.byteorder, '=')
                     # check meta data
                     # some formats do not contain a calibration factor
                     if format not in ['MSEED', 'WAV', 'TSPAIR', 'SLIST']:

--- a/obspy/sac/README.txt
+++ b/obspy/sac/README.txt
@@ -5,10 +5,11 @@ Copyright
 ---------
 GNU Lesser General Public License, Version 3 (LGPLv3)
 
-Copyright (c) 2009-2013 by:
+Copyright (c) 2009-2014 by:
     * Yannik Behr
     * Moritz Beyreuther
     * C. J. Ammon
+    * C. Satriano
 
 
 Overview

--- a/obspy/sac/__init__.py
+++ b/obspy/sac/__init__.py
@@ -59,6 +59,11 @@ Writing is also straight forward. All changes on the data as well as in
 stats and stats['sac'] are written with the following command to a file:
 
 >>> st.write('tmp.sac', format='SAC') #doctest: +SKIP
+
+You can also specify a ``byteorder`` keyword argument to set the
+endianness of the resulting SAC-file. It must be either ``0`` or ``'<'``
+for LSBF or little-endian, ``1`` or ``'>'`` for MSBF or big-endian.
+Defaults to little endian.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -245,7 +245,7 @@ def readSAC(filename, headonly=False, debug_headers=False, fsize=True,
     return Stream([tr])
 
 
-def writeSAC(stream, filename, **kwargs):  # @UnusedVariable
+def writeSAC(stream, filename, byteorder=None, **kwargs):  # @UnusedVariable
     """
     Writes a SAC file.
 
@@ -258,6 +258,10 @@ def writeSAC(stream, filename, **kwargs):  # @UnusedVariable
     :param stream: The ObsPy Stream object to write.
     :type filename: str
     :param filename: Name of file to write.
+    :type byteorder: int or str, optional
+    :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
+        little-endian, ``1`` or ``'>'`` for MBF or big-endian.
+        Defaults to little endian.
 
     .. rubric:: Example
 
@@ -265,11 +269,24 @@ def writeSAC(stream, filename, **kwargs):  # @UnusedVariable
     >>> st = read()
     >>> st.write("test.sac", format="SAC")  #doctest: +SKIP
     """
+    if byteorder is not None and byteorder not in [0, 1]:
+        if byteorder == '<':
+            byteorder = 0
+        elif byteorder == '>':
+            byteorder = 1
+        else:
+            msg = "Invalid byte order. It must be either '<', '>', '=', " + \
+                  "0 or 1"
+            raise ValueError(msg)
+
     # Translate the common (renamed) entries
     base, ext = os.path.splitext(filename)
     for i, trace in enumerate(stream):
         t = SacIO(trace)
         if len(stream) != 1:
             filename = "%s%02d%s" % (base, i + 1, ext)
+        if (byteorder == 1 and t.byteorder == 'little') or \
+           (byteorder == 0 and t.byteorder == 'big'):
+            t.swap_byte_order()
         t.WriteSacBinary(filename)
     return

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -245,7 +245,7 @@ def readSAC(filename, headonly=False, debug_headers=False, fsize=True,
     return Stream([tr])
 
 
-def writeSAC(stream, filename, byteorder=None, **kwargs):  # @UnusedVariable
+def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
     """
     Writes a SAC file.
 
@@ -260,7 +260,7 @@ def writeSAC(stream, filename, byteorder=None, **kwargs):  # @UnusedVariable
     :param filename: Name of file to write.
     :type byteorder: int or str, optional
     :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
-        little-endian, ``1`` or ``'>'`` for MBF or big-endian.
+        little-endian, ``1`` or ``'>'`` for MSBF or big-endian.
         Defaults to little endian.
 
     .. rubric:: Example
@@ -269,15 +269,13 @@ def writeSAC(stream, filename, byteorder=None, **kwargs):  # @UnusedVariable
     >>> st = read()
     >>> st.write("test.sac", format="SAC")  #doctest: +SKIP
     """
-    if byteorder is not None and byteorder not in [0, 1]:
-        if byteorder == '<':
-            byteorder = 0
-        elif byteorder == '>':
-            byteorder = 1
-        else:
-            msg = "Invalid byte order. It must be either '<', '>', '=', " + \
-                  "0 or 1"
-            raise ValueError(msg)
+    if byteorder in ("<", 0, "0"):
+        byteorder = 0
+    elif byteorder in (">", 1, "1"):
+        byteorder = 1
+    else:
+        msg = "Invalid byte order. It must be either '<', '>', 0 or 1"
+        raise ValueError(msg)
 
     # Translate the common (renamed) entries
     base, ext = os.path.splitext(filename)

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -1176,7 +1176,10 @@ class SacIO(object):
         """
         If trace changed since read, adapt header values
         """
-        self.seis = np.require(self.seis, native_str('<f4'))
+        if self.byteorder == 'big':
+            self.seis = np.require(self.seis, native_str('>f4'))
+        else:
+            self.seis = np.require(self.seis, native_str('<f4'))
         self.SetHvalue('npts', self.seis.size)
         if self.seis.size == 0:
             return
@@ -1224,9 +1227,6 @@ class SacIO(object):
         """
         Swap byte order of SAC-file in memory.
 
-        Currently seems to work only for conversion from big-endian to
-        little-endian.
-
         :param: None
         :return: None
 
@@ -1235,15 +1235,14 @@ class SacIO(object):
         >>> t.swap_byte_order() # doctest: +SKIP
         """
         if self.byteorder == 'big':
-            bs = 'L'
+            bs = '<'
+            self.byteorder = 'little'
         elif self.byteorder == 'little':
-            bs = 'B'
-        self.seis.byteswap(True)
-        self.hf.byteswap(True)
-        self.hi.byteswap(True)
-        self.seis = self.seis.newbyteorder(bs)
-        self.hf = self.hf.newbyteorder(bs)
-        self.hi = self.hi.newbyteorder(bs)
+            bs = '>'
+            self.byteorder = 'big'
+        self.seis = self.seis.byteswap(True).newbyteorder(bs)
+        self.hf = self.hf.byteswap(True).newbyteorder(bs)
+        self.hi = self.hi.byteswap(True).newbyteorder(bs)
 
     def __getattr__(self, hname):
         """

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -58,7 +58,7 @@ SAC_EXTRA = ('depmin', 'depmax', 'odelta', 'o', 'a', 't0', 't1', 't2', 't3',
              'kt6', 'kt7', 'kt8', 'kt9', 'kf', 'kuser0', 'kuser1', 'kuser2',
              'kdatrd', 'kinst', 'cmpinc', 'xminimum', 'xmaximum', 'yminimum',
              'ymaximum', 'unused6', 'unused7', 'unused8', 'unused9',
-             'unused10', 'unused11', 'unused12')
+             'unused10', 'unused11', 'unused12', 'unused13')
 
 FDICT = {'delta': 0, 'depmin': 1, 'depmax': 2, 'scale': 3,
          'odelta': 4, 'b': 5, 'e': 6, 'o': 7, 'a': 8, 'int1': 9,
@@ -82,7 +82,7 @@ IDICT = {'nzyear': 0, 'nzjday': 1, 'nzhour': 2, 'nzmin': 3,
          'istreg': 20, 'ievreg': 21, 'ievtype': 22, 'iqual': 23,
          'isynth': 24, 'imagtyp': 25, 'imagsrc': 26,
          'leven': 35, 'lpspol': 36, 'lovrok': 37,
-         'lcalda': 38}
+         'lcalda': 38, 'unused13': 39}
 
 SDICT = {'kstnm': 0, 'kevnm': 1, 'khole': 2, 'ko': 3, 'ka': 4,
          'kt0': 5, 'kt1': 6, 'kt2': 7, 'kt3': 8, 'kt4': 9,

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -2,10 +2,10 @@
 # ------------------------------------------------------------------
 # Filename: sacio.py
 #  Purpose: Read & Write Seismograms, Format SAC.
-#   Author: Yannik Behr, C. J. Ammon's
+#   Author: Yannik Behr, C. J. Ammon's, C. Satriano
 #    Email: yannik.behr@vuw.ac.nz
 #
-# Copyright (C) 2008-2012 Yannik Behr, C. J. Ammon's
+# Copyright (C) 2008-2014 Yannik Behr, C. J. Ammon's, C. Satriano
 # ------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -249,7 +249,7 @@ class CoreTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tmpfile = tf.name
             tr.write(tmpfile, format="SAC")
-            filecmp.cmp(file, tmpfile, shallow=False)
+            self.assertTrue(filecmp.cmp(file, tmpfile, shallow=False))
         # test some more entries, I can see from the plot
         self.assertEqual(tr.stats.station, "CDV")
         self.assertEqual(tr.stats.channel, "Q")

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -13,7 +13,6 @@ import copy
 import numpy as np
 import os
 import unittest
-import filecmp
 
 
 class CoreTestCase(unittest.TestCase):
@@ -249,7 +248,13 @@ class CoreTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tmpfile = tf.name
             tr.write(tmpfile, format="SAC")
-            self.assertTrue(filecmp.cmp(file, tmpfile, shallow=False))
+            tr2 = read(tmpfile)[0]
+            self.assertEqual(tr.stats.station, tr2.stats.station)
+            self.assertEqual(tr.stats.npts, tr2.stats.npts)
+            self.assertEqual(tr.stats.delta, tr2.stats.delta)
+            self.assertEqual(tr.stats.starttime, tr2.stats.starttime)
+            self.assertEqual(tr.stats.sac.b, tr2.stats.sac.b)
+            np.testing.assert_array_equal(tr.data, tr2.data)
         # test some more entries, I can see from the plot
         self.assertEqual(tr.stats.station, "CDV")
         self.assertEqual(tr.stats.channel, "Q")

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -109,6 +109,30 @@ class CoreTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(self.testdata[0:10],
                                              tr.data[0:10])
 
+    def test_swapbytesViaObsPy(self):
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            trbe = read(self.filebe, format='SAC')[0]
+            trbe.write(tempfile, format='SAC', byteorder='<')
+            tr = read(tempfile, format='SAC')[0]
+            trle = read(self.file, format='SAC')[0]
+            self.assertEqual(tr.stats.station, trle.stats.station)
+            self.assertEqual(tr.stats.npts, trle.stats.npts)
+            self.assertEqual(tr.stats.delta, trle.stats.delta)
+            self.assertEqual(tr.stats.sac.b, trle.stats.sac.b)
+            np.testing.assert_array_almost_equal(tr.data[0:10], trle.data[0:10])
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            trle = read(self.file, format='SAC')[0]
+            trle.write(tempfile, format='SAC', byteorder='>')
+            tr = read(tempfile, format='SAC')[0]
+            trbe = read(self.filebe, format='SAC')[0]
+            self.assertEqual(tr.stats.station, trbe.stats.station)
+            self.assertEqual(tr.stats.npts, trbe.stats.npts)
+            self.assertEqual(tr.stats.delta, trbe.stats.delta)
+            self.assertEqual(tr.stats.sac.b, trbe.stats.sac.b)
+            np.testing.assert_array_almost_equal(tr.data[0:10], trbe.data[0:10])
+
     def test_readHeadViaObsPy(self):
         """
         Read files via L{obspy.Stream}

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -120,7 +120,8 @@ class CoreTestCase(unittest.TestCase):
             self.assertEqual(tr.stats.npts, trle.stats.npts)
             self.assertEqual(tr.stats.delta, trle.stats.delta)
             self.assertEqual(tr.stats.sac.b, trle.stats.sac.b)
-            np.testing.assert_array_almost_equal(tr.data[0:10], trle.data[0:10])
+            np.testing.assert_array_almost_equal(tr.data[0:10],
+                                                 trle.data[0:10])
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             trle = read(self.file, format='SAC')[0]
@@ -131,7 +132,8 @@ class CoreTestCase(unittest.TestCase):
             self.assertEqual(tr.stats.npts, trbe.stats.npts)
             self.assertEqual(tr.stats.delta, trbe.stats.delta)
             self.assertEqual(tr.stats.sac.b, trbe.stats.sac.b)
-            np.testing.assert_array_almost_equal(tr.data[0:10], trbe.data[0:10])
+            np.testing.assert_array_almost_equal(tr.data[0:10],
+                                                 trbe.data[0:10])
 
     def test_readHeadViaObsPy(self):
         """

--- a/obspy/sac/tests/test_sacio.py
+++ b/obspy/sac/tests/test_sacio.py
@@ -15,7 +15,6 @@ import io
 import numpy as np
 import os
 import unittest
-import filecmp
 
 
 class SacIOTestCase(unittest.TestCase):
@@ -135,8 +134,7 @@ class SacIOTestCase(unittest.TestCase):
         tb = SacIO(tfileb)
         self.assertEqual(tl.GetHvalue('kevnm'), tb.GetHvalue('kevnm'))
         self.assertEqual(tl.GetHvalue('npts'), tb.GetHvalue('npts'))
-        self.assertEqual(tl.GetHvalueFromFile(tfilel, 'kcmpnm'),
-                         tb.GetHvalueFromFile(tfileb, 'kcmpnm'))
+        self.assertEqual(tl.GetHvalue('delta'), tb.GetHvalue('delta'))
         np.testing.assert_array_equal(tl.seis, tb.seis)
 
     def test_swapbytes(self):
@@ -148,7 +146,23 @@ class SacIOTestCase(unittest.TestCase):
             tb = SacIO(tfileb)
             tb.swap_byte_order()
             tb.WriteSacBinary(tempfile)
-            self.assertTrue(filecmp.cmp(tfilel, tempfile, shallow=False))
+            t = SacIO(tempfile)
+            tl = SacIO(tfilel)
+            self.assertEqual(t.GetHvalue('kevnm'), tl.GetHvalue('kevnm'))
+            self.assertEqual(t.GetHvalue('npts'), tl.GetHvalue('npts'))
+            self.assertEqual(t.GetHvalue('delta'), tl.GetHvalue('delta'))
+            np.testing.assert_array_equal(t.seis, tl.seis)
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            tl = SacIO(tfilel)
+            tl.swap_byte_order()
+            tl.WriteSacBinary(tempfile)
+            t = SacIO(tempfile)
+            tb = SacIO(tfileb)
+            self.assertEqual(t.GetHvalue('kevnm'), tb.GetHvalue('kevnm'))
+            self.assertEqual(t.GetHvalue('npts'), tb.GetHvalue('npts'))
+            self.assertEqual(t.GetHvalue('delta'), tb.GetHvalue('delta'))
+            np.testing.assert_array_equal(t.seis, tb.seis)
 
     def test_getdist(self):
         tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')

--- a/obspy/sac/tests/test_sacio.py
+++ b/obspy/sac/tests/test_sacio.py
@@ -15,6 +15,7 @@ import io
 import numpy as np
 import os
 import unittest
+import filecmp
 
 
 class SacIOTestCase(unittest.TestCase):
@@ -147,13 +148,7 @@ class SacIOTestCase(unittest.TestCase):
             tb = SacIO(tfileb)
             tb.swap_byte_order()
             tb.WriteSacBinary(tempfile)
-            tr1 = SacIO(tempfile)
-            tl = SacIO(tfilel)
-            np.testing.assert_array_equal(tl.seis, tr1.seis)
-            self.assertEqual(tl.GetHvalue('kevnm'), tr1.GetHvalue('kevnm'))
-            self.assertEqual(tl.GetHvalue('npts'), tr1.GetHvalue('npts'))
-            self.assertEqual(tl.GetHvalueFromFile(tfilel, 'kcmpnm'),
-                             tr1.GetHvalueFromFile(tempfile, 'kcmpnm'))
+            self.assertTrue(filecmp.cmp(tfilel, tempfile, shallow=False))
 
     def test_getdist(self):
         tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')


### PR DESCRIPTION
This PR replaces #850, hopefully cleaning up the commit history.
It fixes some sac-related code:

  - byte swapping should work correctly now;
  - a header field was missing in the `IDICT`dictionary, implying that this field was aways written to disk as `0`;
  - a test in `tes_core.py` was pointless.

There is still a test failing (see https://github.com/obspy/obspy/pull/850#issuecomment-51202404).
I'm trying to figure this out (any help welcome :wink: )