### PR TITLE
Bugfix for the Lanczos interpolation

### DIFF
--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -290,8 +290,11 @@ def lanczos_interpolation(data, old_start, old_dt, new_start, new_dt, new_npts,
     details and justification please see [Burger2009]_ and [vanDriel2015]_.
     """
     _validate_parameters(data, old_start, old_dt, new_start, new_dt, new_npts)
+
+    # dt and offset in terms of the original sampling interval.
     dt_factor = float(new_dt) / old_dt
-    offset = new_start - old_start
+    offset = (new_start - old_start) / float(old_dt)
+
     if offset < 0:
         raise ValueError("Cannot extrapolate. Make sure to only interpolate "
                          "within the time range of the original signal.")


### PR DESCRIPTION
Fix + regression test for a bug in the Lanczos interpolation routine.

Really bad bug that resulted in a potentially quite significant time shift if the original sampling rate is not 1 Hz and the new and old start times are not identical. Most tests work with 1 Hz as its simple to reason about it so this bug was not caught...