### PR TITLE
Events without origin depths cause catalog plots to fail

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 releases:
+ - obspy.core:
+   * Fix catalog plot with events that have no origin depth or
+     origin time (see #1021)
  - obspy.earthworm
    * Fix Python3 compatibility problem
  - obspy.imaging:

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -40,6 +40,7 @@ from uuid import uuid4
 with standard_library.hooks():
     import urllib.request
 
+import numpy as np
 from pkg_resources import load_entry_point
 
 from obspy.core.event_header import (AmplitudeCategory, AmplitudeUnit,
@@ -3332,7 +3333,7 @@ class Catalog(object):
             if color == 'date':
                 c_ = event.origins[0].get('time')
             else:
-                c_ = event.origins[0].get('depth') / 1e3
+                c_ = (event.origins[0].get('depth') or np.nan) / 1e3
             colors.append(c_)
 
         # Create the colormap for date based plotting.

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -3331,9 +3331,9 @@ class Catalog(object):
             labels.append(('  %.1f' % mag) if mag and label == 'magnitude'
                           else '')
             if color == 'date':
-                c_ = event.origins[0].get('time')
+                c_ = origin.get('time')
             else:
-                c_ = (event.origins[0].get('depth') or np.nan) / 1e3
+                c_ = (origin.get('depth') or np.nan) / 1e3
             colors.append(c_)
 
         # Create the colormap for date based plotting.

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -3331,7 +3331,7 @@ class Catalog(object):
             labels.append(('  %.1f' % mag) if mag and label == 'magnitude'
                           else '')
             if color == 'date':
-                c_ = origin.get('time')
+                c_ = origin.get('time') or np.nan
             else:
                 c_ = (origin.get('depth') or np.nan) / 1e3
             colors.append(c_)
@@ -3341,12 +3341,17 @@ class Catalog(object):
             colormap = plt.get_cmap("RdYlGn_r")
 
         if len(lons) > 1:
+            # if we have a `None` in the origin time list it likely ends up as
+            # min and/or max and causes problems..
+            times_ = np.ma.masked_equal(times, None).compressed()
+            min_time = times_.min()
+            max_time = times_.max()
             title = (
                 "{event_count} events ({start} to {end}) "
                 "- Color codes {colorcode}, size the magnitude".format(
                     event_count=len(self.events),
-                    start=min(times).strftime("%Y-%m-%d"),
-                    end=max(times).strftime("%Y-%m-%d"),
+                    start=min_time.strftime("%Y-%m-%d"),
+                    end=max_time.strftime("%Y-%m-%d"),
                     colorcode="origin time" if color == "date" else "depth"))
         else:
             title = "Event at %s" % times[0].strftime("%Y-%m-%d")

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -273,6 +273,16 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
             map_ax.text(x[0], y[0], labels[0], weight="heavy", color="k",
                         **path_effect_kwargs)
 
+    # scatter plot is removing valid x/y points with invalid color value,
+    # so we plot those points separately.
+    if not isinstance(color, (str, native_str)):
+        if any(np.isnan(color)):
+            mask = np.isnan(color)
+            x_ = np.array(x)[mask]
+            y_ = np.array(y)[mask]
+            size_ = np.array(size)[mask]
+            scatter = bmap.scatter(x_, y_, marker=marker, s=size_, c="0.3",
+                                   zorder=10, cmap=None)
     scatter = bmap.scatter(x, y, marker=marker, s=size, c=color,
                            zorder=10, cmap=colormap)
 

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -119,9 +119,10 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
     min_color = min(color)
     max_color = max(color)
 
-    if isinstance(color[0], (datetime.datetime, UTCDateTime)):
+    if any([isinstance(c, (datetime.datetime, UTCDateTime)) for c in color]):
         datetimeplot = True
-        color = [t and date2num(t) or np.nan for t in color]
+        color = [np.isfinite(float(t)) and date2num(t) or np.nan
+                 for t in color]
     else:
         datetimeplot = False
 
@@ -276,11 +277,11 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
     # scatter plot is removing valid x/y points with invalid color value,
     # so we plot those points separately.
     if not isinstance(color, (str, native_str)):
-        if any(np.isnan(color)):
-            mask = np.isnan(color)
-            x_ = np.array(x)[mask]
-            y_ = np.array(y)[mask]
-            size_ = np.array(size)[mask]
+        nan_points = np.isnan(np.array(color, dtype=np.float))
+        if any(nan_points):
+            x_ = np.array(x)[nan_points]
+            y_ = np.array(y)[nan_points]
+            size_ = np.array(size)[nan_points]
             scatter = bmap.scatter(x_, y_, marker=marker, s=size_, c="0.3",
                                    zorder=10, cmap=None)
     scatter = bmap.scatter(x, y, marker=marker, s=size, c=color,

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -121,7 +121,7 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
 
     if isinstance(color[0], (datetime.datetime, UTCDateTime)):
         datetimeplot = True
-        color = [date2num(t) for t in color]
+        color = [t and date2num(t) or np.nan for t in color]
     else:
         datetimeplot = False
 

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -276,9 +276,13 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
 
     # scatter plot is removing valid x/y points with invalid color value,
     # so we plot those points separately.
-    if not isinstance(color, (str, native_str)):
+    try:
         nan_points = np.isnan(np.array(color, dtype=np.float))
-        if any(nan_points):
+    except ValueError:
+        # `color' was not a list of values, but a list of colors.
+        pass
+    else:
+        if nan_points.any():
             x_ = np.array(x)[nan_points]
             y_ = np.array(y)[nan_points]
             size_ = np.array(size)[nan_points]


### PR DESCRIPTION
~~Fair warning, this catalog is 3645 events long and takes a few minutes to download. I will try to cut it down at some point, but it illustrates the point for now:~~

```python
from obspy import UTCDateTime
from obspy.fdsn import Client

client = Client("IRIS")
starttime = UTCDateTime("2000-06-06T00:00:00")
endtime = UTCDateTime("2014-12-31T00:00:00")

# catalog = client.get_events(starttime=starttime, endtime=endtime,
#                             minmagnitude=5.5, maxmagnitude=6.0, magnitudetype='Mw',
#                             latitude=63.099203, longitude=-149.483061,
#                             minradius=30, maxradius=95)
catalog = client.get_events(eventid=1090422)
catalog.plot()
```
results in:
```python
TypeError                                 Traceback (most recent call last)
/usr/lib64/python3.4/site-packages/obspy/core/util/decorator.py in
echo_func(*args, **kwargs)
     77                         kwargs[nkw] = kwargs[kw]
     78                     del(kwargs[kw])
---> 79             return func(*args, **kwargs)
     80         return echo_func
     81 

/usr/lib64/python3.4/site-packages/obspy/core/event.py in
plot(self, projection, resolution, continent_fill_color, water_fill_color, label,
     color, colormap, show, outfile, **kwargs)
   3333                 c_ = event.origins[0].get('time')
   3334             else:
-> 3335                 c_ = event.origins[0].get('depth') / 1e3
   3336             colors.append(c_)
   3337 

TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

It can be worked around by doing `catalog.plot(color='date')`, but of course, it's not the same plot.