### PR TITLE
SacIO() fails with python 2.7

### DIFF
--- a/obspy/sac/sacio.py
+++ b/obspy/sac/sacio.py
@@ -25,6 +25,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
+import os
 import time
 import warnings
 
@@ -467,8 +468,9 @@ class SacIO(object):
         Test for a valid SAC file using arrays.
         """
         cur_pos = fh.tell()
-        length = fh.seek(0, 2)
-        fh.seek(cur_pos, 0)
+        fh.seek(0, os.SEEK_END)
+        length = fh.tell()
+        fh.seek(cur_pos, os.SEEK_SET)
         try:
             npts = self.GetHvalue('npts')
         except:
@@ -526,7 +528,7 @@ class SacIO(object):
             try:
                 # if it is not a valid SAC-file try with big endian
                 # byte order
-                fh.seek(0, 0)
+                fh.seek(0, os.SEEK_SET)
                 self.hf = frombuffer(fh.read(4 * 70), dtype=native_str('>f4'))
                 self.hi = frombuffer(fh.read(4 * 40), dtype=native_str('>i4'))
                 # read in the char values
@@ -566,7 +568,7 @@ class SacIO(object):
         >>> u.GetHvalueFromFile('test2.sac',"kevnm") # doctest: +SKIP
         'hullahulla      '
         """
-        fh.seek(0, 0)  # set pointer to the file beginning
+        fh.seek(0, os.SEEK_SET)
         try:
             # write the header
             fh.write(self.hf.data)
@@ -616,7 +618,7 @@ class SacIO(object):
             try:
                 # if it is not a valid SAC-file try with big endian
                 # byte order
-                fh.seek(0, 0)
+                fh.seek(0, os.SEEK_SET)
                 self.hf = frombuffer(fh.read(4 * 70), dtype=native_str('>f4'))
                 self.hi = frombuffer(fh.read(4 * 40), dtype=native_str('>i4'))
                 # read in the char values


### PR DESCRIPTION
When using python 2.7, the following code fails:
```python
from obspy.sac import SacIO
with open('test.sac') as fh:
    sac = SacIO(fh)
```
with the following error:
```python
TypeError: unsupported operand type(s) for -: 'NoneType' and 'long'
```

This is related to [this line of code](https://github.com/obspy/obspy/blob/releases/obspy/sac/sacio.py#L470), since `file.seek()` does not return anything in python 2.7, and therefore `length` is `None`.

Tests pass on python 2.7 probably because of: 
```python
from future.builtins import *
```

Following [this answer on Stack Overflow](http://stackoverflow.com/questions/2104080/how-to-check-file-size-in-python/19079887#19079887), I suggest (sorry, I have no time to make a PR):
```python
cur_pos = fh.tell()
fh.seek(0, os.SEEK_END)
size = fh.tell()
fh.seek(cur_pos, os.SEEK_SET)
```
(note also the use of `os.SEEK_END` and `os.SEEK_SET` for better code readability).