### PR TITLE
obspy.signal.rotate.rotate2ZNE seems buggy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@
     * Blockette 100 is now only written for Traces that need it. Previously
       it was written or not for all Traces, depending on whether the last
       Trace needed it or not. (see #1069)
+  - obspy.signal:
+    * Bug fixed within rotate.rotate2ZNE(). Additionally it can now also
+      perform the inverse rotation (see #1061).
   - obspy.station:
     * ObsPy no longer assumes that the StationXML namespace is the default
       namespace (see #1060).

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -159,31 +159,22 @@ def _dip_azimuth2ZSE_base_vector(dip, azimuth):
     dip = np.deg2rad(dip)
     azimuth = np.deg2rad(azimuth)
 
-    # Define the rotation axis for the dip.
-    c1 = 0.0
-    c2 = 0.0
-    c3 = -1.0
-    # Now the dip rotation matrix.
-    dip_rotation_matrix = np.cos(dip) * \
-        np.matrix(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))) + \
-        (1 - np.cos(dip)) * np.matrix(((c1 * c1, c1 * c2, c1 * c3),
-                                       (c2 * c1, c2 * c2, c2 * c3),
-                                       (c3 * c1, c3 * c2, c3 * c3))) + \
-        np.sin(dip) * np.matrix(((0, -c3, c2), (c3, 0, -c1), (-c2, c1, 0)))
-    # Do the same for the azimuth.
-    c1 = -1.0
-    c2 = 0.0
-    c3 = 0.0
-    azimuth_rotation_matrix = np.cos(azimuth) * \
-        np.matrix(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))) + \
-        (1 - np.cos(azimuth)) * np.matrix(((c1 * c1, c1 * c2, c1 * c3),
-                                           (c2 * c1, c2 * c2, c2 * c3),
-                                           (c3 * c1, c3 * c2, c3 * c3))) + \
-        np.sin(azimuth) * np.matrix(((0, -c3, c2), (c3, 0, -c1), (-c2, c1, 0)))
+    # We start with a northwards pointing vector. Thus the dip is just a
+    # rotation around the east axis with the negative angle.
+    dip_rot = np.matrix((
+        (np.cos(-dip), -np.sin(-dip), 0.0),
+        (np.sin(-dip), np.cos(-dip), 0.0),
+        (0.0, 0.0, 1.0)))
 
