### PR TITLE
Sliding Window Generator on Stream and Trace objects.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,11 @@ master:
    * Support for additional event data formats:
      - CMTSOLUTION files used by many waveform solvers.
      - ESRI shapefile write support, useful in GIS applications (see #1066)
+ - obspy.core:
+   * New method for generating sliding windows from Stream/Trace windows.
+     (see #860)
+   * Stream/Trace.slice() now has the optional `nearest_sample` argument from
+     Stream/Trace.trim().
  - obspy.clients.neries:
    * Removed the dedicated client. Data can still be accessed by using the FDSN
      client.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1622,11 +1622,13 @@ class Stream(object):
 
         Please keep in mind that it only returns a new view of the original
         data. Any modifications are applied to the original data as well. If
-        you don't want this you have to create a copy of the yielded windows.
+        you don't want this you have to create a copy of the yielded
+        windows. Also be aware that if you modify the original data and you
+        have overlapping windows, all following windows are affected as well.
 
         Not all yielded windows must have the same number of traces. The
-        algorithm will determine the maximal temporal extends by analysing
-        all Traces and then create windows based on these times.
+        algorithm will determine the maximal temporal extents by analysing
+        all Traces and then creates windows based on these times.
 
         .. rubric:: Example
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1434,8 +1434,9 @@ class Stream(object):
             given ``fill_value``. Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::
@@ -1567,8 +1568,9 @@ class Stream(object):
             Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::
@@ -1656,8 +1658,9 @@ class Stream(object):
             shorter then 99.9 % of the desired length are returned.
         :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1626,6 +1626,24 @@ class Stream(object):
         algorithm will determine the maximal temporal extends by analysing
         all Traces and then create windows based on these times.
 
+        .. rubric:: Example
+
+        >>> import obspy
+        >>> st = obspy.read()
+        >>> for windowed_st in st.slide(window_length=10.0, step=10.0):
+        ...     print(windowed_st)
+        ...     print("---")  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        3 Trace(s) in Stream:
+        ... | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:13.000000Z | ...
+        ... | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:13.000000Z | ...
+        ... | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:13.000000Z | ...
+        ---
+        3 Trace(s) in Stream:
+        ... | 2009-08-24T00:20:13.000000Z - 2009-08-24T00:20:23.000000Z | ...
+        ... | 2009-08-24T00:20:13.000000Z - 2009-08-24T00:20:23.000000Z | ...
+        ... | 2009-08-24T00:20:13.000000Z - 2009-08-24T00:20:23.000000Z | ...
+
+
         :param window_length: The length of each window in seconds.
         :type window_length: float
         :param step: The step between the start times of two successive
@@ -1664,8 +1682,7 @@ class Stream(object):
             raise StopIteration
 
         for start, stop in windows:
-            temp = self.slice(starttime + start,
-                              starttime + stop,
+            temp = self.slice(start, stop,
                               nearest_sample=nearest_sample)
             # It might happen that there is a time frame where there are no
             # windows, e.g. two traces seperated by a large gap.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1614,7 +1614,7 @@ class Stream(object):
         return new
 
     def slide(self, window_length, step, offset=0,
-              include_partial_windows=False):
+              include_partial_windows=False, nearest_sample=True):
         """
         Iterator to return equal length windows of the Stream.
 
@@ -1633,6 +1633,18 @@ class Stream(object):
             the first sample in the trace.
         :param include_partial_windows: Determines if windows that are
             shorter then 99.9 % of the desired length are returned.
+        :type nearest_sample: bool, optional
+        :param nearest_sample: If set to ``True``, the closest sample is
+            selected, if set to ``False``, the next sample containing the time
+            is selected. Defaults to ``True``.
+
+            Given the following trace containing 4 samples, "|" are the
+            sample points, "A" is the requested starttime::
+
+                |        A|         |         |
+
+            ``nearest_sample=True`` will select the second sample point,
+            ``nearest_sample=False`` will select the first sample point.
         """
         starttime = min(tr.stats.starttime for tr in self)
         endtime = max(tr.stats.endtime for tr in self)
@@ -1649,7 +1661,8 @@ class Stream(object):
 
         for start, stop in windows:
             temp = self.slice(starttime + start,
-                              starttime + stop)
+                              starttime + stop,
+                              nearest_sample=nearest_sample)
             # It might happen that there is a time frame where there are no
             # windows, e.g. two traces seperated by a large gap.
             if not temp:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1627,13 +1627,16 @@ class Stream(object):
         all Traces and then create windows based on these times.
 
         :param window_length: The length of each window in seconds.
+        :type window_length: float
         :param step: The step between the start times of two successive
             windows in seconds. Can be negative if an offset is given.
+        :type step: float
         :param offset: The offset of the first window in seconds relative to
-            the first sample in the trace.
+            the start time of the whole interval.
+        :type offset: float
         :param include_partial_windows: Determines if windows that are
             shorter then 99.9 % of the desired length are returned.
-        :type nearest_sample: bool, optional
+        :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
             selected, if set to ``False``, the next sample containing the time
             is selected. Defaults to ``True``.
@@ -1645,6 +1648,7 @@ class Stream(object):
 
             ``nearest_sample=True`` will select the second sample point,
             ``nearest_sample=False`` will select the first sample point.
+        :type nearest_sample: bool, optional
         """
         starttime = min(tr.stats.starttime for tr in self)
         endtime = max(tr.stats.endtime for tr in self)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1685,7 +1685,7 @@ class Stream(object):
             temp = self.slice(start, stop,
                               nearest_sample=nearest_sample)
             # It might happen that there is a time frame where there are no
-            # windows, e.g. two traces seperated by a large gap.
+            # windows, e.g. two traces separated by a large gap.
             if not temp:
                 continue
             yield temp

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1553,7 +1553,8 @@ class Stream(object):
         self.traces = tmp.traces
         return self
 
-    def slice(self, starttime=None, endtime=None, keep_empty_traces=False):
+    def slice(self, starttime=None, endtime=None, keep_empty_traces=False,
+              nearest_sample=True):
         """
         Return new Stream object cut to the given start and end time.
 
@@ -1564,6 +1565,18 @@ class Stream(object):
         :type keep_empty_traces: bool, optional
         :param keep_empty_traces: Empty traces will be kept if set to ``True``.
             Defaults to ``False``.
+        :type nearest_sample: bool, optional
+        :param nearest_sample: If set to ``True``, the closest sample is
+            selected, if set to ``False``, the next sample containing the time
+            is selected. Defaults to ``True``.
+
+            Given the following trace containing 4 samples, "|" are the
+            sample points, "A" is the requested starttime::
+
+                |        A|         |         |
+
+            ``nearest_sample=True`` will select the second sample point,
+            ``nearest_sample=False`` will select the first sample point.
         :return: :class:`~obspy.core.stream.Stream`
 
         .. note::
@@ -1593,7 +1606,8 @@ class Stream(object):
         tmp.traces = []
         new = tmp.copy()
         for trace in self:
-            sliced_trace = trace.slice(starttime=starttime, endtime=endtime)
+            sliced_trace = trace.slice(starttime=starttime, endtime=endtime,
+                                       nearest_sample=nearest_sample)
             if keep_empty_traces is False and not sliced_trace.stats.npts:
                 continue
             new.append(sliced_trace)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1616,7 +1616,7 @@ class Stream(object):
     def slide(self, window_length, step, offset=0,
               include_partial_windows=False, nearest_sample=True):
         """
-        Iterator to return equal length windows of the Stream.
+        Generator yielding equal length sliding windows of the Stream.
 
         Please keep in mind that it only returns a new view of the original
         data. Any modifications are applied to the original data as well. If

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2271,12 +2271,12 @@ class StreamTestCase(unittest.TestCase):
         tr1.stats.sampling_rate = 5.0
 
         # 5 - 10 seconds
-        tr2= Trace(data=np.linspace(25, 75, 51))
+        tr2 = Trace(data=np.linspace(25, 75, 51))
         tr2.stats.starttime = UTCDateTime(5.0)
         tr2.stats.sampling_rate = 5.0
 
         # 15 - 20 seconds
-        tr3= Trace(data=np.linspace(75, 100, 26))
+        tr3 = Trace(data=np.linspace(75, 100, 26))
         tr3.stats.starttime = UTCDateTime(0.0)
         tr3.stats.sampling_rate = 15.0
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2358,6 +2358,46 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(slices[3],
                          st.slice(UTCDateTime(0), UTCDateTime(5)))
 
+    def test_slide_nearest_sample(self):
+        """
+        Tests that the nearest_sample argument is correctly passed to the
+        slice function calls.
+        """
+        tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.starttime = UTCDateTime(0.0)
+        tr.stats.sampling_rate = 5.0
+        st = Stream(traces=[tr, tr.copy()])
+
+        # It defaults to True.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(st.slide(5, 5))
+
+        # Twice per window as two traces.
+        self.assertEqual(patch.call_count, 8)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Force True.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(st.slide(5, 5, nearest_sample=True))
+
+        # Twice per window as two traces.
+        self.assertEqual(patch.call_count, 8)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Set to False.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(st.slide(5, 5, nearest_sample=False))
+
+        # Twice per window as two traces.
+        self.assertEqual(patch.call_count, 8)
+        for arg in patch.call_args_list:
+            self.assertFalse(arg[1]["nearest_sample"])
+
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -431,6 +431,39 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(st2.test, 1)
         self.assertEqual(st2.muh, "Muh")
 
+    def test_slice_nearest_sample(self):
+        """
+        Tests that the nearest_sample argument is correctly passed to the
+        trace function calls.
+        """
+        # It defaults to True.
+        st = read()
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = st[0]
+            st.slice(1, 2)
+
+        self.assertEqual(patch.call_count, 3)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Force True.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = st[0]
+            st.slice(1, 2, nearest_sample=True)
+
+        self.assertEqual(patch.call_count, 3)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Set to False.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = st[0]
+            st.slice(1, 2, nearest_sample=False)
+
+        self.assertEqual(patch.call_count, 3)
+        for arg in patch.call_args_list:
+            self.assertFalse(arg[1]["nearest_sample"])
+
     def test_cutout(self):
         """
         Test cutout method of the Stream object. Compare against equivalent

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2228,6 +2228,103 @@ class StreamTestCase(unittest.TestCase):
                     self.assertEqual(should_change, _gets_merged(
                         trx, to_be_fixed_misalignmnt_ratio))
 
+    def test_slide(self):
+        """
+        Tests for sliding a window across a stream object.
+        """
+        # 0 - 20 seconds
+        tr1 = Trace(data=np.linspace(0, 100, 101))
+        tr1.stats.starttime = UTCDateTime(0.0)
+        tr1.stats.sampling_rate = 5.0
+
+        # 5 - 10 seconds
+        tr2= Trace(data=np.linspace(25, 75, 51))
+        tr2.stats.starttime = UTCDateTime(5.0)
+        tr2.stats.sampling_rate = 5.0
+
+        # 15 - 20 seconds
+        tr3= Trace(data=np.linspace(75, 100, 26))
+        tr3.stats.starttime = UTCDateTime(0.0)
+        tr3.stats.sampling_rate = 15.0
+
+        st = Stream(traces=[tr1, tr2, tr3])
+
+        # First slice it in 4 pieces. Window length is in seconds.
+        slices = []
+        for window_st in st.slide(window_length=5.0, step=5.0):
+            slices.append(window_st)
+
+        self.assertEqual(len(slices), 4)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(0), UTCDateTime(5)))
+        self.assertEqual(slices[1],
+                         st.slice(UTCDateTime(5), UTCDateTime(10)))
+        self.assertEqual(slices[2],
+                         st.slice(UTCDateTime(10), UTCDateTime(15)))
+        self.assertEqual(slices[3],
+                         st.slice(UTCDateTime(15), UTCDateTime(20)))
+
+        # Different step which is the distance between two windows measured
+        # from the start of the first window in seconds.
+        slices = []
+        for window_tr in st.slide(window_length=5.0, step=10.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(0), UTCDateTime(5)))
+        self.assertEqual(slices[1],
+                         st.slice(UTCDateTime(10), UTCDateTime(15)))
+
+        # Offset determines the initial starting point. It defaults to zero.
+        slices = []
+        for window_tr in st.slide(window_length=5.0, step=6.5, offset=8.5):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(8.5), UTCDateTime(13.5)))
+        self.assertEqual(slices[1],
+                         st.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
+
+        # By default only full length windows will be returned so any
+        # remainder that can no longer make up a full window will not be
+        # returned.
+        slices = []
+        for window_tr in st.slide(window_length=15.0, step=15.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 1)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
+
+        # But it can optionally be returned.
+        slices = []
+        for window_tr in st.slide(window_length=15.0, step=15.0,
+                                  include_partial_windows=True):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
+        self.assertEqual(slices[1],
+                         st.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
+
+        # Negative step lengths work together with an offset.
+        slices = []
+        for window_tr in st.slide(window_length=5.0, step=-5.0, offset=20.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 4)
+        self.assertEqual(slices[0],
+                         st.slice(UTCDateTime(15), UTCDateTime(20)))
+        self.assertEqual(slices[1],
+                         st.slice(UTCDateTime(10), UTCDateTime(15)))
+        self.assertEqual(slices[2],
+                         st.slice(UTCDateTime(5), UTCDateTime(10)))
+        self.assertEqual(slices[3],
+                         st.slice(UTCDateTime(0), UTCDateTime(5)))
+
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -684,6 +684,33 @@ class TraceTestCase(unittest.TestCase):
         self.__remove_processing(tr2)
         self.assertEqual(tr_trim, tr2)
 
+    def test_slice_nearest_sample(self):
+        """
+        Tests slicing with the nearest sample flag set to on or off.
+        """
+        tr = Trace(data=np.arange(6))
+        # Samples at:
+        # 0       10       20       30       40       50
+        tr.stats.sampling_rate = 0.1
+
+        # Nearest sample flag defaults to true.
+        tr2 = tr.slice(UTCDateTime(4), UTCDateTime(44))
+        self.assertEqual(tr2.stats.starttime, UTCDateTime(0))
+        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))
+
+        tr2 = tr.slice(UTCDateTime(8), UTCDateTime(48))
+        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
+        self.assertEqual(tr2.stats.endtime, UTCDateTime(50))
+
+        # Setting it to False changes the returned values.
+        tr2 = tr.slice(UTCDateTime(4), UTCDateTime(44), nearest_sample=False)
+        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
+        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))
+
+        tr2 = tr.slice(UTCDateTime(8), UTCDateTime(48), nearest_sample=False)
+        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
+        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))
+
     def test_trimFloatingPoint(self):
         """
         Tests the slicing of trace objects.

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1931,6 +1931,89 @@ class TraceTestCase(unittest.TestCase):
         self.assertRaises(ValueError, tr.resample,
                           sampling_rate=0.5, window=window, no_filter=True)
 
+    def test_slide(self):
+        """
+        Tests for sliding a window across a trace object.
+        """
+        tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.sampling_rate = 5.0
+
+        # First slice it in 4 pieces. Window length is in seconds.
+        slices = []
+        for window_tr in tr.slide(window_length=5.0, step=5.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 4)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(0), UTCDateTime(5)))
+        self.assertEqual(slice[1],
+                         tr.slice(UTCDateTime(5), UTCDateTime(10)))
+        self.assertEqual(slice[2],
+                         tr.slice(UTCDateTime(10), UTCDateTime(15)))
+        self.assertEqual(slice[3],
+                         tr.slice(UTCDateTime(15), UTCDateTime(20)))
+
+        # Different step which is the distance between two windows measured
+        # from the start of the first window in seconds.
+        slices = []
+        for window_tr in tr.slide(window_length=5.0, step=10.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(0), UTCDateTime(5)))
+        self.assertEqual(slice[1],
+                         tr.slice(UTCDateTime(10), UTCDateTime(15)))
+
+        # Offset determines the initial starting point. It defaults to zero.
+        slices = []
+        for window_tr in tr.slide(window_length=5.0, step=6.5, offset=8.5):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(8.5), UTCDateTime(13.5)))
+        self.assertEqual(slice[1],
+                         tr.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
+
+        # By default only full length windows will be returned so any
+        # remainder that can no longer make up a full window will not be
+        # returned.
+        slices = []
+        for window_tr in tr.slide(window_length=15.0, step=15.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 1)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
+
+        # But it can optionally be returned.
+        slices = []
+        for window_tr in tr.slide(window_length=15.0, step=15.0,
+                                  include_partial_windows=True):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 2)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
+
+        # Negative step lengths work.
+        slices = []
+        for window_tr in tr.slide(window_length=5.0, step=-5.0, offset=20.0):
+            slices.append(window_tr)
+
+        self.assertEqual(len(slices), 4)
+        self.assertEqual(slice[0],
+                         tr.slice(UTCDateTime(15), UTCDateTime(20)))
+        self.assertEqual(slice[1],
+                         tr.slice(UTCDateTime(10), UTCDateTime(15)))
+        self.assertEqual(slice[2],
+                         tr.slice(UTCDateTime(5), UTCDateTime(10)))
+        self.assertEqual(slice[3],
+                         tr.slice(UTCDateTime(0), UTCDateTime(5)))
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2042,6 +2042,42 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(slices[3],
                          tr.slice(UTCDateTime(0), UTCDateTime(5)))
 
+    def test_slide_nearest_sample(self):
+        """
+        Tests that the nearest_sample argument is correctly passed to the
+        slice function calls.
+        """
+        tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.starttime = UTCDateTime(0.0)
+        tr.stats.sampling_rate = 5.0
+
+        # It defaults to True.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(tr.slide(5, 5))
+
+        self.assertEqual(patch.call_count, 4)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Force True.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(tr.slide(5, 5, nearest_sample=True))
+
+        self.assertEqual(patch.call_count, 4)
+        for arg in patch.call_args_list:
+            self.assertTrue(arg[1]["nearest_sample"])
+
+        # Set to False.
+        with mock.patch("obspy.core.trace.Trace.slice") as patch:
+            patch.return_value = tr
+            list(tr.slide(5, 5, nearest_sample=False))
+
+        self.assertEqual(patch.call_count, 4)
+        for arg in patch.call_args_list:
+            self.assertFalse(arg[1]["nearest_sample"])
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1936,6 +1936,7 @@ class TraceTestCase(unittest.TestCase):
         Tests for sliding a window across a trace object.
         """
         tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.starttime = UTCDateTime(0.0)
         tr.stats.sampling_rate = 5.0
 
         # First slice it in 4 pieces. Window length is in seconds.
