### PR TITLE
Polarization analysis doesn't work

### DIFF
--- a/misc/docs/source/packages/obspy.signal.rst
+++ b/misc/docs/source/packages/obspy.signal.rst
@@ -29,6 +29,7 @@
        ~filter.lowpass
        ~invsim.pazToFreqResp
        ~trigger.pkBaer
+       ~polarization.polarization_analysis
        ~spectral_estimation.PPSD
        ~spectral_estimation.psd
        ~trigger.recSTALTA

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -458,9 +458,16 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
     :param method: the method to use. one of ``"pm"``, ``"flinn"`` or
         ``"vidale"``.
     :type method: str
-    :returns: Dictionary with posix timestamp, azimuth, incidence angle,
-        errors, rectilinearity, planarity, and/or ellipticity (the returned
-        values depend on the used method).
+    :rtype: dict
+    :returns: Dictionary with keys ``"timestamp"`` (POSIX timestamp, can be
+        used to initialize :class:`~obspy.core.utcdatetime.UTCDateTime`
+        objects), ``"azimuth"``, ``"incidence"`` (incidence angle) and
+        additional keys depending on used method: ``"azimuth_error"`` and
+        ``"incidence_error"`` (for method ``"pm"``), ``"rectilinearity"`` and
+        ``"planarity"`` (for methods ``"flinn"`` and ``"vidale"``) and
+        ``"ellipticity"`` (for method ``"flinn"``). Under each key a
+        :class:`~numpy.ndarray` is stored, giving the respective values
+        corresponding to the ``"timestamp"`` :class:`~numpy.ndarray`.
     """
     if method.lower() not in ["pm", "flinn", "vidale"]:
         msg = "Invalid method ('%s')" % method
@@ -531,34 +538,20 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
 
     res = np.array(res)
 
+    result_dict = {"timestamp": res[:, 0],
+                   "azimuth": res[:, 1],
+                   "incidence": res[:, 2]}
     if method.lower() == "pm":
-        return {
-            "timestamp": res[:, 0],
-            "azimuth": res[:, 1],
-            "incidence": res[:, 2],
-            "azimuth_error": res[:, 3],
-            "incidence_error": res[:, 4]
-
-        }
+        result_dict["azimuth_error"] = res[:, 3]
+        result_dict["incidence_error"] = res[:, 4]
     elif method.lower() == "vidale":
-        return {
-            "timestamp": res[:, 0],
-            "azimuth": res[:, 1],
-            "incidence": res[:, 2],
-            "rectilinearity": res[:, 3],
-            "planarity": res[:, 4],
-            "ellipticity": res[:, 5]
-        }
+        result_dict["rectilinearity"] = res[:, 3]
+        result_dict["planarity"] = res[:, 4]
+        result_dict["ellipticity"] = res[:, 5]
     elif method.lower() == "flinn":
-        return {
-            "timestamp": res[:, 0],
-            "azimuth": res[:, 1],
-            "incidence": res[:, 2],
-            "rectilinearity": res[:, 3],
-            "planarity": res[:, 4]
-        }
-    else:
-        raise NotImplementedError
+        result_dict["rectilinearity"] = res[:, 3]
+        result_dict["planarity"] = res[:, 4]
+    return result_dict
 
 
 if __name__ == "__main__":

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -363,9 +363,9 @@ def particle_motion_odr(stream, noise_thres=0):
     incidence = math.atan2(1.0, in_slope)
 
     az_error = 1.0 / ((1.0 ** 2 + az_slope ** 2) * azimuth) * az_error
-   # az_error = math.degrees(az_error)
+    # az_error = math.degrees(az_error)
     in_error = 1.0 / ((1.0 ** 2 + in_slope ** 2) * incidence) * in_error
-   # in_error = math.degrees(in_error)
+    # in_error = math.degrees(in_error)
 
     azimuth = math.degrees(azimuth)
     incidence = math.degrees(incidence)
@@ -382,7 +382,6 @@ def particle_motion_odr(stream, noise_thres=0):
             azimuth += 180.0
     if azimuth > 180.0:
         azimuth -= 180.0
-
 
     return azimuth, incidence, az_error, in_error
 
@@ -459,9 +458,9 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
     :param method: the method to use. one of ``"pm"``, ``"flinn"`` or
         ``"vidale"``.
     :type method: str
-    :returns: Dictionary with posix timestamp, azimuth, incidence angle, errors,
-        rectilinearity, planarity, and/or ellipticity (the returned values
-        depend on the used method).
+    :returns: Dictionary with posix timestamp, azimuth, incidence angle,
+        errors, rectilinearity, planarity, and/or ellipticity (the returned
+        values depend on the used method).
     """
     if method.lower() not in ["pm", "flinn", "vidale"]:
         msg = "Invalid method ('%s')" % method
