### PR TITLE
Handle non-UTF8 encoding in MoPaD tests better.

### DIFF
--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -4087,10 +4087,11 @@ def main(argv=None):
         # if total decomposition:
         if kwargs_dict['decomp_out_complete']:
             if kwargs_dict['decomp_out_fancy']:
+                decomp = MT.get_full_decomposition()
                 try:
-                    print(MT.get_full_decomposition())
+                    print(decomp)
                 except:
-                    print(MT.get_full_decomposition().encode("utf-8"))
+                    print(decomp.encode('utf-8'))
                 return
             else:
                 return MT.get_decomposition(in_system=kwargs_dict['in_system'],
@@ -5193,7 +5194,7 @@ The 'source mechanism' as a comma-separated list of length:
         try:
             print(aa)
         except:
-            print(aa.encode("utf-8"))
+            print(aa.encode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -44,11 +44,17 @@ class MopadTestCase(unittest.TestCase):
         expected = '''
 Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
-
 '''
+        expected = expected.encode('utf-8')
 
-        self.assertEqual(expected.encode("utf-8"),
-                         out.stdout)
+        result = out.stdout[:-1]
+        if result.startswith(b'b'):
+            # Total mojibake when the system is configured strangely. Mostly
+            # only occurs when building packages, so that LANG=C, and Python
+            # picks ASCII for output encoding.
+            expected = str(expected).encode('ascii')
+
+        self.assertEqual(expected, result)
 
     def test_script_convert_type_tensor(self):
         with CatchOutput() as out:
@@ -145,11 +151,17 @@ Moment Tensor: Mnn =  0.091,  Mee = -0.089, Mdd = -0.002,
 
 Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
-
 '''
+        expected = expected.encode('utf-8')
 
-        self.assertEqual(expected.encode("utf-8"),
-                         out.stdout)
+        result = out.stdout[:-1]
+        if result.startswith(b'b'):
+            # Total mojibake when the system is configured strangely. Mostly
+            # only occurs when building packages, so that LANG=C, and Python
+            # picks ASCII for output encoding.
+            expected = str(expected).encode('ascii')
+
+        self.assertEqual(expected, result)
 
     #
     # obspy-mopad gmt


### PR DESCRIPTION
`print()` will do the necessary encoding itself. If you encode it before-hand, you get printing of byte strings, which will be wrapped in `b''` and have escaped bytes.

I'm not sure if this affects Windows (hence the PR), but everywhere else with UTF-8 should print correctly.