@@ -1944,13 +1945,13 @@ class TraceTestCase(unittest.TestCase):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 4)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(0), UTCDateTime(5)))
-        self.assertEqual(slice[1],
+        self.assertEqual(slices[1],
                          tr.slice(UTCDateTime(5), UTCDateTime(10)))
-        self.assertEqual(slice[2],
+        self.assertEqual(slices[2],
                          tr.slice(UTCDateTime(10), UTCDateTime(15)))
-        self.assertEqual(slice[3],
+        self.assertEqual(slices[3],
                          tr.slice(UTCDateTime(15), UTCDateTime(20)))
 
         # Different step which is the distance between two windows measured
@@ -1960,9 +1961,9 @@ class TraceTestCase(unittest.TestCase):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 2)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(0), UTCDateTime(5)))
-        self.assertEqual(slice[1],
+        self.assertEqual(slices[1],
                          tr.slice(UTCDateTime(10), UTCDateTime(15)))
 
         # Offset determines the initial starting point. It defaults to zero.
@@ -1971,9 +1972,9 @@ class TraceTestCase(unittest.TestCase):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 2)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(8.5), UTCDateTime(13.5)))
-        self.assertEqual(slice[1],
+        self.assertEqual(slices[1],
                          tr.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
 
         # By default only full length windows will be returned so any
@@ -1984,7 +1985,7 @@ class TraceTestCase(unittest.TestCase):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 1)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
 
         # But it can optionally be returned.
@@ -1994,24 +1995,24 @@ class TraceTestCase(unittest.TestCase):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 2)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(0.0), UTCDateTime(15.0)))
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[1],
                          tr.slice(UTCDateTime(15.0), UTCDateTime(20.0)))
 
