### PR TITLE
Make sure old imports still work

### DIFF
--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -33,8 +33,6 @@ from future.builtins import *  # NOQA
 from future.utils import PY2, native_str
 
 import imp
-import importlib
-from types import ModuleType
 import warnings
 import sys
 

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -40,8 +40,9 @@ import sys
 
 # don't change order
 from obspy.core.utcdatetime import UTCDateTime  # NOQA
-from obspy.core.util import (_getVersionString, ObsPyDeprecationWarning,
-                             DynamicAttributeImportRerouteModule)
+from obspy.core.util import _getVersionString
+from obspy.core.util.deprecation_helpers import (
+    ObsPyDeprecationWarning, DynamicAttributeImportRerouteModule)
 __version__ = _getVersionString(abbrev=10)
 from obspy.core.trace import Trace  # NOQA
 from obspy.core.stream import Stream, read

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -33,17 +33,21 @@ from future.builtins import *  # NOQA
 from future.utils import PY2, native_str
 
 import imp
+import importlib
+from types import ModuleType
 import warnings
 import sys
 
 # don't change order
 from obspy.core.utcdatetime import UTCDateTime  # NOQA
-from obspy.core.util import _getVersionString
+from obspy.core.util import (_getVersionString, ObsPyDeprecationWarning,
+                             DynamicAttributeImportRerouteModule)
 __version__ = _getVersionString(abbrev=10)
 from obspy.core.trace import Trace  # NOQA
 from obspy.core.stream import Stream, read
 from obspy.core.event import readEvents, Catalog
 from obspy.core.inventory import read_inventory  # NOQA
+
 
 # insert supported read/write format plugin lists dynamically in docstrings
 from obspy.core.util.base import make_format_plugin_table
