### PR TITLE
station/stationxml: move DataAvailability from Channel to BaseNode

### DIFF
--- a/obspy/station/channel.py
+++ b/obspy/station/channel.py
@@ -150,12 +150,12 @@ class Channel(BaseNode):
         self.data_logger = data_logger
         self.equipment = equipment
         self.response = response
-        self.data_availability = data_availability
         super(Channel, self).__init__(
             code=code, description=description, comments=comments,
             start_date=start_date, end_date=end_date,
             restricted_status=restricted_status, alternate_code=alternate_code,
-            historical_code=historical_code)
+            historical_code=historical_code,
+            data_availability=data_availability)
 
     def __str__(self):
         ret = (

--- a/obspy/station/network.py
+++ b/obspy/station/network.py
@@ -34,7 +34,7 @@ class Network(BaseNode):
                  selected_number_of_stations=None, description=None,
                  comments=None, start_date=None, end_date=None,
                  restricted_status=None, alternate_code=None,
-                 historical_code=None):
+                 historical_code=None, data_availability=None):
         """
         :type code: str
         :param code: The SEED network code.
@@ -64,6 +64,9 @@ class Network(BaseNode):
         :type historical_code: str, optional
         :param historical_code: A previously used code if different from the
             current code.
+        :type data_availability: :class:`~obspy.station.util.DataAvailability`
+        :param data_availability: Information about time series availability
+            for the network.
         """
         self.stations = stations or []
         self.total_number_of_stations = total_number_of_stations
@@ -73,7 +76,8 @@ class Network(BaseNode):
             code=code, description=description, comments=comments,
             start_date=start_date, end_date=end_date,
             restricted_status=restricted_status, alternate_code=alternate_code,
-            historical_code=historical_code)
+            historical_code=historical_code,
+            data_availability=data_availability)
 
     def __getitem__(self, index):
         return self.stations[index]

--- a/obspy/station/station.py
+++ b/obspy/station/station.py
@@ -37,7 +37,7 @@ class Station(BaseNode):
                  selected_number_of_channels=None, description=None,
                  comments=None, start_date=None, end_date=None,
                  restricted_status=None, alternate_code=None,
-                 historical_code=None):
+                 historical_code=None, data_availability=None):
         """
         :type channels: list of :class:`~obspy.station.channel.Channel`
         :param channels: All channels belonging to this station.
@@ -93,6 +93,9 @@ class Station(BaseNode):
         :type historical_code: str, optional
         :param historical_code: A previously used code if different from the
             current code.
+        :type data_availability: :class:`~obspy.station.util.DataAvailability`
+        :param data_availability: Information about time series availability
+            for the station.
         """
         self.latitude = latitude
         self.longitude = longitude
@@ -112,7 +115,8 @@ class Station(BaseNode):
             code=code, description=description, comments=comments,
             start_date=start_date, end_date=end_date,
             restricted_status=restricted_status, alternate_code=alternate_code,
-            historical_code=historical_code)
+            historical_code=historical_code,
+            data_availability=data_availability)
 
     def __str__(self):
         contents = self.get_contents()

--- a/obspy/station/stationxml.py
+++ b/obspy/station/stationxml.py
@@ -139,6 +139,11 @@ def _read_base_node(element, object_to_write_to, _ns):
     object_to_write_to.comments = []
     for comment in element.findall(_ns("Comment")):
         object_to_write_to.comments.append(_read_comment(comment, _ns))
+    # Availability.
+    data_availability = element.find(_ns("DataAvailability"))
+    if data_availability is not None:
+        object_to_write_to.data_availability = \
+            _read_data_availability(data_availability, _ns)
 
 
 def _read_network(net_element, _ns):
@@ -302,11 +307,6 @@ def _read_channel(cha_element, _ns):
     equipment = cha_element.find(_ns("Equipment"))
     if equipment is not None:
         channel.equipment = _read_equipment(equipment, _ns)
-    # Availability.
-    data_availability = cha_element.find(_ns("DataAvailability"))
-    if data_availability is not None:
-        channel.data_availability = _read_data_availability(
-            data_availability, _ns)
     # Finally parse the response.
     response = cha_element.find(_ns("Response"))
     if response is not None:

--- a/obspy/station/util.py
+++ b/obspy/station/util.py
@@ -32,7 +32,7 @@ class BaseNode(ComparingObject):
     """
     def __init__(self, code, description=None, comments=None, start_date=None,
                  end_date=None, restricted_status=None, alternate_code=None,
-                 historical_code=None):
+                 historical_code=None, data_availability=None):
         """
         :type code: str
         :param code: The SEED network, station, or channel code
@@ -53,6 +53,9 @@ class BaseNode(ComparingObject):
         :type historical_code: str, optional
         :param historical_code: A previously used code if different from the
             current code.
+        :type data_availability: :class:`~obspy.station.util.DataAvailability`
+        :param data_availability: Information about time series availability
+            for the network/station/channel.
         """
         self.code = code
         self.comments = comments or []
@@ -62,6 +65,7 @@ class BaseNode(ComparingObject):
         self.restricted_status = restricted_status
         self.alternate_code = alternate_code
         self.historical_code = historical_code
+        self.data_availability = data_availability
 
     @property
     def code(self):


### PR DESCRIPTION
According to the [FDSN xml schema (the extension for data availability)](https://github.com/obspy/obspy/blob/master/obspy/io/stationxml/data/fdsn-station%2Bavailability-1.0.xsd) data availability is defined for all of network/station/channel and not only for channel. It thus should be moved to the parent class `BaseNode`.