### PR TITLE
Velocity reduction with degree offsets not handled correctly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ releases:
    * Fix Python3 compatibility problem
  - obspy.imaging:
    * Fix flipped maps due to bug in Basemap
+   * Fix handling of velocity reduction in section plots with degree offsets
+     (see #1029)
  - obspy.seedlink:
    * Fix Python3 compatibility for seedlink.easyseedlink
  - obspy.station:

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -37,7 +37,7 @@ import scipy.signal as signal
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.util import (FlinnEngdahl, createEmptyDataChunk,
-                             locations2degrees)
+                             kilometer2degrees, locations2degrees)
 from obspy.core.util.base import getMatplotlibVersion
 from obspy.core.util.decorator import deprecated_keywords
 from obspy.imaging.util import (ObsPyAutoDateFormatter, _ID_key, _timestring)
@@ -110,6 +110,8 @@ class WaveformPlotting(object):
         self.sect_norm_method = kwargs.get('norm_method', 'trace')
         self.sect_user_scale = kwargs.get('scale', 1.0)
         self.sect_vred = kwargs.get('vred', None)
+        if self.sect_vred and self.sect_dist_degree:
+            self.sect_vred = kilometer2degrees(self.sect_vred / 1e3)
         if self.type == 'relative':
             self.reftime = kwargs.get('reftime', self.starttime)
         elif self.type == 'section':


### PR DESCRIPTION
The documentation says `vred` is "Perform velocity reduction, in m/s.", and [the code](https://github.com/obspy/obspy/blob/master/obspy/imaging/waveform.py#L1211) uses a simple `offset / vred`. However, the units for `offset` changed if you use `dist_degree=True`.

I put in a simple `vred = kilometer2degrees(vred / 1e3)` to make it deg/s. Not sure if that makes sense, or whether we should use one of the more accurate GC algorithms instead.