-        # Negative step lengths work.
+        # Negative step lengths work together with an offset.
         slices = []
         for window_tr in tr.slide(window_length=5.0, step=-5.0, offset=20.0):
             slices.append(window_tr)
 
         self.assertEqual(len(slices), 4)
-        self.assertEqual(slice[0],
+        self.assertEqual(slices[0],
                          tr.slice(UTCDateTime(15), UTCDateTime(20)))
-        self.assertEqual(slice[1],
+        self.assertEqual(slices[1],
                          tr.slice(UTCDateTime(10), UTCDateTime(15)))
-        self.assertEqual(slice[2],
+        self.assertEqual(slices[2],
                          tr.slice(UTCDateTime(5), UTCDateTime(10)))
-        self.assertEqual(slice[3],
+        self.assertEqual(slices[3],
                          tr.slice(UTCDateTime(0), UTCDateTime(5)))
 
 

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -11,7 +11,8 @@ import unittest
 from ctypes import CDLL
 from ctypes.util import find_library
 
-from obspy.core.util.misc import CatchOutput
+from obspy import UTCDateTime
+from obspy.core.util.misc import CatchOutput, get_window_times
 
 
 class UtilMiscTestCase(unittest.TestCase):
@@ -87,6 +88,150 @@ class UtilMiscTestCase(unittest.TestCase):
                         self.fail(msg % (i, line))
                 if b"import obspy" in line:
                     self.fail(msg % (i, line))
+
+    def test_get_window_times(self):
+        """
+        Tests for the get_window_times() helper function.
+        """
+        # Basic windows. 4 pieces.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=5.0,
+                step=5.0,
+                offset=0.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(0), UTCDateTime(5)),
+                (UTCDateTime(5), UTCDateTime(10)),
+                (UTCDateTime(10), UTCDateTime(15)),
+                (UTCDateTime(15), UTCDateTime(20))
+            ]
+        )
+
+        # Different step size.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=5.0,
+                step=10.0,
+                offset=0.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(0), UTCDateTime(5)),
+                (UTCDateTime(10), UTCDateTime(15))
+                ]
+        )
+
+        # With offset.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=5.0,
+                step=6.5,
+                offset=8.5,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(8.5), UTCDateTime(13.5)),
+                (UTCDateTime(15), UTCDateTime(20))
+            ]
+        )
+
+        # Don't return partial windows.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=15.0,
+                step=15.0,
+                offset=0.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(0), UTCDateTime(15))
+            ]
+        )
+
+        # Return partial windows.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=15.0,
+                step=15.0,
+                offset=0.0,
+                include_partial_windows=True),
+            [
+                (UTCDateTime(0), UTCDateTime(15)),
+                (UTCDateTime(15), UTCDateTime(20))
+            ]
+        )
+
+        # Negative step length has to be used together with an offset.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=5.0,
+                step=-5.0,
+                offset=20.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(15), UTCDateTime(20)),
+                (UTCDateTime(10), UTCDateTime(15)),
+                (UTCDateTime(5), UTCDateTime(10)),
+                (UTCDateTime(0), UTCDateTime(5))
+            ]
+        )
+
+        # Negative step length and not partial windows.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=15.0,
+                step=-15.0,
+                offset=20.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(5), UTCDateTime(20))
+            ]
+        )
+
+        # Negative step length with partial windows.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(20),
+                window_length=15.0,
+                step=-15.0,
+                offset=20.0,
+                include_partial_windows=True),
+            [
+                (UTCDateTime(5), UTCDateTime(20)),
+                (UTCDateTime(0), UTCDateTime(5))
+            ]
+        )
+
+        # Smaller step than window.
+        self.assertEqual(
+            get_window_times(
+                starttime=UTCDateTime(0),
+                endtime=UTCDateTime(2),
+                window_length=1.0,
+                step=0.25,
+                offset=0.0,
+                include_partial_windows=False),
+            [
+                (UTCDateTime(0), UTCDateTime(1)),
+                (UTCDateTime(0.25), UTCDateTime(1.25)),
+                (UTCDateTime(0.5), UTCDateTime(1.5)),
+                (UTCDateTime(0.75), UTCDateTime(1.75)),
+                (UTCDateTime(1.0), UTCDateTime(2.0))
+            ]
+        )
 
 
 def suite():

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1139,6 +1139,19 @@ class Trace(object):
         data. Any modifications are applied to the original data as well. If
         you don't want this you have to create a copy of the yielded windows.
 
