### PR TITLE
Add FDSN web service shortcuts

### DIFF
--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -25,6 +25,7 @@ class FDSNException(Exception):
 # http://www.fdsn.org/webservices/datacenters/
 URL_MAPPINGS = {"IRIS": "http://service.iris.edu",
                 "ORFEUS": "http://www.orfeus-eu.org",
+                "ODC": "http://www.orfeus-eu.org",
                 "USGS": "http://comcat.cr.usgs.gov",
                 "RESIF": "http://ws.resif.fr",
                 "NCEDC": "http://service.ncedc.org",

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -23,6 +23,7 @@ class FDSNException(Exception):
 
 # A curated list collecting some implementations:
 # http://www.fdsn.org/webservices/datacenters/
+# http://www.orfeus-eu.org/eida/eida_odc.html
 URL_MAPPINGS = {
     "BGR": "http://eida.bgr.de",
     "ETH": "http://eida.ethz.ch",

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -35,6 +35,10 @@ URL_MAPPINGS = {"IRIS": "http://service.iris.edu",
                 "GEONET": "http://service.geonet.org.nz",
                 "INGV": "http://webservices.rm.ingv.it",
                 "BGR": "http://eida.bgr.de",
+                "ETH": "http://eida.ethz.ch",
+                "NEIP": "http://eida-sc3.infp.ro",
+                "LMU": "http://erde.geophysik.uni-muenchen.de",
+                "IPGP": "http://eida.ipgp.fr",
                 }
 
 FDSNWS = ("dataselect", "event", "station")

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -23,24 +23,25 @@ class FDSNException(Exception):
 
 # A curated list collecting some implementations:
 # http://www.fdsn.org/webservices/datacenters/
-URL_MAPPINGS = {"IRIS": "http://service.iris.edu",
-                "ORFEUS": "http://www.orfeus-eu.org",
-                "ODC": "http://www.orfeus-eu.org",
-                "USGS": "http://comcat.cr.usgs.gov",
-                "RESIF": "http://ws.resif.fr",
-                "NCEDC": "http://service.ncedc.org",
-                "USP": "http://sismo.iag.usp.br",
-                "GFZ": "http://geofon.gfz-potsdam.de",
-                "NERIES": "http://www.seismicportal.eu",
-                "SCEDC": "http://service.scedc.caltech.edu",
-                "GEONET": "http://service.geonet.org.nz",
-                "INGV": "http://webservices.rm.ingv.it",
-                "BGR": "http://eida.bgr.de",
-                "ETH": "http://eida.ethz.ch",
-                "NEIP": "http://eida-sc3.infp.ro",
-                "LMU": "http://erde.geophysik.uni-muenchen.de",
-                "IPGP": "http://eida.ipgp.fr",
-                }
+URL_MAPPINGS = {
+    "BGR": "http://eida.bgr.de",
+    "ETH": "http://eida.ethz.ch",
+    "GEONET": "http://service.geonet.org.nz",
+    "GFZ": "http://geofon.gfz-potsdam.de",
+    "INGV": "http://webservices.rm.ingv.it",
+    "IPGP": "http://eida.ipgp.fr",
+    "IRIS": "http://service.iris.edu",
+    "LMU": "http://erde.geophysik.uni-muenchen.de",
+    "NCEDC": "http://service.ncedc.org",
+    "NEIP": "http://eida-sc3.infp.ro",
+    "NERIES": "http://www.seismicportal.eu",
+    "ODC": "http://www.orfeus-eu.org",
+    "ORFEUS": "http://www.orfeus-eu.org",
+    "RESIF": "http://ws.resif.fr",
+    "SCEDC": "http://service.scedc.caltech.edu",
+    "USGS": "http://comcat.cr.usgs.gov",
+    "USP": "http://sismo.iag.usp.br",
+    }
 
 FDSNWS = ("dataselect", "event", "station")
 


### PR DESCRIPTION
I would like to propose to add shortcuts for all nodes of the EIDA federation:

 * `ETH`, Switzerland, http://eida.ethz.ch/	
 * `NEIP`, Romania, http://eida-sc3.infp.ro/
    (*not tested yet, service probably up and running*)
 * `LMU`, Germany (BayernNetz), http://erde.geophysik.uni-muenchen.de/
 * `IPGP`/Geoscope, France (volcanological observatories) + Global (GEOSCOPE),  http://eida.ipgp.fr/
    (*not tested yet*)

This is a pretty trivial change, I just would like to discuss if this change should go only to master (enhancement), or if it is sufficiently trivial/useful to add it to release as well.

Maybe `ODC` would be the more appropriate abbreviation for the node at Orfeus. (http://www.orfeus-eu.org) 