### PR TITLE
Python 2 Unicode error with NEIC client

### DIFF
--- a/obspy/neic/client.py
+++ b/obspy/neic/client.py
@@ -118,8 +118,7 @@ class Client(object):
             msg = "channel expression matches less than 3 characters " + \
                   "(use e.g. 'BHZ', 'BH?', 'BH[Z12]', 'B??')"
             raise Exception(msg)
-        seedname = network.ljust(2, " ") + station.ljust(5, " ") + channel + \
-            location.ljust(2, " ")
+        seedname = '%-2s%-5s%s%-2s' % (network, station, channel, location)
         # allow UNIX style "?" wildcard
         seedname = seedname.replace("?", ".")
         return self.getWaveformNSCL(seedname, starttime, endtime - starttime)


### PR DESCRIPTION
Reported on [the mailing list](http://lists.swapbytes.de/archives/obspy-users/2015-April/001678.html):
```python
from obspy import UTCDateTime
from obspy.neic import Client
client = Client()
indivSta = client.getWaveform('HV', 'NPT', '', 'HHN',
                              UTCDateTime(2015, 3, 4, 22, 0),
                              UTCDateTime(2015, 3, 5, 2, 0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/obspy/neic/client.py",
line 121, in getWaveform
    seedname = network.ljust(2, " ") + station.ljust(5, " ") + channel + \
TypeError: must be char, not unicode
```