+        .. rubric:: Example
+
+        >>> import obspy
+        >>> tr = obspy.read()[0]
+        >>> for windowed_tr in tr.slide(window_length=10.0, step=10.0):
+        ...     print("---")  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        ...     print(windowed_tr)
+        ---
+        ... | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:13.000000Z | ...
+        ---
+        ... | 2009-08-24T00:20:13.000000Z - 2009-08-24T00:20:23.000000Z | ...
+
+
         :param window_length: The length of each window in seconds.
         :type window_length: float
         :param step: The step between the start times of two successive
@@ -1175,8 +1188,7 @@ class Trace(object):
             raise StopIteration
 
         for start, stop in windows:
-            yield self.slice(self.stats.starttime + start,
-                             self.stats.starttime + stop,
+            yield self.slice(start, stop,
                              nearest_sample=nearest_sample)
 
         raise StopIteration

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1039,8 +1039,9 @@ class Trace(object):
             given ``fill_value``. Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::
@@ -1101,8 +1102,9 @@ class Trace(object):
         :param endtime: Specify the end time of slice.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::
@@ -1164,8 +1166,9 @@ class Trace(object):
             shorter then 99.9 % of the desired length are returned.
         :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the next sample containing the time
-            is selected. Defaults to ``True``.
+            selected, if set to ``False``, the outer (previous sample for a
+            start time border, next sample for an end time border) sample
+            containing the time is selected. Defaults to ``True``.
 
             Given the following trace containing 4 samples, "|" are the
             sample points, "A" is the requested starttime::

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1131,7 +1131,7 @@ class Trace(object):
         return tr
 
     def slide(self, window_length, step, offset=0,
-              include_partial_windows=False):
+              include_partial_windows=False, nearest_sample=True):
         """
         Iterator to return equal length windows of the Trace.
 
@@ -1146,6 +1146,18 @@ class Trace(object):
             the first sample in the trace.
         :param include_partial_windows: Determines if windows that are
             shorter then 99.9 % of the desired length are returned.
+        :type nearest_sample: bool, optional
+        :param nearest_sample: If set to ``True``, the closest sample is
+            selected, if set to ``False``, the next sample containing the time
+            is selected. Defaults to ``True``.
+
+            Given the following trace containing 4 samples, "|" are the
+            sample points, "A" is the requested starttime::
+
+                |        A|         |         |
+
+            ``nearest_sample=True`` will select the second sample point,
+            ``nearest_sample=False`` will select the first sample point.
         """
         windows = get_window_times(
             starttime=self.stats.starttime,
@@ -1160,7 +1172,8 @@ class Trace(object):
 
         for start, stop in windows:
             yield self.slice(self.stats.starttime + start,
-                             self.stats.starttime + stop)
+                             self.stats.starttime + stop,
+                             nearest_sample=nearest_sample)
 
         raise StopIteration
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1091,7 +1091,7 @@ class Trace(object):
                 pass
         return self
 
