### PR TITLE
isZmap can not handle binary/non-UTF files

### DIFF
--- a/obspy/zmap/core.py
+++ b/obspy/zmap/core.py
@@ -345,10 +345,12 @@ def isZmap(filename):
         filename.seek(0)
         first_line = filename.readline()
         filename.seek(pos)
+        if hasattr(first_line, 'decode'):
+            first_line = first_line.decode()
     else:
         try:
             with open(filename, 'rb') as f:
-                first_line = f.readline()
+                first_line = f.readline().decode()
         except:
             try:
                 first_line = filename.decode()
@@ -358,9 +360,6 @@ def isZmap(filename):
             if line_ending == -1:
                 return False
             first_line = first_line[:line_ending]
-
-    if hasattr(first_line, 'decode'):
-        first_line = first_line.decode('utf-8')
 
     # we expect 10 (standard) or 13 columns (extended)
     columns = first_line.split('\t')

--- a/obspy/zmap/tests/test_zmap.py
+++ b/obspy/zmap/tests/test_zmap.py
@@ -8,7 +8,7 @@ import unittest
 
 from obspy.core.event import readEvents
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util import NamedTemporaryFile
+from obspy.core.util import NamedTemporaryFile, getExampleFile
 from obspy.zmap import core as zmap
 
 
@@ -183,6 +183,15 @@ class ZMAPTestCase(unittest.TestCase):
         with NamedTemporaryFile() as f:
             f.write(self._serialize(test_events).encode('utf-8'))
             self.assertFalse(zmap.isZmap(f.name))
+
+    def test_is_zmap_binary_files(self):
+        """
+        Test zmap format detection on non-ZMAP (e.g. binary) files, see #1022.
+        """
+        # Non-ZMAP file, binary
+        for filename in ["test.mseed", "test.sac"]:
+            file_ = getExampleFile(filename)
+            self.assertFalse(zmap.isZmap(file_))
 
     def test_deserialize(self):
         """


### PR DESCRIPTION
Continuation of an issue that surfaced by chance in #1017.

```
Traceback (most recent call last):
  File "../seishub_extractcatalog1.py", line 66, in <module>
    cat = read(fn)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/util/decorator.py", line 307, in new_func
    return func(*args, **kwargs)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/event.py", line 140, in readEvents
    catalog = _read(pathnames[0], format, **kwargs)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/util/decorator.py", line 215, in wrapped_func
    result = func(filename, *args, **kwargs)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/event.py", line 154, in _read
    **kwargs)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/util/base.py", line 394, in _readFromPlugin
    is_format = isFormat(filename)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/core/util/decorator.py", line 307, in new_func
    return func(*args, **kwargs)
  File "/Users/Peter/anaconda/lib/python2.7/site-packages/obspy-0.10.1-py2.7-macosx-10.5-x86_64.egg/obspy/zmap/core.py", line 363, in isZmap
    first_line = first_line.decode('utf-8')
  File "/Users/Peter/anaconda/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
```

Comment by @QuLogic:
```
Looks like new ZMAP support incorrectly assumes Unicode,
and fails if it's not true (i.e., not a ZMAP file.)

Maybe you can try passing format='quakeml' to bypass autodetection
since you already know the format.
```