### PR TITLE
Simplistic seedlink client

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -109,7 +109,10 @@
      correctly (see #807)
    * New submodule `easyseedlink` providing an easier way to create
      SeedLink clients
-   * Fix MiniSEED record leak in packet parser (see #918)
+   * New `Client` class providing a basic seedlink client for individual
+     requests of finite time windows (i.e. non-continuous programs)
+   * Fix memory leak in `SLClient` (MiniSEED record leak in packet parser,
+     see #918)
  - obspy.seishub:
    * use specified timeout in all requests to server (see #786)
    * Helper method `Client.event.getEvents()` to fetch a `Catalog` object

--- a/misc/docs/source/packages/obspy.seedlink.rst
+++ b/misc/docs/source/packages/obspy.seedlink.rst
@@ -9,6 +9,8 @@
        :toctree: autogen
        :nosignatures:
 
+       ~basic_client.Client
+       ~easyseedlink.EasySeedLinkClient
        ~slclient.SLClient
        ~slpacket.SLPacket
        ~client.slnetstation.SLNetStation
@@ -23,6 +25,7 @@
        :toctree: autogen
        :nosignatures:
 
+       basic_client
        easyseedlink
        slclient
        slpacket

--- a/obspy/seedlink/__init__.py
+++ b/obspy/seedlink/__init__.py
@@ -6,8 +6,10 @@ obspy.seedlink - SeedLink client for ObsPy
 The obspy.seedlink module provides an implementation of the SeedLink client
 protocol for ObsPy.
 
-A higher level client is provided in the :mod:`obspy.seedlink.easyseedlink`
-module.
+For simple requests of finite time windows see
+:class:`~obspy.seedlink.basic_client.Client`. To work with continuous data
+streams see :class:`~obspy.seedlink.easyseedlink.EasySeedLinkClient`, or for
+lower-level packet handling see :class:`~obspy.seedlink.slclient.SLClient`.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org) & Anthony Lomax
@@ -26,6 +28,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+from .basic_client import Client  # NOQA
+from .slclient import SLClient  # NOQA
+from .easyseedlink import EasySeedLinkClient  # NOQA
 
 if __name__ == '__main__':
     import doctest

--- a/obspy/seedlink/basic_client.py
+++ b/obspy/seedlink/basic_client.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""
+SeedLink request client for ObsPy.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (http://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA @UnusedWildImport
+
+import warnings
+
+from obspy import Stream
+from obspy.seedlink.slclient import SLClient, SLPacket
+from obspy.seedlink.client.seedlinkconnection import SeedLinkConnection
+
+
+class Client(object):
+    """
+    SeedLink request client.
+
+    This client is intended for requests of specific, finite time windows.
+    To work with continuous realtime data streams please see
+    :class:`~obspy.seedlink.slclient.SLClient` and
+    :class:`~obspy.seedlink.easyseedlink.EasySeedLinkClient`.
+
+    :type server: str
+    :param server: Server name or IP address to connect to (e.g.
+        "localhost", "rtserver.ipgp.fr")
+    :type port: int
+    :param port: Port at which the seedlink server is operating (default is
+        `18000`).
+    :type timeout: float
+    :param timeout: Network timeout for low-level network connection in
+        seconds.
+    :type debug: bool
+    :param debug: Switches on debugging output.
+    """
+    def __init__(self, server, port=18000, timeout=20, debug=False):
+        """
+        Initializes the SeedLink request client.
+        """
+        self.timeout = timeout
+        self.debug = debug
+        self._slclient = SLClient(loglevel=debug and "DEBUG" or "CRITICAL")
+        self._server_url = "%s:%i" % (server, port)
+
+    def _connect(self):
+        """
+        Open new connection to seedlink server.
+        """
+        self._slclient.slconn = SeedLinkConnection()
+        self._slclient.slconn.setSLAddress(self._server_url)
+        self._slclient.slconn.netto = self.timeout
+
+    def get_waveform(self, network, station, location, channel, starttime,
+                     endtime):
+        """
+        Request waveform data from the seedlink server.
+
+        >>> from obspy import UTCDateTime
+        >>> client = Client('rtserver.ipgp.fr')
+        >>> t = UTCDateTime() - 3600
+        >>> client.get_waveform("G", "FDF", "00", "BHZ", t, t + 5)  # NOQA # doctest: +ELLIPSIS
+        <obspy.core.stream.Stream object at 0x...>
+
+        :type network: str
+        :param network: Network code. No wildcards supported.
+        :type station: str
+        :param station: Station code. No wildcards supported.
+        :type location: str
+        :param location: Location code. No wildcards supported.
+        :type channel: str
+        :param channel: Channel code. No wildcards supported.
+        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param starttime: Start time of requested time window.
+        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param endtime: End time of requested time window.
+        """
+        if len(location) > 2:
+            msg = ("Location code ('%s') only supports a maximum of 2 "
+                   "characters.") % location
+            raise ValueError(msg)
+        elif len(location) == 1:
+            msg = "Single character location codes are untested."
+            warnings.warn(msg)
+        if location:
+            loccha = "%2s%3s" % (location, channel)
+        else:
+            loccha = channel
+        seedlink_id = "%s_%s:%s" % (network, station, loccha)
+        self._slclient.multiselect = seedlink_id
+        self._slclient.begin_time = starttime
+        self._slclient.end_time = endtime
+        self._connect()
+        self._slclient.initialize()
+        self.stream = Stream()
+        self._slclient.run(packet_handler=self._packet_handler)
+        stream = self.stream
+        stream.trim(starttime, endtime)
+        self.stream = None
+        return stream
+
+    def _packet_handler(self, count, slpack):
+        """
+        Custom packet handler that accumulates all waveform packets in a
+        stream.
+        """
+        # check if not a complete packet
+        if slpack is None or (slpack == SLPacket.SLNOPACKET) or \
+                (slpack == SLPacket.SLERROR):
+            return False
+
+        # get basic packet info
+        type_ = slpack.getType()
+        if self.debug:
+            print(type_)
+
+        # process INFO packets here
+        if type_ == SLPacket.TYPE_SLINF:
+            if self.debug:
+                print(SLPacket.TYPE_SLINF)
+            return False
+        elif type_ == SLPacket.TYPE_SLINFT:
+            if self.debug:
+                print("Complete INFO:" + self.slconn.getInfoString())
+            return False
+
+        # process packet data
+        trace = slpack.getTrace()
+        if trace is None:
+            if self.debug:
+                print("Blockette contains no trace")
+            return False
+
+        # new samples add to the main stream which is then trimmed
+        self.stream += trace
+        self.stream.merge(-1)
+        return False
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod(exclude_empty=True)

--- a/obspy/seedlink/slclient.py
+++ b/obspy/seedlink/slclient.py
@@ -217,10 +217,20 @@ class SLClient(object):
             if self.end_time is not None:
                 self.slconn.setEndTime(self.end_time)
 
-    def run(self):
+    def run(self, packet_handler=None):
         """
         Start this SLClient.
+
+        :type packet_handler: func
+        :param packet_handler: Custom packet handler funtion to override
+            `self.packetHandler` for this seedlink request. The function will
+            be repeatedly called with two arguments: the current packet counter
+            (`int`) and the currently served seedlink packet
+            (:class:`~obspy.seedlink.SLPacket`). The function should return
+            `True` to abort the request or `False` to continue the request.
         """
+        if packet_handler is None:
+            packet_handler = self.packetHandler
         if self.infolevel is not None:
             self.slconn.requestInfo(self.infolevel)
         # Loop with the connection manager
@@ -231,7 +241,7 @@ class SLClient(object):
                 break
             try:
                 # do something with packet
-                terminate = self.packetHandler(count, slpack)
+                terminate = packet_handler(count, slpack)
                 if terminate:
                     break
             except SeedLinkException as sle:

--- a/obspy/seedlink/tests/test_basic_client.py
+++ b/obspy/seedlink/tests/test_basic_client.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+The obspy.seedlink.basic_client test suite.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+from obspy import UTCDateTime
+from obspy.seedlink.basic_client import Client
+
+
+class ClientTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = Client("rtserver.ipgp.fr")
+
+    def test_get_waveform(self):
+        t = UTCDateTime() - 3600
+        for request in [["G", "FDF", "00", "LHN", t, t + 20],
+                        ["G", "CLF", "00", "BHZ", t, t + 10]]:
+            st = self.client.get_waveform(*request)
+            self.assertTrue(len(st) > 0)
+            for tr in st:
+                self.assertEqual(tr.id, ".".join(request[:4]))
+            self.assertTrue(any([len(tr) > 0 for tr in st]))
+            st.merge(1)
+            self.assertTrue(abs(tr.stats.starttime - request[4]) < 1)
+            self.assertTrue(abs(tr.stats.endtime - request[5]) < 1)
+
+
+def suite():
+    return unittest.makeSuite(ClientTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
.. that implements the usual `Client.get_waveform(net, sta, loc, cha, start, end)` routine for quick and easy requesting of finite time windows via seedlink.

Although this might be adding to the confusion in `obspy.seedlink` I think this might be useful as it covers a different use case (simple requests of finite time windows) than the existing client structures (oriented at more complex use cases, especially working on continuous data streams).

e.g.
```python
>>> from obspy import UTCDateTime
>>> from obspy.seedlink import Client
>>> client = Client('rtserver.ipgp.fr')
>>> t = UTCDateTime() - 3600
>>> client.get_waveform("G", "FDF", "00", "BHZ", t, t + 5)
<obspy.core.stream.Stream object at 0x...>
```

Would still need more docs..