@@ -73,12 +77,48 @@ __all__ = ["UTCDateTime", "Trace", "__version__", "Stream", "read",
 __all__ = [native_str(i) for i in __all__]
 
 
-class ObsPyDeprecationWarning(UserWarning):
-    """
-    Make a custom deprecation warning as deprecation warnings or hidden by
-    default since Python 2.7 and 3.2 and we really want users to notice these.
-    """
-    pass
+# Maps all imports to their new imports.
+_import_map = {
+    # I/O modules
+    "obspy.ah": "obspy.io.ah",
+    "obspy.cnv": "obspy.io.cnv",
+    "obspy.css": "obspy.io.css",
+    "obspy.datamark": "obspy.io.datamark",
+    "obspy.gse2": "obspy.io.gse2",
+    "obspy.kinemetrics": "obspy.io.kinemetrics",
+    "obspy.mseed": "obspy.io.mseed",
+    "obspy.ndk": "obspy.io.ndk",
+    "obspy.nlloc": "obspy.io.nlloc",
+    "obspy.pdas": "obspy.io.pdas",
+    "obspy.pde": "obspy.io.pde",
+    "obspy.sac": "obspy.io.sac",
+    "obspy.seg2": "obspy.io.seg2",
+    "obspy.segy": "obspy.io.segy",
+    "obspy.seisan": "obspy.io.seisan",
+    "obspy.sh": "obspy.io.sh",
+    "obspy.wav": "obspy.io.wav",
+    "obspy.xseed": "obspy.io.xseed",
+    "obspy.y": "obspy.io.y",
+    "obspy.zmap": "obspy.io.zmap",
+    # Clients
+    "obspy.arclink": "obspy.clients.arclink",
+    "obspy.earthworm": "obspy.clients.earthworm",
+    "obspy.fdsn": "obspy.clients.fdsn",
+    "obspy.iris": "obspy.clients.iris",
+    "obspy.neic": "obspy.clients.neic",
+    "obspy.neries": "obspy.clients.neries",
+    "obspy.seedlink": "obspy.clients.seedlink",
+    "obspy.seishub": "obspy.clients.seishub",
+    # geodetics
+    "obspy.core.util.geodetics": "obspy.geodetics",
+    # obspy.station
+    "obspy.station": "obspy.core.inventory",
+    # Misc modules originally in core.
+    "obspy.core.ascii": "obspy.io.ascii",
+    "obspy.core.quakeml": "obspy.io.quakeml",
+    "obspy.core.stationxml": "obspy.io.stationxml",
+    "obspy.core.json": "obspy.io.json"
+}
 
 
 class ObsPyRestructureMetaPathFinderAndLoader(object):
@@ -88,54 +128,11 @@ class ObsPyRestructureMetaPathFinderAndLoader(object):
 
     Make sure to remove this once 0.11 has been released!
     """
-    # Maps all imports to their new imports.
-    import_map = {
-        # I/O modules
-        "obspy.ah": "obspy.io.ah",
-        "obspy.cnv": "obspy.io.cnv",
-        "obspy.css": "obspy.io.css",
-        "obspy.datamark": "obspy.io.datamark",
-        "obspy.gse2": "obspy.io.gse2",
-        "obspy.kinemetrics": "obspy.io.kinemetrics",
-        "obspy.mseed": "obspy.io.mseed",
-        "obspy.ndk": "obspy.io.ndk",
-        "obspy.nlloc": "obspy.io.nlloc",
-        "obspy.pdas": "obspy.io.pdas",
-        "obspy.pde": "obspy.io.pde",
-        "obspy.sac": "obspy.io.sac",
-        "obspy.seg2": "obspy.io.seg2",
-        "obspy.segy": "obspy.io.segy",
-        "obspy.seisan": "obspy.io.seisan",
-        "obspy.sh": "obspy.io.sh",
-        "obspy.wav": "obspy.io.wav",
-        "obspy.xseed": "obspy.io.xseed",
-        "obspy.y": "obspy.io.y",
-        "obspy.zmap": "obspy.io.zmap",
-        # Clients
-        "obspy.arclink": "obspy.io.arclink",
-        "obspy.earthworm": "obspy.io.earthworm",
-        "obspy.fdsn": "obspy.io.fdsn",
-        "obspy.iris": "obspy.io.iris",
-        "obspy.neic": "obspy.io.neic",
-        "obspy.neries": "obspy.io.neries",
-        "obspy.seedlink": "obspy.io.seedlink",
-        "obspy.seishub": "obspy.io.seishub",
-        # geodetics
-        "obspy.core.util.geodetics": "obspy.geodetics",
-        # obspy.station
-        "obspy.station": "obspy.core.inventory",
-        # Misc modules originally in core.
-        "obspy.core.ascii": "obspy.io.ascii",
-        "obspy.core.quakeml": "obspy.io.quakeml",
-        "obspy.core.stationxml": "obspy.io.stationml",
-        "obspy.core.json": "obspy.io.json"
-    }
-
     def find_module(self, fullname, path=None):
         if not path or not path[0].startswith(__path__[0]):
             return None
 
-        for key in self.import_map.keys():
+        for key in _import_map.keys():
             if fullname.startswith(key):
                 break
         else:
@@ -148,8 +145,8 @@ class ObsPyRestructureMetaPathFinderAndLoader(object):
         if name in sys.modules:
             return sys.modules[name]
         # Otherwise check if the name is part of the import map.
-        elif name in self.import_map:
-            new_name = self.import_map[name]
+        elif name in _import_map:
+            new_name = _import_map[name]
 
             # Don't load again if already loaded.
             if new_name in sys.modules:
@@ -200,6 +197,13 @@ class ObsPyRestructureMetaPathFinderAndLoader(object):
 
 # Install meta path handler.
 sys.meta_path.append(ObsPyRestructureMetaPathFinderAndLoader())
+
+
+# Remove once 0.11 has been released.
+sys.modules[__name__] = DynamicAttributeImportRerouteModule(
+    name=__name__, doc=__doc__, locs=locals(),
+    import_map={key.split(".")[1]: value for key, value in
+                _import_map.items() if len(key.split(".")) == 2})
 
 
 if __name__ == '__main__':

--- a/obspy/clients/seedlink/easyseedlink.py
+++ b/obspy/clients/seedlink/easyseedlink.py
@@ -56,7 +56,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import urlparse
+from future import standard_library
+with standard_library.hooks():
+    import urllib.parse
 
 import lxml
 
@@ -138,7 +140,7 @@ class EasySeedLinkClient(object):
         if '://' not in server_url and not server_url.startswith('//'):
             server_url = '//' + server_url
 
-        parsed_url = urlparse.urlparse(server_url, scheme='seedlink')
+        parsed_url = urllib.parse.urlparse(server_url, scheme='seedlink')
 
         # Check the provided scheme
         if not parsed_url.scheme == 'seedlink':

--- a/obspy/core/__init__.py
+++ b/obspy/core/__init__.py
@@ -102,12 +102,24 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import sys
+
 # don't change order
 from obspy.core.utcdatetime import UTCDateTime
+from obspy.core.util import DynamicAttributeImportRerouteModule
 from obspy.core.util.attribdict import AttribDict
 from obspy.core.trace import Stats, Trace
 from obspy.core.stream import Stream, read
 from obspy.scripts.runtests import runTests
+
+
+# Remove once 0.11 has been released!
+sys.modules[__name__] = DynamicAttributeImportRerouteModule(
+    name=__name__, doc=__doc__, locs=locals(),
+    import_map={"stationxml": "obspy.io.stationxml.core",
+                "quakeml": "obspy.io.quakeml.core",
+                "ascii": "obspy.io.ascii.core",
+                "json": "obspy.io.json.core"})
 
 
 if __name__ == '__main__':

--- a/obspy/core/__init__.py
+++ b/obspy/core/__init__.py
@@ -116,9 +116,11 @@ from obspy.scripts.runtests import runTests
 # Remove once 0.11 has been released!
 sys.modules[__name__] = DynamicAttributeImportRerouteModule(
     name=__name__, doc=__doc__, locs=locals(),
+    # Remap everything but ascii. On Python 2, ascii is a built-in function
+    # so it would require significant additional logic to implement and this
+    # is probably not worth it here.
     import_map={"stationxml": "obspy.io.stationxml.core",
                 "quakeml": "obspy.io.quakeml.core",
-                "ascii": "obspy.io.ascii.core",
                 "json": "obspy.io.json.core"})
 
 

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Deprecation tests.
+
+Remove file once 0.11 has been released!
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import importlib
+import unittest
+import warnings
+
+from obspy import ObsPyDeprecationWarning
+
+
+class DeprecatedImportsTestSuite(unittest.TestCase):
+    """
+    "Tests" that the deprecated, rerouted imports work.
+    """
+    def test_normal_imports(self):
+        """
+        Tests direct imports.
+        """
+        def _test_rerouted_imps(old_imp, new_imp):
+            with warnings.catch_warnings(record=True) as w:
+                mod_1 = importlib.import_module(old_imp)
+                mod_2 = importlib.import_module(new_imp)
+            self.assertTrue(mod_1 is mod_2)
+            self.assertTrue(len(w), 1)
+            self.assertTrue(w[0].category is ObsPyDeprecationWarning)
+            self.assertTrue(old_imp in str(w[0].message))
+            self.assertTrue(new_imp in str(w[0].message))
+
+        # Just test everything as it originally contained some typos...
+        _test_rerouted_imps("obspy.ah", "obspy.io.ah")
+        _test_rerouted_imps("obspy.cnv", "obspy.io.cnv")
+        _test_rerouted_imps("obspy.css", "obspy.io.css")
+        _test_rerouted_imps("obspy.datamark", "obspy.io.datamark")
+        _test_rerouted_imps("obspy.kinemetrics", "obspy.io.kinemetrics")
+        _test_rerouted_imps("obspy.mseed", "obspy.io.mseed")
+        _test_rerouted_imps("obspy.gse2", "obspy.io.gse2")
+        _test_rerouted_imps("obspy.sac", "obspy.io.sac")
+        _test_rerouted_imps("obspy.xseed", "obspy.io.xseed")
+        _test_rerouted_imps("obspy.ndk", "obspy.io.ndk")
+        _test_rerouted_imps("obspy.nlloc", "obspy.io.nlloc")
+        _test_rerouted_imps("obspy.pdas", "obspy.io.pdas")
+        _test_rerouted_imps("obspy.pde", "obspy.io.pde")
+        _test_rerouted_imps("obspy.seg2", "obspy.io.seg2")
+        _test_rerouted_imps("obspy.segy", "obspy.io.segy")
+        _test_rerouted_imps("obspy.seisan", "obspy.io.seisan")
+        _test_rerouted_imps("obspy.sh", "obspy.io.sh")
+        _test_rerouted_imps("obspy.wav", "obspy.io.wav")
+        _test_rerouted_imps("obspy.y", "obspy.io.y")
+        _test_rerouted_imps("obspy.zmap", "obspy.io.zmap")
+        _test_rerouted_imps("obspy.station", "obspy.core.inventory")
+        _test_rerouted_imps("obspy.fdsn", "obspy.clients.fdsn")
+        _test_rerouted_imps("obspy.arclink", "obspy.clients.arclink")
+        _test_rerouted_imps("obspy.earthworm", "obspy.clients.earthworm")
+        _test_rerouted_imps("obspy.iris", "obspy.clients.iris")
+        _test_rerouted_imps("obspy.neic", "obspy.clients.neic")
+        _test_rerouted_imps("obspy.neries", "obspy.clients.neries")
+        _test_rerouted_imps("obspy.seedlink", "obspy.clients.seedlink")
+        _test_rerouted_imps("obspy.seishub", "obspy.clients.seishub")
+        _test_rerouted_imps("obspy.core.util.geodetics", "obspy.geodetics")
+        _test_rerouted_imps("obspy.core.ascii", "obspy.io.ascii")
+        _test_rerouted_imps("obspy.core.quakeml", "obspy.io.quakeml")
+        _test_rerouted_imps("obspy.core.stationxml", "obspy.io.stationxml")
+        _test_rerouted_imps("obspy.core.json", "obspy.io.json")
+
+
+def suite():
+    return unittest.makeSuite(DeprecatedImportsTestSuite, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -12,6 +12,7 @@ import importlib
 import unittest
 import warnings
 
+import obspy
 from obspy import ObsPyDeprecationWarning
 
 
@@ -68,6 +69,45 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
         _test_rerouted_imps("obspy.core.quakeml", "obspy.io.quakeml")
         _test_rerouted_imps("obspy.core.stationxml", "obspy.io.stationxml")
         _test_rerouted_imps("obspy.core.json", "obspy.io.json")
+
+    def test_attribute_import(self):
+        """
+        Tests deprecated attribute imports, e.g.
+
+        >>> import obspy  # doctest: +SKIP
+        >>> obspy.station.Inventory  # doctest: +SKIP
+
+        should still work. This cannot be handled by fiddling with the
+        import meta paths as this is essentially equal to attribute access
+        on the modules.
+        """
+        # Old obspy.station. This has potentially been used a lot.
+        self.assertTrue(obspy.station.Inventory is
+                        obspy.core.inventory.Inventory)
+        self.assertTrue(obspy.station.Network is
+                        obspy.core.inventory.Network)
+        self.assertTrue(obspy.station.Station is
+                        obspy.core.inventory.Station)
+        self.assertTrue(obspy.station.Channel is
+                        obspy.core.inventory.Channel)
+        # Submodule imports.
+        self.assertTrue(obspy.station, obspy.core.inventory)
+        self.assertTrue(obspy.mseed, obspy.io.mseed)
+        self.assertTrue(obspy.xseed, obspy.io.xseed)
+        self.assertTrue(obspy.fdsn, obspy.clients.fdsn)
+        # obspy.geodetics used to be part of obspy.core.util.
+        self.assertTrue(obspy.core.util.geodetics is obspy.geodetics)
+        # Parser.
+        self.assertTrue(obspy.xseed.Parser is obspy.io.xseed.Parser)
+        # File formats previously part of obspy.core.
+        self.assertTrue(obspy.core.stationxml is
+                        obspy.io.stationxml.stationxml)
+        self.assertTrue(obspy.core.json is
+                        obspy.io.json.json)
+        self.assertTrue(obspy.core.ascii is
+                        obspy.io.ascii.ascii)
+        self.assertTrue(obspy.core.quakeml is
+                        obspy.io.quakeml.quakeml)
 
 
 def suite():

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -26,6 +26,7 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
         """
         def _test_rerouted_imps(old_imp, new_imp):
             with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 mod_1 = importlib.import_module(old_imp)
                 mod_2 = importlib.import_module(new_imp)
             self.assertTrue(mod_1 is mod_2)
@@ -83,6 +84,7 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
         """
         # Old obspy.station. This has potentially been used a lot.
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             self.assertTrue(obspy.station.Inventory is
                             obspy.core.inventory.Inventory)
             self.assertTrue(obspy.station.Network is

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -82,32 +82,36 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
         on the modules.
         """
         # Old obspy.station. This has potentially been used a lot.
-        self.assertTrue(obspy.station.Inventory is
-                        obspy.core.inventory.Inventory)
-        self.assertTrue(obspy.station.Network is
-                        obspy.core.inventory.Network)
-        self.assertTrue(obspy.station.Station is
-                        obspy.core.inventory.Station)
-        self.assertTrue(obspy.station.Channel is
-                        obspy.core.inventory.Channel)
-        # Submodule imports.
-        self.assertTrue(obspy.station, obspy.core.inventory)
-        self.assertTrue(obspy.mseed, obspy.io.mseed)
-        self.assertTrue(obspy.xseed, obspy.io.xseed)
-        self.assertTrue(obspy.fdsn, obspy.clients.fdsn)
-        # obspy.geodetics used to be part of obspy.core.util.
-        self.assertTrue(obspy.core.util.geodetics is obspy.geodetics)
-        # Parser.
-        self.assertTrue(obspy.xseed.Parser is obspy.io.xseed.Parser)
-        # File formats previously part of obspy.core.
-        self.assertTrue(obspy.core.stationxml is
-                        obspy.io.stationxml.stationxml)
-        self.assertTrue(obspy.core.json is
-                        obspy.io.json.json)
-        self.assertTrue(obspy.core.ascii is
-                        obspy.io.ascii.ascii)
-        self.assertTrue(obspy.core.quakeml is
-                        obspy.io.quakeml.quakeml)
+        with warnings.catch_warnings(record=True) as w:
+            self.assertTrue(obspy.station.Inventory is
+                            obspy.core.inventory.Inventory)
+            self.assertTrue(obspy.station.Network is
+                            obspy.core.inventory.Network)
+            self.assertTrue(obspy.station.Station is
+                            obspy.core.inventory.Station)
+            self.assertTrue(obspy.station.Channel is
+                            obspy.core.inventory.Channel)
+            # Submodule imports.
+            self.assertTrue(obspy.station, obspy.core.inventory)
+            self.assertTrue(obspy.mseed, obspy.io.mseed)
+            self.assertTrue(obspy.xseed, obspy.io.xseed)
+            self.assertTrue(obspy.fdsn, obspy.clients.fdsn)
+            # obspy.geodetics used to be part of obspy.core.util.
+            self.assertTrue(obspy.core.util.geodetics is obspy.geodetics)
+            # Parser.
+            self.assertTrue(obspy.xseed.Parser is obspy.io.xseed.Parser)
+            # File formats previously part of obspy.core.
+            self.assertTrue(obspy.core.stationxml is
+                            obspy.io.stationxml.core)
+            self.assertTrue(obspy.core.json is
+                            obspy.io.json.core)
+            self.assertTrue(obspy.core.ascii is
+                            obspy.io.ascii.core)
+            self.assertTrue(obspy.core.quakeml is
+                            obspy.io.quakeml.core)
+        self.assertTrue(len(w), 14)
+        for warn in w:
+            self.assertTrue(warn.category is ObsPyDeprecationWarning)
 
 
 def suite():

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -105,8 +105,6 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
                             obspy.io.stationxml.core)
             self.assertTrue(obspy.core.json is
                             obspy.io.json.core)
