### PR TITLE
Add possibility to read files with `tbz` suffix

### DIFF
--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -119,8 +119,8 @@ def uncompress_file(func):
             raise IOError(msg)
         # check if we got a compressed file or archive
         obj_list = []
-        if filename.endswith('.tar') or filename.endswith('.tgz') or \
-                filename.endswith('.tar.gz') or filename.endswith('.tar.bz2'):
+        SUFFIX_TAR = ('tar', 'tgz', 'tar.gz', 'tbz', 'tar.bz2')
+        if filename.endswith(SUFFIX_TAR):
             # tarfile module
             try:
                 import tarfile

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -17,8 +17,10 @@ import functools
 import inspect
 import os
 import socket
+import tarfile
 import unittest
 import warnings
+import zipfile
 
 import numpy as np
 
@@ -119,30 +121,20 @@ def uncompress_file(func):
             raise IOError(msg)
         # check if we got a compressed file or archive
         obj_list = []
-        SUFFIX_TAR = ('tar', 'tgz', 'tar.gz', 'tbz', 'tar.bz2')
-        if filename.endswith(SUFFIX_TAR):
-            # tarfile module
+        if tarfile.is_tarfile(filename):
             try:
-                import tarfile
-                if not tarfile.is_tarfile(filename):
-                    raise
                 # reading with transparent compression
-                tar = tarfile.open(filename, 'r|*')
-                for tarinfo in tar:
-                    # only handle regular files
-                    if not tarinfo.isfile():
-                        continue
-                    data = tar.extractfile(tarinfo).read()
-                    obj_list.append(data)
-                tar.close()
+                with tarfile.open(filename, 'r|*') as tar:
+                    for tarinfo in tar:
+                        # only handle regular files
+                        if not tarinfo.isfile():
+                            continue
+                        data = tar.extractfile(tarinfo).read()
+                        obj_list.append(data)
             except:
                 pass
-        elif filename.endswith('.zip'):
-            # zipfile module
+        elif zipfile.is_zipfile(filename):
             try:
-                import zipfile
-                if not zipfile.is_zipfile(filename):
-                    raise
                 zip = zipfile.ZipFile(filename)
                 obj_list = [zip.read(name) for name in zip.namelist()]
             except:


### PR DESCRIPTION
Minor change to be able to read files with `tbz` suffix. This is handled the same way as all tarfiles and ending `tar.bz2` was already supported.  Also *simplified* the condition (not sure but I find this more readable). Maybe the constant tuple could/should be moved elsewhere.