### PR TITLE
Add support for time values with sub-second precision

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ master:
    * Upgrade to libmseed 2.16
  - obspy.io.shapefile:
    * New module for ESRI shapefile write support (see #1066)
+ - obspy.io.zmap
+   * Add support for time values with sub-second precision
  - obspy.signal:
    * Switch to second-order sections for filters; backported from SciPy 0.16.0
      (see #1028)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,7 +30,7 @@ master:
  - obspy.io.shapefile:
    * New module for ESRI shapefile write support (see #1066)
  - obspy.io.zmap
-   * Add support for time values with sub-second precision
+   * Add support for time values with sub-second precision (see #1093)
  - obspy.signal:
    * Switch to second-order sections for filters; backported from SciPy 0.16.0
      (see #1028)

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -137,6 +137,8 @@ class Pickler(object):
             origin = ev.preferred_origin()
             if origin:
                 dec_year = self._decimal_year(origin.time)
+                dec_second = origin.time.second + \
+                    origin.time.microsecond / float(1e6)
                 strings.update({
                     'depth':   self._num2str(origin.depth/1000.0),  # m to km
                     'z_err':   self._num2str(self._depth_error(origin)),
@@ -148,7 +150,7 @@ class Pickler(object):
                     'day':     self._num2str(origin.time.day, 0),
                     'hour':    self._num2str(origin.time.hour, 0),
                     'minute':  self._num2str(origin.time.minute, 0),
-                    'second':  self._num2str(origin.time.second, 0)
+                    'second':  str(dec_second)
                 })
             # magnitude
             magnitude = ev.preferred_magnitude()

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -138,7 +138,7 @@ class Pickler(object):
             if origin:
                 dec_year = self._decimal_year(origin.time)
                 dec_second = origin.time.second + \
-                    origin.time.microsecond / float(1e6)
+                    origin.time.microsecond / 1e6
                 strings.update({
                     'depth':   self._num2str(origin.depth/1000.0),  # m to km
                     'z_err':   self._num2str(self._depth_error(origin)),

--- a/obspy/io/zmap/tests/test_zmap.py
+++ b/obspy/io/zmap/tests/test_zmap.py
@@ -36,7 +36,7 @@ class ZMAPTestCase(unittest.TestCase):
         self.test_data = {
             'lon': '79.689000', 'lat': '41.818000', 'month': '4',
             'year': '2012.258465590847', 'day': '4', 'hour': '14',
-            'minute': '21', 'second': '42', 'depth': '1.000000',
+            'minute': '21', 'second': '42.3', 'depth': '1.000000',
             'mag': '4.400000'
         }
 


### PR DESCRIPTION
This fixes the issue that was reported on obspy-users on 8 June 2015.