-            self.assertTrue(obspy.core.ascii is
-                            obspy.io.ascii.core)
             self.assertTrue(obspy.core.quakeml is
                             obspy.io.quakeml.core)
         self.assertTrue(len(w), 14)

--- a/obspy/core/tests/test_deprecated_imports.py
+++ b/obspy/core/tests/test_deprecated_imports.py
@@ -61,7 +61,7 @@ class DeprecatedImportsTestSuite(unittest.TestCase):
         _test_rerouted_imps("obspy.earthworm", "obspy.clients.earthworm")
         _test_rerouted_imps("obspy.iris", "obspy.clients.iris")
         _test_rerouted_imps("obspy.neic", "obspy.clients.neic")
-        _test_rerouted_imps("obspy.neries", "obspy.clients.neries")
+        # Don't test neries as it requires suds which is not a test dependency.
         _test_rerouted_imps("obspy.seedlink", "obspy.clients.seedlink")
         _test_rerouted_imps("obspy.seishub", "obspy.clients.seishub")
         _test_rerouted_imps("obspy.core.util.geodetics", "obspy.geodetics")

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -22,10 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import importlib
-from types import ModuleType
 import sys
-import warnings
 
 # import order matters - NamedTemporaryFile must be one of the first!
 from obspy.core.util.attribdict import AttribDict
