### PR TITLE
basic seedlink client: properly timeout for requests that do not deliver data

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,8 @@ releases:
    * Don't prematurely close waveform figure if returning its handle
  - obspy.seedlink:
    * Fix Python3 compatibility for seedlink.easyseedlink
+   * Basic seedlink client: Properly timeout requests with valid station
+     selection but no data available in selected time window (see # 1045)
  - obspy.signal:
    * Fix return data types/values of polarization routines (see #1026)
  - obspy.station:

--- a/obspy/seedlink/basic_client.py
+++ b/obspy/seedlink/basic_client.py
@@ -46,14 +46,15 @@ class Client(object):
         """
         self.timeout = timeout
         self.debug = debug
-        self._slclient = SLClient(loglevel=debug and "DEBUG" or "CRITICAL")
+        self._slclient = SLClient(loglevel=debug and "DEBUG" or "CRITICAL",
+                                  timeout=self.timeout)
         self._server_url = "%s:%i" % (server, port)
 
     def _connect(self):
         """
         Open new connection to seedlink server.
         """
-        self._slclient.slconn = SeedLinkConnection()
+        self._slclient.slconn = SeedLinkConnection(timeout=self.timeout)
         self._slclient.slconn.setSLAddress(self._server_url)
         self._slclient.slconn.netto = self.timeout
 

--- a/obspy/seedlink/slclient.py
+++ b/obspy/seedlink/slclient.py
@@ -96,6 +96,9 @@ class SLClient(object):
     :type  end_time: str
     :var infolevel: INFO LEVEL for info request only.
     :type  infolevel: str
+    :type timeout: float
+    :param timeout: Timeout in seconds, passed on to the underlying
+        SeedLinkConnection.
     """
     VERSION = "1.2.0X00"
     VERSION_YEAR = "2011"
@@ -104,7 +107,7 @@ class SLClient(object):
     PROGRAM_NAME = "SLClient v" + VERSION
     VERSION_INFO = PROGRAM_NAME + " (" + VERSION_DATE + ")"
 
-    def __init__(self, loglevel='DEBUG'):
+    def __init__(self, loglevel='DEBUG', timeout=None):
         """
         Creates a new instance of SLClient with the specified logging object
         """
@@ -123,7 +126,8 @@ class SLClient(object):
         self.begin_time = None
         self.end_time = None
         self.infolevel = None
-        self.slconn = SeedLinkConnection()
+        self.timeout = timeout
+        self.slconn = SeedLinkConnection(timeout=timeout)
 
     def parseCmdLineArgs(self, args):
         """


### PR DESCRIPTION
Currently requests for valid station selectors but for which no data is available in requested time window never terminate (looping endlessly, like is general behavior for the underlying seedlink client).