### PR TITLE
setup.py: add setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ INSTALL_REQUIRES = [
     'scipy>=0.7.2',
     'matplotlib',
     'lxml',
+    'setuptools',
     'sqlalchemy']
 EXTRAS_REQUIRE = {
     'tests': ['flake8>=2', 'pyimgur'],


### PR DESCRIPTION
There are several import from the `pkg_resources` module provided by the `setuptools` packages within the code. 
```
petr% grep pkg_ -r * |grep import
grep: misc/docs/source/tutorial/ObsPyTutorial.pdf: No such file or directory
misc/installer/salt-formula/obspy/dependencies.sls:{% from "obspy/map.jinja" import pkg_deps with context %}
obspy/core/event.py:from pkg_resources import load_entry_point
obspy/core/stream.py:from pkg_resources import load_entry_point
obspy/core/tests/test_waveform_plugins.py:from pkg_resources import load_entry_point
obspy/core/util/base.py:from pkg_resources import iter_entry_points, load_entry_point
obspy/station/inventory.py:from pkg_resources import load_entry_point
setup.py:        from pkg_resources import EntryPoint
```

Therefore adding `setuptools` as explicit requirement, its a "library dependency". 

However, given the fact that `setuptools` has to be installed anyway, we might want it to become an normal install time dependency and get ride of the try/except constructs in the `setup.py` file. Any opinions on this? 