### PR TITLE
Fix mlabday epoch in array_processing.

### DIFF
--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis.rst
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis.rst
@@ -13,7 +13,7 @@ the blasting of the AGFA skyscraper in Munich. We execute
   prewhitening is disabled.
 * ``semb_thres`` and ``vel_thres`` are set to infinitesimally small numbers
   and must not be changed.
-* The ``timestamp`` will be written in ``'mlabdays'``, which can be read
+* The ``timestamp`` will be written in ``'mlabday'``, which can be read
   directly by our plotting routine.
 * ``stime`` and ``etime`` have to be given in the UTCDateTime format.
 

--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_1.py
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_1.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 
 from obspy.core import AttribDict, UTCDateTime, read
 from obspy.signal import cornFreq2Paz
@@ -90,7 +91,9 @@ for i, lab in enumerate(labels):
     ax.set_xlim(out[0, 0], out[-1, 0])
     ax.set_ylim(out[:, i + 1].min(), out[:, i + 1].max())
 
-
+locator = mdates.AutoDateLocator()
+ax.xaxis.set_major_locator(locator)
+ax.xaxis.set_major_formatter(mdates.AutoDateFormatter(locator))
 fig.autofmt_xdate()
 fig.subplots_adjust(top=0.95, right=0.95, bottom=0.2, hspace=0)
 plt.show()

--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
@@ -77,7 +77,7 @@ kwargs = dict(
     # frequency properties
     frqlow=1.0, frqhigh=8.0, prewhiten=0,
     # restrict output
-    semb_thres=-1e9, vel_thres=-1e9, timestamp='mlabday',
+    semb_thres=-1e9, vel_thres=-1e9,
     stime=UTCDateTime("20080217110515"), etime=UTCDateTime("20080217110545")
 )
 out = array_processing(st, **kwargs)

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -1016,8 +1016,8 @@ def array_processing(stream, win_len, win_frac, sll_x, slm_x, sll_y, slm_y,
     if timestamp == 'julsec':
         pass
     elif timestamp == 'mlabday':
-        # 719162 == hours between 1970 and 0001
-        res[:, 0] = res[:, 0] / (24. * 3600) + 719162
+        # 719163 == days between 1970 and 0001 + 1
+        res[:, 0] = res[:, 0] / (24. * 3600) + 719163
     else:
         msg = "Option timestamp must be one of 'julsec', or 'mlabday'"
         raise ValueError(msg)


### PR DESCRIPTION
The numerical date used in matplotlib is days from 0001-01-01 + 1. Fixes #870.

Also, add date formatting on the beamforming example.