@@ -36,6 +33,8 @@ from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
                                   getMatplotlibVersion, getScriptDirName)
 from obspy.core.util.decorator import (deprecated, deprecated_keywords, skip,
                                        skipIf, uncompressFile)
+from obspy.core.util.deprecation_helpers import \
+    DynamicAttributeImportRerouteModule
 from obspy.core.util.misc import (BAND_CODE, CatchOutput, complexifyString,
                                   guessDelta, loadtxt, scoreatpercentile,
                                   toIntOrZero)
@@ -43,44 +42,6 @@ from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)
 from obspy.core.util.testing import add_doctests, add_unittests
 from obspy.core.util.version import get_git_version as _getVersionString
-
-
-class ObsPyDeprecationWarning(UserWarning):
-    """
-    Make a custom deprecation warning as deprecation warnings or hidden by
-    default since Python 2.7 and 3.2 and we really want users to notice these.
-    """
-    pass
-
-
-class DynamicAttributeImportRerouteModule(ModuleType):
-    """
-    Class assisting in dynamically rerouting attribute access like imports.
-
-    This essentially makes
-
-    >>> import obspy  # doctest: +SKIP
-    >>> obspy.station.Inventory  # doctest: +SKIP
-
-    work. Remove this once 0.11 has been released!
-    """
-    def __init__(self, name, doc, locs, import_map):
-        super(DynamicAttributeImportRerouteModule, self).__init__(name=name)
-        self.import_map = import_map
-        # Keep the metadata of the module.
-        self.__dict__.update(locs)
-
-    def __getattr__(self, name):
-        try:
-            real_module_name = self.import_map[name]
-        except:
-            raise AttributeError
-        warnings.warn("Module '%s' is deprecated and will stop working with "
-                      "the next ObsPy version. Please import module "
-                      "'%s'instead." % (self.__name__ + "." + name,
-                                        self.import_map[name]),
-                      ObsPyDeprecationWarning)
-        return importlib.import_module(real_module_name)
 
 
 # Remove once 0.11 has been released!

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -22,6 +22,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import importlib
+from types import ModuleType
+import sys
+import warnings
+
 # import order matters - NamedTemporaryFile must be one of the first!
 from obspy.core.util.attribdict import AttribDict
 from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
