### PR TITLE
Section plot fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ releases:
    * Fix flipped maps due to bug in Basemap
    * Fix handling of velocity reduction in section plots with degree offsets
      (see #1029)
+   * Allow section plots over existing figures by not modifying existing lines
  - obspy.seedlink:
    * Fix Python3 compatibility for seedlink.easyseedlink
  - obspy.station:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ releases:
    * Fix Python3 compatibility problem
  - obspy.imaging:
    * Fix flipped maps due to bug in Basemap
+   * Fix handling of velocity reduction in section plots with degree offsets
+     (see #1029)
  - obspy.seedlink:
    * Fix Python3 compatibility for seedlink.easyseedlink
  - obspy.station:

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1186,14 +1186,12 @@ class WaveformPlotting(object):
         # Init time vectors
         self.__sectInitTime()
 
-    def __sectScaleTraces(self, scale=None):
+    def __sectScaleTraces(self):
         """
         The traces have to be scaled to fit between 0-1., each trace
         gets 1./num_traces space. adjustable by scale=1.0.
         """
-        if scale:
-            self.sect_user_scale = scale
-        self._sect_scale = self._tr_num * 1.5 * (1. / self.sect_user_scale)
+        self._sect_scale = self.sect_user_scale / (self._tr_num * 1.5)
 
     def __sectInitTime(self):
         """
@@ -1238,7 +1236,7 @@ class WaveformPlotting(object):
             # Scale, normalize and shift traces by offset
             # for plotting
             ax.plot(self._tr_data[_tr] / self._tr_normfac[_tr] *
-                    (1. / self._sect_scale) +
+                    self._sect_scale +
                     self._tr_offsets_norm[_tr],
                     self._tr_times[_tr])
         return ax

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -37,7 +37,7 @@ import scipy.signal as signal
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.util import (FlinnEngdahl, createEmptyDataChunk,
-                             locations2degrees)
+                             kilometer2degrees, locations2degrees)
 from obspy.core.util.base import getMatplotlibVersion
 from obspy.core.util.decorator import deprecated_keywords
 from obspy.imaging.util import (ObsPyAutoDateFormatter, _ID_key, _timestring)
@@ -110,6 +110,8 @@ class WaveformPlotting(object):
         self.sect_norm_method = kwargs.get('norm_method', 'trace')
         self.sect_user_scale = kwargs.get('scale', 1.0)
         self.sect_vred = kwargs.get('vred', None)
+        if self.sect_vred and self.sect_dist_degree:
+            self.sect_vred = kilometer2degrees(self.sect_vred / 1e3)
         if self.type == 'relative':
             self.reftime = kwargs.get('reftime', self.starttime)
         elif self.type == 'section':

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1062,9 +1062,9 @@ class WaveformPlotting(object):
         """
         # Initialise data and plot
         self.__sectInitTraces()
-        ax = self.__sectInitPlot()
+        ax, lines = self.__sectInitPlot()
         # Setting up line properties
-        for line in ax.lines:
+        for line in lines:
             line.set_alpha(self.alpha)
             line.set_linewidth(self.linewidth)
             line.set_color(self.color)
@@ -1231,15 +1231,16 @@ class WaveformPlotting(object):
         self.__sectNormalizeTraces()
         # Calculate scaling factor
         self.__sectScaleTraces()
+        lines = []
         # ax.plot() preferred over containers
         for _tr in range(self._tr_num):
-            # Scale, normalize and shift traces by offset
-            # for plotting
-            ax.plot(self._tr_data[_tr] / self._tr_normfac[_tr] *
-                    self._sect_scale +
-                    self._tr_offsets_norm[_tr],
-                    self._tr_times[_tr])
-        return ax
+            # Scale, normalize and shift traces by offset for plotting
+            data = ((self._tr_data[_tr] / self._tr_normfac[_tr] *
+                     self._sect_scale) +
+                    self._tr_offsets_norm[_tr])
+            time = self._tr_times[_tr]
+            lines += ax.plot(data, time)
+        return ax, lines
 
     def __sectNormalizeTraces(self):
         """


### PR DESCRIPTION
This supersedes #1029 to reduce the branching. These are all related to section plots.
 * Correct units for velocity reduction when using degree offsets (see #1029 for full explanation).
 * Allow overlaying multiple section plots by not modifying lines from previous plots.