### PR TITLE
Streaming to/from file-like objects for obspy.sac

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -82,6 +82,8 @@
    * read support for PDAS waveform files
  - obspy.sac:
    * New `byteorder` option for writing sac files to disk.
+   * Can now read/write from/to file-like objects like io.BytesIO and open
+     files.
  - obspy.seedlink:
    * bugfix: INFO responses from the IRIS ringserver are now parsed
      correctly (see #807)

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -5,6 +5,7 @@ Py3k compatibility module
 from future.utils import PY2
 
 import inspect
+import io
 import numpy as np
 import sys
 
@@ -38,6 +39,46 @@ if PY2:
 else:
     def frombuffer(data, dtype):
         return np.array(memoryview(data)).view(dtype).copy()  # NOQA
+
+
+def is_text_buffer(obj):
+    """
+    Helper function determining if the passed object is an object that can
+    read and write text or not.
+
+    :param obj: The object to be tested.
+    :return: True/False
+    """
+    # Default open()'ed files and StringIO don't inherit from any of the io
+    # classes thus we only test the methods of the objects which in Python 2
+    # should be safe enough.
+    if PY2:
+        if hasattr(obj, "read") and hasattr(obj, "write") \
+                and hasattr(obj, "seek") and hasattr(obj, "tell"):
+            return True
+        return False
+
+    return isinstance(obj, io.TextIOBase)
+
+
+def is_bytes_buffer(obj):
+    """
+    Helper function determining if the passed object is an object that can
+    read and write bytes or not.
+
+    :param obj: The object to be tested.
+    :return: True/False
+    """
+    # Default open()'ed files and StringIO don't inherit from any of the io
+    # classes thus we only test the methods of the objects which in Python 2
+    # should be safe enough.
+    if PY2:
+        if hasattr(obj, "read") and hasattr(obj, "write") \
+                and hasattr(obj, "seek") and hasattr(obj, "tell"):
+            return True
+        return False
+
+    return isinstance(obj, io.BufferedIOBase)
 
 
 def round_away(number):

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -49,10 +49,11 @@ def is_text_buffer(obj):
     :param obj: The object to be tested.
     :return: True/False
     """
-    # Default open()'ed files and StringIO don't inherit from any of the io
-    # classes thus we only test the methods of the objects which in Python 2
-    # should be safe enough.
-    if PY2:
+    # Default open()'ed files and StringIO (in Python 2) don't inherit from any
+    # of the io classes thus we only test the methods of the objects which
+    # in Python 2 should be safe enough.
+    if PY2 and not isinstance(obj, io.BufferedIOBase) and \
+            not isinstance(obj, io.TextIOBase):
         if hasattr(obj, "read") and hasattr(obj, "write") \
                 and hasattr(obj, "seek") and hasattr(obj, "tell"):
             return True
@@ -69,10 +70,11 @@ def is_bytes_buffer(obj):
     :param obj: The object to be tested.
     :return: True/False
     """
-    # Default open()'ed files and StringIO don't inherit from any of the io
-    # classes thus we only test the methods of the objects which in Python 2
-    # should be safe enough.
-    if PY2:
+    # Default open()'ed files and StringIO (in Python 2) don't inherit from any
+    # of the io classes thus we only test the methods of the objects which
+    # in Python 2 should be safe enough.
+    if PY2 and not isinstance(obj, io.BufferedIOBase) and \
+            not isinstance(obj, io.TextIOBase):
         if hasattr(obj, "read") and hasattr(obj, "write") \
                 and hasattr(obj, "seek") and hasattr(obj, "tell"):
             return True

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -20,6 +20,7 @@ from obspy.core.util.misc import toIntOrZero
 from pkg_resources import iter_entry_points, load_entry_point
 import doctest
 import inspect
+import io
 import numpy as np
 import os
 import sys
@@ -46,7 +47,7 @@ _sys_is_le = sys.byteorder == 'little'
 NATIVE_BYTEORDER = _sys_is_le and '<' or '>'
 
 
-class NamedTemporaryFile(object):
+class NamedTemporaryFile(io.BufferedIOBase):
     """
     Weak replacement for the Python's tempfile.TemporaryFile.
 
@@ -81,13 +82,22 @@ class NamedTemporaryFile(object):
     >>> os.path.exists(tf.name)
     False
     """
-
     def __init__(self, dir=None, suffix='.tmp', prefix='obspy-'):
         fd, self.name = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
         self._fileobj = os.fdopen(fd, 'w+b', 0)  # 0 -> do not buffer
 
-    def __getattr__(self, attr):
-        return getattr(self._fileobj, attr)
+    def read(self, *args, **kwargs):
+        return self._fileobj.read(*args, **kwargs)
+
+    def write(self, *args, **kwargs):
+        return self._fileobj.write(*args, **kwargs)
+
+    def seek(self, *args, **kwargs):
+        self._fileobj.seek(*args, **kwargs)
+        return self._fileobj.tell()
+
+    def tell(self, *args, **kwargs):
+        return self._fileobj.tell(*args, **kwargs)
 
     def __enter__(self):
         return self

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -24,8 +24,8 @@ def isSAC(filename):
     """
     Checks whether a file is a SAC file or not.
 
-    :type filename: str or file-like object
     :param filename: SAC file to be checked.
+    :type filename: str, open file, or file-like object
     :rtype: bool
     :return: ``True`` if a SAC file.
 
@@ -46,8 +46,8 @@ def _isSAC(buf):
     """
     Checks whether a file-like object contains a SAC file or not.
 
-    :type buf: file-like object or open file.
     :param buf: SAC file to be checked.
+    :type buf: file-like object or open file.
     :rtype: bool
     :return: ``True`` if a SAC file.
     """
@@ -113,8 +113,8 @@ def isSACXY(filename):
     """
     Checks whether a file is alphanumeric SAC file or not.
 
-    :type filename: str or file-like object.
     :param filename: Alphanumeric SAC file to be checked.
+    :type filename: str, open file, or file-like object
     :rtype: bool
     :return: ``True`` if a alphanumeric SAC file.
 
@@ -135,15 +135,11 @@ def _isSACXY(buf):
     """
     Checks whether a file is alphanumeric SAC file or not.
 
-    :type buf: file-like object oropen file
     :param buf: Alphanumeric SAC file to be checked.
+    :type buf: file-like object or open file
     :rtype: bool
     :return: ``True`` if a alphanumeric SAC file.
     """
-    # First find out if it is a text or a binary file. This should
-    # always be true if a file is a text-file and only true for a
-    # binary file in rare occasions (Recipe 173220 found on
-    # http://code.activestate.com/
     cur_pos = buf.tell()
     try:
         try:
@@ -173,18 +169,18 @@ def readSACXY(filename, headonly=False, debug_headers=False,
         This function should NOT be called directly, it registers via the
         ObsPy :func:`~obspy.core.stream.read` function, call this instead.
 
-    :type filename: filename of file-like object.
     :param filename: Alphanumeric SAC file to be read.
-    :type headonly: bool, optional
+    :type filename: str, open file, or file-like object
     :param headonly: If set to True, read only the head. This is most useful
         for scanning available data in huge (temporary) data sets.
-    :type debug_headers: bool, optional
+    :type headonly: bool
     :param debug_headers: Extracts also the SAC headers ``'nzyear', 'nzjday',
         'nzhour', 'nzmin', 'nzsec', 'nzmsec', 'delta', 'scale', 'npts',
         'knetwk', 'kstnm', 'kcmpnm'`` which are usually directly mapped to the
         :class:`~obspy.core.stream.Stream` object if set to ``True``. Those
         values are not synchronized with the Stream object itself and won't
         be used during writing of a SAC file! Defaults to ``False``.
+    :type debug_headers: bool
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
 
@@ -211,18 +207,18 @@ def _readSACXY(buf, headonly=False, debug_headers=False,
         This function should NOT be called directly, it registers via the
         ObsPy :func:`~obspy.core.stream.read` function, call this instead.
 
-    :type buf: file or file-like object
     :param buf: Alphanumeric SAC file to be read.
-    :type headonly: bool, optional
+    :type buf: file or file-like object
     :param headonly: If set to True, read only the head. This is most useful
         for scanning available data in huge (temporary) data sets.
-    :type debug_headers: bool, optional
+    :type headonly: bool
     :param debug_headers: Extracts also the SAC headers ``'nzyear', 'nzjday',
         'nzhour', 'nzmin', 'nzsec', 'nzmsec', 'delta', 'scale', 'npts',
         'knetwk', 'kstnm', 'kcmpnm'`` which are usually directly mapped to the
         :class:`~obspy.core.stream.Stream` object if set to ``True``. Those
         values are not synchronized with the Stream object itself and won't
         be used during writing of a SAC file! Defaults to ``False``.
+    :type debug_headers: bool
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
 
@@ -255,10 +251,11 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
         the :meth:`~obspy.core.stream.Stream.write` method of an
         ObsPy :class:`~obspy.core.stream.Stream` object, call this instead.
 
-    :type stream: :class:`~obspy.core.stream.Stream`
     :param stream: The ObsPy Stream object to write.
-    :type filename: str
-    :param filename: Name of file to write.
+    :type stream: :class:`~obspy.core.stream.Stream`
+    :param filename: File or object to write to. If its not a filename,
+        it only supports writing Streams objects containing a single Trace.
+    :type filename: str, open file, or file-like object
 
     .. rubric:: Example
 
@@ -296,10 +293,10 @@ def _writeSACXY(trace, buf, **kwargs):  # @UnusedVariable
         the :meth:`~obspy.core.trace.Stream.write` method of an
         ObsPy :class:`~obspy.core.trace.Stream` object, call this instead.
 
-    :type trace: :class:`~obspy.core.trace.Trace`
     :param trace: The ObsPy Trace object to write.
-    :type filename: open file or file-like object
-    :param filename: Object to write to.
+    :type trace: :class:`~obspy.core.trace.Trace`
+    :param buf: Object to write to.
+    :type buf: file-like object
     """
     t = SacIO(trace)
     t.WriteSacXY(buf)
@@ -314,21 +311,21 @@ def readSAC(filename, headonly=False, debug_headers=False, fsize=True,
         This function should NOT be called directly, it registers via the
         ObsPy :func:`~obspy.core.stream.read` function, call this instead.
 
-    :type filename: filename, open file, or file-like object.
     :param filename: SAC file to be read.
-    :type headonly: bool, optional
+    :type filename: str, open file, or file-like object
     :param headonly: If set to True, read only the head. This is most useful
         for scanning available data in huge (temporary) data sets.
-    :type debug_headers: bool, optional
+    :type headonly: bool
     :param debug_headers: Extracts also the SAC headers ``'nzyear', 'nzjday',
         'nzhour', 'nzmin', 'nzsec', 'nzmsec', 'delta', 'scale', 'npts',
         'knetwk', 'kstnm', 'kcmpnm'`` which are usually directly mapped to the
         :class:`~obspy.core.stream.Stream` object if set to ``True``. Those
         values are not synchronized with the Stream object itself and won't
         be used during writing of a SAC file! Defaults to ``False``.
-    :type fsize: bool, optional
+    :type debug_headers: bool
     :param fsize: Check if file size is consistent with theoretical size
         from header. Defaults to ``True``.
+    :type fsize: bool
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
 
@@ -358,21 +355,21 @@ def _readSAC(buf, headonly=False, debug_headers=False, fsize=True,
         This function should NOT be called directly, it registers via the
         ObsPy :func:`~obspy.core.stream.read` function, call this instead.
 
-    :type buf: file or file-like object.
     :param buf: SAC file to be read.
-    :type headonly: bool, optional
+    :type buf: file or file-like object.
     :param headonly: If set to True, read only the head. This is most useful
         for scanning available data in huge (temporary) data sets.
-    :type debug_headers: bool, optional
+    :type headonly: bool
     :param debug_headers: Extracts also the SAC headers ``'nzyear', 'nzjday',
         'nzhour', 'nzmin', 'nzsec', 'nzmsec', 'delta', 'scale', 'npts',
         'knetwk', 'kstnm', 'kcmpnm'`` which are usually directly mapped to the
         :class:`~obspy.core.stream.Stream` object if set to ``True``. Those
         values are not synchronized with the Stream object itself and won't
         be used during writing of a SAC file! Defaults to ``False``.
-    :type fsize: bool, optional
+    :type debug_headers: bool
     :param fsize: Check if file size is consistent with theoretical size
         from header. Defaults to ``True``.
+    :type fsize: bool
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
     """
@@ -401,15 +398,15 @@ def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
         the :meth:`~obspy.core.stream.Stream.write` method of an
         ObsPy :class:`~obspy.core.stream.Stream` object, call this instead.
 
-    :type stream: :class:`~obspy.core.stream.Stream`
     :param stream: The ObsPy Stream object to write.
-    :type filename: str or file-like object
+    :type stream: :class:`~obspy.core.stream.Stream`
     :param filename: Name of file to write. If it is not a filename, it only
         supports writing single Trace streams.
-    :type byteorder: int or str, optional
+    :type filename: str, open file, or file-like object
     :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
         little-endian, ``1`` or ``'>'`` for MSBF or big-endian.
         Defaults to little endian.
+    :type byteorder: int or str
 
     .. rubric:: Example
 
@@ -448,14 +445,14 @@ def _writeSAC(trace, buf, byteorder="<", **kwargs):  # @UnusedVariable
         the :meth:`~obspy.core.stream.Stream.write` method of an
         ObsPy :class:`~obspy.core.stream.Stream` object, call this instead.
 
-    :type trace: :class:`~obspy.core.trace.Trace`
     :param trace: The ObsPy Trace object to write.
-    :type buf: open file or file-like object
+    :type trace: :class:`~obspy.core.trace.Trace`
     :param buf: Object to write to.
-    :type byteorder: int or str, optional
+    :type buf: open file or file-like object
     :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
         little-endian, ``1`` or ``'>'`` for MSBF or big-endian.
         Defaults to little endian.
+    :type byteorder: int or str
     """
     if byteorder in ("<", 0, "0"):
         byteorder = 0

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -35,9 +35,11 @@ def isSAC(filename):
     """
     if is_bytes_buffer(filename):
         return _isSAC(filename)
-    else:
+    elif isinstance(filename, (str, bytes)):
         with open(filename, "rb") as fh:
             return _isSAC(fh)
+    else:
+        raise ValueError("Cannot open '%s'." % filename)
 
 
 def _isSAC(buf):
@@ -292,10 +294,12 @@ def readSAC(filename, headonly=False, debug_headers=False, fsize=True,
     if is_bytes_buffer(filename):
         return _readSAC(buf=filename, headonly=headonly,
                         debug_headers=debug_headers, fsize=fsize, **kwargs)
-    else:
+    elif isinstance(filename, (str, bytes)):
         with open(filename, "rb") as fh:
             return _readSAC(buf=fh, headonly=headonly,
                             debug_headers=debug_headers, fsize=fsize, **kwargs)
+    else:
+        raise ValueError("Cannot open '%s'." % filename)
 
 
 def _readSAC(buf, headonly=False, debug_headers=False, fsize=True,
@@ -375,15 +379,17 @@ def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
                              "one Trace")
         _writeSAC(stream[0], filename, byteorder=byteorder, **kwargs)
         return
-
-    # Otherwise treat it as a filename
-    # Translate the common (renamed) entries
-    base, ext = os.path.splitext(filename)
-    for i, trace in enumerate(stream):
-        if len(stream) != 1:
-            filename = "%s%02d%s" % (base, i + 1, ext)
-        with open(filename, "wb") as fh:
-            _writeSAC(trace, fh, byteorder=byteorder, **kwargs)
+    elif isinstance(filename, (str, bytes)):
+        # Otherwise treat it as a filename
+        # Translate the common (renamed) entries
+        base, ext = os.path.splitext(filename)
+        for i, trace in enumerate(stream):
+            if len(stream) != 1:
+                filename = "%s%02d%s" % (base, i + 1, ext)
+            with open(filename, "wb") as fh:
+                _writeSAC(trace, fh, byteorder=byteorder, **kwargs)
+    else:
+        raise ValueError("Cannot open '%s'." % filename)
 
 
 def _writeSAC(trace, buf, byteorder="<", **kwargs):  # @UnusedVariable

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -44,7 +44,7 @@ def isSAC(filename):
 
 def _isSAC(buf):
     """
-    Checks whether a file-like obejcts contains a SAC file or not.
+    Checks whether a file-like object contains a SAC file or not.
 
     :type buf: file-like object or open file.
     :param buf: SAC file to be checked.

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -253,8 +253,10 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
 
     :param stream: The ObsPy Stream object to write.
     :type stream: :class:`~obspy.core.stream.Stream`
-    :param filename: File or object to write to. If its not a filename,
-        it only supports writing Streams objects containing a single Trace.
+    :param filename: Name of file to write. In case an open file or
+        file-like object is passed, this function only supports writing
+        Stream objects containing a single Trace. This is a limitation of
+        the SAC file format. An exception will be raised in case its necessary.
     :type filename: str, open file, or file-like object
 
     .. rubric:: Example
@@ -400,8 +402,10 @@ def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
 
     :param stream: The ObsPy Stream object to write.
     :type stream: :class:`~obspy.core.stream.Stream`
-    :param filename: Name of file to write. If it is not a filename, it only
-        supports writing single Trace streams.
+    :param filename: Name of file to write. In case an open file or
+        file-like object is passed, this function only supports writing
+        Stream objects containing a single Trace. This is a limitation of
+        the SAC file format. An exception will be raised in case its necessary.
     :type filename: str, open file, or file-like object
     :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
         little-endian, ``1`` or ``'>'`` for MSBF or big-endian.

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -256,7 +256,8 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
     :param filename: Name of file to write. In case an open file or
         file-like object is passed, this function only supports writing
         Stream objects containing a single Trace. This is a limitation of
-        the SAC file format. An exception will be raised in case its necessary.
+        the SAC file format. An exception will be raised in case it's
+        necessary.
     :type filename: str, open file, or file-like object
 
     .. rubric:: Example
@@ -405,7 +406,8 @@ def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
     :param filename: Name of file to write. In case an open file or
         file-like object is passed, this function only supports writing
         Stream objects containing a single Trace. This is a limitation of
-        the SAC file format. An exception will be raised in case its necessary.
+        the SAC file format. An exception will be raised in case it's
+        necessary.
     :type filename: str, open file, or file-like object
     :param byteorder: Must be either ``0`` or ``'<'`` for LSBF or
         little-endian, ``1`` or ``'>'`` for MSBF or big-endian.

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -14,7 +14,7 @@ from future.builtins import *  # NOQA
 from future.utils import native_str
 
 from obspy import Trace, Stream
-from obspy.core.compatibility import is_bytes_buffer, is_text_buffer
+from obspy.core.compatibility import is_bytes_buffer
 from obspy.sac.sacio import SacIO
 import os
 import struct
@@ -122,10 +122,10 @@ def isSACXY(filename):
 
     >>> isSACXY('/path/to/testxy.sac')  #doctest: +SKIP
     """
-    if is_bytes_buffer(filename) or is_text_buffer(filename):
+    if is_bytes_buffer(filename):
         return _isSACXY(filename)
     elif isinstance(filename, (str, bytes)):
-        with open(filename, "rt") as fh:
+        with open(filename, "rb") as fh:
             return _isSACXY(fh)
     else:
         raise ValueError("Cannot open '%s'." % filename)
@@ -193,8 +193,7 @@ def readSACXY(filename, headonly=False, debug_headers=False,
     >>> from obspy import read # doctest: +SKIP
     >>> st = read("/path/to/testxy.sac") # doctest: +SKIP
     """
-    # Alphanumeric so bytes and text should both work.
-    if is_bytes_buffer(filename) or is_text_buffer(filename):
+    if is_bytes_buffer(filename):
         return _readSACXY(buf=filename, headonly=headonly,
                           debug_headers=debug_headers, **kwargs)
     else:
@@ -268,7 +267,7 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
     >>> st.write("testxy.sac", format="SACXY")  #doctest: +SKIP
     """
     # SAC can only store one Trace per file.
-    if is_bytes_buffer(filename) or is_text_buffer(filename):
+    if is_bytes_buffer(filename):
         if len(stream) > 1:
             raise ValueError("If writing to a file-like object in the SAC "
                              "format, the Stream object must only contain "
@@ -282,7 +281,7 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
         for i, trace in enumerate(stream):
             if len(stream) != 1:
                 filename = "%s%02d%s" % (base, i + 1, ext)
-            with open(filename, "wt") as fh:
+            with open(filename, "wb") as fh:
                 _writeSACXY(trace, fh, **kwargs)
     else:
         raise ValueError("Cannot open '%s'." % filename)

--- a/obspy/sac/core.py
+++ b/obspy/sac/core.py
@@ -270,8 +270,8 @@ def writeSACXY(stream, filename, **kwargs):  # @UnusedVariable
     if is_bytes_buffer(filename):
         if len(stream) > 1:
             raise ValueError("If writing to a file-like object in the SAC "
-                             "format, the Stream object must only contain "
-                             "one Trace")
+                             "format, the Stream object can only contain "
+                             "one Trace.")
         _writeSACXY(stream[0], filename, **kwargs)
         return
     elif isinstance(filename, (str, bytes)):
@@ -422,8 +422,8 @@ def writeSAC(stream, filename, byteorder="<", **kwargs):  # @UnusedVariable
     if is_bytes_buffer(filename):
         if len(stream) > 1:
             raise ValueError("If writing to a file-like object in the SAC "
-                             "format, the Stream object must only contain "
-                             "one Trace")
+                             "format, the Stream object can only contain "
+                             "one Trace.")
         _writeSAC(stream[0], filename, byteorder=byteorder, **kwargs)
         return
     elif isinstance(filename, (str, bytes)):

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -2,10 +2,11 @@
 # ------------------------------------------------------------------
 # Filename: sacio.py
 #  Purpose: Read & Write Seismograms, Format SAC.
-#   Author: Yannik Behr, C. J. Ammon's, C. Satriano
+#   Author: Yannik Behr, C. J. Ammon's, C. Satriano, L. Krischer
 #    Email: yannik.behr@vuw.ac.nz
 #
-# Copyright (C) 2008-2014 Yannik Behr, C. J. Ammon's, C. Satriano
+# Copyright (C) 2008-2015 Yannik Behr, C. J. Ammon's, C. Satriano,
+#                         L. Krischer
 # ------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -15,7 +16,6 @@ from future.utils import native_str
 from obspy import UTCDateTime, Trace
 from obspy.core.compatibility import frombuffer
 from obspy.core.util import gps2DistAzimuth, AttribDict
-from obspy.core import compatibility
 import numpy as np
 import time
 import warnings
@@ -108,35 +108,6 @@ class SacIOError(Exception):
     Raised if the given SAC file can't be read.
     """
     pass
-
-
-def _isText(filename, blocksize=512):
-    """
-    Check if it is a text or a binary file.
-    """
-    # This should  always be true if a file is a text-file and only true for a
-    # binary file in rare occasions (see Recipe 173220 found on
-    # http://code.activestate.com/)
-    text_characters = str("").join(list(map(chr, range(32, 127))) +
-                                   list("\n\r\t\b")).encode('ascii', 'ignore')
-    _null_trans = compatibility.maketrans(b"", b"")
-    with open(filename, 'rb') as fp:
-        s = fp.read(blocksize)
-    if b"\0" in s:
-        return False
-
-    if not s:  # Empty files are considered text
-        return True
-
-    # Get the non-text characters (maps a character to itself then
-    # use the 'remove' option to get rid of the text characters.)
-    t = s.translate(_null_trans, text_characters)
-
-    # If more than 30% non-text characters, then
-    # this is considered a binary file
-    if len(t) / len(s) > 0.30:
-        return 0
-    return True
 
 
 class SacIO(object):

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -1455,6 +1455,7 @@ def attach_resp(tr, resp_file, todisp=False, tovel=False, torad=False,
     :param tohz: change to Hertz
 
     >>> from obspy import Trace
+    >>> import os
     >>> tr = Trace()
     >>> respfile = os.path.join(os.path.dirname(__file__), 'tests', 'data',
     ...                         'RESP.NZ.CRLZ.10.HHZ')

--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -552,9 +552,9 @@ class SacIO(object):
 
         >>> from obspy.sac import SacIO # doctest: +SKIP
         >>> with open('test.sac', 'rb') as fh:
-        ...     tr = SacIO('test.sac') # doctest: +SKIP
+        ...     tr = SacIO(fh) # doctest: +SKIP
         >>> with open('test2.sac', 'wb') as fh:
-        ...     tr.WriteSacBinary('test2.sac') # doctest: +SKIP
+        ...     tr.WriteSacBinary(fh) # doctest: +SKIP
         >>> with open('test2.sac', 'rb') as fh:
         ...     u = SacIO(fh) # doctest: +SKIP
         >>> u.SetHvalue('kevnm','hullahulla') # doctest: +SKIP
@@ -806,7 +806,7 @@ class SacIO(object):
         >>> with open('test2.sac', 'wb') as fh:
         ...     tr.WriteSacXY(fh) # doctest: +SKIP
         >>> with open('test2.sac', 'wb') as fh:
-        ...     tr.IsValidXYSacFile('test2.sac') # doctest: +SKIP
+        ...     tr.IsValidXYSacFile(fh) # doctest: +SKIP
         True
         """
         # header

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -605,20 +605,6 @@ class CoreTestCase(unittest.TestCase):
         np.testing.assert_array_equal(tr.data, tr2.data)
         self.assertEqual(tr, tr2)
 
-    def test_readXYwriteXY_from_StringIO(self):
-        """
-        Reading/writing XY sac files from/to io.StringIO.
-        """
-        # Original.
-        st = readSACXY(self.filexy)
-
-        with io.StringIO() as fh:
-            writeSACXY(st, fh)
-            fh.seek(0, 0)
-            st2 = readSACXY(fh)
-
-        self.assertTrue(st == st2)
-
     def test_readXYwriteXY_from_BytesIO(self):
         """
         Reading/writing XY sac files from/to io.BytesIO. It's alphanumeric
@@ -631,22 +617,6 @@ class CoreTestCase(unittest.TestCase):
             writeSACXY(st, fh)
             fh.seek(0, 0)
             st2 = readSACXY(fh)
-
-        self.assertTrue(st == st2)
-
-    def test_readXYwriteXY_from_open_file_text_mode(self):
-        """
-        Reading/writing XY sac files to open files in text mode.
-        """
-        # Original.
-        st = readSACXY(self.filexy)
-
-        with NamedTemporaryFile() as tf:
-            with open(tf.name, "wt") as fh:
-                writeSACXY(st, fh)
-                fh.seek(0, 0)
-            with open(tf.name, "rt") as fh:
-                st2 = readSACXY(fh)
 
         self.assertTrue(st == st2)
 
@@ -721,24 +691,17 @@ class CoreTestCase(unittest.TestCase):
             buf.seek(0, 0)
             self.assertFalse(isSACXY(buf))
 
-    def test_is_sacxy_string_io(self):
+    def test_is_sacxy_string_io_raises(self):
         """
-        Tests the isSACXY function for StringIO objects.
+        Tests the isSACXY function for StringIO objects where it should
+        raise. I/O is binary only.
         """
         with io.StringIO() as buf:
             # Read file to BytesIO.
             with open(self.filexy, "rt") as fh:
                 buf.write(fh.read())
             buf.seek(0, 0)
-            self.assertTrue(isSACXY(buf))
-
-        # Should naturally fail for other files.
-        with io.StringIO() as buf:
-            # Read file to BytesIO.
-            with open(__file__, "rt") as fh:
-                buf.write(fh.read())
-            buf.seek(0, 0)
-            self.assertFalse(isSACXY(buf))
+            self.assertRaises(ValueError, isSACXY, buf)
 
     def test_is_sacxy_open_file_binary_mode(self):
         """
@@ -750,15 +713,12 @@ class CoreTestCase(unittest.TestCase):
         with open(__file__, "rb") as fh:
             self.assertFalse(isSACXY(fh))
 
-    def test_is_sacxy_open_file_text_mode(self):
+    def test_is_sacxy_open_file_text_mode_fails(self):
         """
-        Tests the isSACXY function for open files in text mode.
+        Tests that the isSACXY function for open files in text mode fails.
         """
         with open(self.filexy, "rt") as fh:
-            self.assertTrue(isSACXY(fh))
-
-        with open(__file__, "rt") as fh:
-            self.assertFalse(isSACXY(fh))
+            self.assertRaises(ValueError, isSACXY, fh)
 
 
 def suite():

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -660,8 +660,7 @@ class CoreTestCase(unittest.TestCase):
         Should raise a ValueError.
         """
         with io.StringIO() as buf:
-            with open(__file__, "rt") as fh:
-                buf.write(fh.read())
+            buf.write("abcdefghijklmnopqrstuvwxyz")
             buf.seek(0, 0)
             self.assertRaises(ValueError, isSAC, buf)
 

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -498,7 +498,7 @@ class CoreTestCase(unittest.TestCase):
             tr = readSAC(buf)[0]
 
         # Open file normally and make sure the results are identical.
-        tr2 = read(self.file)[0]
+        tr2 = readSAC(self.file)[0]
         np.testing.assert_array_equal(tr.data, tr2.data)
         self.assertEqual(tr, tr2)
 
@@ -531,6 +531,9 @@ class CoreTestCase(unittest.TestCase):
             # Attempt to read from it.
             tr2 = read(buf)[0]
 
+        # depmen is different as it is actually calculated on the fly.
+        del tr.stats.sac.depmen
+        del tr2.stats.sac.depmen
         np.testing.assert_array_equal(tr.data, tr2.data)
         self.assertEqual(tr, tr2)
 

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -733,6 +733,15 @@ class CoreTestCase(unittest.TestCase):
         with io.BytesIO() as fh:
             st.write(fh, format="sacxy")
 
+        # Will fail if the stream contains more than one trace.
+        st = read()
+        self.assertTrue(len(st) > 1)
+        with io.BytesIO() as fh:
+            self.assertRaises(ValueError, st.write, fh, format="sac")
+
+        with io.BytesIO() as fh:
+            self.assertRaises(ValueError, st.write, fh, format="sacxy")
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -561,6 +561,14 @@ class CoreTestCase(unittest.TestCase):
         with io.BytesIO() as fh:
             self.assertRaises(ValueError, st.write, fh, format="sac")
 
+    def test_writing_to_io_string_io_fails(self):
+        """
+        Writing to io.StringIO should fail on all platforms.
+        """
+        st = read()[:1]
+        with io.StringIO() as fh:
+            self.assertRaises(ValueError, st.write, fh, format="sac")
+
     def test_read_via_obspy_from_bytes_io(self):
         """
         Read sac files from a BytesIO object via ObsPy.

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -539,11 +539,9 @@ class CoreTestCase(unittest.TestCase):
         st = readSAC(self.file)
 
         with NamedTemporaryFile() as tf_out:
-            with open(tf_out.name, "wb") as fh:
-                writeSAC(st, fh)
-
-            with open(tf_out.name, "rb") as fh:
-                st2 = readSAC(fh)
+            writeSAC(st, tf_out)
+            tf_out.seek(0, 0)
+            st2 = readSAC(tf_out)
 
         tr = st[0]
         tr2 = st2[0]
@@ -628,11 +626,9 @@ class CoreTestCase(unittest.TestCase):
         st = readSACXY(self.filexy)
 
         with NamedTemporaryFile() as tf:
-            with open(tf.name, "wb") as fh:
-                writeSACXY(st, fh)
-                fh.seek(0, 0)
-            with open(tf.name, "rb") as fh:
-                st2 = readSACXY(fh)
+            writeSACXY(st, tf)
+            tf.seek(0, 0)
+            st2 = readSACXY(tf)
 
         self.assertTrue(st == st2)
 

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -9,7 +9,8 @@ from future.builtins import *  # NOQA
 from obspy import Stream, Trace, read, UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.sac import SacIO, SacError, SacIOError
-from obspy.sac.core import readSAC, writeSAC, readSACXY, writeSACXY
+from obspy.sac.core import readSAC, writeSAC, readSACXY, writeSACXY, isSAC, \
+    isSACXY
 import copy
 import io
 import numpy as np
@@ -664,6 +665,100 @@ class CoreTestCase(unittest.TestCase):
                 st2 = readSACXY(fh)
 
         self.assertTrue(st == st2)
+
+    def test_is_sac_bytes_io(self):
+        """
+        Tests the isSAC function for BytesIO objects.
+        """
+        with io.BytesIO() as buf:
+            # Read file to BytesIO.
+            with open(self.file, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertTrue(isSAC(buf))
+
+        # Should naturally fail for an XY file.
+        with io.BytesIO() as buf:
+            # Read file to BytesIO.
+            with open(self.filexy, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertFalse(isSAC(buf))
+
+    def test_is_sac_string_io_raises(self):
+        """
+        Should raise a ValueError.
+        """
+        with io.StringIO() as buf:
+            with open(__file__, "rt") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertRaises(ValueError, isSAC, buf)
+
+    def test_is_sac_open_file(self):
+        """
+        Tests the isSAC function for open files.
+        """
+        with open(self.file, "rb") as fh:
+            self.assertTrue(isSAC(fh))
+
+    def test_is_sacxy_bytes_io(self):
+        """
+        Tests the isSACXY function for BytesIO objects.
+        """
+        with io.BytesIO() as buf:
+            # Read file to BytesIO.
+            with open(self.filexy, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertTrue(isSACXY(buf))
+
+        # Should naturally fail for a normal sac file.
+        with io.BytesIO() as buf:
+            # Read file to BytesIO.
+            with open(self.file, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertFalse(isSACXY(buf))
+
+    def test_is_sacxy_string_io(self):
+        """
+        Tests the isSACXY function for StringIO objects.
+        """
+        with io.StringIO() as buf:
+            # Read file to BytesIO.
+            with open(self.filexy, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertTrue(isSACXY(buf))
+
+        # Should naturally fail for other files.
+        with io.StringIO() as buf:
+            # Read file to BytesIO.
+            with open(__file__, "rt") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+            self.assertFalse(isSACXY(buf))
+
+    def test_is_sacxy_open_file_binary_mode(self):
+        """
+        Tests the isSACXY function for open files in binary mode.
+        """
+        with open(self.filexy, "rb") as fh:
+            self.assertTrue(isSACXY(fh))
+
+        with open(__file__, "rb") as fh:
+            self.assertTrue(isSACXY(fh))
+
+    def test_is_sacxy_open_file_text_mode(self):
+        """
+        Tests the isSACXY function for open files in text mode.
+        """
+        with open(self.filexy, "rt") as fh:
+            self.assertTrue(isSACXY(fh))
+
+        with open(__file__, "rt") as fh:
+            self.assertTrue(isSACXY(fh))
 
 
 def suite():

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -727,7 +727,7 @@ class CoreTestCase(unittest.TestCase):
         """
         with io.StringIO() as buf:
             # Read file to BytesIO.
-            with open(self.filexy, "rb") as fh:
+            with open(self.filexy, "rt") as fh:
                 buf.write(fh.read())
             buf.seek(0, 0)
             self.assertTrue(isSACXY(buf))
@@ -748,7 +748,7 @@ class CoreTestCase(unittest.TestCase):
             self.assertTrue(isSACXY(fh))
 
         with open(__file__, "rb") as fh:
-            self.assertTrue(isSACXY(fh))
+            self.assertFalse(isSACXY(fh))
 
     def test_is_sacxy_open_file_text_mode(self):
         """
@@ -758,7 +758,7 @@ class CoreTestCase(unittest.TestCase):
             self.assertTrue(isSACXY(fh))
 
         with open(__file__, "rt") as fh:
-            self.assertTrue(isSACXY(fh))
+            self.assertFalse(isSACXY(fh))
 
 
 def suite():

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -9,7 +9,7 @@ from future.builtins import *  # NOQA
 from obspy import Stream, Trace, read, UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.sac import SacIO, SacError, SacIOError
-from obspy.sac.core import readSAC, writeSAC
+from obspy.sac.core import readSAC, writeSAC, readSACXY, writeSACXY
 import copy
 import io
 import numpy as np
@@ -603,6 +603,67 @@ class CoreTestCase(unittest.TestCase):
         del tr2.stats.sac.depmen
         np.testing.assert_array_equal(tr.data, tr2.data)
         self.assertEqual(tr, tr2)
+
+    def test_readXYwriteXY_from_StringIO(self):
+        """
+        Reading/writing XY sac files from/to io.StringIO.
+        """
+        # Original.
+        st = readSACXY(self.filexy)
+
+        with io.StringIO() as fh:
+            writeSACXY(st, fh)
+            fh.seek(0, 0)
+            st2 = readSACXY(fh)
+
+        self.assertTrue(st == st2)
+
+    def test_readXYwriteXY_from_BytesIO(self):
+        """
+        Reading/writing XY sac files from/to io.BytesIO. It's alphanumeric
+        so bytes should also do the trick.
+        """
+        # Original.
+        st = readSACXY(self.filexy)
+
+        with io.BytesIO() as fh:
+            writeSACXY(st, fh)
+            fh.seek(0, 0)
+            st2 = readSACXY(fh)
+
+        self.assertTrue(st == st2)
+
+    def test_readXYwriteXY_from_open_file_text_mode(self):
+        """
+        Reading/writing XY sac files to open files in text mode.
+        """
+        # Original.
+        st = readSACXY(self.filexy)
+
+        with NamedTemporaryFile() as tf:
+            with open(tf.name, "wt") as fh:
+                writeSACXY(st, fh)
+                fh.seek(0, 0)
+            with open(tf.name, "rt") as fh:
+                st2 = readSACXY(fh)
+
+        self.assertTrue(st == st2)
+
+    def test_readXYwriteXY_from_open_file_binary_mode(self):
+        """
+        Reading/writing XY sac files to open files in binary mode.
+        """
+        # Original.
+        st = readSACXY(self.filexy)
+
+        with NamedTemporaryFile() as tf:
+            with open(tf.name, "wb") as fh:
+                writeSACXY(st, fh)
+                fh.seek(0, 0)
+            with open(tf.name, "rb") as fh:
+                st2 = readSACXY(fh)
+
+        self.assertTrue(st == st2)
 
 
 def suite():

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -720,6 +720,19 @@ class CoreTestCase(unittest.TestCase):
         with open(self.filexy, "rt") as fh:
             self.assertRaises(ValueError, isSACXY, fh)
 
+    def test_writing_to_file_like_objects_with_obspy(self):
+        """
+        Very simple test just executing a common operation and making sure
+        it does not fail.
+        """
+        st = read()[:1]
+
+        with io.BytesIO() as fh:
+            st.write(fh, format="sac")
+
+        with io.BytesIO() as fh:
+            st.write(fh, format="sacxy")
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')

--- a/obspy/sac/tests/test_core.py
+++ b/obspy/sac/tests/test_core.py
@@ -10,6 +10,7 @@ from obspy import Stream, Trace, read, UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.sac import SacIO, SacError, SacIOError
 import copy
+import io
 import numpy as np
 import os
 import unittest
@@ -477,6 +478,38 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr.stats.sac.knetwk, '-12345  ')
         self.assertEqual(tr.stats.sac.kstnm, 'CDV     ')
         self.assertEqual(tr.stats.sac.kcmpnm, 'Q       ')
+
+    def test_read_via_obspy_from_bytes_io(self):
+        """
+        Read sac files from a BytesIO object via ObsPy.
+        """
+        with io.BytesIO() as buf:
+            # Read file to BytesIO.
+            with open(self.file, "rb") as fh:
+                buf.write(fh.read())
+            buf.seek(0, 0)
+
+            # Attempt to read from it.
+            tr = read(buf)[0]
+
+        # Open file normally and make sure the results are identical.
+        tr2 = read(self.file)[0]
+        np.testing.assert_array_equal(tr.data, tr2.data)
+        self.assertEqual(tr, tr2)
+
+    def test_write_via_obspy_to_bytes_io(self):
+        """
+        Read sac files from a BytesIO object via ObsPy.
+        """
+        tr = read(self.file)[0]
+        with io.BytesIO() as buf:
+            tr.write(buf, format="sac")
+            buf.seek(0, 0)
+            # Attempt to read from it.
+            tr2 = read(buf)[0]
+
+        np.testing.assert_array_equal(tr.data, tr2.data)
+        self.assertEqual(tr, tr2)
 
 
 def suite():

--- a/obspy/sac/tests/test_sacio.py
+++ b/obspy/sac/tests/test_sacio.py
@@ -69,7 +69,8 @@ class SacIOTestCase(unittest.TestCase):
             self.assertEqual(t.GetHvalue("kstnm"), "STA     ")
             t.SetHvalue("kstnm", "spiff")
             self.assertEqual(t.GetHvalue('kstnm'), 'spiff   ')
-            t.WriteSacBinary(tempfile)
+            with open(tempfile, "wb") as fh:
+                t.WriteSacBinary(fh)
             self.assertEqual(os.stat(sacfile)[6], os.stat(tempfile)[6])
             self.assertEqual(os.path.exists(tempfile), True)
             with open(tempfile, "rb") as fh:
@@ -77,7 +78,9 @@ class SacIOTestCase(unittest.TestCase):
             self.assertEqual((t.hf is not None), True)
             t.SetHvalue("kstnm", "spoff")
             self.assertEqual(t.GetHvalue('kstnm'), 'spoff   ')
-            t.WriteSacHeader(tempfile)
+            # Open with modification!
+            with open(tempfile, "rb+") as fh:
+                t.WriteSacHeader(fh)
             t.SetHvalueInFile(tempfile, "kcmpnm", 'Z       ')
             self.assertEqual(t.GetHvalueFromFile(tempfile, "kcmpnm"),
                              'Z       ')
@@ -113,7 +116,8 @@ class SacIOTestCase(unittest.TestCase):
                 self.assertEqual(e.IsValidSacFile(fh), False)
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            d.WriteSacBinary(tempfile)
+            with open(tempfile, "wb") as fh:
+                d.WriteSacBinary(fh)
             size1 = os.stat(tempfile)[6]
             size2 = os.stat(tfile)[6]
         self.assertEqual(size1, size2)
@@ -164,7 +168,8 @@ class SacIOTestCase(unittest.TestCase):
             with open(tfileb, "rb") as fh:
                 tb = SacIO(fh)
             tb.swap_byte_order()
-            tb.WriteSacBinary(tempfile)
+            with open(tempfile, "wb") as fh:
+                tb.WriteSacBinary(fh)
             with open(tempfile, "rb") as fh:
                 t = SacIO(fh)
             with open(tfilel, "rb") as fh:
@@ -178,7 +183,8 @@ class SacIOTestCase(unittest.TestCase):
             with open(tfilel, "rb") as fh:
                 tl = SacIO(fh)
             tl.swap_byte_order()
-            tl.WriteSacBinary(tempfile)
+            with open(tempfile, "wb") as fh:
+                tl.WriteSacBinary(fh)
             with open(tempfile, "rb") as fh:
                 t = SacIO(fh)
             with open(tfileb, "rb") as fh:
@@ -199,7 +205,8 @@ class SacIOTestCase(unittest.TestCase):
             t.SetHvalue('stla', -41.2869)
             t.SetHvalue('stlo', 174.7746)
             t.SetHvalue('lcalda', 1)
-            t.WriteSacBinary(tempfile)
+            with open(tempfile, "wb") as fh:
+                t.WriteSacBinary(fh)
             with open(tempfile, "rb") as fh:
                 t2 = SacIO(fh)
         b = np.array([18486532.5788 / 1000., 65.654154562, 305.975459869],
@@ -366,9 +373,11 @@ class SacIOTestCase(unittest.TestCase):
             with open(tempfile, "rb") as fh:
                 trace = SacIO(fh)
             trace.SetHvalue('stel', 91.0)
-            trace.WriteSacHeader(tempfile)
+            # Open with modification!
+            with open(tempfile, "rb+") as fh:
+                trace.WriteSacHeader(fh)
             with open(tempfile, "rb") as fh:
-                trace = SacIO(fh)
+                SacIO(fh)
 
     def test_read_with_fsize(self):
         """

--- a/obspy/sac/tests/test_sacio.py
+++ b/obspy/sac/tests/test_sacio.py
@@ -30,7 +30,8 @@ class SacIOTestCase(unittest.TestCase):
         Test for SacIO '_get_date_'-function to calculate timestamp
         """
         fn = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
-        t = SacIO(fn)
+        with open(fn, "rb") as fh:
+            t = SacIO(fh)
         self.assertEqual(t.reftime.timestamp, 269596800.0)
         diff = t.GetHvalue('npts')
         self.assertEqual(int(t.endtime - t.starttime), diff)
@@ -47,7 +48,8 @@ class SacIOTestCase(unittest.TestCase):
                         dtype=native_str('<f4'))
         sacfile = os.path.join(self.path, 'test.sac')
         t = SacIO()
-        t.ReadSacFile(sacfile)
+        with open(sacfile, "rb") as fh:
+            t.ReadSacFile(fh)
         np.testing.assert_array_equal(t.seis[0:11], data)
         self.assertEqual(t.GetHvalue('npts'), 100)
         self.assertEqual(t.GetHvalue("kstnm"), "STA     ")
@@ -60,7 +62,8 @@ class SacIOTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             t = SacIO()
-            t.ReadSacFile(sacfile)
+            with open(sacfile, "rb") as fh:
+                t.ReadSacFile(fh)
             self.assertEqual(t.GetHvalue('npts'), 100)
             self.assertEqual(t.GetHvalue("kcmpnm"), "Q       ")
             self.assertEqual(t.GetHvalue("kstnm"), "STA     ")
@@ -69,7 +72,8 @@ class SacIOTestCase(unittest.TestCase):
             t.WriteSacBinary(tempfile)
             self.assertEqual(os.stat(sacfile)[6], os.stat(tempfile)[6])
             self.assertEqual(os.path.exists(tempfile), True)
-            t.ReadSacHeader(tempfile)
+            with open(tempfile, "rb") as fh:
+                t.ReadSacHeader(fh)
             self.assertEqual((t.hf is not None), True)
             t.SetHvalue("kstnm", "spoff")
             self.assertEqual(t.GetHvalue('kstnm'), 'spoff   ')
@@ -77,12 +81,15 @@ class SacIOTestCase(unittest.TestCase):
             t.SetHvalueInFile(tempfile, "kcmpnm", 'Z       ')
             self.assertEqual(t.GetHvalueFromFile(tempfile, "kcmpnm"),
                              'Z       ')
-            self.assertEqual(
-                SacIO(tempfile, headonly=True).GetHvalue('kcmpnm'), 'Z       ')
-            self.assertEqual(t.IsValidSacFile(tempfile), True)
+            with open(tempfile, "rb") as fh:
+                self.assertEqual(
+                    SacIO(fh, headonly=True).GetHvalue('kcmpnm'), 'Z       ')
+            with open(tempfile, "rb") as fh:
+                self.assertEqual(t.IsValidSacFile(fh), True)
             self.assertEqual(t.IsValidXYSacFile(tempfile), False)
             self.assertEqual(SacIO().GetHvalueFromFile(sacfile, 'npts'), 100)
-            self.assertEqual(SacIO(sacfile).GetHvalue('npts'), 100)
+            with open(sacfile, "rb") as fh:
+                self.assertEqual(SacIO(fh).GetHvalue('npts'), 100)
 
     def test_readWriteXY(self):
         """
@@ -91,14 +98,19 @@ class SacIOTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
-            t = SacIO(tfile)
+            with open(tfile, "rb") as fh:
+                t = SacIO(fh)
             t.WriteSacXY(tempfile)
-            d = SacIO(tempfile, alpha=True)
+            with open(tempfile, "rb") as fh:
+                d = SacIO(fh, alpha=True)
             e = SacIO()
-            e.ReadSacXY(tempfile)
+            with open(tempfile, "rb") as fh:
+                e.ReadSacXY(fh)
             self.assertEqual(e.GetHvalue('npts'), d.GetHvalue('npts'))
-            self.assertEqual(e.IsValidXYSacFile(tempfile), True)
-            self.assertEqual(e.IsValidSacFile(tempfile), False)
+            with open(tempfile, "rb") as fh:
+                self.assertEqual(e.IsValidXYSacFile(fh), True)
+            with open(tempfile, "rb") as fh:
+                self.assertEqual(e.IsValidSacFile(fh), False)
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             d.WriteSacBinary(tempfile)
@@ -111,16 +123,20 @@ class SacIOTestCase(unittest.TestCase):
         tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            t = SacIO(tfile)
+            with open(tfile, "rb") as fh:
+                t = SacIO(fh)
             t.WriteSacXY(tempfile)
-            d = SacIO(tempfile, alpha=True)
+            with open(tempfile, "rb") as fh:
+                d = SacIO(fh, alpha=True)
             e = SacIO()
-            e.ReadSacXYHeader(tempfile)
+            with open(tempfile, "rb") as fh:
+                e.ReadSacXYHeader(fh)
             self.assertEqual(e.GetHvalue('npts'), d.GetHvalue('npts'))
             self.assertEqual(e.GetHvalue('depmen'), d.GetHvalue('depmen'))
             self.assertEqual(e.starttime, d.starttime)
             self.assertNotEqual(e.seis.size, d.seis.size)
-            c = SacIO(tempfile, alpha=True, headonly=True)
+            with open(tempfile, "rb") as fh:
+                c = SacIO(fh, alpha=True, headonly=True)
         self.assertEqual(e.seis.size, c.seis.size)
 
     def test_readBigEnd(self):
@@ -130,8 +146,10 @@ class SacIOTestCase(unittest.TestCase):
         tfilel = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
         tfileb = os.path.join(os.path.dirname(__file__), 'data',
                               'test.sac.swap')
-        tl = SacIO(tfilel)
-        tb = SacIO(tfileb)
+        with open(tfilel, "rb") as fh:
+            tl = SacIO(fh)
+        with open(tfileb, "rb") as fh:
+            tb = SacIO(fh)
         self.assertEqual(tl.GetHvalue('kevnm'), tb.GetHvalue('kevnm'))
         self.assertEqual(tl.GetHvalue('npts'), tb.GetHvalue('npts'))
         self.assertEqual(tl.GetHvalue('delta'), tb.GetHvalue('delta'))
@@ -143,22 +161,28 @@ class SacIOTestCase(unittest.TestCase):
                               'test.sac.swap')
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            tb = SacIO(tfileb)
+            with open(tfileb, "rb") as fh:
+                tb = SacIO(fh)
             tb.swap_byte_order()
             tb.WriteSacBinary(tempfile)
-            t = SacIO(tempfile)
-            tl = SacIO(tfilel)
+            with open(tempfile, "rb") as fh:
+                t = SacIO(fh)
+            with open(tfilel, "rb") as fh:
+                tl = SacIO(fh)
             self.assertEqual(t.GetHvalue('kevnm'), tl.GetHvalue('kevnm'))
             self.assertEqual(t.GetHvalue('npts'), tl.GetHvalue('npts'))
             self.assertEqual(t.GetHvalue('delta'), tl.GetHvalue('delta'))
             np.testing.assert_array_equal(t.seis, tl.seis)
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            tl = SacIO(tfilel)
+            with open(tfilel, "rb") as fh:
+                tl = SacIO(fh)
             tl.swap_byte_order()
             tl.WriteSacBinary(tempfile)
-            t = SacIO(tempfile)
-            tb = SacIO(tfileb)
+            with open(tempfile, "rb") as fh:
+                t = SacIO(fh)
+            with open(tfileb, "rb") as fh:
+                tb = SacIO(fh)
             self.assertEqual(t.GetHvalue('kevnm'), tb.GetHvalue('kevnm'))
             self.assertEqual(t.GetHvalue('npts'), tb.GetHvalue('npts'))
             self.assertEqual(t.GetHvalue('delta'), tb.GetHvalue('delta'))
@@ -168,14 +192,16 @@ class SacIOTestCase(unittest.TestCase):
         tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            t = SacIO(tfile)
+            with open(tfile, "rb") as fh:
+                t = SacIO(fh)
             t.SetHvalue('evla', 48.15)
             t.SetHvalue('evlo', 11.58333)
             t.SetHvalue('stla', -41.2869)
             t.SetHvalue('stlo', 174.7746)
             t.SetHvalue('lcalda', 1)
             t.WriteSacBinary(tempfile)
-            t2 = SacIO(tempfile)
+            with open(tempfile, "rb") as fh:
+                t2 = SacIO(fh)
         b = np.array([18486532.5788 / 1000., 65.654154562, 305.975459869],
                      dtype=native_str('>f4'))
         self.assertEqual(t2.GetHvalue('dist'), b[0])
@@ -187,11 +213,13 @@ class SacIOTestCase(unittest.TestCase):
         Assertion is raised if file is not a SAC file
         """
         t = SacIO()
-        self.assertRaises(SacError, t.ReadSacFile, __file__)
+        with open(__file__, "rb") as fh:
+            self.assertRaises(SacError, t.ReadSacFile, fh)
 
     def test_getattr(self):
         tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
-        tr = SacIO(tfile)
+        with open(tfile, "rb") as fh:
+            tr = SacIO(fh)
         self.assertEqual(tr.npts, tr.GetHvalue('npts'))
         self.assertEqual(tr.kstnm, tr.GetHvalue('kstnm'))
 
@@ -335,10 +363,12 @@ class SacIOTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             tr.write(tempfile, format="SAC")
-            trace = SacIO(tempfile)
+            with open(tempfile, "rb") as fh:
+                trace = SacIO(fh)
             trace.SetHvalue('stel', 91.0)
             trace.WriteSacHeader(tempfile)
-            trace = SacIO(tempfile)
+            with open(tempfile, "rb") as fh:
+                trace = SacIO(fh)
 
     def test_read_with_fsize(self):
         """
@@ -349,16 +379,22 @@ class SacIOTestCase(unittest.TestCase):
         shorter_file = os.path.join(self.path, 'seism-shorter.sac')
         t = SacIO()
         # default
-        self.assertRaises(SacError, t.ReadSacFile, longer_file)
-        self.assertRaises(SacError, t.ReadSacFile, shorter_file)
+        with open(longer_file, "rb") as fh:
+            self.assertRaises(SacError, t.ReadSacFile, fh)
+        with open(shorter_file, "rb") as fh:
+            self.assertRaises(SacError, t.ReadSacFile, fh)
         # fsize=True
-        self.assertRaises(SacError, t.ReadSacFile, longer_file, fsize=True)
-        self.assertRaises(SacError, t.ReadSacFile, shorter_file, fsize=True)
+        with open(longer_file, "rb") as fh:
+            self.assertRaises(SacError, t.ReadSacFile, fh, fsize=True)
+        with open(shorter_file, "rb") as fh:
+            self.assertRaises(SacError, t.ReadSacFile, fh, fsize=True)
         # using fsize=False should not work for shorter file
         # (this is not supported by SAC) ...
-        self.assertRaises(SacIOError, t.ReadSacFile, shorter_file, fsize=False)
+        with open(shorter_file, "rb") as fh:
+            self.assertRaises(SacIOError, t.ReadSacFile, fh, fsize=False)
         # ...but it should work for longer file
-        t.ReadSacFile(longer_file, fsize=False)
+        with open(longer_file, "rb") as fh:
+            t.ReadSacFile(fh, fsize=False)
         # checking trace
         self.assertEqual(t.GetHvalue('nzyear'), 1981)
         self.assertEqual(t.GetHvalue('nzjday'), 88)

--- a/obspy/sac/tests/test_sacio.py
+++ b/obspy/sac/tests/test_sacio.py
@@ -103,7 +103,8 @@ class SacIOTestCase(unittest.TestCase):
             tfile = os.path.join(os.path.dirname(__file__), 'data', 'test.sac')
             with open(tfile, "rb") as fh:
                 t = SacIO(fh)
-            t.WriteSacXY(tempfile)
+            with open(tempfile, "wb") as fh:
+                t.WriteSacXY(fh)
             with open(tempfile, "rb") as fh:
                 d = SacIO(fh, alpha=True)
             e = SacIO()
@@ -129,7 +130,8 @@ class SacIOTestCase(unittest.TestCase):
             tempfile = tf.name
             with open(tfile, "rb") as fh:
                 t = SacIO(fh)
-            t.WriteSacXY(tempfile)
+            with open(tempfile, 'wb') as fh:
+                t.WriteSacXY(fh)
             with open(tempfile, "rb") as fh:
                 d = SacIO(fh, alpha=True)
             e = SacIO()


### PR DESCRIPTION
This PR adds support for reading/writing from/to file-like objects and open files to `obspy.sac`. This enables things like

```python
In [1]: import io

In [2]: import obspy

In [3]: with io.BytesIO() as fh:
   ...:     obspy.read()[:1].write(fh, format="sac")
```

Also works with sacxy.

```python
In [4]: with io.BytesIO() as fh:
   ...:     obspy.read()[:1].write(fh, format="sacxy")
```

It will fail if the stream object to be written has more than one Trace as the SAC format does not support that use case.

```python
In [5]: with io.BytesIO() as fh:
   ...:     obspy.read().write(fh, format="sac")
---------------------------------------------------------------------------
...
... in writeSAC(stream, filename, byteorder, **kwargs)
    422     if is_bytes_buffer(filename):
    423         if len(stream) > 1:
--> 424             raise ValueError("If writing to a file-like object in the SAC "
    425                              "format, the Stream object must only contain "
    426                              "one Trace")

ValueError: If writing to a file-like object in the SAC format, the Stream object can only contain one Trace.
```

It will only work with file-like objects in bytes mode. On Python 2 it additionally works with `StringIO.StringIO` and files opened in text mode with the built-in `open()` method but I'd consider this bad style.

To this end I added two new functions to `obspy.core.compatibility`: `is_text_buffer()` and `is_bytes_buffer()`. These check if the passed object can read/write text or bytes respectively. I think this is a fairly solid and stable way of doing these things across Python versions and we should add that to other formats as well.

The scheme to read from filenames or file-like object thus looks like this:

```python
    if is_bytes_buffer(filename):
        return _readSAC(buf=filename, headonly=headonly,
                        debug_headers=debug_headers, fsize=fsize, **kwargs)
    elif isinstance(filename, (str, bytes)):
        with open(filename, "rb") as fh:
            return _readSAC(buf=fh, headonly=headonly,
                            debug_headers=debug_headers, fsize=fsize, **kwargs)
    else:
        raise ValueError("Cannot open '%s'." % filename)
```

This should be able to handle everything thrown at it in the correct fashion, the underlying `_readSAC()` function only works with file-like objects. Once again, we should really add something like this to the other formats as well.

A side effect of this PR is that sacio now completely works with file-like objects but that should not affect too many people. I did not put any effort into reorganizing `obspy.sac` as one of the next things on our list is apparently to rewrite `obspy.sac`.

I wrote like 20 new tests so I am fairly sure it works as intended :-)