### PR TITLE
Precision issue of floating point second (i.e. microsecond) initialization in UTCDateTime

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,10 @@
       spectrum actually the instrument response was never inverted and
       thus instead of a deconvolution a convolution was performed
       (see #1104).
+    * Fixing floating point precision/rounding issue with UTCDateTime when
+      initializing with floating point seconds, i.e. with microseconds,
+      that could lead to microseconds being off by 1 microsecond
+      (see #1096)
   - obspy.fdsn:
     * More detailed error messages on failing requests (see #1079)
   - obspy.mseed:

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -960,6 +960,17 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(d1.formatIRISWebService(),
                          d2.formatIRISWebService())
 
+    def test_floating_point_second_initialization(self):
+        """
+        Tests floating point precision issues in initialization of UTCDateTime
+        objects with floating point seconds.
+
+        See issue #1096.
+        """
+        for microns in np.arange(0, 5999, dtype=np.int):
+            t = UTCDateTime(2011, 1, 25, 15, 32, 12 + microns / 1e6)
+            self.assertEqual(microns, t.microsecond)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -444,13 +444,13 @@ class UTCDateTimeTestCase(unittest.TestCase):
         Tests subtraction of floats from UTCDateTime
         """
         time = UTCDateTime(2010, 0o5, 31, 19, 54, 24.490)
-        res = -0.045149
+        delta = -0.045149
+        expected = UTCDateTime("2010-05-31T19:54:24.535149Z")
 
-        result1 = UTCDateTime("2010-05-31T19:54:24.535149Z")
-        result2 = time + (-res)
-        result3 = time - res
-        self.assertAlmostEqual(result2 - result3, 0.0)
-        self.assertAlmostEqual(result1.timestamp, result2.timestamp, 6)
+        got1 = time + (-delta)
+        got2 = time - delta
+        self.assertAlmostEqual(got1 - got2, 0.0)
+        self.assertAlmostEqual(expected.timestamp, got1.timestamp, 6)
 
     def test_issue159(self):
         """

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -945,6 +945,21 @@ class UTCDateTimeTestCase(unittest.TestCase):
         dt = UTCDateTime(2106, 2, 7, 6, 28, 16)
         self.assertEqual(dt.__str__(), '2106-02-07T06:28:16.000000Z')
 
+    def test_format_IRIS_webservice(self):
+        """
+        Tests the format IRIS webservice function.
+
+        See issue #1096.
+        """
+        # These are parse slightly differently (1 microsecond difference but
+        # the IRIS webservice string should be identical as its only
+        # accurate to three digits.
+        d1 = UTCDateTime(2011, 1, 25, 15, 32, 12.26)
+        d2 = UTCDateTime("2011-01-25T15:32:12.26")
+
+        self.assertEqual(d1.formatIRISWebService(),
+                         d2.formatIRISWebService())
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -446,7 +446,7 @@ class UTCDateTimeTestCase(unittest.TestCase):
         time = UTCDateTime(2010, 0o5, 31, 19, 54, 24.490)
         res = -0.045149
 
-        result1 = UTCDateTime("2010-05-31T19:54:24.535148Z")
+        result1 = UTCDateTime("2010-05-31T19:54:24.535149Z")
         result2 = time + (-res)
         result3 = time - res
         self.assertAlmostEqual(result2 - result3, 0.0)

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -324,7 +324,7 @@ class UTCDateTime(object):
         # check if seconds are given as float value
         if len(args) == 6 and isinstance(args[5], float):
             _frac, _sec = math.modf(round(args[5], 6))
-            kwargs['microsecond'] = int(_frac * 1e6)
+            kwargs['microsecond'] = int(round(_frac * 1e6))
             kwargs['second'] = int(_sec)
             args = args[0:5]
         dt = datetime.datetime(*args, **kwargs)


### PR DESCRIPTION
Before:

```python
>>> from obspy import UTCDateTime
>>> d1 = UTCDateTime(2011,  1, 25, 15, 32, 12.26)
>>> d2 = UTCDateTime("2011-01-25T15:32:12.26")
>>> print(d1.formatIRISWebService())
2011-01-25T15:32:12.259
>>> print(d2.formatIRISWebService())
2011-01-25T15:32:12.260
```

After:

```python
>>> from obspy import UTCDateTime
>>> d1 = UTCDateTime(2011,  1, 25, 15, 32, 12.26)
>>> d2 = UTCDateTime("2011-01-25T15:32:12.26")
>>> print(d1.formatIRISWebService())
2011-01-25T15:32:12.260
>>> print(d2.formatIRISWebService())
2011-01-25T15:32:12.260
```