### PR TITLE
obspy.fdsn.client.Client.get_waveforms() raises NotImplementedError

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 0.10.x:
+  - obspy.fdsn:
+    * More detailed error messages on failing requests (see #1079)
   - obspy.mseed:
     * Blockette 100 is now only written for Traces that need it. Previously
       it was written or not for all Traces, depending on whether the last

--- a/obspy/fdsn/header.py
+++ b/obspy/fdsn/header.py
@@ -18,7 +18,11 @@ from obspy import UTCDateTime, __version__
 
 
 class FDSNException(Exception):
-    pass
+    def __init__(self, value, server_info=None):
+        if server_info is not None:
+            value = "\n".join([value, "Detailed response of server:", "",
+                               server_info])
+        super(FDSNException, self).__init__(value)
 
 
 # A curated list collecting some implementations:


### PR DESCRIPTION
```python
Python 2.7.8 (default, Apr 14 2015, 16:15:56) 
[GCC 4.2.1 Compatible Apple LLVM 5.1 (clang-503.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from obspy.fdsn.client import Client
>>> from obspy.core.utcdatetime import UTCDateTime
>>> client = Client("IRIS")
>>> st = client.get_waveforms('N4', 'X58A', '*', 'HNZ', UTCDateTime(2015, 5, 1, 0, 0), UTCDateTime(2015, 2, 11, 0, 0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/antelope/python2.7.8/lib/python2.7/site-packages/obspy/fdsn/client.py", line 594, in get_waveforms
    data_stream = self._download(url)
  File "/opt/antelope/python2.7.8/lib/python2.7/site-packages/obspy/fdsn/client.py", line 1188, in _download
    raise NotImplementedError(msg)
NotImplementedError: Bad request. Please contact the developers.
>>>
```