### PR TITLE
switch to using miniconda in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,34 @@ python:
   - 3.3
   - 3.4
 sudo: false
-before_install:
+install:
   - lsb_release -a # get info on the operating system
-  - pip install --upgrade pip
-  - pip install --upgrade setuptools
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == '2' ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy==1.8.2 scipy==0.14.0 matplotlib==1.3.1 basemap==1.0.7 flake8 future lxml sqlalchemy mock nose
+  - source activate test-environment
+  # install packages not available via conda
   - pip install wheel
   - wget -q -O - 'https://github.com/obspy/wheelhouse/archive/master.tar.gz' | tar -C /tmp -xzf -
-  - pip install --use-wheel --no-index --find-links=/tmp/wheelhouse-master numpy==1.8.2 scipy==0.14.0 lxml sqlalchemy mock nose pyproj
+  - pip install --use-wheel --no-index --find-links=/tmp/wheelhouse-master pyproj
   - pip install --use-wheel --find-links=/tmp/wheelhouse-master coveralls
   - pip install geographiclib
-  - pip install --use-wheel --no-index --find-links=/tmp/wheelhouse-master matplotlib==1.3.1
-  - pip install --use-wheel --no-index --find-links=/tmp/wheelhouse-master basemap==1.0.7
-  - pip install flake8
-  - pip install future
   # current pyimgur stable release has a py2.6 incompatibility
   - pip install https://github.com/megies/PyImgur/archive/py26.zip
   - pip freeze
-install:
+  - conda list
+  # done installing dependencies
   - git version
   - git fetch origin --tags --unshallow
   - git remote add obspy git://github.com/obspy/obspy.git


### PR DESCRIPTION
I'd like to switch to using Miniconda for setting up our test environments in Travis, in order to install the 'gdal' module for testing of #1066 (has some problem installing from source using pypi in Travis: https://travis-ci.org/obspy/obspy/jobs/65150311#L4921).