### PR TITLE
obspy.mseed Blockette 100 fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
 0.10.x:
+  - obspy.mseed:
+    * Blockette 100 is now only written for Traces that need it. Previously
+      it was written or not for all Traces, depending on whether the last
+      Trace needed it or not. (see #1069)
   - obspy.station:
     * ObsPy no longer assumes that the StationXML namespace is the default
       namespace (see #1060).

--- a/obspy/mseed/core.py
+++ b/obspy/mseed/core.py
@@ -594,15 +594,6 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
         else:
             trace_attr['timing_quality'] = timing_quality = 0
 
-        # Determine if a blockette 100 will be needed to represent the input
-        # sample rate or if the sample rate in the fixed section of the data
-        # header will suffice (see ms_genfactmult in libmseed/genutils.c)
-        if trace.stats.sampling_rate >= 32727.0 or \
-           trace.stats.sampling_rate <= (1.0 / 32727.0):
-            use_blkt_100 = True
-        else:
-            use_blkt_100 = False
-
         if sequence_number is not None:
             trace_attr['sequence_number'] = sequence_number
         elif hasattr(trace.stats, 'mseed') and \
@@ -828,7 +819,11 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
                 del msr
                 raise Exception('Error in msr_addblockette')
         # Only use Blockette 100 if necessary.
-        if use_blkt_100:
+        # Determine if a blockette 100 will be needed to represent the input
+        # sample rate or if the sample rate in the fixed section of the data
+        # header will suffice (see ms_genfactmult in libmseed/genutils.c)
+        if trace.stats.sampling_rate >= 32727.0 or \
+                        trace.stats.sampling_rate <= (1.0 / 32727.0):
             size = C.sizeof(blkt_100_s)
             blkt100 = C.c_char(b' ')
             C.memset(C.pointer(blkt100), 0, size)

--- a/obspy/mseed/core.py
+++ b/obspy/mseed/core.py
@@ -823,7 +823,7 @@ def writeMSEED(stream, filename, encoding=None, reclen=None, byteorder=None,
         # sample rate or if the sample rate in the fixed section of the data
         # header will suffice (see ms_genfactmult in libmseed/genutils.c)
         if trace.stats.sampling_rate >= 32727.0 or \
-                        trace.stats.sampling_rate <= (1.0 / 32727.0):
+                trace.stats.sampling_rate <= (1.0 / 32727.0):
             size = C.sizeof(blkt_100_s)
             blkt100 = C.c_char(b' ')
             C.memset(C.pointer(blkt100), 0, size)


### PR DESCRIPTION
This PR fixes a bug in `obspy.mseed` that has been reported to me.

It probably never really resulted in a problem because usually

1. The sampling rate is not in the problematic range or
2. all traces have the same sampling rate

I nonetheless also added a test.