@@ -513,17 +512,16 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
             except IndexError:
                 break
 
-            #we plot against the centre of the sliding window
-
+            # we plot against the centre of the sliding window
             if method.lower() == "pm":
                 azimuth, incidence, error_az, error_inc = \
                     particle_motion_odr(data, var_noise)
                 res.append(np.array([newstart.timestamp + float(nstep) / fs,
-                    azimuth, incidence, error_az,error_inc]))
+                           azimuth, incidence, error_az, error_inc]))
             if method.lower() == "flinn":
                 azimuth, incidence, reclin, plan = flinn(data, var_noise)
-                res.append(np.array([newstart.timestamp + float(nstep) / fs, azimuth,
-                                     incidence, reclin, plan]))
+                res.append(np.array([newstart.timestamp + float(nstep) / fs,
+                                    azimuth, incidence, reclin, plan]))
 
             if verbose:
                 print(newstart, newstart + nsamp / fs, res[-1][1:])
@@ -533,11 +531,9 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
 
     res = np.array(res)
 
-    npt = len(res[:, 0])
-
     if method.lower() == "pm":
         return {
-            "timestamp": res[:,0],
+            "timestamp": res[:, 0],
             "azimuth": res[:, 1],
             "incidence": res[:, 2],
             "azimuth_error": res[:, 3],
@@ -546,7 +542,7 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
         }
     elif method.lower() == "vidale":
         return {
-            "timestamp": res[:,0],
+            "timestamp": res[:, 0],
             "azimuth": res[:, 1],
             "incidence": res[:, 2],
             "rectilinearity": res[:, 3],
@@ -555,7 +551,7 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
         }
     elif method.lower() == "flinn":
         return {
-            "timestamp": res[:,0],
+            "timestamp": res[:, 0],
             "azimuth": res[:, 1],
             "incidence": res[:, 2],
             "rectilinearity": res[:, 3],

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -359,12 +359,32 @@ def particle_motion_odr(stream, noise_thres=0):
     in_slope = out.beta[0]
     in_error = out.sd_beta[0]
 
-    azim = math.atan2(1.0, az_slope)
-    inc = math.atan2(1.0, in_slope)
-    az_error = 1.0 / ((1.0 ** 2 + az_slope ** 2) * azim) * az_error
-    in_error = 1.0 / ((1.0 ** 2 + in_slope ** 2) * inc) * in_error
+    azimuth = math.atan2(1.0, az_slope)
+    incidence = math.atan2(1.0, in_slope)
 
-    return math.degrees(azim), math.degrees(inc), az_error, in_error
+    az_error = 1.0 / ((1.0 ** 2 + az_slope ** 2) * azimuth) * az_error
+   # az_error = math.degrees(az_error)
+    in_error = 1.0 / ((1.0 ** 2 + in_slope ** 2) * incidence) * in_error
+   # in_error = math.degrees(in_error)
+
+    azimuth = math.degrees(azimuth)
+    incidence = math.degrees(incidence)
+
+    if azimuth < 0.0:
+        azimuth = 360.0 + azimuth
+    if incidence < 0.0:
+        incidence += 180.0
+    if incidence > 90.0:
+        incidence = 180.0 - incidence
+        if azimuth > 180.0:
+            azimuth -= 180.0
+        else:
+            azimuth += 180.0
+    if azimuth > 180.0:
+        azimuth -= 180.0
+
+
+    return azimuth, incidence, az_error, in_error
 
 
 def _get_s_point(stream, stime, etime):
@@ -414,8 +434,7 @@ def _get_s_point(stream, stime, etime):
 
 
 def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
-                          etime, verbose=False, timestamp="mlabday",
-                          method="pm", var_noise=0.0):
+                          etime, verbose=False, method="pm", var_noise=0.0):
     """
     Method carrying out polarization analysis with the Flinn, Jurkevics,
     ParticleMotion, or Vidale algorithm.
@@ -437,17 +456,10 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
     :type stime: :class:`obspy.core.utcdatetime.UTCDateTime`
     :param etime: End time of interest
     :type etime: :class:`obspy.core.utcdatetime.UTCDateTime`
-    :param timestamp: valid values: ``"julsec"`` and ``"mlabday"``;
-        ``"julsec"`` returns the timestamp in seconds since
-        ``1970-01-01T00:00:00``, ``"mlabday"`` returns the timestamp in days
-        (decimals represent hours, minutes and seconds) since
-        ``0001-01-01T00:00:00`` as needed for matplotlib date plotting (see
-        e.g. matplotlibs num2date)
-    :type timestamp: str
     :param method: the method to use. one of ``"pm"``, ``"flinn"`` or
         ``"vidale"``.
     :type method: str
-    :returns: Dictionary with azimuth, incidence angle, errors,
+    :returns: Dictionary with posix timestamp, azimuth, incidence angle, errors,
         rectilinearity, planarity, and/or ellipticity (the returned values
         depend on the used method).
     """
