### PR TITLE
readDatamark bug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,9 @@ releases:
  - obspy.core:
    * Fix catalog plot with events that have no origin depth or
      origin time (see #1021)
- - obspy.earthworm
+ - obspy.datamark:
+   * Fix datawide=3 and datawide=0.5 block reading
+ - obspy.earthworm:
    * Fix Python3 compatibility problem
  - obspy.imaging:
    * Fix flipped maps due to bug in Basemap

--- a/obspy/datamark/core.py
+++ b/obspy/datamark/core.py
@@ -80,11 +80,12 @@ def readDATAMARK(filename, century="20", **kwargs):  # @UnusedVariable
         start = 0
         while leng < sz:
             pklen = fpin.read(4)
-            if len(pklen) == 0:
-                break  # EOF
+            if len(pklen) < 4:
+                break
             leng = 4
-            # equiv to Str4Int
             truelen = np.fromstring(pklen, native_str('>i'))[0]
+            if truelen == 0:
+                break
             buff = fpin.read(6)
             leng += 6
 
@@ -111,7 +112,7 @@ def readDATAMARK(filename, century="20", **kwargs):  # @UnusedVariable
                 srate = ord(buff[3:4])
                 xlen = (srate - 1) * datawide
                 if datawide == 0:
-                    xlen = srate / 2
+                    xlen = srate // 2
                     datawide = 0.5
 
                 idata00 = fpin.read(4)
@@ -133,7 +134,7 @@ def readDATAMARK(filename, century="20", **kwargs):  # @UnusedVariable
                     warnings.warn(msg)
 
                 if datawide == 0.5:
-                    for i in range(srate // 2):
+                    for i in range(xlen):
                         idata2 = output[chanum][-1] + \
                             np.fromstring(sdata[i:i + 1], np.int8)[0] >> 4
                         output[chanum].append(idata2)
@@ -155,7 +156,7 @@ def readDATAMARK(filename, century="20", **kwargs):  # @UnusedVariable
                 elif datawide == 3:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[3 * i:3 * (i + 1)] + ' ',
+                            np.fromstring(sdata[3 * i:3 * (i + 1)] + b' ',
                                           native_str('>i'))[0] >> 8
                         output[chanum].append(idata2)
                 elif datawide == 4:


### PR DESCRIPTION
Hi,

this bug wasn't occurring in 0.9.2, before the refactor to py3. The reason it's there is , of course, because tests don't test all `datawide`. Here is an example with datawide=3:

```python
In [49]: st = read('11031100.00')
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-49-a2e4c63ee40f> in <module>()
----> 1 st = read('11031100.00')

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\core\util\d
ecorator.pyc in new_func(*args, **kwargs)
    305                             except IOError:
    306                                 pass
--> 307             return func(*args, **kwargs)
    308
    309         new_func.__name__ = func.__name__

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\core\stream
.pyc in read(pathname_or_url, format, headonly, starttime, endtime, nearest_samp
le, dtype, apply_calib, **kwargs)
    229         pathname = pathname_or_url
    230         for file in sorted(glob(pathname)):
--> 231             st.extend(_read(file, format, headonly, **kwargs).traces)
    232         if len(st) == 0:
    233             # try to give more specific information why the stream is em
pty

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\core\util\d
ecorator.pyc in wrapped_func(filename, *args, **kwargs)
    213         else:
    214             # no compressions
--> 215             result = func(filename, *args, **kwargs)
    216         return result
    217     return wrapped_func

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\core\stream
.pyc in _read(filename, format, headonly, **kwargs)
    273     """
    274     stream, format = _readFromPlugin('waveform', filename, format=format
,
--> 275                                      headonly=headonly, **kwargs)
    276     # set _format identifier for each element
    277     for trace in stream:

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\core\util\b
ase.pyc in _readFromPlugin(plugin_type, filename, format, **kwargs)
    417         raise TypeError(msg % (format_ep.name, ', '.join(EPS)))
    418     # read
--> 419     list_obj = readFormat(filename, **kwargs)
    420     return list_obj, format_ep.name
    421

C:\Anaconda\lib\site-packages\obspy-0.10.1-py2.7-win-amd64.egg\obspy\datamark\co
re.pyc in readDATAMARK(filename, century, **kwargs)
    156                     for i in range((xlen // datawide)):
    157                         idata2 = output[chanum][-1] +\
--> 158                             np.fromstring(sdata[3 * i:3 * (i + 1)] + ' '
,
    159                                           native_str('>i'))[0] >> 8
    160                         output[chanum].append(idata2)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xfb in position 0: ordinal
not in range(128)

In [50]:
```
with this file:
http://homepage.oma.be/lecocq/11031100.00

