### PR TITLE
Modify git version to match PEP440.

### DIFF
--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -65,14 +65,22 @@ def call_git_describe(abbrev=4):
                   cwd=OBSPY_ROOT, stdout=PIPE, stderr=PIPE)
 
         p.stderr.close()
-        line = p.stdout.readline().decode()
+        line = p.stdout.readline().decode().strip()
         p.stdout.close()
 
         # (this line prevents official releases)
         # should work again now, see #482 and obspy/obspy@b437f31
         if "-" not in line and "." not in line:
-            line = "0.0.0-g%s" % line
-        return line.strip()
+            version = "0.0.0.dev0+g%s" % line
+        else:
+            parts = line.split('-')
+            version = parts[0]
+            try:
+                version += '.dev' + parts[1]
+                version += '+' + '-'.join(parts[2:])
+            except IndexError:
+                pass
+        return version
     except:
         return None
 
@@ -105,7 +113,7 @@ def get_git_version(abbrev=4):
 
     # If we still don't have anything, that's an error.
     if version is None:
-        return '0.0.0-tar/zipball'
+        return '0.0.0+tar/zipball'
 
     # If the current version is different from what's in the
     # RELEASE-VERSION file, update the file to be current.

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -117,7 +117,7 @@ def call_git_describe(abbrev=4):
         try:
             version += '.dev+' + parts[1]
             if remote_tracking_branch is not None:
-                version += '-' + remote_tracking_branch
+                version += '.' + remote_tracking_branch
         # IndexError means we are at a release version tag cleanly,
         # add nothing additional
         except IndexError:

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -109,13 +109,12 @@ def call_git_describe(abbrev=4):
     # (this line prevents official releases)
     # should work again now, see #482 and obspy/obspy@b437f31
     if "-" not in line and "." not in line:
-        version = "0.0.0.dev0+.g%s" % line
+        version = "0.0.0.dev+.g%s" % line
     else:
-        parts = line.split('-')
+        parts = line.split('-', 1)
         version = parts[0]
         try:
-            version += '.dev' + parts[1]
-            version += '+' + '-'.join(parts[2:])
+            version += '.dev+' + parts[1]
             if remote_tracking_branch is not None:
                 version += "." + remote_tracking_branch
         # IndexError means we are at a release version tag cleanly,

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -83,7 +83,7 @@ def call_git_describe(abbrev=4):
         p.stdout.close()
         remote_info = [line_ for line_ in remote_info
                        if line_.startswith('*')][0]
