### PR TITLE
obspy.earthworm client times out on Py3.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 releases:
- - fixing python3 compatibility for seedlink.easyseedlink
+ - obspy.earthworm
+   * Fix Python3 compatibility problem
+ - obspy.seedlink:
+   * Fix Python3 compatibility for seedlink.easyseedlink
 
 0.10.1: (doi: 10.5281/zenodo.16248)
  - minor changes for correct distribution of official release

--- a/obspy/earthworm/__init__.py
+++ b/obspy/earthworm/__init__.py
@@ -12,32 +12,32 @@ obspy.earthworm - Earthworm Wave Server client for ObsPy.
 Basic Usage
 -----------
 (1) :meth:`~obspy.earthworm.client.Client.getWaveform()`: The following example
-    illustrates how to request and plot 30 seconds of all three broadband
-    channels (``"BH*"``) of station ``"TUCA"`` of the `Pacific Northwest
-    Seismic Network <http://pnsn.org/>`_ (``"UW"``).
+    illustrates how to request and plot 30 seconds of all three short period
+    channels (``"EH*"``) of station ``"ACH"`` of the `Alaska Volcano
+    Observatory <https://www.avo.alaska.edu/>`_ (``"AV"``).
 
     >>> from obspy.earthworm import Client
-    >>> client = Client("pele.ess.washington.edu", 16017)
-    >>> response = client.availability("UW", "TUCA", channel="BHZ")
-    >>> print response  # doctest: +SKIP
-    [('UW',
-      'TUCA',
+    >>> client = Client("pubavo1.wr.usgs.gov", 16022)
+    >>> response = client.availability('AV', 'ACH', channel='EHE')
+    >>> print(response)  # doctest: +SKIP
+    [('AV',
+      'ACH',
       '--',
-      'BHZ',
-      UTCDateTime(2011, 11, 27, 0, 0, 0, 525000),
-      UTCDateTime(2011, 12, 29, 20, 50, 31, 525000))]
+      'EHE',
+      UTCDateTime(2015, 1, 22, 7, 26, 32, 679000),
+      UTCDateTime(2015, 3, 23, 7, 26, 29, 919966)]
     >>> t = response[0][4]
-    >>> st = client.getWaveform('UW', 'TUCA', '', 'BH*', t + 100, t + 130)
+    >>> st = client.getWaveform('AV', 'ACH', '--', 'EH*', t + 100, t + 130)
     >>> st.plot()  # doctest: +SKIP
 
     .. plot::
 
         from obspy.earthworm import Client
         from obspy import UTCDateTime
-        client = Client("pele.ess.washington.edu", 16017, timeout=5)
-        response = client.availability("UW", "TUCA", channel="BHZ")
+        client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
+        response = client.availability('AV', 'ACH', channel='EHE')
         t = response[0][4]
-        st = client.getWaveform('UW', 'TUCA', '', 'BH*', t + 100, t + 130)
+        st = client.getWaveform('AV', 'ACH', '--', 'EH*', t + 100, t + 130)
         st.plot()
 """
 from __future__ import (absolute_import, division, print_function,

--- a/obspy/earthworm/client.py
+++ b/obspy/earthworm/client.py
@@ -79,9 +79,9 @@ class Client(object):
         >>> from obspy.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
         >>> dt = UTCDateTime() - 2000  # now - 2000 seconds
-        >>> st = client.getWaveform('AV', 'ACH', '--', 'EHE', dt, dt + 10)
+        >>> st = client.getWaveform('AV', 'ACH', '', 'EHE', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
-        >>> st = client.getWaveform('AV', 'ACH', '--', 'EH*', dt, dt + 10)
+        >>> st = client.getWaveform('AV', 'ACH', '', 'EH*', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
 
         .. plot::
@@ -90,9 +90,9 @@ class Client(object):
             from obspy import UTCDateTime
             client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
             dt = UTCDateTime() - 2000  # now - 2000 seconds
-            st = client.getWaveform('AV', 'ACH', '--', 'EHE', dt, dt + 10)
+            st = client.getWaveform('AV', 'ACH', '', 'EHE', dt, dt + 10)
             st.plot()
-            st = client.getWaveform('AV', 'ACH', '--', 'EH*', dt, dt + 10)
+            st = client.getWaveform('AV', 'ACH', '', 'EH*', dt, dt + 10)
             st.plot()
         """
         # replace wildcards in last char of channel and fetch all 3 components
@@ -158,7 +158,7 @@ class Client(object):
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
         >>> t = UTCDateTime() - 2000  # now - 2000 seconds
         >>> client.saveWaveform('AV.ACH.--.EHE.mseed',
-        ...                     'AV', 'ACH', '--', 'EHE',
+        ...                     'AV', 'ACH', '', 'EHE',
         ...                     t, t + 10, format='MSEED')  # doctest: +SKIP
         """
         st = self.getWaveform(network, station, location, channel, starttime,
@@ -180,7 +180,6 @@ class Client(object):
         :param station: Station code, e.g. ``'TUCA'``, wildcards allowed.
         :type location: str
         :param location: Location code, e.g. ``'--'``, wildcards allowed.
-            Use ``'--'`` for empty location codes.
         :type channel: str
         :param channel: Channel code, e.g. ``'BHZ'``, wildcards allowed.
         :rtype: list
@@ -216,6 +215,8 @@ class Client(object):
           UTCDateTime(...))]
         """
         # build up possibly wildcarded trace id pattern for query
+        if location == '':
+            location = '--'
         pattern = ".".join((network, station, location, channel))
         # get overview of all available data, winston wave servers can not
         # restrict the query via network, station etc. so we do that manually

--- a/obspy/earthworm/client.py
+++ b/obspy/earthworm/client.py
@@ -77,22 +77,22 @@ class Client(object):
         .. rubric:: Example
 
         >>> from obspy.earthworm import Client
-        >>> client = Client("pele.ess.washington.edu", 16017)
-        >>> dt = UTCDateTime(2013, 1, 17) - 2000  # now - 2000 seconds
-        >>> st = client.getWaveform('UW', 'TUCA', '', 'BHZ', dt, dt + 10)
+        >>> client = Client("pubavo1.wr.usgs.gov", 16022)
+        >>> dt = UTCDateTime() - 2000  # now - 2000 seconds
+        >>> st = client.getWaveform('AV', 'ACH', '--', 'EHE', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
-        >>> st = client.getWaveform('UW', 'TUCA', '', 'BH*', dt, dt + 10)
+        >>> st = client.getWaveform('AV', 'ACH', '--', 'EH*', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
 
         .. plot::
 
             from obspy.earthworm import Client
             from obspy import UTCDateTime
-            client = Client("pele.ess.washington.edu", 16017, timeout=5)
-            dt = UTCDateTime(2013, 1, 17) - 2000  # now - 2000 seconds
-            st = client.getWaveform('UW', 'TUCA', '', 'BHZ', dt, dt + 10)
+            client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
+            dt = UTCDateTime() - 2000  # now - 2000 seconds
+            st = client.getWaveform('AV', 'ACH', '--', 'EHE', dt, dt + 10)
             st.plot()
-            st = client.getWaveform('UW', 'TUCA', '', 'BH*', dt, dt + 10)
+            st = client.getWaveform('AV', 'ACH', '--', 'EH*', dt, dt + 10)
             st.plot()
         """
         # replace wildcards in last char of channel and fetch all 3 components
@@ -155,9 +155,10 @@ class Client(object):
         .. rubric:: Example
 
         >>> from obspy.earthworm import Client
-        >>> client = Client("pele.ess.washington.edu", 16017)
+        >>> client = Client("pubavo1.wr.usgs.gov", 16022)
         >>> t = UTCDateTime() - 2000  # now - 2000 seconds
-        >>> client.saveWaveform('UW.TUCA..BHZ.mseed', 'UW', 'TUCA', '', 'BHZ',
+        >>> client.saveWaveform('AV.ACH.--.EHE.mseed',
+        ...                     'AV', 'ACH', '--', 'EHE',
         ...                     t, t + 10, format='MSEED')  # doctest: +SKIP
         """
         st = self.getWaveform(network, station, location, channel, starttime,
@@ -191,28 +192,28 @@ class Client(object):
         .. rubric:: Example
 
         >>> from obspy.earthworm import Client
-        >>> client = Client("pele.ess.washington.edu", 16017, timeout=5)
-        >>> response = client.availability(network="UW", station="TUCA",
-        ...         channel="BH*")
-        >>> print(response)  # doctest: +SKIP
-        [('UW',
-          'TUCA',
+        >>> client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
+        >>> response = client.availability(network="AV", station="ACH",
+        ...                                channel="EH*")
+        >>> print(response)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+        [('AV',
+          'ACH',
           '--',
-          'BHE',
-          UTCDateTime(2011, 11, 27, 0, 0, 0, 525000),
-          UTCDateTime(2011, 12, 29, 20, 50, 31, 525000)),
-         ('UW',
-          'TUCA',
+          'EHE',
+          UTCDateTime(...),
+          UTCDateTime(...)),
+         ('AV',
+          'ACH',
           '--',
-          'BHN',
-          UTCDateTime(2011, 11, 27, 0, 0, 0, 525000),
-          UTCDateTime(2011, 12, 29, 20, 50, 31, 525000)),
-         ('UW',
-          'TUCA',
+          'EHN',
+          UTCDateTime(...),
+          UTCDateTime(...)),
+         ('AV',
+          'ACH',
           '--',
-          'BHZ',
-          UTCDateTime(2011, 11, 27, 0, 0, 0, 525000),
-          UTCDateTime(2011, 12, 29, 20, 50, 31, 525000))]
+          'EHZ',
+          UTCDateTime(...),
+          UTCDateTime(...))]
         """
         # build up possibly wildcarded trace id pattern for query
         pattern = ".".join((network, station, location, channel))

--- a/obspy/earthworm/tests/test_client.py
+++ b/obspy/earthworm/tests/test_client.py
@@ -44,7 +44,7 @@ class ClientTestCase(unittest.TestCase):
         start = UTCDateTime() - 3600
         end = start + 1.0
         # example 1 -- 1 channel, cleanup
-        stream = client.getWaveform('AV', 'ACH', '--', 'EHE', start, end)
+        stream = client.getWaveform('AV', 'ACH', '', 'EHE', start, end)
         self.assertEqual(len(stream), 1)
         delta = stream[0].stats.delta
         trace = stream[0]
@@ -58,7 +58,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(trace.stats.location, '')
         self.assertEqual(trace.stats.channel, 'EHE')
         # example 2 -- 1 channel, no cleanup
-        stream = client.getWaveform('AV', 'ACH', '--', 'EHE', start, end,
+        stream = client.getWaveform('AV', 'ACH', '', 'EHE', start, end,
                                     cleanup=False)
         self.assertTrue(len(stream) >= 2)
         summed_length = sum(len(tr) for tr in stream)
@@ -73,7 +73,7 @@ class ClientTestCase(unittest.TestCase):
             self.assertEqual(trace.stats.location, '')
             self.assertEqual(trace.stats.channel, 'EHE')
         # example 3 -- component wildcarded with '?'
-        stream = client.getWaveform('AV', 'ACH', '--', 'EH?', start, end)
+        stream = client.getWaveform('AV', 'ACH', '', 'EH?', start, end)
         self.assertEqual(len(stream), 3)
         for trace in stream:
             self.assertEqual(len(trace), 101)
@@ -100,7 +100,7 @@ class ClientTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             testfile = tf.name
             # 1 channel, cleanup (using SLIST to avoid dependencies)
-            client.saveWaveform(testfile, 'AV', 'ACH', '--', 'EHE', start, end,
+            client.saveWaveform(testfile, 'AV', 'ACH', '', 'EHE', start, end,
                                 format="SLIST")
             stream = read(testfile)
         self.assertEqual(len(stream), 1)

--- a/obspy/earthworm/tests/test_client.py
+++ b/obspy/earthworm/tests/test_client.py
@@ -22,11 +22,18 @@ class ClientTestCase(unittest.TestCase):
     def setUp(self):
         # Monkey patch: set lower default precision of all UTCDateTime objects
         UTCDateTime.DEFAULT_PRECISION = 4
-        self.client = Client("pele.ess.washington.edu", 16017, timeout=7)
+        self.client = Client("pubavo1.wr.usgs.gov", 16022, timeout=30.0)
 
     def tearDown(self):
         # restore default precision of all UTCDateTime objects
         UTCDateTime.DEFAULT_PRECISION = 6
+
+    @skip_on_network_error
+    def test_availability(self):
+        data = self.client.availability()
+        seeds = ["%s.%s.%s.%s" % (net, sta, loc, cha)
+                 for net, sta, loc, cha, _start, _stop in data]
+        self.assertTrue('AV.ACH.--.EHE' in seeds)
 
     @skip_on_network_error
     def test_getWaveform(self):
@@ -34,52 +41,52 @@ class ClientTestCase(unittest.TestCase):
         Tests getWaveform method.
         """
         client = self.client
-        start = UTCDateTime(2013, 1, 17)
-        end = start + 30
+        start = UTCDateTime(2015, 3, 22)
+        end = start + 1.0
         # example 1 -- 1 channel, cleanup
-        stream = client.getWaveform('UW', 'TUCA', '', 'BHZ', start, end)
+        stream = client.getWaveform('AV', 'ACH', '--', 'EHE', start, end)
         self.assertEqual(len(stream), 1)
         delta = stream[0].stats.delta
         trace = stream[0]
-        self.assertTrue(len(trace) == 1201)
+        self.assertEqual(len(trace), 101)
         self.assertTrue(trace.stats.starttime >= start - delta)
         self.assertTrue(trace.stats.starttime <= start + delta)
         self.assertTrue(trace.stats.endtime >= end - delta)
         self.assertTrue(trace.stats.endtime <= end + delta)
-        self.assertEqual(trace.stats.network, 'UW')
-        self.assertEqual(trace.stats.station, 'TUCA')
+        self.assertEqual(trace.stats.network, 'AV')
+        self.assertEqual(trace.stats.station, 'ACH')
         self.assertEqual(trace.stats.location, '')
-        self.assertEqual(trace.stats.channel, 'BHZ')
+        self.assertEqual(trace.stats.channel, 'EHE')
         # example 2 -- 1 channel, no cleanup
-        stream = client.getWaveform('UW', 'TUCA', '', 'BHZ', start, end,
+        stream = client.getWaveform('AV', 'ACH', '--', 'EHE', start, end,
                                     cleanup=False)
         self.assertTrue(len(stream) >= 2)
         summed_length = sum(len(tr) for tr in stream)
-        self.assertTrue(summed_length == 1201)
+        self.assertEqual(summed_length, 101)
         self.assertTrue(stream[0].stats.starttime >= start - delta)
         self.assertTrue(stream[0].stats.starttime <= start + delta)
         self.assertTrue(stream[-1].stats.endtime >= end - delta)
         self.assertTrue(stream[-1].stats.endtime <= end + delta)
         for trace in stream:
-            self.assertEqual(trace.stats.network, 'UW')
-            self.assertEqual(trace.stats.station, 'TUCA')
+            self.assertEqual(trace.stats.network, 'AV')
+            self.assertEqual(trace.stats.station, 'ACH')
             self.assertEqual(trace.stats.location, '')
-            self.assertEqual(trace.stats.channel, 'BHZ')
+            self.assertEqual(trace.stats.channel, 'EHE')
         # example 3 -- component wildcarded with '?'
-        stream = client.getWaveform('UW', 'TUCA', '', 'BH?', start, end)
+        stream = client.getWaveform('AV', 'ACH', '--', 'EH?', start, end)
         self.assertEqual(len(stream), 3)
         for trace in stream:
-            self.assertTrue(len(trace) == 1201)
+            self.assertEqual(len(trace), 101)
             self.assertTrue(trace.stats.starttime >= start - delta)
             self.assertTrue(trace.stats.starttime <= start + delta)
             self.assertTrue(trace.stats.endtime >= end - delta)
             self.assertTrue(trace.stats.endtime <= end + delta)
-            self.assertEqual(trace.stats.network, 'UW')
-            self.assertEqual(trace.stats.station, 'TUCA')
+            self.assertEqual(trace.stats.network, 'AV')
+            self.assertEqual(trace.stats.station, 'ACH')
             self.assertEqual(trace.stats.location, '')
-        self.assertEqual(stream[0].stats.channel, 'BHZ')
-        self.assertEqual(stream[1].stats.channel, 'BHN')
-        self.assertEqual(stream[2].stats.channel, 'BHE')
+        self.assertEqual(stream[0].stats.channel, 'EHZ')
+        self.assertEqual(stream[1].stats.channel, 'EHN')
+        self.assertEqual(stream[2].stats.channel, 'EHE')
 
     @skip_on_network_error
     def test_saveWaveform(self):
@@ -88,60 +95,30 @@ class ClientTestCase(unittest.TestCase):
         """
         # initialize client
         client = self.client
-        start = UTCDateTime(2013, 1, 17)
-        end = start + 30
+        start = UTCDateTime(2015, 3, 22)
+        end = start + 1.0
         with NamedTemporaryFile() as tf:
             testfile = tf.name
             # 1 channel, cleanup (using SLIST to avoid dependencies)
-            client.saveWaveform(testfile, 'UW', 'TUCA', '', 'BHZ', start, end,
+            client.saveWaveform(testfile, 'AV', 'ACH', '--', 'EHE', start, end,
                                 format="SLIST")
             stream = read(testfile)
         self.assertEqual(len(stream), 1)
         delta = stream[0].stats.delta
         trace = stream[0]
-        self.assertTrue(len(trace) == 1201)
+        self.assertEqual(len(trace), 101)
         self.assertTrue(trace.stats.starttime >= start - delta)
         self.assertTrue(trace.stats.starttime <= start + delta)
         self.assertTrue(trace.stats.endtime >= end - delta)
         self.assertTrue(trace.stats.endtime <= end + delta)
-        self.assertEqual(trace.stats.network, 'UW')
-        self.assertEqual(trace.stats.station, 'TUCA')
+        self.assertEqual(trace.stats.network, 'AV')
+        self.assertEqual(trace.stats.station, 'ACH')
         self.assertEqual(trace.stats.location, '')
-        self.assertEqual(trace.stats.channel, 'BHZ')
-
-    @skip_on_network_error
-    def test_availability(self):
-        data = self.client.availability()
-        seeds = ["%s.%s.%s.%s" % (d[0], d[1], d[2], d[3]) for d in data]
-        self.assertTrue('UW.TUCA.--.BHZ' in seeds)
-
-
-class ClientUSGSTestCase(unittest.TestCase):
-    """
-    Minimal test suite using an alternative wave server located at
-    pubavo1.wr.usgs.gov:16022
-    """
-    def setUp(self):
-        # Monkey patch: set lower default precision of all UTCDateTime objects
-        UTCDateTime.DEFAULT_PRECISION = 4
-        self.client = Client("pubavo1.wr.usgs.gov", 16022, timeout=30.0)
-
-    def tearDown(self):
-        # restore default precision of all UTCDateTime objects
-        UTCDateTime.DEFAULT_PRECISION = 6
-
-    @skip_on_network_error
-    def test_availabilityAndGetWaveform(self):
-        response = self.client.availability("AV", "ACH", channel="EHE")
-        self.assertGreaterEqual(len(response), 1)
-        t = UTCDateTime()
-        st = self.client.getWaveform('AV', 'ACH', '--', 'EHE', t - 120, t - 60)
-        self.assertGreaterEqual(len(st), 1)
+        self.assertEqual(trace.stats.channel, 'EHE')
 
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(ClientUSGSTestCase, 'test'))
     suite.addTest(unittest.makeSuite(ClientTestCase, 'test'))
     return suite
 

--- a/obspy/earthworm/tests/test_client.py
+++ b/obspy/earthworm/tests/test_client.py
@@ -41,7 +41,7 @@ class ClientTestCase(unittest.TestCase):
         Tests getWaveform method.
         """
         client = self.client
-        start = UTCDateTime(2015, 3, 22)
+        start = UTCDateTime() - 3600
         end = start + 1.0
         # example 1 -- 1 channel, cleanup
         stream = client.getWaveform('AV', 'ACH', '--', 'EHE', start, end)
@@ -95,7 +95,7 @@ class ClientTestCase(unittest.TestCase):
         """
         # initialize client
         client = self.client
-        start = UTCDateTime(2015, 3, 22)
+        start = UTCDateTime() - 3600
         end = start + 1.0
         with NamedTemporaryFile() as tf:
             testfile = tf.name

--- a/obspy/earthworm/waveserver.py
+++ b/obspy/earthworm/waveserver.py
@@ -150,7 +150,7 @@ def getSockCharLine(sock, timeout=10.):
     chunks = []
     indat = b'^'
     try:
-        while indat[-1] != b'\n':
+        while indat[-1:] != b'\n':
             # see http://obspy.org/ticket/383
             # indat = sock.recv(8192)
             indat = sock.recv(1)

--- a/obspy/earthworm/waveserver.py
+++ b/obspy/earthworm/waveserver.py
@@ -215,9 +215,9 @@ def getMenu(server, port, scnl=None, timeout=None):
         if flag in ['FN', 'FC', 'FU']:
             print('request returned %s - %s' % (flag, RETURNFLAG_KEY[flag]))
             return []
-        if tokens[7] in DATATYPE_KEY:
+        if tokens[7].encode() in DATATYPE_KEY:
             elen = 8  # length of return entry if location included
-        elif tokens[6] in DATATYPE_KEY:
+        elif tokens[6].encode() in DATATYPE_KEY:
             elen = 7  # length of return entry if location omitted
         else:
             print('no type token found in getMenu')


### PR DESCRIPTION
Okay this one is a follow up on  #989, which fixed Py2 behavior. Py3 still fails with a timeout:
```
petr% python3.4 ./test-ew.py
socket timeout in getSockCharLine()
socket timeout in getSockCharLine()
 ```
I also checked the public server I indicated earlier. It should be available on `pubavo1.wr.usgs.gov:16022`. A minimal connection test can be performed with telnet, the request `MENU: 0` should provide a sort of inventory. This is what I obtain:
```
petr% telnet pubavo1.wr.usgs.gov 16022
Trying 130.118.181.39...
Connected to pubavo1.wr.usgs.gov.
Escape character is '^]'.
MENU: 0
  239 ACH EHE AV 1421685777.065 1426869775.0500011 s4  76 ACH EHN AV 1421685777.065 1426869774.0500011 s4  74 ACH EHZ AV 1421685777.065 1
[...]
```