-    def slice(self, starttime=None, endtime=None):
+    def slice(self, starttime=None, endtime=None, nearest_sample=True):
         """
         Return a new Trace object with data going from start to end time.
 
@@ -1099,6 +1099,19 @@ class Trace(object):
         :param starttime: Specify the start time of slice.
         :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param endtime: Specify the end time of slice.
+        :type nearest_sample: bool, optional
+        :param nearest_sample: If set to ``True``, the closest sample is
+            selected, if set to ``False``, the next sample containing the time
+            is selected. Defaults to ``True``.
+
+            Given the following trace containing 4 samples, "|" are the
+            sample points, "A" is the requested starttime::
+
+                |        A|         |         |
+
+            ``nearest_sample=True`` will select the second sample point,
+            ``nearest_sample=False`` will select the first sample point.
+
         :return: New :class:`~obspy.core.trace.Trace` object. Does not copy
             data but just passes a reference to it.
 
@@ -1113,7 +1126,8 @@ class Trace(object):
         """
         tr = copy(self)
         tr.stats = deepcopy(self.stats)
-        tr.trim(starttime=starttime, endtime=endtime)
+        tr.trim(starttime=starttime, endtime=endtime,
+                nearest_sample=nearest_sample)
         return tr
 
     def slide(self, window_length, step, offset=0,

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1133,7 +1133,7 @@ class Trace(object):
     def slide(self, window_length, step, offset=0,
               include_partial_windows=False, nearest_sample=True):
         """
-        Iterator to return equal length windows of the Trace.
+        Generator yielding equal length sliding windows of the Trace.
 
         Please keep in mind that it only returns a new view of the original
         data. Any modifications are applied to the original data as well. If

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1140,13 +1140,16 @@ class Trace(object):
         you don't want this you have to create a copy of the yielded windows.
 
         :param window_length: The length of each window in seconds.
+        :type window_length: float
         :param step: The step between the start times of two successive
             windows in seconds. Can be negative if an offset is given.
+        :type step: float
         :param offset: The offset of the first window in seconds relative to
-            the first sample in the trace.
+            the start time of the whole interval.
+        :type offset: float
         :param include_partial_windows: Determines if windows that are
             shorter then 99.9 % of the desired length are returned.
-        :type nearest_sample: bool, optional
+        :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
             selected, if set to ``False``, the next sample containing the time
             is selected. Defaults to ``True``.
@@ -1158,6 +1161,7 @@ class Trace(object):
 
             ``nearest_sample=True`` will select the second sample point,
             ``nearest_sample=False`` will select the first sample point.
+        :type nearest_sample: bool, optional
         """
         windows = get_window_times(
             starttime=self.stats.starttime,

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1119,7 +1119,7 @@ class Trace(object):
     def slide(self, window_length, step, offset=0,
               include_partial_windows=False):
         """
-        Iterator to return equal length windows of the trace.
+        Iterator to return equal length windows of the Trace.
 
         Please keep in mind that it only returns a new view of the original
         data. Any modifications are applied to the original data as well. If

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1139,7 +1139,9 @@ class Trace(object):
 
         Please keep in mind that it only returns a new view of the original
         data. Any modifications are applied to the original data as well. If
-        you don't want this you have to create a copy of the yielded windows.
+        you don't want this you have to create a copy of the yielded
+        windows. Also be aware that if you modify the original data and you
+        have overlapping windows, all following windows are affected as well.
 
         .. rubric:: Example
 

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -534,7 +534,8 @@ def get_window_times(starttime, endtime, window_length, step, offset,
         windows = [_i for _i in windows
                    if abs(_i[1] - _i[0]) > 0.999 * window_length]
 
-    return windows
+    t = type(starttime)
+    return [(t(_i[0]), t(_i[1])) for _i in windows]
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -515,6 +515,8 @@ def get_window_times(starttime, endtime, window_length, step, offset,
     if step > 0:
         end = endtime.timestamp - 0.001 * step
     else:
+        # This minus is correct here due to the way the actual window times
+        # are calculate later on.
         end = starttime.timestamp - 0.001 * abs(step)
     # Left sides of each window.
     indices = np.arange(start=starttime.timestamp + offset,


### PR DESCRIPTION
It would be really useful to have a generator on the `Stream` and `Trace` object yielding windows. I imagine something like the following:

```python
for windowed_st in st.slide(window_length=100, step=50):
    # windowed_st has to contain a copy of the data as to not modify the original data.
    windowed_st.taper()
    ...
```