### PR TITLE
remove problematic `.__add__()` handling of custom float/complex types

### DIFF
--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -152,20 +152,10 @@ class CustomComplex(complex):
     def __init__(self, *args):
         pass
 
-    def __add__(self, other):
-        new = self.__class__(complex(self) + other)
-        new.__dict__.update(**self.__dict__)
-        return new
-
     def __iadd__(self, other):
         new = self.__class__(complex(self) + other)
         new.__dict__.update(**self.__dict__)
         self = new
-
-    def __mul__(self, other):
-        new = self.__class__(complex(self) * other)
-        new.__dict__.update(**self.__dict__)
-        return new
 
     def __imul__(self, other):
         new = self.__class__(complex(self) * other)
@@ -184,20 +174,10 @@ class CustomFloat(float):
     def __init__(self, *args):
         pass
 
-    def __add__(self, other):
-        new = self.__class__(float(self) + other)
-        new.__dict__.update(**self.__dict__)
-        return new
-
     def __iadd__(self, other):
         new = self.__class__(float(self) + other)
         new.__dict__.update(**self.__dict__)
         self = new
-
-    def __mul__(self, other):
-        new = self.__class__(float(self) * other)
-        new.__dict__.update(**self.__dict__)
-        return new
 
     def __imul__(self, other):
         new = self.__class__(float(self) * other)


### PR DESCRIPTION
I think we need to remove those `__add__` methods, they can interfere badly with computations on e.g. latitude values of events/stations...
```python
from obspy import readEvents, read_inventory
from urllib import urlopen
catalog = readEvents("https://raw.githubusercontent.com/obspy/docs/master/workshops/2014_mess/data/obspy/event_tohoku_mainshock.xml")
inventory = read_inventory(urlopen("https://raw.githubusercontent.com/obspy/docs/master/workshops/2014_mess/data/obspy/station_BFO.xml"), "STATIONXML")
from obspy.core.util.geodetics import gps2DistAzimuth
station = inventory[0][0]
event = catalog[0]
origin = event.origins[0]
print gps2DistAzimuth(origin.latitude, origin.longitude,
                      station.latitude, station.longitude)
```

One of these lines inside the geodetics routine makes problems because the derived values get again initilaized as a Latitude object and fall out of bounds (>180)..
```python
lat2 = lat2 * 2.0 * math.pi / 360.
```