### PR TITLE
Handle non-UTF8 IO a little better.

### DIFF
--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -4091,7 +4091,7 @@ def main(argv=None):
                 try:
                     print(decomp)
                 except:
-                    print(decomp.encode('utf-8'))
+                    print(decomp.replace('°', ' deg'))
                 return
             else:
                 return MT.get_decomposition(in_system=kwargs_dict['in_system'],
@@ -5194,7 +5194,7 @@ The 'source mechanism' as a comma-separated list of length:
         try:
             print(aa)
         except:
-            print(aa.encode('utf-8'))
+            print(aa.replace('°', ' deg'))
 
 
 if __name__ == '__main__':

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -5,7 +5,6 @@ The obspy-mopad script test suite.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY3
 from future import standard_library
 
 import io
@@ -52,12 +51,8 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         try:
             expected = expected.encode(sys.stdout.encoding)
         except:
-            expected = expected.encode('utf-8')
-            if PY3:
-                # This may look like Py3k does extra stuff, but it's actually
-                # saner!
-                expected = repr(expected)
-                expected = expected.encode('ascii')
+            expected = expected.replace('°', ' deg')
+            expected = expected.encode(sys.stdout.encoding)
 
         self.assertEqual(expected, result)
 
@@ -162,12 +157,8 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         try:
             expected = expected.encode(sys.stdout.encoding)
         except:
-            expected = expected.encode('utf-8')
-            if PY3:
-                # This may look like Py3k does extra stuff, but it's actually
-                # saner!
-                expected = repr(expected)
-                expected = expected.encode('ascii')
+            expected = expected.replace('°', ' deg')
+            expected = expected.encode(sys.stdout.encoding)
 
         self.assertEqual(expected, result)
 

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -49,10 +49,16 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 
         result = out.stdout[:-1]
         try:
-            expected = expected.encode(sys.stdout.encoding)
+            if sys.stdout.encoding is not None:
+                expected = expected.encode(sys.stdout.encoding)
+            else:
+                expected = expected.encode()
         except:
             expected = expected.replace('°', ' deg')
-            expected = expected.encode(sys.stdout.encoding)
+            if sys.stdout.encoding is not None:
+                expected = expected.encode(sys.stdout.encoding)
+            else:
+                expected = expected.encode()
 
         self.assertEqual(expected, result)
 
@@ -155,10 +161,16 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 
         result = out.stdout[:-1]
         try:
-            expected = expected.encode(sys.stdout.encoding)
+            if sys.stdout.encoding is not None:
+                expected = expected.encode(sys.stdout.encoding)
+            else:
+                expected = expected.encode()
         except:
             expected = expected.replace('°', ' deg')
-            expected = expected.encode(sys.stdout.encoding)
+            if sys.stdout.encoding is not None:
+                expected = expected.encode(sys.stdout.encoding)
+            else:
+                expected = expected.encode()
 
         self.assertEqual(expected, result)
 


### PR DESCRIPTION
Instead of printing out a bytes object, just replace the problematic character. It won't look as fancy, but at least you won't see strange escaped characters and quotes around it.