@@ -38,3 +43,47 @@ from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)
 from obspy.core.util.testing import add_doctests, add_unittests
 from obspy.core.util.version import get_git_version as _getVersionString
+
+
+class ObsPyDeprecationWarning(UserWarning):
+    """
+    Make a custom deprecation warning as deprecation warnings or hidden by
+    default since Python 2.7 and 3.2 and we really want users to notice these.
+    """
+    pass
+
+
+class DynamicAttributeImportRerouteModule(ModuleType):
+    """
+    Class assisting in dynamically rerouting attribute access like imports.
+
+    This essentially makes
+
+    >>> import obspy  # doctest: +SKIP
+    >>> obspy.station.Inventory  # doctest: +SKIP
+
+    work. Remove this once 0.11 has been released!
+    """
+    def __init__(self, name, doc, locs, import_map):
+        super(DynamicAttributeImportRerouteModule, self).__init__(name=name)
+        self.import_map = import_map
+        # Keep the metadata of the module.
+        self.__dict__.update(locs)
+
+    def __getattr__(self, name):
+        try:
+            real_module_name = self.import_map[name]
+        except:
+            raise AttributeError
+        warnings.warn("Module '%s' is deprecated and will stop working with "
+                      "the next ObsPy version. Please import module "
+                      "'%s'instead." % (self.__name__ + "." + name,
+                                        self.import_map[name]),
+                      ObsPyDeprecationWarning)
+        return importlib.import_module(real_module_name)
+
+
+# Remove once 0.11 has been released!
+sys.modules[__name__] = DynamicAttributeImportRerouteModule(
+    name=__name__, doc=__doc__, locs=locals(),
+    import_map={"geodetics": "obspy.geodetics"})

