### PR TITLE
set remote tracking branch in Travis..

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   - git status
   - git branch -vv
   - git remote -vv
+  # try to set correct remote tracking branch (to get branch info in version number of reports at tests.obspy.org)
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then GITHUB_LABEL=`python -c "from urllib import urlopen; import json; print(json.loads(urlopen(\"https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST\").read()).get('head').get('label'))"`; export GITHUB_FORK=`echo $GITHUB_LABEL | sed 's#:.*##'`; export GITHUB_REMOTE=${GITHUB_FORK}/obspy; export GITHUB_BRANCH=`echo $GITHUB_LABEL | sed 's#.*:##'`; else export GITHUB_REMOTE=$TRAVIS_REPO_SLUG; export GITHUB_BRANCH=$TRAVIS_BRANCH; export GITHUB_FORK=`echo $TRAVIS_REPO_SLUG | sed 's#/.*##'`; fi && git remote add $GITHUB_FORK git://github.com/$GITHUB_REMOTE && git fetch $GITHUB_FORK +refs/heads/$GITHUB_BRANCH && git checkout -b tested_branch && git branch --set-upstream-to=$GITHUB_FORK/$GITHUB_BRANCH
   - pip install --no-deps --use-mirrors .
   - git status
 script:


### PR DESCRIPTION
.. to get branch info in version number (so we see immediately what branch a test report at tests.obspy.org is coming from).