### PR TITLE
Bugfix for libmseed when writing negative timestamps with microsecond accuracy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@
       Trace needed it or not. (see #1069)
     * Fixed a bug that prevented microsecond accuracy for times before 1970
       (see #1102).
+    * Updated to libmseed 2.17.
   - obspy.signal:
     * Bug fixed within rotate.rotate2ZNE(). Additionally it can now also
       perform the inverse rotation (see #1061).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@
     * Blockette 100 is now only written for Traces that need it. Previously
       it was written or not for all Traces, depending on whether the last
       Trace needed it or not. (see #1069)
+    * Fixed a bug that prevented microsecond accuracy for times before 1970
+      (see #1102).
   - obspy.signal:
     * Bug fixed within rotate.rotate2ZNE(). Additionally it can now also
       perform the inverse rotation (see #1061).

--- a/obspy/mseed/scripts/recordanalyzer.py
+++ b/obspy/mseed/scripts/recordanalyzer.py
@@ -275,7 +275,7 @@ class RecordAnalyser(object):
         elif blkt_type == 1001:
             _tmp = self.file.read(4)
             try:
-                unpack_values = unpack(native_str('%sBBxB' % self.endian),
+                unpack_values = unpack(native_str('%sbbxb' % self.endian),
                                        _tmp)
             except:
                 if len(_tmp) == 0:

--- a/obspy/mseed/src/libmseed/ChangeLog
+++ b/obspy/mseed/src/libmseed/ChangeLog
@@ -1,3 +1,47 @@
+2015.213: 2.17
+	- Round Fixed Section Data Header start time values to the nearest
+	tenth of millisecond and restrict the microsecond offset value
+	to a range between -50 and +49 as recommended in SEED.  Previously
+	start times were truncated at tenths of millisecond resolution
+	and the microsecond offset value was between 0 and +99.  This also
+	addresses a bug where microsecond offsets were off by 100ms for times
+	before Jan 1 1970.  Thanks to Lion Krischer for reporting.
+
+	Note to future hackers: the definition of HPTMODULUS governing the
+	time tick interval for high precision time values implies that this
+	tick interval may be changed.  In reality, this should not be changed
+	from the default, microsecond tick value without thorough testing.
+	Some logic is know to be dependent on the microsecond tick.
+
+2015.134: 2.16m
+	- Add defines for needed integer types and macros from inttypes.h
+	missing in older MSVC versions.  MSVC 2010 and later appear to have
+	enough C99 support.
+	- Add define tests for _WIN32 and _WIN64 to cover all WINs.
+	- ms_fread(): Add cast to quiet warning for conversion from size_t
+	to int.  In this case the read will always be <= MAXRECLEN, much
+	smaller than int, making the conversion safe.
+
+2015.113: 2.16
+	- Update minor release version in Makefile.
+
+2015.108:
+	- Cleanup of lmplatform.h removing unneeded headers and using C99
+	standard headers except for a few platform specific cases.
+	- Convert all printf() and scanf() usage of %lld for 64-bit integers
+	to use the C99 PRId64 and SCNd64 macros for portability (MingGW).
+	- Change detection of Linux/Cygwin to set global define LMP_LINUX
+	instead of LMP_GLIB2 (now marked as deprecated).
+	- Change detection of Windows to set global define LMP_WIN instead
+	of LMP_WIN32 (now marked as deprecated).
+	- Add detection of __MINGW64__ define.
+	- Tested building on Win7 with: Open Watcom 1.9, MinGW gcc 4.8.1 and
+	Cygwin 1.7.35 (gcc 2.9.2).
+
+2015.074:
+	- Define NTP-Posix time epoch conversion constant specifically as
+	a long long integer to avoid warnings on some compilers.
+
 2015.070: 2.15
 	- Fix infinite loop if blockette chain is corrupt.  Patch submitted
 	by Elliott Sales de Andrade.

--- a/obspy/mseed/src/libmseed/Makefile
+++ b/obspy/mseed/src/libmseed/Makefile
@@ -5,7 +5,7 @@
 #   CFLAGS : Specify compiler options to use
 
 MAJOR_VER = 2
-MINOR_VER = 13
+MINOR_VER = 17
 CURRENT_VER = $(MAJOR_VER).$(MINOR_VER)
 COMPAT_VER = $(MAJOR_VER).$(MINOR_VER)
 

--- a/obspy/mseed/src/libmseed/README
+++ b/obspy/mseed/src/libmseed/README
@@ -18,6 +18,7 @@ information regarding the library interface see the documentation in
 the 'doc' directory.  For example uses of libmseed see the source code
 in the 'examples' directory.
 
+-- License --
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GNU Library General Public License as
@@ -29,7 +30,7 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 Library General Public License (GNU-LGPL) for more details.  The
 GNU-LGPL and further information can be found here:
-http://www.gnu.org/
+http://www.gnu.org/licenses/
 
 
 Chad Trabant, IRIS Data Management Center

--- a/obspy/mseed/src/libmseed/doc/ms_intro.3
+++ b/obspy/mseed/src/libmseed/doc/ms_intro.3
@@ -546,8 +546,8 @@ main() {
   precords = mst_pack (mst, &record_handler, srcname, 4096, DE_STEIM2,
                        1, &psamples, 1, verbose, NULL);
 
-  ms_log (0, "Packed %lld samples into %d records\n",
-             (long long int)psamples, precords);
+  ms_log (0, "Packed %"PRId64" samples into %d records\n",
+             psamples, precords);
 
   /* Disconnect datasamples pointer, otherwise mst_free() will free it */
   mst->datasamples = NULL;

--- a/obspy/mseed/src/libmseed/doc/msr_pack.3
+++ b/obspy/mseed/src/libmseed/doc/msr_pack.3
@@ -177,8 +177,8 @@ main() {
   /* Pack the record(s) */
   precords = msr_pack (msr, &record_handler, srcname, &psamples, 1, verbose);
 
-  ms_log (0, "Packed %lld samples into %d records\n",
-             (long long int)psamples, precords);
+  ms_log (0, "Packed %"PRId64" samples into %d records\n",
+             psamples, precords);
 
   msr_free (&msr);
 }

--- a/obspy/mseed/src/libmseed/doc/msr_parse.3
+++ b/obspy/mseed/src/libmseed/doc/msr_parse.3
@@ -99,7 +99,7 @@ The following example illustrates the intended usage:
         {
           /* Only print error if offset is still within buffer length */
           if ( verbose && offset < recbuflen )
-          ms_log (2, "Error parsing record at offset %lld\n", (long long int) offset);
+          ms_log (2, "Error parsing record at offset %"PRId64"\n", offset);
         }
       else /* Succesfully found and parsed record */
         {

--- a/obspy/mseed/src/libmseed/doc/mst_pack.3
+++ b/obspy/mseed/src/libmseed/doc/mst_pack.3
@@ -154,8 +154,8 @@ main() {
   precords = mst_pack (mst, &record_handler, srcname, 4096, DE_STEIM2,
                        1, &psamples, 1, verbose, NULL);
 
-  ms_log (0, "Packed %lld samples into %d records\n",
-             (long long int)psamples, precords);
+  ms_log (0, "Packed %"PRId64" samples into %d records\n",
+             psamples, precords);
 
   mst_free (&mst);
 }

--- a/obspy/mseed/src/libmseed/example/msview.c
+++ b/obspy/mseed/src/libmseed/example/msview.c
@@ -8,7 +8,7 @@
  *
  * Written by Chad Trabant, ORFEUS/EC-Project MEREDIAN
  *
- * modified 2006.331
+ * modified 2015.108
  ***************************************************************************/
 
 #include <stdio.h>
@@ -85,8 +85,8 @@ main (int argc, char **argv)
   ms_readmsr (&msr, NULL, 0, NULL, NULL, 0, 0, 0);
   
   if ( basicsum )
-    ms_log (1, "Records: %lld, Samples: %lld\n",
-	    (long long int)totalrecs, (long long int)totalsamps);
+    ms_log (1, "Records: %"PRId64", Samples: %"PRId64"\n",
+	    totalrecs, totalsamps);
   
   return 0;
 }  /* End of main() */

--- a/obspy/mseed/src/libmseed/fileutils.c
+++ b/obspy/mseed/src/libmseed/fileutils.c
@@ -5,7 +5,7 @@
  * Written by Chad Trabant
  *   IRIS Data Management Center
  *
- * modified: 2013.117
+ * modified: 2015.108
  ***************************************************************************/
 
 #include <stdio.h>
@@ -420,7 +420,7 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 	    {
 	      if ( ! feof (msfp->fp) )
 		{
-		  ms_log (2, "Short read of %d bytes starting from %lld\n",
+		  ms_log (2, "Short read of %d bytes starting from %"PRId64"\n",
 			  readsize, msfp->filepos);
 		  retcode = MS_GENERROR;
 		  break;
@@ -460,7 +460,7 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
       if ( msfp->packtype && (msfp->packtype < 0 || msfp->filepos == msfp->packhdroffset) && MSFPBUFLEN(msfp) >= 48 )
 	{
 	  char hdrstr[30];
-	  long long datasize;
+	  int64_t datasize;
 	  
 	  /* Determine bytes to skip before header: either initial ID block or type-specific chksum block */
 	  packskipsize = ( msfp->packtype < 0 ) ? 10 : packtypes[msfp->packtype][2];
@@ -472,7 +472,7 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 	  memset (hdrstr, 0, sizeof(hdrstr));
 	  memcpy (hdrstr, MSFPREADPTR(msfp) + (packtypes[msfp->packtype][0] + packskipsize - packtypes[msfp->packtype][1]),
 		  packtypes[msfp->packtype][1]);
-	  sscanf (hdrstr, " %lld", &datasize);
+	  sscanf (hdrstr, " %"SCNd64, &datasize);
 	  packdatasize = (off_t) datasize;
 	  
 	  /* Next pack header = File position + skipsize + header size + data size
@@ -481,10 +481,10 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 	  msfp->packhdroffset = msfp->filepos + packskipsize + packtypes[msfp->packtype][0] + packdatasize;
 	  
 	  if ( verbose > 1 )
-	    ms_log (1, "Read packed file header at offset %lld (%d bytes follow), chksum offset: %lld\n",
-		    (long long int) (msfp->filepos + packskipsize), packdatasize,
-		    (long long int) msfp->packhdroffset);
-	  
+	    ms_log (1, "Read packed file header at offset %"PRId64" (%d bytes follow), chksum offset: %"PRId64"\n",
+		    (msfp->filepos + packskipsize), packdatasize,
+		    msfp->packhdroffset);
+
 	  /* Shift buffer to new reading offset (aligns records in buffer) */
 	  ms_shift_msfp (msfp, msfp->readoffset + (packskipsize + packtypes[msfp->packtype][0]));
 	} /* End of packed header processing */
@@ -504,8 +504,8 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 		{
 		  if ( verbose > 1 )
 		    {
-		      ms_log (1, "Skipping (jump) packed section for %s (%d bytes) starting at offset %lld\n",
-			      srcname, (msfp->packhdroffset - msfp->filepos), (long long int) msfp->filepos);
+		      ms_log (1, "Skipping (jump) packed section for %s (%d bytes) starting at offset %"PRId64"\n",
+			      srcname, (msfp->packhdroffset - msfp->filepos), msfp->filepos);
 		    }
 		  
 		  msfp->readoffset += (msfp->packhdroffset - msfp->filepos);
@@ -518,8 +518,8 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 		{
 		  if ( verbose > 1 )
 		    {
-		      ms_log (1, "Skipping (seek) packed section for %s (%d bytes) starting at offset %lld\n",
-			      srcname, (msfp->packhdroffset - msfp->filepos), (long long int) msfp->filepos);
+		      ms_log (1, "Skipping (seek) packed section for %s (%d bytes) starting at offset %"PRId64"\n",
+			      srcname, (msfp->packhdroffset - msfp->filepos), msfp->filepos);
 		    }
 
 		  if ( lmp_fseeko (msfp->fp, msfp->packhdroffset, SEEK_SET) )
@@ -583,11 +583,11 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 		  if ( verbose > 1 )
 		    {
 		      if ( MS_ISVALIDBLANK((char *)MSFPREADPTR(msfp)) )
-			ms_log (1, "Skipped %d bytes of blank/noise record at byte offset %lld\n",
-				MINRECLEN, (long long) msfp->filepos);
+			ms_log (1, "Skipped %d bytes of blank/noise record at byte offset %"PRId64"\n",
+				MINRECLEN, msfp->filepos);
 		      else
-			ms_log (1, "Skipped %d bytes of non-data record at byte offset %lld\n",
-				MINRECLEN, (long long) msfp->filepos);
+			ms_log (1, "Skipped %d bytes of non-data record at byte offset %"PRId64"\n",
+				MINRECLEN, msfp->filepos);
 		    }
 		  
 		  /* Skip MINRECLEN bytes, update reading offset and file position */
@@ -597,8 +597,8 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 	      /* Parsing errors */ 
 	      else
 		{
-		  ms_log (2, "Cannot detect record at byte offset %lld: %s\n",
-			  (long long) msfp->filepos, msfile);
+		  ms_log (2, "Cannot detect record at byte offset %"PRId64": %s\n",
+			  msfp->filepos, msfile);
 		  
 		  /* Print common errors and raw details if verbose */
 		  ms_parse_raw (MSFPREADPTR(msfp), MSFPBUFLEN(msfp), verbose, -1);
@@ -670,11 +670,11 @@ ms_readmsr_main (MSFileParam **ppmsfp, MSRecord **ppmsr, const char *msfile,
 		      if ( verbose )
 			{
 			  if ( msfp->filesize )
-			    ms_log (1, "Truncated record at byte offset %lld, filesize %d: %s\n",
-				    (long long) msfp->filepos, msfp->filesize, msfile);
+			    ms_log (1, "Truncated record at byte offset %"PRId64", filesize %d: %s\n",
+				    msfp->filepos, msfp->filesize, msfile);
 			  else
-			    ms_log (1, "Truncated record at byte offset %lld\n",
-				    (long long) msfp->filepos);
+			    ms_log (1, "Truncated record at byte offset %"PRId64"\n",
+				    msfp->filepos);
 			}
 		      
 		      retcode = MS_ENDOFFILE;
@@ -976,7 +976,7 @@ ms_fread (char *buf, int size, int num, FILE *stream)
 {
   int read = 0;
   
-  read = fread (buf, size, num, stream);
+  read = (int) fread (buf, size, num, stream);
   
   if ( read <= 0 && size && num )
     {

--- a/obspy/mseed/src/libmseed/libmseed.h
+++ b/obspy/mseed/src/libmseed/libmseed.h
@@ -30,8 +30,8 @@ extern "C" {
 
 #include "lmplatform.h"
 
-#define LIBMSEED_VERSION "2.15"
-#define LIBMSEED_RELEASE "2015.070"
+#define LIBMSEED_VERSION "2.17"
+#define LIBMSEED_RELEASE "2015.213"
 
 #define MINRECLEN   128      /* Minimum Mini-SEED record length, 2^7 bytes */
                              /* Note: the SEED specification minimum is 256 */
@@ -658,6 +658,7 @@ extern hptime_t ms_btime2hptime (BTime *btime);
 extern char*    ms_btime2isotimestr (BTime *btime, char *isotimestr);
 extern char*    ms_btime2mdtimestr (BTime *btime, char *mdtimestr);
 extern char*    ms_btime2seedtimestr (BTime *btime, char *seedtimestr);
+extern int      ms_hptime2tomsusecoffset (hptime_t hptime, hptime_t *toms, int8_t *usecoffset);
 extern int      ms_hptime2btime (hptime_t hptime, BTime *btime);
 extern char*    ms_hptime2isotimestr (hptime_t hptime, char *isotimestr, flag subsecond);
 extern char*    ms_hptime2mdtimestr (hptime_t hptime, char *mdtimestr, flag subsecond);

--- a/obspy/mseed/src/libmseed/lmplatform.c
+++ b/obspy/mseed/src/libmseed/lmplatform.c
@@ -35,7 +35,7 @@
 off_t
 lmp_ftello (FILE *stream)
 {
-#if defined(LMP_WIN32)
+#if defined(LMP_WIN)
   return (off_t) ftell (stream);
 
 #else
@@ -54,7 +54,7 @@ lmp_ftello (FILE *stream)
 int
 lmp_fseeko (FILE *stream, off_t offset, int whence)
 {
-#if defined(LMP_WIN32)
+#if defined(LMP_WIN)
   return (int) fseek (stream, (long int) offset, whence);
   
 #else

--- a/obspy/mseed/src/libmseed/lmplatform.h
+++ b/obspy/mseed/src/libmseed/lmplatform.h
@@ -18,7 +18,7 @@
  *
  * Written by Chad Trabant, IRIS Data Management Center
  *
- * modified: 2014.074
+ * modified: 2015.134
  ***************************************************************************/
 
 #ifndef LMPLATFORM_H
@@ -34,7 +34,7 @@ extern "C" {
      layout exactly as specified, i.e. no padding.
 
      If "ATTRIBUTE_PACKED" is defined at compile time (e.g. -DATTRIBUTE_PACKED)
-     the preprocessor will use the define below to add the "packed" attribute 
+     the preprocessor will use the define below to add the "packed" attribute
      to effected structs.  This attribute is supported by GCC and increasingly
      more compilers.
   */
@@ -44,71 +44,63 @@ extern "C" {
   #define LMP_PACKED
 #endif
 
-  /* Make some guesses about the system libraries based
-   * on the architecture.  Currently the assumptions are:
-   * Linux => glibc2 libraries (LMP_GLIBC2)
-   * Sun => Solaris libraties (LMP_SOLARIS)
-   * BSD => BSD libraries, including Apple Mac OS X (LMP_BSD)
-   * WIN32 => WIN32 and Windows Sockets 2 (LMP_WIN32)
-   */
+/* C99 standard headers */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+#include <string.h>
+#include <ctype.h>
 
+/* Set architecture specific defines and features */
 #if defined(__linux__) || defined(__linux) || defined(__CYGWIN__)
-  #define LMP_GLIBC2 1
+  #define LMP_LINUX 1
+  #define LMP_GLIBC2 1 /* Deprecated */
 
-  #include <stdlib.h>
-  #include <stdio.h>
   #include <unistd.h>
-  #include <stdarg.h>
   #include <inttypes.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <netdb.h>
-  #include <sys/time.h>
-  #include <string.h>
-  #include <ctype.h>
-  #include <features.h>
-  
+
 #elif defined(__sun__) || defined(__sun)
   #define LMP_SOLARIS 1
 
-  #include <stdlib.h>
-  #include <stdio.h>
   #include <unistd.h>
-  #include <stdarg.h>
   #include <inttypes.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <netdb.h>
-  #include <sys/time.h>
-  #include <string.h>
-  #include <ctype.h>
-  
+
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   #define LMP_BSD 1
 
-  #include <stdlib.h>
-  #include <stdio.h>
   #include <unistd.h>
-  #include <stdarg.h>
   #include <inttypes.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <netdb.h>
-  #include <sys/time.h>
-  #include <string.h>
-  #include <ctype.h>
 
-#elif defined(WIN32) || defined(WIN64)
-  #define LMP_WIN32 1
+#elif defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+  #define LMP_WIN 1
+  #define LMP_WIN32 1 /* Deprecated */
 
   #include <windows.h>
-  #include <stdarg.h>
-  #include <winsock.h>
-  #include <stdio.h>
   #include <sys/types.h>
-  #include <ctype.h>
+
+  /* For pre-MSVC 2010 define standard int types, otherwise use inttypes.h */
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    typedef signed char int8_t;
+    typedef unsigned char uint8_t;
+    typedef signed short int int16_t;
+    typedef unsigned short int uint16_t;
+    typedef signed int int32_t;
+    typedef unsigned int uint32_t;
+    typedef signed __int64 int64_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #include <inttypes.h>
+  #endif
 
   #if defined(_MSC_VER)
+    #if !defined(PRId64)
+      #define PRId64 "I64d"
+    #endif
+    #if !defined(SCNd64)
+      #define SCNd64 "I64d"
+    #endif
+
     #define snprintf _snprintf
     #define vsnprintf _vsnprintf
     #define strcasecmp _stricmp
@@ -118,41 +110,10 @@ extern "C" {
     #define fileno _fileno
   #endif
 
-  #if defined(__MINGW32__) 
-    #define fstat _fstat 
-    #define stat _stat 
-  #endif 
-
-  typedef signed char int8_t;
-  typedef unsigned char uint8_t;
-  typedef signed short int int16_t;
-  typedef unsigned short int uint16_t;
-  typedef signed int int32_t;
-  typedef unsigned int uint32_t;
-  typedef signed __int64 int64_t;
-  typedef unsigned __int64 uint64_t;
-
-#else
-  #include <stdlib.h>
-  #include <stdio.h>
-  #include <unistd.h>
-  #include <stdarg.h>
-  #include <inttypes.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <netdb.h>
-  #include <sys/time.h>
-  #include <string.h>
-  #include <ctype.h>
-
-  typedef signed char int8_t;
-  typedef unsigned char uint8_t;
-  typedef signed short int int16_t;
-  typedef unsigned short int uint16_t;
-  typedef signed int int32_t;
-  typedef unsigned int uint32_t;
-  typedef signed long long int64_t;
-  typedef unsigned long long uint64_t;
+  #if defined(__MINGW32__) || defined(__MINGW64__)
+    #define fstat _fstat
+    #define stat _stat
+  #endif
 
 #endif
 

--- a/obspy/mseed/src/libmseed/msrutils.c
+++ b/obspy/mseed/src/libmseed/msrutils.c
@@ -358,7 +358,16 @@ msr_normalize_header ( MSRecord *msr, flag verbose )
 	  sec = msr->starttime / (HPTMODULUS / 10000);
 	  usec = msr->starttime - (sec * (HPTMODULUS / 10000));
 	  usec /= (HPTMODULUS / 1000000);
-	  
+
+      /* Deal with negative timestamps and a negative offset.
+       *
+       * The value is rounded down when writing the fixed header
+       * thus the offset needs to be relative to the next smaller
+       * value representable by the BTIME definition. */
+      if (msr->starttime <= 0 && usec < 0) {
+        usec += 100;
+      }
+
 	  msr->Blkt1001->usec = (int8_t) usec;
 	  offset += sizeof (struct blkt_1001_s);
 	}

--- a/obspy/mseed/src/libmseed/msrutils.c
+++ b/obspy/mseed/src/libmseed/msrutils.c
@@ -7,7 +7,7 @@
  *   ORFEUS/EC-Project MEREDIAN
  *   IRIS Data Management Center
  *
- * modified: 2012.088
+ * modified: 2015.213
  ***************************************************************************/
 
 #include <stdio.h>
@@ -257,6 +257,8 @@ int
 msr_normalize_header ( MSRecord *msr, flag verbose )
 {
   struct blkt_link_s *cur_blkt;
+  hptime_t hptimems;
+  int8_t usecoffset;
   char seqnum[7];
   int offset = 0;
   int blktcnt = 0;
@@ -265,6 +267,9 @@ msr_normalize_header ( MSRecord *msr, flag verbose )
   
   if ( ! msr )
     return -1;
+  
+  /* Get start time rounded to tenths of milliseconds and microsecond offset */
+  ms_hptime2tomsusecoffset (msr->starttime, &hptimems, &usecoffset);
   
   /* Update values in fixed section of data header */
   if ( msr->fsdh )
@@ -285,7 +290,7 @@ msr_normalize_header ( MSRecord *msr, flag verbose )
       ms_strncpopen (msr->fsdh->station, msr->station, 5);
       ms_strncpopen (msr->fsdh->location, msr->location, 2);
       ms_strncpopen (msr->fsdh->channel, msr->channel, 3);
-      ms_hptime2btime (msr->starttime, &(msr->fsdh->start_time));
+      ms_hptime2btime (hptimems, &(msr->fsdh->start_time));
       
       /* When the sampling rate is <= 32767 Hertz determine the factor
        * and multipler through rational approximation.  For higher rates
@@ -311,7 +316,7 @@ msr_normalize_header ( MSRecord *msr, flag verbose )
 	msr->fsdh->blockette_offset = 0;
     }
   
-  /* Traverse blockette chain and performs necessary updates*/
+  /* Traverse blockette chain and perform necessary updates*/
   cur_blkt = msr->blkts;
   
   if ( cur_blkt && verbose > 2 )
@@ -352,23 +357,7 @@ msr_normalize_header ( MSRecord *msr, flag verbose )
       
       else if ( cur_blkt->blkt_type == 1001 )
 	{
-	  hptime_t sec, usec;
-	  
-	  /* Insert microseconds offset */
-	  sec = msr->starttime / (HPTMODULUS / 10000);
-	  usec = msr->starttime - (sec * (HPTMODULUS / 10000));
-	  usec /= (HPTMODULUS / 1000000);
-
-      /* Deal with negative timestamps and a negative offset.
-       *
-       * The value is rounded down when writing the fixed header
-       * thus the offset needs to be relative to the next smaller
-       * value representable by the BTIME definition. */
-      if (msr->starttime <= 0 && usec < 0) {
-        usec += 100;
-      }
-
-	  msr->Blkt1001->usec = (int8_t) usec;
+	  msr->Blkt1001->usec = usecoffset;
 	  offset += sizeof (struct blkt_1001_s);
 	}
       
@@ -779,9 +768,9 @@ msr_print (MSRecord *msr, flag details)
     }
   else
     {
-      ms_log (0, "%s, %06d, %c, %d, %lld samples, %-.10g Hz, %s\n",
+      ms_log (0, "%s, %06d, %c, %d, %"PRId64" samples, %-.10g Hz, %s\n",
 	      srcname, msr->sequence_number, msr->dataquality,
-	      msr->reclen, (long long int) msr->samplecnt, msr->samprate, time);
+	      msr->reclen, msr->samplecnt, msr->samprate, time);
     }
 
   /* Report information in the blockette chain */

--- a/obspy/mseed/src/libmseed/pack.c
+++ b/obspy/mseed/src/libmseed/pack.c
@@ -879,7 +879,16 @@ msr_update_header ( MSRecord *msr, char *rawrec, flag swapflag,
       sec = msr->starttime / (HPTMODULUS / 10000);
       usec = msr->starttime - (sec * (HPTMODULUS / 10000));
       usec /= (HPTMODULUS / 1000000);
-      
+
+      /* Deal with negative timestamps and a negative offset.
+       *
+       * The value is rounded down when writing the fixed header
+       * thus the offset needs to be relative to the next smaller
+       * value representable by the BTIME definition. */
+      if (msr->starttime <= 0 && usec < 0) {
+        usec += 100;
+      }
+
       /* Update microseconds offset in blockette chain entry */
       msr->Blkt1001->usec = (int8_t) usec;
       

--- a/obspy/mseed/src/libmseed/pack.c
+++ b/obspy/mseed/src/libmseed/pack.c
@@ -7,7 +7,7 @@
  * Written by Chad Trabant,
  *   IRIS Data Management Center
  *
- * modified: 2015.062
+ * modified: 2015.213
  ***************************************************************************/
 
 #include <stdio.h>
@@ -847,6 +847,8 @@ msr_update_header ( MSRecord *msr, char *rawrec, flag swapflag,
 		    struct blkt_1001_s *blkt1001, flag verbose )
 {
   struct fsdh_s *fsdh;
+  hptime_t hptimems;
+  int8_t usecoffset;
   char seqnum[7];
   
   if ( ! msr || ! rawrec )
@@ -861,8 +863,11 @@ msr_update_header ( MSRecord *msr, char *rawrec, flag swapflag,
   snprintf (seqnum, 7, "%06d", msr->sequence_number);
   memcpy (fsdh->sequence_number, seqnum, 6);
   
+  /* Get start time rounded to tenths of milliseconds and microsecond offset */
+  ms_hptime2tomsusecoffset (msr->starttime, &hptimems, &usecoffset);
+  
   /* Update fixed-section start time */
-  ms_hptime2btime (msr->starttime, &(fsdh->start_time));
+  ms_hptime2btime (hptimems, &(fsdh->start_time));
   
   /* Swap byte order? */
   if ( swapflag )
@@ -870,30 +875,14 @@ msr_update_header ( MSRecord *msr, char *rawrec, flag swapflag,
       MS_SWAPBTIME (&fsdh->start_time);
     }
   
-  /* Update microseconds if Blockette 1001 is present */
+  /* Update microsecond offset value if Blockette 1001 is present */
   if ( msr->Blkt1001 && blkt1001 )
     {
-      hptime_t sec, usec;
-      
-      /* Calculate microseconds offset */
-      sec = msr->starttime / (HPTMODULUS / 10000);
-      usec = msr->starttime - (sec * (HPTMODULUS / 10000));
-      usec /= (HPTMODULUS / 1000000);
-
-      /* Deal with negative timestamps and a negative offset.
-       *
-       * The value is rounded down when writing the fixed header
-       * thus the offset needs to be relative to the next smaller
-       * value representable by the BTIME definition. */
-      if (msr->starttime <= 0 && usec < 0) {
-        usec += 100;
-      }
-
       /* Update microseconds offset in blockette chain entry */
-      msr->Blkt1001->usec = (int8_t) usec;
+      msr->Blkt1001->usec = usecoffset;
       
       /* Update microseconds offset in packed header */
-      blkt1001->usec = (int8_t) usec;
+      blkt1001->usec = usecoffset;
     }
   
   return 0;

--- a/obspy/mseed/src/libmseed/parseutils.c
+++ b/obspy/mseed/src/libmseed/parseutils.c
@@ -5,7 +5,7 @@
  * Written by Chad Trabant
  *   IRIS Data Management Center
  *
- * modified: 2015.070
+ * modified: 2015.108
  ***************************************************************************/
 
 #include <stdio.h>
@@ -169,7 +169,7 @@ msr_parse_selection ( char *recbuf, int recbuflen, int64_t *offset,
       if ( retval )
         {
           if ( verbose )
-            ms_log (2, "Error parsing record at offset %lld\n", *offset);
+            ms_log (2, "Error parsing record at offset %"PRId64"\n", *offset);
 	  
           *offset += MINRECLEN;
         }
@@ -284,7 +284,7 @@ ms_detect ( const char *record, int recbuflen )
 	  
           /* Calculate record size in bytes as 2^(blkt_1000->reclen) */
 	  reclen = (unsigned int) 1 << blkt_1000->reclen;
-	  
+          
 	  break;
         }
       

--- a/obspy/mseed/src/libmseed/tracelist.c
+++ b/obspy/mseed/src/libmseed/tracelist.c
@@ -5,7 +5,7 @@
  *
  * Written by Chad Trabant, IRIS Data Management Center
  *
- * modified: 2014.248
+ * modified: 2015.108
  ***************************************************************************/
 
 #include <stdio.h>
@@ -1054,12 +1054,12 @@ mstl_printtracelist ( MSTraceList *mstl, flag timeformat,
 		ms_log (0, "%-17s %-24s %-24s %-4s\n",
 			id->srcname, stime, etime, gapstr);
 	      else
-		ms_log (0, "%-17s %-24s %-24s %-s %-3.3g %-lld\n",
-			id->srcname, stime, etime, gapstr, seg->samprate, (long long int)seg->samplecnt);
+		ms_log (0, "%-17s %-24s %-24s %-s %-3.3g %-"PRId64"\n",
+			id->srcname, stime, etime, gapstr, seg->samprate, seg->samplecnt);
 	    }
 	  else if ( details > 0 && gaps <= 0 )
-	    ms_log (0, "%-17s %-24s %-24s %-3.3g %-lld\n",
-		    id->srcname, stime, etime, seg->samprate, (long long int)seg->samplecnt);
+	    ms_log (0, "%-17s %-24s %-24s %-3.3g %-"PRId64"\n",
+		    id->srcname, stime, etime, seg->samprate, seg->samplecnt);
 	  else
 	    ms_log (0, "%-17s %-24s %-24s\n", id->srcname, stime, etime);
 	  
@@ -1130,9 +1130,9 @@ mstl_printsynclist ( MSTraceList *mstl, char *dccid, flag subsecond )
 	  ms_hptime2seedtimestr (seg->endtime, endtime, subsecond);
 	  
 	  /* Print SYNC line */
-	  ms_log (0, "%s|%s|%s|%s|%s|%s||%.10g|%lld|||||||%s\n",
+	  ms_log (0, "%s|%s|%s|%s|%s|%s||%.10g|%"PRId64"|||||||%s\n",
 		  id->network, id->station, id->location, id->channel,
-		  starttime, endtime, seg->samprate, (long long int)seg->samplecnt,
+		  starttime, endtime, seg->samprate, seg->samplecnt,
 		  yearday);
 	  
 	  seg = seg->next;

--- a/obspy/mseed/src/libmseed/traceutils.c
+++ b/obspy/mseed/src/libmseed/traceutils.c
@@ -5,7 +5,7 @@
  *
  * Written by Chad Trabant, IRIS Data Management Center
  *
- * modified: 2014.248
+ * modified: 2015.108
  ***************************************************************************/
 
 #include <stdio.h>
@@ -1397,12 +1397,12 @@ mst_printtracelist ( MSTraceGroup *mstg, flag timeformat,
 	    ms_log (0, "%-17s %-24s %-24s %-4s\n",
 		    srcname, stime, etime, gapstr);
 	  else
-	    ms_log (0, "%-17s %-24s %-24s %-s %-3.3g %-lld\n",
-		    srcname, stime, etime, gapstr, mst->samprate, (long long int)mst->samplecnt);
+	    ms_log (0, "%-17s %-24s %-24s %-s %-3.3g %-"PRId64"\n",
+		    srcname, stime, etime, gapstr, mst->samprate, mst->samplecnt);
 	}
       else if ( details > 0 && gaps <= 0 )
-	ms_log (0, "%-17s %-24s %-24s %-3.3g %-lld\n",
-		srcname, stime, etime, mst->samprate, (long long int)mst->samplecnt);
+	ms_log (0, "%-17s %-24s %-24s %-3.3g %-"PRId64"\n",
+		srcname, stime, etime, mst->samprate, mst->samplecnt);
       else
 	ms_log (0, "%-17s %-24s %-24s\n", srcname, stime, etime);
       
@@ -1470,9 +1470,9 @@ mst_printsynclist ( MSTraceGroup *mstg, char *dccid, flag subsecond )
       ms_hptime2seedtimestr (mst->endtime, etime, subsecond);
       
       /* Print SYNC line */
-      ms_log (0, "%s|%s|%s|%s|%s|%s||%.10g|%lld|||||||%s\n",
+      ms_log (0, "%s|%s|%s|%s|%s|%s||%.10g|%"PRId64"|||||||%s\n",
 	      mst->network, mst->station, mst->location, mst->channel,
-	      stime, etime, mst->samprate, (long long int)mst->samplecnt,
+	      stime, etime, mst->samprate, mst->samplecnt,
 	      yearday);
       
       mst = mst->next;

--- a/obspy/mseed/src/libmseed/unpack.c
+++ b/obspy/mseed/src/libmseed/unpack.c
@@ -13,7 +13,7 @@
  *   ORFEUS/EC-Project MEREDIAN
  *   IRIS Data Management Center
  *
- * modified: 2014.197
+ * modified: 2015.108
  ***************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
@@ -813,8 +813,8 @@ msr_unpack_data ( MSRecord *msr, int swapflag, flag verbose )
     }
   
   if ( verbose > 2 )
-    ms_log (1, "%s: Unpacking %lld samples\n",
-	    UNPACK_SRCNAME, (long long int)msr->samplecnt);
+    ms_log (1, "%s: Unpacking %"PRId64" samples\n",
+	    UNPACK_SRCNAME, msr->samplecnt);
   
   /* Decide if this is a encoding that we can decode */
   switch (msr->encoding)

--- a/obspy/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/mseed/tests/test_mseed_special_issues.py
@@ -731,6 +731,45 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             st[2].stats.sampling_rate,
             st2[2].stats.sampling_rate))
 
+    def test_microsecond_accuracy_reading_and_writing_before_1970(self):
+        """
+        Tests that reading and writing data with microsecond accuray and
+        before 1970 works as expected.
+        """
+        # For the sake of sanity check first for times after 1970.
+        starttime = UTCDateTime(0) + 123456.789123
+
+        tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.starttime = starttime
+
+        with io.BytesIO() as fh:
+            tr.write(fh, format="mseed")
+            fh.seek(0, 0)
+            tr2 = read(fh)[0]
+
+        del tr2.stats.mseed
+        del tr2.stats._format
+
+        self.assertEqual(tr2.stats.starttime, starttime)
+        self.assertEqual(tr2, tr)
+
+        # Now do the same, but this time before 1970.
+        starttime = UTCDateTime(0) - 123456.789123
+
+        tr = Trace(data=np.linspace(0, 100, 101))
+        tr.stats.starttime = starttime
+
+        with io.BytesIO() as fh:
+            tr.write(fh, format="mseed")
+            fh.seek(0, 0)
+            tr2 = read(fh)[0]
+
+        del tr2.stats.mseed
+        del tr2.stats._format
+
+        self.assertEqual(tr2.stats.starttime, starttime)
+        self.assertEqual(tr2, tr)
+
 
 def suite():
     return unittest.makeSuite(MSEEDSpecialIssueTestCase, 'test')

--- a/obspy/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/mseed/tests/test_mseed_special_issues.py
@@ -742,7 +742,6 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                       -1.123449, -1.123450, -1.123451, -1.123499]
 
         for timestamp in timestamps:
-            # For the sake of sanity check first for times after 1970.
             starttime = UTCDateTime(timestamp)
             self.assertEqual(starttime.timestamp, timestamp)
 

--- a/obspy/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/mseed/tests/test_mseed_special_issues.py
@@ -733,42 +733,32 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
 
     def test_microsecond_accuracy_reading_and_writing_before_1970(self):
         """
-        Tests that reading and writing data with microsecond accuray and
+        Tests that reading and writing data with microsecond accuracy and
         before 1970 works as expected.
         """
-        # For the sake of sanity check first for times after 1970.
-        starttime = UTCDateTime(0) + 123456.789123
+        # Test a couple of timestamps. Positive and negative ones.
+        timestamps = [123456.789123, -123456.789123, 1.123400, 1.123412,
+                      1.123449, 1.123450, 1.123499, -1.123400, -1.123412,
+                      -1.123449, -1.123450, -1.123451, -1.123499]
 
-        tr = Trace(data=np.linspace(0, 100, 101))
-        tr.stats.starttime = starttime
+        for timestamp in timestamps:
+            # For the sake of sanity check first for times after 1970.
+            starttime = UTCDateTime(timestamp)
+            self.assertEqual(starttime.timestamp, timestamp)
 
-        with io.BytesIO() as fh:
-            tr.write(fh, format="mseed")
-            fh.seek(0, 0)
-            tr2 = read(fh)[0]
+            tr = Trace(data=np.linspace(0, 100, 101))
+            tr.stats.starttime = starttime
 
-        del tr2.stats.mseed
-        del tr2.stats._format
+            with io.BytesIO() as fh:
+                tr.write(fh, format="mseed")
+                fh.seek(0, 0)
+                tr2 = read(fh)[0]
 
-        self.assertEqual(tr2.stats.starttime, starttime)
-        self.assertEqual(tr2, tr)
+            del tr2.stats.mseed
+            del tr2.stats._format
 
-        # Now do the same, but this time before 1970.
-        starttime = UTCDateTime(0) - 123456.789123
-
-        tr = Trace(data=np.linspace(0, 100, 101))
-        tr.stats.starttime = starttime
-
-        with io.BytesIO() as fh:
-            tr.write(fh, format="mseed")
-            fh.seek(0, 0)
-            tr2 = read(fh)[0]
-
-        del tr2.stats.mseed
-        del tr2.stats._format
-
-        self.assertEqual(tr2.stats.starttime, starttime)
-        self.assertEqual(tr2, tr)
+            self.assertEqual(tr2.stats.starttime, starttime)
+            self.assertEqual(tr2, tr)
 
 
 def suite():


### PR DESCRIPTION
`libmseed` has a bug when writing timestamps smaller than 0 with microsecond accuracy (which involves Blockette 1001). This PR fixes that.

I also added a test and fixed a small issue with the record analyzer.

@CTrabant: 4072176f67da7f6429d62994562980f421191043 is a patch for `libmseed`.