### PR TITLE
Lanczos Resampling/Interpolation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ master:
  - obspy.signal:
    * Switch to second-order sections for filters; backported from SciPy 0.16.0
      (see #1028)
+   * New Lanczos interpolation/resampling (see #1101)
 
 0.10.x:
   - obspy.fdsn:

--- a/misc/docs/source/bibliography/Burger2009.bib
+++ b/misc/docs/source/bibliography/Burger2009.bib
@@ -1,0 +1,7 @@
+@book{Burger2009,
+  author = {Burger, W. and Burge, M.J.},
+  isbn = {978-1-84800-194-7},
+  publisher = {Springer},
+  title = {{Principles of Digital Image Processing: Core Algorithms}},
+  year = {2009}
+}

--- a/misc/docs/source/bibliography/vanDriel2015.bib
+++ b/misc/docs/source/bibliography/vanDriel2015.bib
@@ -1,0 +1,11 @@
+@article{vanDriel2015,
+  author = {van Driel, M. and Krischer, L. and St\"ahler, S. C. and Hosseini, K. and Nissen-Meyer, T.},
+  title = {Instaseis: instant global seismograms based on a broadband waveform database},
+  journal = {Solid Earth},
+  volume = {6},
+  year = {2015},
+  number = {2},
+  pages = {701--717},
+  url = {http://www.solid-earth.net/6/701/2015/},
+  doi = {10.5194/se-6-701-2015}
+}

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -109,6 +109,10 @@ class ObsPyRestructureMetaPathFinderAndLoader(object):
     Make sure to remove this once 0.11 has been released!
     """
     def find_module(self, fullname, path=None):
+        # Compatibility with namespace paths.
+        if hasattr(path, "_path"):
+            path = path._path
+
         if not path or not path[0].startswith(__path__[0]):
             return None
 

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1815,6 +1815,70 @@ class TraceTestCase(unittest.TestCase):
             self.assertEqual(int_tr.stats.delta, 2.0)
             self.assertLessEqual(int_tr.stats.endtime, org_tr.stats.endtime)
 
+    def test_interpolation_time_shift(self):
+        """
+        Tests the time shift of the interpolation.
+        """
+        tr = read()[0]
+        tr.stats.sampling_rate = 1.0
+        tr.data = tr.data[:500]
+        tr.interpolate(method="lanczos", sampling_rate=10.0, a=20)
+        tr.stats.sampling_rate = 1.0
+        tr.data = tr.data[:500]
+        tr.stats.starttime = UTCDateTime(0)
+
+        org_tr = tr.copy()
+
+        # Now this does not do much for now but actually just shifts the
+        # samples.
+        tr.interpolate(method="lanczos", sampling_rate=1.0, a=1,
+                       time_shift=0.2)
+        self.assertEqual(tr.stats.starttime, org_tr.stats.starttime + 0.2)
+        self.assertEqual(tr.stats.endtime, org_tr.stats.endtime + 0.2)
+        np.testing.assert_allclose(tr.data, org_tr.data, atol=1E-9)
+
+        tr.interpolate(method="lanczos", sampling_rate=1.0, a=1,
+                       time_shift=0.4)
+        self.assertEqual(tr.stats.starttime, org_tr.stats.starttime + 0.6)
+        self.assertEqual(tr.stats.endtime, org_tr.stats.endtime + 0.6)
+        np.testing.assert_allclose(tr.data, org_tr.data, atol=1E-9)
+
+        tr.interpolate(method="lanczos", sampling_rate=1.0, a=1,
+                       time_shift=-0.6)
+        self.assertEqual(tr.stats.starttime, org_tr.stats.starttime)
+        self.assertEqual(tr.stats.endtime, org_tr.stats.endtime)
+        np.testing.assert_allclose(tr.data, org_tr.data, atol=1E-9)
+
+        # This becomes more interesting when also fixing the sample
+        # positions. Then one can shift by subsample accuracy while leaving
+        # the sample positions intact. Note that there naturally are some
+        # boundary effects and as the interpolation method does not deal
+        # with any kind of extrapolation you will loose the first or last
+        # samples.
+        # This is a fairly extreme example but of course there are errors
+        # when doing an interpolation - an shift using an FFT is more accurate.
+        tr.interpolate(method="lanczos", sampling_rate=1.0, a=50,
+                       starttime=tr.stats.starttime + tr.stats.delta,
+                       time_shift=0.2)
+        # The sample point did not change but we lost the first sample,
+        # as we shifted towards the future.
+        self.assertEqual(tr.stats.starttime, org_tr.stats.starttime + 1.0)
+        self.assertEqual(tr.stats.endtime, org_tr.stats.endtime)
+        # The data naturally also changed.
+        self.assertRaises(AssertionError, np.testing.assert_allclose,
+                          tr.data, org_tr.data[1:], atol=1E-9)
+        # Shift back. This time we will loose the last sample.
+        tr.interpolate(method="lanczos", sampling_rate=1.0, a=50,
+                       starttime=tr.stats.starttime,
+                       time_shift=-0.2)
+        self.assertEqual(tr.stats.starttime, org_tr.stats.starttime + 1.0)
+        self.assertEqual(tr.stats.endtime, org_tr.stats.endtime - 1.0)
+        # But the data (aside from edge effects - we are going forward and
+        # backwards again so they go twice as far!) should now again be the
+        # same as we started out with.
+        np.testing.assert_allclose(
+            tr.data[100:-100], org_tr.data[101:-101], atol=1E-9, rtol=1E-4)
+
     def test_interpolation_arguments(self):
         """
         Test case for the interpolation arguments.

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1853,10 +1853,10 @@ class TraceTestCase(unittest.TestCase):
         # positions. Then one can shift by subsample accuracy while leaving
         # the sample positions intact. Note that there naturally are some
         # boundary effects and as the interpolation method does not deal
-        # with any kind of extrapolation you will loose the first or last
+        # with any kind of extrapolation you will lose the first or last
         # samples.
         # This is a fairly extreme example but of course there are errors
-        # when doing an interpolation - an shift using an FFT is more accurate.
+        # when doing an interpolation - a shift using an FFT is more accurate.
         tr.interpolate(method="lanczos", sampling_rate=1.0, a=50,
                        starttime=tr.stats.starttime + tr.stats.delta,
                        time_shift=0.2)
@@ -1867,7 +1867,7 @@ class TraceTestCase(unittest.TestCase):
         # The data naturally also changed.
         self.assertRaises(AssertionError, np.testing.assert_allclose,
                           tr.data, org_tr.data[1:], atol=1E-9)
-        # Shift back. This time we will loose the last sample.
+        # Shift back. This time we will lose the last sample.
         tr.interpolate(method="lanczos", sampling_rate=1.0, a=50,
                        starttime=tr.stats.starttime,
                        time_shift=-0.2)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2171,7 +2171,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
     @raise_if_masked
     @_add_processing_info
     def interpolate(self, sampling_rate, method="weighted_average_slopes",
-                    starttime=None, npts=None):
+                    starttime=None, npts=None, *args, **kwargs):
         """
         Interpolate the data using various interpolation techniques.
 
@@ -2274,7 +2274,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                                   dt)) + 1
         self.data = np.atleast_1d(func(np.require(self.data, dtype=np.float64),
                                        old_start, old_dt, starttime, dt, npts,
-                                       type=method))
+                                       type=method, *args, **kwargs))
         self.stats.starttime = UTCDateTime(starttime)
         self.stats.delta = dt
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2171,7 +2171,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
     @raise_if_masked
     @_add_processing_info
     def interpolate(self, sampling_rate, method="weighted_average_slopes",
-                    starttime=None, npts=None, *args, **kwargs):
+                    starttime=None, npts=None, time_shift=0.0,
+                    *args, **kwargs):
         """
         Interpolate the data using various interpolation techniques.
 
@@ -2214,6 +2215,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :param npts: The new number of samples. Will be set to the best
             fitting  number to retain the current end time of the trace if
             not given.
+        :type time_shift: float
+        :param time_shift: Interpolation also can shift the data with
+            subsample accuracy. The time shift is always given in seconds. A
+            positive shift means the data is shifted towards the future,
+            e.g. a positive time delta.
 
         .. rubric:: _`Usage Examples`
 
@@ -2251,32 +2257,44 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             raise ValueError("The time step must be positive.")
         dt = 1.0 / sampling_rate
 
-        if isinstance(method, int) or method in ["linear", "nearest", "zero",
-                                                 "slinear", "quadratic",
-                                                 "cubic"]:
-            func = _get_function_from_entry_point('interpolate',
-                                                  'interpolate_1d')
-        else:
-            func = _get_function_from_entry_point('interpolate', method)
-        old_start = self.stats.starttime.timestamp
-        old_dt = self.stats.delta
+        # We just shift the old start time. The interpolation will take care
+        # of the rest.
+        if time_shift:
+            self.stats.starttime += time_shift
 
-        if starttime is not None:
-            try:
-                starttime = starttime.timestamp
-            except AttributeError:
-                pass
-        else:
-            starttime = self.stats.starttime.timestamp
+        try:
+            if isinstance(method, int) or \
+                    method in ["linear", "nearest", "zero", "slinear",
+                               "quadratic", "cubic"]:
+                func = _get_function_from_entry_point('interpolate',
+                                                      'interpolate_1d')
+            else:
+                func = _get_function_from_entry_point('interpolate', method)
+            old_start = self.stats.starttime.timestamp
+            old_dt = self.stats.delta
 
-        if npts is None:
-            npts = int(math.floor((self.stats.endtime.timestamp - starttime) /
-                                  dt)) + 1
-        self.data = np.atleast_1d(func(np.require(self.data, dtype=np.float64),
-                                       old_start, old_dt, starttime, dt, npts,
-                                       type=method, *args, **kwargs))
-        self.stats.starttime = UTCDateTime(starttime)
-        self.stats.delta = dt
+            if starttime is not None:
+                try:
+                    starttime = starttime.timestamp
+                except AttributeError:
+                    pass
+            else:
+                starttime = self.stats.starttime.timestamp
+            endtime = self.stats.endtime.timestamp
+            if npts is None:
+                npts = int(math.floor((endtime - starttime) / dt)) + 1
+
+            self.data = np.atleast_1d(func(
+                np.require(self.data, dtype=np.float64), old_start, old_dt,
+                starttime, dt, npts, type=method, *args, **kwargs))
+            self.stats.starttime = UTCDateTime(starttime)
+            self.stats.delta = dt
+        except:
+            # Revert the start time change if something went wrong.
+            if time_shift:
+                self.stats.starttime -= time_shift
+            # re-raise last exception.
+            raise
 
         return self
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2219,7 +2219,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :param time_shift: Interpolation also can shift the data with
             subsample accuracy. The time shift is always given in seconds. A
             positive shift means the data is shifted towards the future,
-            e.g. a positive time delta.
+            e.g. a positive time delta. Please note that a time shift in
+            the Fourier domain is always more accurate then this. When using
+            Lanczos interpolation with large values of ``a`` and away from the
+            boundaries this is nonetheless pretty good.
 
         .. rubric:: _`Usage Examples`
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2176,8 +2176,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         Interpolate the data using various interpolation techniques.
 
-        Be careful when downsampling data and make sure to apply a proper
-        anti-aliasing lowpass filter in case its necessary.
+        Be careful when downsampling data and make sure to apply an appropriate
+        anti-aliasing lowpass filter before interpolating in case it's
+        necessary.
 
         .. note::
 
@@ -2203,7 +2204,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         * ``"lanczos"``: This offers the highest quality interpolation and
           should be chosen whenever possible. It is only due to legacy
           reasons that this is not the default method. The one downside it
-          has that it can be fairly expensive. See the
+          has is that it can be fairly expensive. See the
           :func:`~obspy.signal.interpolation.lanczos_interpolation` function
           for more details.
         * ``"weighted_average_slopes"``: This is the interpolation method used
@@ -2211,7 +2212,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
           :func:`~obspy.signal.interpolation.weighted_average_slopes` for
           more details.
         * ``"slinear"``, ``"quadratic"`` and ``"cubic"``: spline interpolation
-          of first, second or third order
+          of first, second or third order.
         * ``"linear"``: Linear interpolation.
         * ``"nearest"``: Nearest neighbour interpolation.
         * ``"zero"``: Last encountered value interpolation.
@@ -2238,7 +2239,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             subsample accuracy. The time shift is always given in seconds. A
             positive shift means the data is shifted towards the future,
             e.g. a positive time delta. Please note that a time shift in
-            the Fourier domain is always more accurate then this. When using
+            the Fourier domain is always more accurate than this. When using
             Lanczos interpolation with large values of ``a`` and away from the
             boundaries this is nonetheless pretty good.
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2176,14 +2176,14 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         Interpolate the data using various interpolation techniques.
 
-        No filter, antialiasing, ... is applied so make sure the data is
-        suitable for the operation to be performed.
+        Be careful when downsampling data and make sure to apply a proper
+        anti-aliasing lowpass filter in case its necessary.
 
         .. note::
 
             The :class:`~Trace` object has three different methods to change
             the sampling rate of its data: :meth:`~.resample`,
-            :meth:`~.decimate`, and :meth:`~.interpolate`
+            :meth:`~.decimate`, and :meth:`~.interpolate`.
 
             Make sure to choose the most appropriate one for the problem at
             hand.
@@ -2195,18 +2195,36 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             original data, use :meth:`~.copy` to create a copy of your Trace
             object.
 
+        .. rubric:: _`Interpolation Methods:`
+
+        The chosen method is crucial and we will elaborate a bit about the
+        choices here:
+
+        * ``"lanczos"``: This offers the highest quality interpolation and
+          should be chosen whenever possible. It is only due to legacy
+          reasons that this is not the default method. The one downside it
+          has that it can be fairly expensive. See the
+          :func:`~obspy.signal.interpolation.lanczos_interpolation` function
+          for more details.
+        * ``"weighted_average_slopes"``: This is the interpolation method used
+          by SAC. Refer to
+          :func:`~obspy.signal.interpolation.weighted_average_slopes` for
+          more details.
+        * ``"slinear"``, ``"quadratic"`` and ``"cubic"``: spline interpolation
+          of first, second or third order
+        * ``"linear"``: Linear interpolation.
+        * ``"nearest"``: Nearest neighbour interpolation.
+        * ``"zero"``: Last encountered value interpolation.
+
+        .. rubric:: _`Parameters:`
 
         :param sampling_rate: The new sampling rate in ``Hz``.
-        :param method: The kind of interpolation to perform as a string (
+        :param method: The kind of interpolation to perform as a string. One of
             ``"linear"``, ``"nearest"``, ``"zero"``, ``"slinear"``,
-            ``"quadratic"``, ``"cubic"``, or ``"weighted_average_slopes"``
-            where ``"slinear"``, ``"quadratic"`` and ``"cubic"`` refer  to a
-            spline interpolation of first,  second or third order) or as an
-            integer specifying the order of the spline interpolator to use.
-            Defaults to ``"weighted_average_slopes"`` which is the
-            interpolation technique used by SAC. Refer to
-            :func:`~obspy.signal.interpolation.weighted_average_slopes` for
-            more details.
+            ``"quadratic"``, ``"cubic"``, ``"lanczos"``, or
+            ``"weighted_average_slopes"``. Alternatively an integer
+            specifying the order of the spline interpolator to use also works.
+            Defaults to ``"weighted_average_slopes"``.
         :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime` or int
         :param starttime: The start time (or timestamp) for the new
             interpolated stream. Will be set to current start time of the
@@ -2216,7 +2234,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             fitting  number to retain the current end time of the trace if
             not given.
         :type time_shift: float
-        :param time_shift: Interpolation also can shift the data with
+        :param time_shift: Interpolation can also shift the data with
             subsample accuracy. The time shift is always given in seconds. A
             positive shift means the data is shifted towards the future,
             e.g. a positive time delta. Please note that a time shift in
@@ -2224,8 +2242,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             Lanczos interpolation with large values of ``a`` and away from the
             boundaries this is nonetheless pretty good.
 
-        .. rubric:: _`Usage Examples`
+        .. rubric:: _`New in version 0.11:`
 
+        * New parameter ``time_shift``.
+        * New interpolation method ``lanczos``.
+
+
+        .. rubric:: _`Usage Examples`
 
         >>> from obspy import read
         >>> tr = read()[0]

--- a/obspy/geodetics/__init__.py
+++ b/obspy/geodetics/__init__.py
@@ -29,7 +29,7 @@ sys.modules[__name__] = DynamicAttributeImportRerouteModule(
     import_map={},
     function_map={
         "calcVincentyInverse": "obspy.geodetics.base.calc_vincenty_inverse",
-        "gps2DistAzimuth": "obspy.geodetics.base.gps2dist_azimuth",
+        "gps2DistAzimuth": "obspy.geodetics.base.gps2dist_azimuth"
     })
 
 if __name__ == '__main__':

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -114,6 +114,41 @@ clibsignal.hermite_interpolation.argtypes = [
     C.c_int, C.c_int, C.c_double, C.c_double]
 clibsignal.hermite_interpolation.restype = C.c_void_p
 
+clibsignal.lanczos_resample.argtypes = [
+    # y_in
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags=native_str('C_CONTIGUOUS')),
+    # y_out
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags=native_str('C_CONTIGUOUS')),
+    # dt
+    C.c_double,
+    # len_in
+    C.c_int,
+    # len_out,
+    C.c_int,
+    # a,
+    C.c_int,
+    # window
+    C.c_int]
+clibsignal.lanczos_resample.restype = C.c_void_p
+
+clibsignal.calculate_kernel.argtypes = [
+    # double *x
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags=native_str('C_CONTIGUOUS')),
+    # double *y
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags=native_str('C_CONTIGUOUS')),
+    # int len
+    C.c_int,
+    # int a,
+    C.c_int,
+    # int return_type,
+    C.c_int,
+    # enum lanczos_window_type window
+    C.c_int]
+clibsignal.calculate_kernel.restype = C.c_void_p
 
 STALEN = 64
 NETLEN = 64

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -133,7 +133,7 @@ clibsignal.lanczos_resample.argtypes = [
     C.c_int,
     # window
     C.c_int]
-clibsignal.lanczos_resample.restype = C.c_void_p
+clibsignal.lanczos_resample.restype = None
 
 clibsignal.calculate_kernel.argtypes = [
     # double *x
@@ -150,7 +150,7 @@ clibsignal.calculate_kernel.argtypes = [
     C.c_int,
     # enum lanczos_window_type window
     C.c_int]
-clibsignal.calculate_kernel.restype = C.c_void_p
+clibsignal.calculate_kernel.restype = None
 
 STALEN = 64
 NETLEN = 64

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -123,6 +123,8 @@ clibsignal.lanczos_resample.argtypes = [
                            flags=native_str('C_CONTIGUOUS')),
     # dt
     C.c_double,
+    # offset
+    C.c_double,
     # len_in
     C.c_int,
     # len_out,

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -293,10 +293,13 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     if offset < 0:
         raise ValueError("Cannot extrapolate.")
 
+    if a < 1:
+        raise ValueError("a must be at least 1.")
+
     return_data = np.zeros(new_npts, dtype="float64")
 
     clibsignal.lanczos_resample(data, return_data, dt_factor, offset,
-                                len(data), len(return_data), a, 0)
+                                len(data), len(return_data), int(a), 0)
     return return_data
 
 

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -182,7 +182,7 @@ _LANCZOS_KERNEL_MAP = {
 
 
 def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
-                          a, window="lanczos"):
+                          a, window="lanczos", *args, **kwargs):
     r"""
     Function performing Lanczos resampling, see
     http://en.wikipedia.org/wiki/Lanczos_resampling for details. Essentially a

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -217,8 +217,7 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     :param window: The window used to multiply the sinc function with. One
         of ``"lanczos"``, ``"hanning"``, ``"blackmann"``.
     """
-    old_end, new_end = _validate_parameters(data, old_start, old_dt,
-                                            new_start, new_dt, new_npts)
+    _validate_parameters(data, old_start, old_dt, new_start, new_dt, new_npts)
     dt_factor = float(new_dt) / old_dt
     offset = new_start - old_start
     if offset < 0:

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -298,8 +298,9 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
 
     return_data = np.zeros(new_npts, dtype="float64")
 
-    clibsignal.lanczos_resample(data, return_data, dt_factor, offset,
-                                len(data), len(return_data), int(a), 0)
+    clibsignal.lanczos_resample(
+        np.require(data, dtype=np.float64), return_data, dt_factor, offset,
+        len(data), len(return_data), int(a), 0)
     return return_data
 
 

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -241,33 +241,34 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
 
     **Mathematical Details:**
 
-    The :math:`sinc` function is defined as
+    The :math:`\operatorname{sinc}` function is defined as
 
     .. math::
 
-        sinc(t) = \frac{\sin(\pi t)}{\pi t}.
+        \operatorname{sinc}(t) = \frac{\sin(\pi t)}{\pi t}.
 
-    The Lanczos kernel is then given by a multiplication of the :math:`sinc`
-    function with an additional window function resulting in a finite support
-    kernel.
+    The Lanczos kernel is then given by a multiplication of the
+    :math:`\operatorname{sinc}` function with an additional window function
+    resulting in a finite support kernel.
 
     .. math::
 
         \begin{align}
             L(t) =
             \begin{cases}
-                sinc(t)\, \cdot sinc(t/a)
+                \operatorname{sinc}(t)\, \cdot \operatorname{sinc}(t/a)
                     & \text{if } t \in [-a, a]
-                    \text{ and `window`} = \text{`lanczos`}\\
-                sinc(t)\, \cdot \frac{1}{2}
+                    \text{ and } \texttt{window} = \texttt{lanczos}\\
+                \operatorname{sinc}(t)\, \cdot \frac{1}{2}
                 (1 + \cos(\pi\, t/a))
                     & \text{if } t \in [-a, a]
-                    \text{ and `window`} = \text{`hanning`}\\
-                sinc(t)\, \cdot \left( \frac{21}{50} + \frac{1}{2}
+                    \text{ and } \texttt{window} = \texttt{lanczos}\\
+                \operatorname{sinc}(t)\, \cdot \left( \frac{21}{50} +
+                \frac{1}{2}
                 \cos(\pi\, t/a) + \frac{2}{25} \cos (2\pi\, t/a) \right)
-                    & \text{if } t \in [-a, a] \text{ and `window`} =
-                    \text{`blackman`}\\
-                0                     & \text{else,}
+                    & \text{if } t \in [-a, a]
+                    \text{ and } \texttt{window} = \texttt{lanczos}\\
+                0                     & \text{else}
             \end{cases}
         \end{align}
 
@@ -279,9 +280,10 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     .. math::
 
         \begin{align}
-            S(t_j) = \sum_{i = \left \lfloor{x}\right \rfloor - a + 1}
-                          ^{\left \lfloor{x}\right \rfloor + a}
-            s_i L(t_j - i),
+            S(t_j) =
+                \sum_{i = \left \lfloor{t_j / \Delta t}\right \rfloor -a + 1}
+                    ^{\left \lfloor{t_j / \Delta t}\right \rfloor + a}
+            s_i L(t_j/\Delta t - i),
         \end{align}
 
     where :math:`\lfloor \cdot \rfloor` denotes the floor function. For more

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -182,14 +182,23 @@ _LANCZOS_KERNEL_MAP = {
 
 
 def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
-                          a, window="lanczos", *args, **kwargs):
+                          a, window="lanczos"):
     r"""
     Function performing Lanczos resampling, see
     http://en.wikipedia.org/wiki/Lanczos_resampling for details. Essentially a
-    finite support version of sinc resampling (ideal reconstruction filter).
-    For large values of ``a`` it converges towards sinc resampling. If used
-    for downsampling, make sure to apply a proper anti-aliasing lowpass filter
-    first.
+    finite support version of sinc resampling (the ideal reconstruction
+    filter). For large values of ``a`` it converges towards sinc resampling. If
+    used for downsampling, make sure to apply a proper anti-aliasing lowpass
+    filter first.
+
+    .. note::
+
+        In most cases you do not want to call this method directly but invoke
+        it via either the :meth:`obspy.core.stream.Stream.interpolate` or the
+        :meth:`obspy.core.trace.Trace.interpolate` method. These offer a nicer
+        API that naturally integrates with the rest of ObsPy. Use
+        ``method="lanczos"`` to use this interpolation method. In that case the
+        only additional parameters of interest are ``a`` and ``window``.
 
     :type data: array_like
     :param data: Array to interpolate.
@@ -205,16 +214,23 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     :type new_npts: int
     :param new_npts: The new number of samples.
     :type a: int
-    :param a: The width of the window in samples on either side.
+    :param a: The width of the window in samples on either side. Runtimes
+        scales linearly with the value of ``a`` but the interpolation also get
+        better.
     :type window: str
     :param window: The window used to multiply the sinc function with. One
-        of ``"lanczos"``, ``"hanning"``, ``"blackman"``.
+        of ``"lanczos"``, ``"hanning"``, ``"blackman"``. The window determines
+        the trade-off between "sharpness" and the amplitude of the wiggles in
+        the pass and stop band. Please use the
+        :func:`~obspy.signal.interpolation.plot_lanczos_windows` function to
+        judge these for any given application.
 
     Values of ``a`` >= 20 show good results even for data that has
     energy close to the Nyquist frequency. If your data is way oversampled
     you can get away with much smaller ``a``'s.
 
-    To get an idea of the response of the filter, please use the
+    To get an idea of the response of the filter and the effect of the
+    different windows, please use the
     :func:`~obspy.signal.interpolation.plot_lanczos_windows` function.
 
     Also be aware of any boundary effects. All values outside the data
@@ -268,7 +284,8 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
             s_i L(t_j - i),
         \end{align}
 
-    where :math:`\lfloor \cdot \rfloor` denotes the floor function.
+    where :math:`\lfloor \cdot \rfloor` denotes the floor function. For more
+    details and justification please see [Burger2009]_ and [vanDriel2015]_.
     """
     _validate_parameters(data, old_start, old_dt, new_start, new_dt, new_npts)
     dt_factor = float(new_dt) / old_dt

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -188,7 +188,7 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     http://en.wikipedia.org/wiki/Lanczos_resampling for details. Essentially a
     finite support version of sinc resampling (the ideal reconstruction
     filter). For large values of ``a`` it converges towards sinc resampling. If
-    used for downsampling, make sure to apply a appropriate anti-aliasing
+    used for downsampling, make sure to apply an appropriate anti-aliasing
     lowpass filter first.
 
     .. note::
@@ -323,9 +323,9 @@ def calculate_lanczos_kernel(x, a, window):
 
     Returns a dictionary of arrays:
 
-    * ``"full_kernel"``: The tapered sinc function evaluated at samples x.
-    * ``"only_sinc"``: The sinc function evaluated at samples x.
-    * ``"only_taper"``: The taper function evaluated at samples x.
+    * ``"full_kernel"``: The tapered sinc function evaluated at samples ``x``.
+    * ``"only_sinc"``: The sinc function evaluated at samples ``x``.
+    * ``"only_taper"``: The taper function evaluated at samples ``x``.
     """
     window = window.lower()
     if window not in _LANCZOS_KERNEL_MAP:

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -177,7 +177,7 @@ def weighted_average_slopes(data, old_start, old_dt, new_start, new_dt,
 _LANCZOS_KERNEL_MAP = {
     "lanczos": 0,
     "hanning": 1,
-    "blackmann": 2
+    "blackman": 2
 }
 
 
@@ -215,7 +215,7 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     :param a: The width of the window in samples on either side.
     :type window: str
     :param window: The window used to multiply the sinc function with. One
-        of ``"lanczos"``, ``"hanning"``, ``"blackmann"``.
+        of ``"lanczos"``, ``"hanning"``, ``"blackman"``.
     """
     _validate_parameters(data, old_start, old_dt, new_start, new_dt, new_npts)
     dt_factor = float(new_dt) / old_dt
@@ -240,7 +240,7 @@ def calculate_lanczos_kernel(x, a, window):
     :param a: The width of the window in samples on either side.
     :type window: str
     :param window: The window used to multiply the sinc function with. One
-        of ``"lanczos"``, ``"hanning"``, ``"blackmann"``.
+        of ``"lanczos"``, ``"hanning"``, ``"blackman"``.
 
     Return a dictionary of arrays.
     """

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -220,11 +220,14 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     old_end, new_end = _validate_parameters(data, old_start, old_dt,
                                             new_start, new_dt, new_npts)
     dt_factor = float(new_dt) / old_dt
+    offset = new_start - old_start
+    if offset < 0:
+        raise ValueError("Cannot extrapolate.")
 
     return_data = np.zeros(new_npts, dtype="float64")
 
-    clibsignal.lanczos_resample(data, return_data, dt_factor, len(data),
-                                len(return_data), a, 0)
+    clibsignal.lanczos_resample(data, return_data, dt_factor, offset,
+                                len(data), len(return_data), a, 0)
     return return_data
 
 

--- a/obspy/signal/src/lanczos_resampling.c
+++ b/obspy/signal/src/lanczos_resampling.c
@@ -20,7 +20,7 @@ enum lanczos_window_type {
 
 
 /* Sinc function */
-double sinc(double x) {
+static double sinc(double x) {
     if (fabs(x) < 1E-10) {
         return 1.0;
     }
@@ -29,13 +29,13 @@ double sinc(double x) {
 
 
 /* Standard Lanczos Kernel */
-double lanczos_kernel(double x, int a) {
+static double lanczos_kernel(double x, int a) {
     return sinc(x / (double)a);
 }
 
 
 /* von Hann window or raised cosine window*/
-double hanning_kernel(double x, int a) {
+static double hanning_kernel(double x, int a) {
     return 0.5 * (1.0 + cos(x / (double)a * M_PI));
 }
 
@@ -44,7 +44,7 @@ double hanning_kernel(double x, int a) {
  *
  * Values are taken from http://mathworld.wolfram.com/BlackmanFunction.html
  */
-double blackman_kernel(double x, int a) {
+static double blackman_kernel(double x, int a) {
     return 21.0 / 50.0 +
            0.5 * cos(x / (double)a * M_PI) +
            2.0 / 25.0 * cos(2.0 * x / (double)a * M_PI);

--- a/obspy/signal/src/lanczos_resampling.c
+++ b/obspy/signal/src/lanczos_resampling.c
@@ -40,7 +40,7 @@ double hanning_kernel(double x, int a) {
  *
  * Values are taken from http://mathworld.wolfram.com/BlackmanFunction.html
  */
-double blackmann_kernel(double x, int a) {
+double blackman_kernel(double x, int a) {
     return 21.0 / 50.0 +
            0.5 * cos(x / (double)a * M_PI) +
            2.0 / 25.0 * cos(2.0 * x / (double)a * M_PI);
@@ -87,7 +87,7 @@ void lanczos_resample(double *y_in, double *y_out, double dt, double offset,
                     y_out[idx] += y_in[i] * sinc(_x) * hanning_kernel(_x, a);
                 }
                 else if (window == BLACKMAN) {
-                    y_out[idx] += y_in[i] * sinc(_x) * blackmann_kernel(_x, a);
+                    y_out[idx] += y_in[i] * sinc(_x) * blackman_kernel(_x, a);
                 }
             }
         }
@@ -129,7 +129,7 @@ void calculate_kernel(double *x, double *y, int len, int a,
                     y[idx] = sinc(value) * hanning_kernel(value, a);
                 }
                 else if (window == BLACKMAN) {
-                    y[idx] = sinc(value) * blackmann_kernel(value, a);
+                    y[idx] = sinc(value) * blackman_kernel(value, a);
                 }
             }
             else {
@@ -150,7 +150,7 @@ void calculate_kernel(double *x, double *y, int len, int a,
                     y[idx] = hanning_kernel(value, a);
                 }
                 else if (window == BLACKMAN) {
-                    y[idx] = blackmann_kernel(value, a);
+                    y[idx] = blackman_kernel(value, a);
                 }
             }
             else {

--- a/obspy/signal/src/lanczos_resampling.c
+++ b/obspy/signal/src/lanczos_resampling.c
@@ -1,0 +1,160 @@
+/*--------------------------------------------------------------------
+# Filename: lanczos_resampling.c
+#  Purpose: Lanczos resampling with different kernels
+#           each point.
+#   Author: Lion Krischer
+# Copyright (C) 2015 Lion Krischer and Martin van Driel
+#---------------------------------------------------------------------*/
+#include <math.h>
+
+
+enum lanczos_window_type {
+    LANCZOS = 0,
+    HANNING = 1,
+    BLACKMAN = 2,
+};
+
+
+/* Sinc function */
+double sinc(double x) {
+    if (fabs(x) < 1E-10) {
+        return 1.0;
+    }
+    return sin(M_PI * x) / (M_PI * x);
+}
+
+
+/* Standard Lanczos Kernel */
+double lanczos_kernel(double x, int a) {
+    return sinc(x / (double)a);
+}
+
+
+/* von Hann window or raised cosine window*/
+double hanning_kernel(double x, int a) {
+    return 0.5 * (1.0 + cos(x / (double)a * M_PI));
+}
+
+
+/* Blackman window
+ *
+ * Values are taken from http://mathworld.wolfram.com/BlackmanFunction.html
+ */
+double blackmann_kernel(double x, int a) {
+    return 21.0 / 50.0 +
+           0.5 * cos(x / (double)a * M_PI) +
+           2.0 / 25.0 * cos(2.0 * x / (double)a * M_PI);
+}
+
+
+/* Lanczos resampling with different kernels.
+ *
+ * Parameters:
+ *
+ *     y_in: The data values to be interpolated.
+ *     y_out: The output array. Must already be initialized with zeros.
+ *     dt: The sampling rate factor.
+ *     len_in: The length of the input array.
+ *     len_out: The length of the output array.
+ *     a: The width of the taper in samples on either side.
+ *     lanczos_window_type: Which taper window to choose.
+ *
+ * Output will be written to y_out.
+ */
+void lanczos_resample(double *y_in, double *y_out, double dt, int len_in,
+                      int len_out, int a, enum lanczos_window_type window) {
+
+    int idx, i, m;
+    double x, _x;
+
+    for (idx=0; idx < len_out; idx++) {
+        x = dt * idx;
+        for (m=-a; m<=a; m++) {
+            i = (int)floor(x) - m;
+            if (i < 0 || i >= len_in) {
+                continue;
+            }
+            _x = x - i;
+            /* Apply kernel and sum up if within 'a' samples on either side. */
+            if (-a <= _x && _x <= a) {
+                if (window == LANCZOS) {
+                    y_out[idx] += y_in[i] * sinc(_x) * lanczos_kernel(_x, a);
+                }
+                else if (window == HANNING) {
+                    y_out[idx] += y_in[i] * sinc(_x) * hanning_kernel(_x, a);
+                }
+                else if (window == BLACKMAN) {
+                    y_out[idx] += y_in[i] * sinc(_x) * blackmann_kernel(_x, a);
+                }
+            }
+        }
+    }
+    return;
+}
+
+
+/* Helper function to be able to analyze and plot the actually used kernels.
+ *
+ * Parameters:
+ *
+ *     x: The input x values.
+ *     y: The output array. Must have the same number of samples as x.
+ *     len: The length of x and y.
+ *     a: The width of the taper in samples on either side.
+ *     return type: The type of kernel to return. Useful for plotting.
+ *         0: Returns the sinc function tapered with the chosen window.
+ *         1: Returns only the sinc function.
+ *         2: Returns only the chosen taper window.
+ *     lanczos_window_type: Which taper window to choose.
+ *
+ */
+void calculate_kernel(double *x, double *y, int len, int a,
+                      int return_type, enum lanczos_window_type window) {
+    int idx;
+    double value;
+
+    for (idx=0; idx<len; idx++) {
+        value = x[idx];
+
+        /* Sinc times window */
+        if (return_type == 0) {
+            if (-a <= value && value <= a) {
+                if (window == LANCZOS) {
+                    y[idx] = sinc(value) * lanczos_kernel(value, a);
+                }
+                else if (window == HANNING) {
+                    y[idx] = sinc(value) * hanning_kernel(value, a);
+                }
+                else if (window == BLACKMAN) {
+                    y[idx] = sinc(value) * blackmann_kernel(value, a);
+                }
+            }
+            else {
+                y[idx] = 0.0;
+            }
+        }
+        /* Only sinc */
+        else if (return_type == 1) {
+            y[idx] = sinc(value);
+        }
+        /* Only window */
+        else if (return_type == 2) {
+            if (-a <= value && value <= a) {
+                if (window == LANCZOS) {
+                    y[idx] = lanczos_kernel(value, a);
+                }
+                else if (window == HANNING) {
+                    y[idx] = hanning_kernel(value, a);
+                }
+                else if (window == BLACKMAN) {
+                    y[idx] = blackmann_kernel(value, a);
+                }
+            }
+            else {
+                y[idx] = 0.0;
+            }
+        }
+
+    }
+    return;
+}

--- a/obspy/signal/src/lanczos_resampling.c
+++ b/obspy/signal/src/lanczos_resampling.c
@@ -54,6 +54,8 @@ double blackmann_kernel(double x, int a) {
  *     y_in: The data values to be interpolated.
  *     y_out: The output array. Must already be initialized with zeros.
  *     dt: The sampling rate factor.
+ *     offset: The offset of the first sample in the output array relative
+ *         to the input array.
  *     len_in: The length of the input array.
  *     len_out: The length of the output array.
  *     a: The width of the taper in samples on either side.
@@ -61,14 +63,15 @@ double blackmann_kernel(double x, int a) {
  *
  * Output will be written to y_out.
  */
-void lanczos_resample(double *y_in, double *y_out, double dt, int len_in,
-                      int len_out, int a, enum lanczos_window_type window) {
+void lanczos_resample(double *y_in, double *y_out, double dt, double offset,
+                      int len_in, int len_out, int a,
+                      enum lanczos_window_type window) {
 
     int idx, i, m;
     double x, _x;
 
     for (idx=0; idx < len_out; idx++) {
-        x = dt * idx;
+        x = dt * idx + offset;
         for (m=-a; m<=a; m++) {
             i = (int)floor(x) - m;
             if (i < 0 || i >= len_in) {

--- a/obspy/signal/src/lanczos_resampling.c
+++ b/obspy/signal/src/lanczos_resampling.c
@@ -5,6 +5,10 @@
 #   Author: Lion Krischer
 # Copyright (C) 2015 Lion Krischer and Martin van Driel
 #---------------------------------------------------------------------*/
+
+/* Windows apparently needs this */
+#define _USE_MATH_DEFINES
+
 #include <math.h>
 
 

--- a/obspy/signal/src/libsignal.def
+++ b/obspy/signal/src/libsignal.def
@@ -16,3 +16,5 @@ EXPORTS
     calcSteer
     generalizedBeamformer
     hermite_interpolation
+    lanczos_resample
+    calculate_kernel

--- a/obspy/signal/tests/test_interpolation.py
+++ b/obspy/signal/tests/test_interpolation.py
@@ -51,7 +51,6 @@ class InterpolationTestCase(unittest.TestCase):
             values["full_kernel"], np.sinc(x) * np.sinc(x / 5.0),
             atol=1E-9)
 
-
     def test_lanczos_interpolation(self):
         """
         Tests against the instaseis implementation which should work well

--- a/obspy/signal/tests/test_interpolation.py
+++ b/obspy/signal/tests/test_interpolation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+The interpolation test suite for ObsPy.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+import numpy as np
+from obspy.signal.interpolation import (lanczos_interpolation,
+                                        calculate_lanczos_kernel)
+
+
+class InterpolationTestCase(unittest.TestCase):
+    """
+    Interpolation test case
+    """
+    def test_calculate_lanczos_kernel(self):
+        """
+        Tests the kernels implemented in C against their numpy counterpart.
+        """
+        x = np.linspace(-5, 5, 11)
+
+        values = calculate_lanczos_kernel(x, 5, "hanning")
+        np.testing.assert_allclose(
+            values["only_sinc"], np.sinc(x), atol=1E-9)
+        np.testing.assert_allclose(
+            values["only_taper"], np.hanning(len(x)), atol=1E-9)
+        np.testing.assert_allclose(
+            values["full_kernel"], np.sinc(x) * np.hanning(len(x)),
+            atol=1E-9)
+
+        values = calculate_lanczos_kernel(x, 5, "blackman")
+        np.testing.assert_allclose(
+            values["only_sinc"], np.sinc(x), atol=1E-9)
+        np.testing.assert_allclose(
+            values["only_taper"], np.blackman(len(x)), atol=1E-9)
+        np.testing.assert_allclose(
+            values["full_kernel"], np.sinc(x) * np.blackman(len(x)),
+            atol=1E-9)
+
+        values = calculate_lanczos_kernel(x, 5, "lanczos")
+        np.testing.assert_allclose(
+            values["only_sinc"], np.sinc(x), atol=1E-9)
+        np.testing.assert_allclose(
+            values["only_taper"], np.sinc(x / 5.0), atol=1E-9)
+        np.testing.assert_allclose(
+            values["full_kernel"], np.sinc(x) * np.sinc(x / 5.0),
+            atol=1E-9)
+
+
+def suite():
+    return unittest.makeSuite(InterpolationTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_interpolation.py
+++ b/obspy/signal/tests/test_interpolation.py
@@ -52,6 +52,47 @@ class InterpolationTestCase(unittest.TestCase):
             atol=1E-9)
 
 
+    def test_lanczos_interpolation(self):
+        """
+        Tests against the instaseis implementation which should work well
+        enough.
+        """
+        data = np.array([0.92961609, 0.31637555, 0.18391881, 0.20456028,
+                         0.56772503, 0.5955447, 0.96451452, 0.6531771,
+                         0.74890664, 0.65356987])
+        dt = 1.0
+
+        # Scenario 1.
+        new_dt = 0.45
+        a = 1
+
+        expected_output = np.array([
+            0.92961609, 0.55712768, 0.31720733, 0.24275977, 0.17825931,
+            0.16750234, 0.17561933, 0.20626905, 0.37726064, 0.5647072,
+            0.47145546, 0.59222238, 0.58665834, 0.91241347, 0.79909224,
+            0.61631275, 0.61258393, 0.61611633, 0.73239733, 0.56371682,
+            0.65356987])
+
+        output = lanczos_interpolation(
+            data, old_dt=dt, new_start=0.0, old_start=0.0, new_dt=new_dt,
+            new_npts=21, a=a)
+        np.testing.assert_allclose(output, expected_output, atol=1E-9)
+
+        # Scenario 2.
+        new_dt = 0.72
+        a = 12
+
+        expected_output = np.array([
+            0.92961609, 0.54632548, 0.14335148, 0.19675436, 0.19030867,
+            0.41722415, 0.60644459, 0.6018648,  0.88751628, 0.90970863,
+            0.58602723, 0.71521445, 0.83288791])
+
+        output = lanczos_interpolation(
+            data, old_dt=dt, new_start=0.0, old_start=0.0, new_dt=new_dt,
+            new_npts=13, a=a)
+        np.testing.assert_allclose(output, expected_output, atol=1E-9)
+
+
 def suite():
     return unittest.makeSuite(InterpolationTestCase, 'test')
 

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,7 @@ ENTRY_POINTS = {
         'interpolate_1d = obspy.signal.interpolation:interpolate_1d',
         'weighted_average_slopes = '
         'obspy.signal.interpolation:weighted_average_slopes',
+        'lanczos = obspy.signal.interpolation:lanczos_interpolation'
         ],
     'obspy.plugin.rotate': [
         'rotate_NE_RT = obspy.signal.rotate:rotate_NE_RT',


### PR DESCRIPTION
This PR adds Lanczos interpolation to ObsPy as has already been discussed a couple of times. Its an extended version of what we already had in Instaseis rewritten in C. I hooked it into `Stream.interpolate`/`Trace.interpolate` as it is a kind of interpolation method and it fits the existing API very well.

It is almost always better then the existing interpolation methods and should come in very handy for changing the sampling rate. Results are pretty nice:

```python
import matplotlib.pylab as plt
import numpy as np
import obspy

data = np.sin(np.linspace(0, 200 * np.pi, 250))

tr = obspy.Trace(data=data)

tr2 = tr.copy()
tr2.interpolate(method="lanczos", a=25, sampling_rate=100)

plt.figure(figsize=(18, 8))
plt.plot(tr.times(), tr.data, "o", label="samples")
plt.plot(tr2.times(), tr2.data, label="resampled")
plt.plot(np.linspace(0, 249, 10000),
         np.sin(np.linspace(0, 200 * np.pi, 10000)), "--",
         label="original", color="k")
plt.legend()
plt.xlim(30, 40)
plt.show()
```

<img width="1057" alt="screen shot 2015-07-31 at 00 40 55" src="https://cloud.githubusercontent.com/assets/800487/8996975/da6cc77a-371c-11e5-97ca-bc42f78578a8.png">

I put quite some work into the documentation - pages of interest:

* http://www.geophysik.uni-muenchen.de/~krischer/doc_lanczos/packages/autogen/obspy.signal.interpolation.lanczos_interpolation.html
* http://www.geophysik.uni-muenchen.de/~krischer/doc_lanczos/packages/autogen/obspy.signal.interpolation.plot_lanczos_windows.html
* http://www.geophysik.uni-muenchen.de/~krischer/doc_lanczos/packages/autogen/obspy.core.trace.Trace.interpolate.html

It currently supports three different windows to taper the sinc function which represent different trade-offs between accuracy and "wiggliness". If somebody feels we need more please let me know.

![obspy-signal-interpolation-plot_lanczos_windows-1](https://cloud.githubusercontent.com/assets/800487/8997147/5d6d2f60-371e-11e5-9553-21a65dbd123d.png)

Furthermore the `interpolate()` method now has an additional argument: `time_shift` - a cheap way to shift seismograms by subsamples. Not as good as a Fourier domain shift but still pretty useful in many cases.

There is still some optimization potential in the C code which could speed it up so if anyone wants to have a go: Please feel free :-)

@martinvandriel Just pinging you to make you aware of this.

Should be ready for review!