-    # Now simply rotate a north pointing unit vector with both matrixes.
-    temp = np.dot(azimuth_rotation_matrix, [[0.0], [-1.0], [0.0]])
-    return np.array(np.dot(dip_rotation_matrix, temp)).ravel()
+    # Azimuth is rotation around the vertical axis, again with the negative
+    # angle.
+    azi_rot = np.matrix((
+        (1.0, 0.0, 0.0),
+        (0.0, np.cos(-azimuth), -np.sin(-azimuth)),
+        (0.0, np.sin(-azimuth), np.cos(-azimuth))))
+
+    return np.array(np.dot((azi_rot * dip_rot ),
+                           np.array([0.0, -1.0, 0.0]))).ravel()
 
 
 def rotate2ZNE(data_1, azimuth_1, dip_1, data_2, azimuth_2, dip_2, data_3,

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -155,12 +155,12 @@ def _dip_azimuth2ZSE_base_vector(dip, azimuth):
     >>> r(_dip_azimuth2ZSE_base_vector(0, 270)) #doctest: +NORMALIZE_WHITESPACE
     array([ 0., 0., -1.])
     """
-    dip = -np.deg2rad(dip)
-    azimuth = -np.deg2rad(azimuth)
+    dip = np.deg2rad(dip)
+    azimuth = np.deg2rad(azimuth)
 
-    return np.array([np.sin(dip),
+    return np.array([-np.sin(dip),
                      -np.cos(azimuth) * np.cos(dip),
-                     -np.sin(azimuth) * np.cos(dip)])
+                     np.sin(azimuth) * np.cos(dip)])
 
 
 def rotate2ZNE(data_1, azimuth_1, dip_1, data_2, azimuth_2, dip_2, data_3,

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -197,15 +197,20 @@ def rotate2ZNE(data_1, azimuth_1, dip_1, data_2, azimuth_2, dip_2, data_3,
         `inverse` is `False`. Otherwise they will be oriented as specified
         by the dips and azimuths.
 
-    >>> # An input of ZNE yields an output of ZNE
+    An input of ZNE yields an output of ZNE
+
     >>> rotate2ZNE(np.arange(3), 0, -90, np.arange(3) * 2, 0, 0, \
             np.arange(3) * 3, 90, 0) # doctest: +NORMALIZE_WHITESPACE
     (array([ 0., 1., 2.]), array([ 0., 2., 4.]), array([ 0., 3., 6.]))
-    >>> # An input of ZSE yields an output of ZNE
+
+    An input of ZSE yields an output of ZNE
+
     >>> rotate2ZNE(np.arange(3), 0, -90, np.arange(3) * 2, 180, 0, \
             np.arange(3) * 3, 90, 0) # doctest: +NORMALIZE_WHITESPACE
     (array([ 0., 1., 2.]), array([ 0., -2., -4.]), array([ 0., 3., 6.]))
-    >>> # Mixed up components should get rotated to ZNE.
+
+    Mixed up components should get rotated to ZNE.
+
     >>> rotate2ZNE(np.arange(3), 0, 0, np.arange(3) * 2, 90, 0, \
             np.arange(3) * 3, 0, -90) # doctest: +NORMALIZE_WHITESPACE
     (array([ 0., 3., 6.]), array([ 0., 1., 2.]), array([ 0., 2., 4.]))

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -155,26 +155,12 @@ def _dip_azimuth2ZSE_base_vector(dip, azimuth):
     >>> r(_dip_azimuth2ZSE_base_vector(0, 270)) #doctest: +NORMALIZE_WHITESPACE
     array([ 0., 0., -1.])
     """
-    # Convert both to radian.
-    dip = np.deg2rad(dip)
-    azimuth = np.deg2rad(azimuth)
+    dip = -np.deg2rad(dip)
+    azimuth = -np.deg2rad(azimuth)
 
-    # We start with a northwards pointing vector. Thus the dip is just a
-    # rotation around the east axis with the negative angle.
-    dip_rot = np.matrix((
-        (np.cos(-dip), -np.sin(-dip), 0.0),
-        (np.sin(-dip), np.cos(-dip), 0.0),
-        (0.0, 0.0, 1.0)))
-
-    # Azimuth is rotation around the vertical axis, again with the negative
-    # angle.
-    azi_rot = np.matrix((
-        (1.0, 0.0, 0.0),
-        (0.0, np.cos(-azimuth), -np.sin(-azimuth)),
-        (0.0, np.sin(-azimuth), np.cos(-azimuth))))
-
-    return np.array(np.dot((azi_rot * dip_rot ),
-                           np.array([0.0, -1.0, 0.0]))).ravel()
+    return np.array([np.sin(dip),
+                     -np.cos(azimuth) * np.cos(dip),
+                     -np.sin(azimuth) * np.cos(dip)])
 
 
 def rotate2ZNE(data_1, azimuth_1, dip_1, data_2, azimuth_2, dip_2, data_3,

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from obspy.signal import (rotate_LQT_ZNE, rotate_NE_RT, rotate_RT_NE,
                           rotate_ZNE_LQT)
-from obspy.signal.rotate import _dip_azimuth2ZSE_base_vector
+from obspy.signal.rotate import _dip_azimuth2ZSE_base_vector, rotate2ZNE
 
 
 class RotateTestCase(unittest.TestCase):
@@ -132,6 +132,30 @@ class RotateTestCase(unittest.TestCase):
         new_n, new_e = rotate_RT_NE(new_n, new_e, ba)
         self.assertTrue(np.allclose(data_n, new_n, rtol=1E-7, atol=1E-12))
         self.assertTrue(np.allclose(data_e, new_e, rtol=1E-7, atol=1E-12))
+
+    def test_rotate2ZNE_round_trip(self):
+        """
+        The rotate2ZNE() function has an inverse argument. Thus round
+        tripping should work.
+        """
+        z = np.ones(10, dtype=np.float64)
+        n = 2.0 * np.ones(10, dtype=np.float64)
+        e = 3.0 * np.ones(10, dtype=np.float64)
+
+        # Random values.
+        dip_1, dip_2, dip_3 = 0.0, 30.0, 60.0
+        azi_1, azi_2, azi_3 = 0.0, 170.0, 35.0
+
+        a, b, c = rotate2ZNE(z, azi_1, dip_1, n, azi_2, dip_2, e, azi_3, dip_3)
+
+        z_new, n_new, e_new = rotate2ZNE(a, azi_1, dip_1,
+                                         b, azi_2, dip_2,
+                                         c, azi_3, dip_3,
+                                         inverse=True)
+
+        self.assertTrue(np.allclose(z, z_new, rtol=1E-7, atol=1e-7))
+        self.assertTrue(np.allclose(n, n_new, rtol=1E-7, atol=1e-7))
+        self.assertTrue(np.allclose(e, e_new, rtol=1E-7, atol=1e-7))
 
     def test_base_vector_from_azimuth_and_dip_calculation(self):
         """

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -172,9 +172,9 @@ class RotateTestCase(unittest.TestCase):
         v2_ref = np.array([np.sqrt(2.0), -np.sqrt(3.0), 1.0]) / np.sqrt(6.0)
         v3_ref = np.array([np.sqrt(2.0), np.sqrt(3.0), 1.0]) / np.sqrt(6.0)
 
-        self.assertTrue(np.allclose(v1, v1_ref, rtol=1E-7, atol=1e-7))
-        self.assertTrue(np.allclose(v2, v2_ref, rtol=1E-7, atol=1e-7))
-        self.assertTrue(np.allclose(v3, v3_ref, rtol=1E-7, atol=1e-7))
+        self.assertTrue(np.allclose(v1, v1_ref, rtol=1E-7, atol=1E-7))
+        self.assertTrue(np.allclose(v2, v2_ref, rtol=1E-7, atol=1E-7))
+        self.assertTrue(np.allclose(v3, v3_ref, rtol=1E-7, atol=1E-7))
 
     def test_galperin_configuration(self):
         """
@@ -198,11 +198,9 @@ class RotateTestCase(unittest.TestCase):
         n_ref = np.array([0.0, fac * 2.0 * np.sqrt(3.0), 0.0])
         e_ref = np.array([0.0, 0.0, -4.0 * fac])
 
-        np.testing.assert_allclose(e, e_ref)
-
-        self.assertTrue(np.allclose(z, z_ref))
-        self.assertTrue(np.allclose(n, n_ref))
-        self.assertTrue(np.allclose(e, e_ref))
+        self.assertTrue(np.allclose(z, z_ref, rtol=1E-7, atol=1E-7))
+        self.assertTrue(np.allclose(n, n_ref, rtol=1E-7, atol=1E-7))
+        self.assertTrue(np.allclose(e, e_ref, rtol=1E-7, atol=1E-7))
 
 
 def suite():

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -176,6 +176,34 @@ class RotateTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(v2, v2_ref, rtol=1E-7, atol=1e-7))
         self.assertTrue(np.allclose(v3, v3_ref, rtol=1E-7, atol=1e-7))
 
+    def test_galperin_configuration(self):
+        """
+        Equal arrays on a Galperin configuration should result in only the
+        vertical component remaining.
+        """
+        dip = - (90.0 - np.rad2deg(np.arctan(np.sqrt(2.0))))
+
+        u = np.array([1.0, 0.0, 1.0])
+        v = np.array([1.0, 1.0, -1.0])
+        w = np.array([1.0, -1.0, -1.0])
+
+        z, n, e = rotate2ZNE(
+            u, -90, dip,
+            v, 30, dip,
+            w, 150, dip)
+
+        fac = 1.0 / np.sqrt(6.0)
+
+        z_ref = np.array([fac * 3.0 * np.sqrt(2.0), 0.0, -fac * np.sqrt(2.0)])
+        n_ref = np.array([0.0, fac * 2.0 * np.sqrt(3.0), 0.0])
+        e_ref = np.array([0.0, 0.0, -4.0 * fac])
+
+        np.testing.assert_allclose(e, e_ref)
+
+        self.assertTrue(np.allclose(z, z_ref))
+        self.assertTrue(np.allclose(n, n_ref))
+        self.assertTrue(np.allclose(e, e_ref))
+
 
 def suite():
     return unittest.makeSuite(RotateTestCase, 'test')

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from obspy.signal import (rotate_LQT_ZNE, rotate_NE_RT, rotate_RT_NE,
                           rotate_ZNE_LQT)
+from obspy.signal.rotate import _dip_azimuth2ZSE_base_vector
 
 
 class RotateTestCase(unittest.TestCase):
@@ -131,6 +132,25 @@ class RotateTestCase(unittest.TestCase):
         new_n, new_e = rotate_RT_NE(new_n, new_e, ba)
         self.assertTrue(np.allclose(data_n, new_n, rtol=1E-7, atol=1E-12))
         self.assertTrue(np.allclose(data_e, new_e, rtol=1E-7, atol=1E-12))
+
+    def test_base_vector_from_azimuth_and_dip_calculation(self):
+        """
+        Tests the _dip_azimuth2ZSE_base_vector() method against a solution
+        from the Wieland book.
+        """
+        dip = - (90.0 - np.rad2deg(np.arctan(np.sqrt(2.0))))
+
+        v1 = _dip_azimuth2ZSE_base_vector(dip, -90.0)
+        v2 = _dip_azimuth2ZSE_base_vector(dip, 30.0)
+        v3 = _dip_azimuth2ZSE_base_vector(dip, 150.0)
+
+        v1_ref = np.array([np.sqrt(2.0), 0.0, -2.0]) / np.sqrt(6.0)
+        v2_ref = np.array([np.sqrt(2.0), -np.sqrt(3.0), 1.0]) / np.sqrt(6.0)
+        v3_ref = np.array([np.sqrt(2.0), np.sqrt(3.0), 1.0]) / np.sqrt(6.0)
+
+        self.assertTrue(np.allclose(v1, v1_ref, rtol=1E-7, atol=1e-7))
+        self.assertTrue(np.allclose(v2, v2_ref, rtol=1E-7, atol=1e-7))
+        self.assertTrue(np.allclose(v3, v3_ref, rtol=1E-7, atol=1e-7))
 
 
 def suite():


### PR DESCRIPTION
I am failing to understand the result of rotate2ZNE and I think the problem is in _dip_azimuth2ZSE_base_vector. If I build the matrix, I observe two problems: 

~~~~{.python}
#!/usr/bin/env python
import numpy as np
from obspy.signal.rotate import _dip_azimuth2ZSE_base_vector

dip_1, dip_2, dip_3, = 35.3, 35.3, 35.3
azimuth_1, azimuth_2, azimuth_3 = 0., 120., 240.

base_vector_1 = _dip_azimuth2ZSE_base_vector(dip_1, azimuth_1)
base_vector_2 = _dip_azimuth2ZSE_base_vector(dip_2, azimuth_2)
base_vector_3 = _dip_azimuth2ZSE_base_vector(dip_3, azimuth_3)

T = np.matrix([base_vector_1, base_vector_2, base_vector_3]).transpose()
print(T)
[[-0.57785762  0.28892881  0.28892881]
 [-0.81613759  0.4080688   0.4080688 ]
 [ 0.          0.8660254  -0.8660254 ]]

~~~~

according to Wieland, this is what the matrix should look like:

![wieland](https://cloud.githubusercontent.com/assets/2306288/7860781/4bfae708-054c-11e5-8735-8d2aecef7209.png)

However, for the Z component (first line of T, last line in Wielands notation), the values are not all the same. Secondly, the matrix is not invertible, which it should be because the components are linearly independent;

~~~~{.python}
  File "/home/ex/anaconda/lib/python2.7/site-packages/numpy/linalg/linalg.py", line 90, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
numpy.linalg.linalg.LinAlgError: Singular matrix
~~~~

This is what I would need at the moment, because I want to compute UVW given NEZ.

Also, the tests seem to cover only very specific examples (orthogonal bases).