-        remote_info = re.sub(r".*? \[(.*?)\] .*", r"\1", remote_info)
+        remote_info = re.sub(r".*? \[([^ :]*).*?\] .*", r"\1", remote_info)
         remote, branch = remote_info.split("/")
         # find out real name of remote
         p = Popen(['git', 'remote', '-v'],
@@ -102,7 +102,8 @@ def call_git_describe(abbrev=4):
         else:
             remote = None
         if remote is not None:
-            remote_tracking_branch = "%s/%s" % (remote, branch)
+            remote_tracking_branch = re.sub(r'[^A-Za-z0-9._-]', r'_',
+                                            '%s-%s' % (remote, branch))
     except (OSError, ValueError):
         pass
 
@@ -116,7 +117,7 @@ def call_git_describe(abbrev=4):
         try:
             version += '.dev+' + parts[1]
             if remote_tracking_branch is not None:
-                version += "." + remote_tracking_branch
+                version += '-' + remote_tracking_branch
         # IndexError means we are at a release version tag cleanly,
         # add nothing additional
         except IndexError:
@@ -152,7 +153,7 @@ def get_git_version(abbrev=4):
 
     # If we still don't have anything, that's an error.
     if version is None:
-        return '0.0.0+tar/zipball'
+        return '0.0.0+archive'
 
     # If the current version is different from what's in the
     # RELEASE-VERSION file, update the file to be current.

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -155,12 +155,33 @@ def get_git_version(abbrev=4):
     if version is None:
         return '0.0.0+archive'
 
+    # pip uses its normalized version number (strict PEP440) instead of our
+    # original version number, so we bow to pip and use the normalized version
+    # number internally, too, to avoid discrepancies.
+    version = _normalize_version(version)
+
     # If the current version is different from what's in the
     # RELEASE-VERSION file, update the file to be current.
     if version != release_version:
         write_release_version(version)
 
     # Finally, return the current version.
+    return version
+
+
+def _normalize_version(version):
+    """
+    Normalize version number string to adhere with PEP440 strictly.
+    """
+    # only adapt local version part right
+    version = re.match(r'(.*?\+)(.*)', version)
+    # no upper case letters
+    local_version = version.group(2).lower()
+    # only alphanumeric and "." in local part
+    local_version = re.sub(r'[^A-Za-z0-9.]', r'.', local_version)
+    version = version.group(1) + local_version
+    # make sure there's a "0" after ".dev"
+    version = re.sub(r'\.dev\+', r'.dev0+', version)
     return version
 
 

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -36,6 +36,7 @@
 import inspect
 import io
 import os
+import re
 from subprocess import PIPE, Popen
 
 
@@ -63,21 +64,58 @@ def call_git_describe(abbrev=4):
         p = Popen(['git', 'describe', '--dirty', '--abbrev=%d' % abbrev,
                    '--always', '--tags'],
                   cwd=OBSPY_ROOT, stdout=PIPE, stderr=PIPE)
-
         p.stderr.close()
         line = p.stdout.readline().decode().strip()
         p.stdout.close()
 
+        remote_tracking_branch = None
+        try:
+            # find out local alias of remote and name of remote tracking branch
+            p = Popen(['git', 'branch', '-vv'],
+                      cwd=OBSPY_ROOT, stdout=PIPE, stderr=PIPE)
+            p.stderr.close()
+            remote_info = [line_.decode().rstrip()
+                           for line_ in p.stdout.readlines()]
+            p.stdout.close()
+            remote_info = [line_ for line_ in remote_info
+                           if line_.startswith('*')][0]
+            remote_info = re.sub(r".*? \[(.*?)\] .*", r"\1", remote_info)
+            remote, branch = remote_info.split("/")
+            # find out real name of remote
+            p = Popen(['git', 'remote', '-v'],
+                      cwd=OBSPY_ROOT, stdout=PIPE, stderr=PIPE)
+            p.stderr.close()
+            stdout = [line_.decode().strip() for line_ in p.stdout.readlines()]
+            p.stdout.close()
+            remote = [line_ for line_ in stdout
+                      if line_.startswith(remote)][0].split()[1]
+            if remote.startswith("git@github.com:"):
+                remote = re.sub(r"git@github.com:(.*?)/.*", r"\1", remote)
+            elif remote.startswith("https://github.com/"):
+                remote = re.sub(r"https://github.com/(.*?)/.*", r"\1", remote)
+            elif remote.startswith("git://github.com"):
+                remote = re.sub(r"git://github.com/(.*?)/.*", r"\1", remote)
+            else:
+                remote = None
+            if remote is not None:
+                remote_tracking_branch = "%s/%s" % (remote, branch)
+        except:
+            pass
+
         # (this line prevents official releases)
         # should work again now, see #482 and obspy/obspy@b437f31
         if "-" not in line and "." not in line:
-            version = "0.0.0.dev0+g%s" % line
+            version = "0.0.0.dev0+.g%s" % line
         else:
             parts = line.split('-')
             version = parts[0]
             try:
                 version += '.dev' + parts[1]
                 version += '+' + '-'.join(parts[2:])
+                if remote_tracking_branch is not None:
+                    version += "." + remote_tracking_branch
+            # IndexError means we are at a release version tag cleanly,
+            # add nothing additional
             except IndexError:
                 pass
         return version


### PR DESCRIPTION
The revision number (after last tag) is now the "dev" version and the commit hash is the "local version" as defined in PEP440.

This fixes a warning on Travis, though I don't know if many people install development versions with `pip` instead of `setup.py.