### PR TITLE
Bug in `Trace.remove_response(..., water_level=None)`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,12 @@
 0.10.x:
+  - obspy.core:
+    * Fixed a bug when using
+      `Trace.remove_response(..., water_level=None)`.
+      With that setting that is supposed to not use any water level
+      stabilization in the inversion of the instrument response
+      spectrum actually the instrument response was never inverted and
+      thus instead of a deconvolution a convolution was performed
+      (see #1104).
   - obspy.fdsn:
     * More detailed error messages on failing requests (see #1079)
   - obspy.mseed:

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2411,9 +2411,20 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         freq_response, freqs = \
             self.stats.response.get_evalresp_response(self.stats.delta, nfft,
                                                       output=output, **kwargs)
+
+        # frequency domain pre-filtering of data spectrum
+        # (apply cosine taper in frequency domain)
         if pre_filt:
             data *= c_sac_taper(freqs, flimit=pre_filt)
-        if water_level is not None:
+
+        if water_level is None:
+            # No water level used, so just directly invert the response.
+            # First entry is at zero frequency and value is zero, too.
+            # Just do not invert the first value (and set to 0 to make sure).
+            freq_response[0] = 0.0
+            freq_response[1:] = 1.0 / freq_response[1:]
+        else:
+            # Invert spectrum with specified water level.
             specInv(freq_response, water_level)
         data *= freq_response
 


### PR DESCRIPTION
When water level was set to `None` (i.e. no water level used, solely relying on `pre_filt`) the instrument response spectrum was never inverted but multiplied in frequency domain anyway, thus resulting in a convolution rather a deconvolution, resulting in completely unexpected and unusable results.
Before the fix this was just simply circumvented by specifying a high water_level value (e.g. `water_level=600`) which effectively means no water level at all.

Thanks to @cja12 for letting me know!

Here is a notebook to visualize the issue (esp. see bug last three boxes):
https://gist.github.com/megies/73af368d7f625fb13b0d