### PR TITLE
readEvents not working with wildcarded filename

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 0.10.x:
   - obspy.core:
+    * Fix reading of multiple catalog files using globs (see #1065).
     * Fixed a bug when using
       `Trace.remove_response(..., water_level=None)`.
       With that setting that is supposed to not use any water level

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -139,11 +139,10 @@ def readEvents(pathname_or_url=None, format=None, **kwargs):
                 raise IOError(2, "No such file or directory", pathname)
 
         catalog = _read(pathnames[0], format, **kwargs)
-        if len(pathnames) == 1:
-            return catalog
-        else:
+        if len(pathnames) > 1:
             for filename in pathnames[1:]:
                 catalog.extend(_read(filename, format, **kwargs).events)
+        return catalog
 
 
 @uncompressFile

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -130,7 +130,7 @@ def readEvents(pathname_or_url=None, format=None, **kwargs):
     else:
         pathname = pathname_or_url
         # File name(s)
-        pathnames = glob.glob(pathname)
+        pathnames = sorted(glob.glob(pathname))
         if not pathnames:
             # try to give more specific information why the stream is empty
             if glob.has_magic(pathname) and not glob.glob(pathname):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -192,6 +192,7 @@ class CatalogTestCase(unittest.TestCase):
     def setUp(self):
         # directory where the test files are located
         path = os.path.join(os.path.dirname(__file__), 'data')
+        self.path = path
         self.image_dir = os.path.join(os.path.dirname(__file__), 'images')
         self.iris_xml = os.path.join(path, 'iris_events.xml')
         self.neries_xml = os.path.join(path, 'neries_events.xml')
@@ -237,6 +238,17 @@ class CatalogTestCase(unittest.TestCase):
         self.assertEqual(catalog[0]._format, 'QUAKEML')
         self.assertEqual(catalog[1]._format, 'QUAKEML')
         self.assertEqual(catalog[2]._format, 'QUAKEML')
+
+    def test_readEvents_with_wildcard(self):
+        """
+        Tests the readEvents function with a filename wild card.
+        """
+        # without wildcard..
+        expected = readEvents(self.iris_xml)
+        expected += readEvents(self.neries_xml)
+        # with wildcard
+        got = readEvents(os.path.join(self.path, "*_events.xml"))
+        self.assertEqual(expected, got)
 
     def test_append(self):
         """


### PR DESCRIPTION
Currently `readEvents` seems broken due to the `map_example_filename` decorator, always returning `None` when reading multiple files.