### PR TITLE
client.fdsn: add shortcut for new EIDA node KOERI

### DIFF
--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -32,6 +32,7 @@ URL_MAPPINGS = {
     "INGV": "http://webservices.rm.ingv.it",
     "IPGP": "http://eida.ipgp.fr",
     "IRIS": "http://service.iris.edu",
+    "KOERI": "http://eida.koeri.boun.edu.tr",
     "LMU": "http://erde.geophysik.uni-muenchen.de",
     "NCEDC": "http://service.ncedc.org",
     "NEIP": "http://eida-sc3.infp.ro",


### PR DESCRIPTION
Minor edit of the URL map to add a new EIDA node. Formally this is a new feature, so I branched from master, but I'd propose that it is ported back to releases as well.