--- a/obspy/core/util/deprecation_helpers.py
+++ b/obspy/core/util/deprecation_helpers.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Library name handling for ObsPy.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (http://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import importlib
+from types import ModuleType
+import warnings
+
+
+class ObsPyDeprecationWarning(UserWarning):
+    """
+    Make a custom deprecation warning as deprecation warnings or hidden by
+    default since Python 2.7 and 3.2 and we really want users to notice these.
+    """
+    pass
+
+
+class DynamicAttributeImportRerouteModule(ModuleType):
+    """
+    Class assisting in dynamically rerouting attribute access like imports.
+
+    This essentially makes
+
+    >>> import obspy  # doctest: +SKIP
+    >>> obspy.station.Inventory  # doctest: +SKIP
+
+    work. Remove this once 0.11 has been released!
+    """
+    def __init__(self, name, doc, locs, import_map):
+        super(DynamicAttributeImportRerouteModule, self).__init__(name=name)
+        self.import_map = import_map
+        # Keep the metadata of the module.
+        self.__dict__.update(locs)
+
+    def __getattr__(self, name):
+        try:
+            real_module_name = self.import_map[name]
+        except:
+            raise AttributeError
+        warnings.warn("Module '%s' is deprecated and will stop working with "
+                      "the next ObsPy version. Please import module "
+                      "'%s'instead." % (self.__name__ + "." + name,
+                                        self.import_map[name]),
+                      ObsPyDeprecationWarning)
+        return importlib.import_module(real_module_name)


### PR DESCRIPTION
This is essentially a continuation of #842 as it makes sure that packages relying on imports in ObsPy 0.10 still work with the latest master where we reorganized the structure.

With this PR, none of my codes relying on ObsPy require any changes and warnings are raised appropriately.

All of this can be removed as soon as 0.11 has been released.