@@ -460,7 +472,7 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
     # check that sampling rates do not vary
     fs = stream[0].stats.sampling_rate
     if len(stream) != len(stream.select(sampling_rate=fs)):
-        msg = "in array sampling rates of traces in stream are not equal"
+        msg = "sampling rates of traces in stream are not equal"
         raise ValueError(msg)
 
     if verbose:
@@ -468,7 +480,6 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
         print(stream)
         print("stime = " + str(stime) + ", etime = " + str(etime))
 
-    # offset of arrays
     spoint, _epoint = _get_s_point(stream, stime, etime)
     if method.lower() == "vidale":
         res = vidale_adapt(stream, var_noise, fs, frqlow, frqhigh, spoint,
@@ -502,58 +513,53 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
             except IndexError:
                 break
 
+            #we plot against the centre of the sliding window
+
             if method.lower() == "pm":
                 azimuth, incidence, error_az, error_inc = \
                     particle_motion_odr(data, var_noise)
-                if abs(error_az) < 0.1 and abs(error_inc) < 0.1:
-                    res.append(np.array([newstart.timestamp + nsamp / fs,
-                                         azimuth, incidence, error_az,
-                                         error_inc]))
+                res.append(np.array([newstart.timestamp + float(nstep) / fs,
+                    azimuth, incidence, error_az,error_inc]))
             if method.lower() == "flinn":
                 azimuth, incidence, reclin, plan = flinn(data, var_noise)
-                res.append(np.array([newstart.timestamp + nsamp / fs, azimuth,
+                res.append(np.array([newstart.timestamp + float(nstep) / fs, azimuth,
                                      incidence, reclin, plan]))
 
             if verbose:
                 print(newstart, newstart + nsamp / fs, res[-1][1:])
             offset += nstep
 
-            newstart += nstep / fs
+            newstart += float(nstep) / fs
+
     res = np.array(res)
-    # XXX: not used for any return
-    if timestamp == "julsec":
-        pass
-    elif timestamp == "mlabday":
-        # 719163 == hours between 1970 and 0001 + 1
-        res[:, 0] = res[:, 0] / (24. * 3600) + 719163
-    else:
-        msg = "Option timestamp must be one of 'julsec', or 'mlabday'"
-        raise ValueError(msg)
 
     npt = len(res[:, 0])
-    npt //= 2
 
     if method.lower() == "pm":
         return {
-            "azimuth": res[npt, 1],
-            "incidence": res[npt, 2],
-            "azimuth_error": res[npt, 3],
-            "incidence_error": res[npt, 4]
+            "timestamp": res[:,0],
+            "azimuth": res[:, 1],
+            "incidence": res[:, 2],
+            "azimuth_error": res[:, 3],
+            "incidence_error": res[:, 4]
+
         }
     elif method.lower() == "vidale":
         return {
-            "azimuth": res[npt, 1],
-            "incidence": res[npt, 2],
-            "rectilinearity": res[npt, 3],
-            "planarity": res[npt, 4],
-            "ellipticity": res[npt, 5]
+            "timestamp": res[:,0],
+            "azimuth": res[:, 1],
+            "incidence": res[:, 2],
+            "rectilinearity": res[:, 3],
+            "planarity": res[:, 4],
+            "ellipticity": res[:, 5]
         }
     elif method.lower() == "flinn":
         return {
-            "azimuth": res[npt, 1],
-            "incidence": res[npt, 2],
-            "rectilinearity": res[npt, 3],
-            "planarity": res[npt, 4],
+            "timestamp": res[:,0],
+            "azimuth": res[:, 1],
+            "incidence": res[:, 2],
+            "rectilinearity": res[:, 3],
+            "planarity": res[:, 4]
         }
     else:
         raise NotImplementedError

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -11,6 +11,7 @@ import unittest
 from os.path import dirname, join
 
 import numpy as np
+from numpy.testing import assert_allclose
 from scipy import signal
 
 import obspy
@@ -133,10 +134,23 @@ class PolarizationTestCase(unittest.TestCase):
             verbose=False, stime=t, etime=e, method="pm",
             var_noise=0.0)
 
-        self.assertAlmostEqual(out["azimuth"], 26.56505117707799)
-        self.assertAlmostEqual(out["incidence"], 65.905157447889309)
-        self.assertAlmostEqual(out["azimuth_error"], 0.000000)
-        self.assertAlmostEqual(out["incidence_error"], 0.000000)
+        # all values should be equal for the test data, so check first value
+        # and make sure all values are almost equal
+        self.assertEqual(out["timestamp"][0], 1393632001.0)
+        self.assertAlmostEqual(out["azimuth"][0], 26.56505117707799)
+        self.assertAlmostEqual(out["incidence"][0], 65.905157447889309)
+        self.assertAlmostEqual(out["azimuth_error"][0], 0.000000)
+        self.assertAlmostEqual(out["incidence_error"][0], 0.000000)
+        for key in ["azimuth", "incidence"]:
+            got = out[key]
+            assert_allclose(got / got[0], np.ones_like(got), rtol=1e-4)
+        for key in ["azimuth_error", "incidence_error"]:
+            got = out[key]
+            expected = np.empty_like(got)
+            expected.fill(got[0])
+            assert_allclose(got, expected, rtol=1e-4, atol=1e-16)
+        assert_allclose(out["timestamp"] - out["timestamp"][0],
+                        np.arange(0, 92, 1))
 
     def test_polarization_flinn(self):
         st = _create_test_data()
@@ -148,10 +162,18 @@ class PolarizationTestCase(unittest.TestCase):
             verbose=False, stime=t, etime=e,
             method="flinn", var_noise=0.0)
 
-        self.assertAlmostEqual(out["azimuth"], 26.56505117707799)
-        self.assertAlmostEqual(out["incidence"], 65.905157447889309)
-        self.assertAlmostEqual(out["rectilinearity"], 1.000000)
-        self.assertAlmostEqual(out["planarity"], 1.000000)
+        # all values should be equal for the test data, so check first value
+        # and make sure all values are almost equal
+        self.assertEqual(out["timestamp"][0], 1393632001.0)
+        self.assertAlmostEqual(out["azimuth"][0], 26.56505117707799)
+        self.assertAlmostEqual(out["incidence"][0], 65.905157447889309)
+        self.assertAlmostEqual(out["rectilinearity"][0], 1.000000)
+        self.assertAlmostEqual(out["planarity"][0], 1.000000)
+        for key in ["azimuth", "incidence", "rectilinearity", "planarity"]:
+            got = out[key]
+            assert_allclose(got / got[0], np.ones_like(got), rtol=1e-4)
+        assert_allclose(out["timestamp"] - out["timestamp"][0],
+                        np.arange(0, 92, 1))
 
     def test_polarization_vidale(self):
         st = _create_test_data()
@@ -163,11 +185,20 @@ class PolarizationTestCase(unittest.TestCase):
             verbose=False, stime=t, etime=e,
             method="vidale", var_noise=0.0)
 
-        self.assertAlmostEqual(out["azimuth"], 26.56505117707799)
-        self.assertAlmostEqual(out["incidence"], 65.905157447889309)
-        self.assertAlmostEqual(out["rectilinearity"], 1.000000)
-        self.assertAlmostEqual(out["planarity"], 1.000000)
-        self.assertAlmostEqual(out["ellipticity"], 3.8195545129768958e-06)
+        # all values should be equal for the test data, so check first value
+        # and make sure all values are almost equal
+        self.assertEqual(out["timestamp"][0], 1393632003.0)
+        self.assertAlmostEqual(out["azimuth"][0], 26.56505117707799)
+        self.assertAlmostEqual(out["incidence"][0], 65.905157447889309)
+        self.assertAlmostEqual(out["rectilinearity"][0], 1.000000)
+        self.assertAlmostEqual(out["planarity"][0], 1.000000)
+        self.assertAlmostEqual(out["ellipticity"][0], 3.8195545129768958e-06)
+        for key in ["azimuth", "incidence", "rectilinearity", "planarity",
+                    "ellipticity"]:
+            got = out[key]
+            assert_allclose(got / got[0], np.ones_like(got), rtol=1e-4)
+        assert_allclose(out["timestamp"] - out["timestamp"][0],
+                        np.arange(0, 97.85, 0.05), rtol=1e-5)
 
 
 def suite():

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -130,7 +130,7 @@ class PolarizationTestCase(unittest.TestCase):
 
         out = polarization.polarization_analysis(
             st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
-            verbose=False, timestamp='mlabday', stime=t, etime=e, method="pm",
+            verbose=False, stime=t, etime=e, method="pm",
             var_noise=0.0)
 
         self.assertAlmostEqual(out["azimuth"], 26.56505117707799)
@@ -145,7 +145,7 @@ class PolarizationTestCase(unittest.TestCase):
 
         out = polarization.polarization_analysis(
             st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
-            verbose=False, timestamp='mlabday', stime=t, etime=e,
+            verbose=False, stime=t, etime=e,
             method="flinn", var_noise=0.0)
 
         self.assertAlmostEqual(out["azimuth"], 26.56505117707799)
@@ -160,7 +160,7 @@ class PolarizationTestCase(unittest.TestCase):
 
         out = polarization.polarization_analysis(
             st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
-            verbose=False, timestamp='mlabday', stime=t, etime=e,
+            verbose=False, stime=t, etime=e,
             method="vidale", var_noise=0.0)
 
         self.assertAlmostEqual(out["azimuth"], 26.56505117707799)


### PR DESCRIPTION
Claudia Roeoesli contacted me because of problems with the new polarization module.

After polishing the code it seems that the polarization_analysis function is no longer working properly. Looking into the code, I've seen that the dictionary returned by the function only give back the last (npts) value rather than a vector. Also the time stamp is now missing. Should be easy to fix?!

Cheers Jo