### PR TITLE
is_StationXML(): less rigorous (and faster) checking of file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,13 @@
   - obspy.station:
     * ObsPy no longer assumes that the StationXML namespace is the default
       namespace (see #1060).
+    * Checking if a file is a StationXML file is less rigorous (and much
+      faster) now (not checking strict validity against xsd schema but
+      only looking for a FDSNStationXML root element, see #1114).
+      This means that `read_inventory()` without explicitly specified
+      format will correctly detect more files as StationXML that have very
+      slight breaches of the schema but still can be interpreted as
+      StationXML.
   - obspy.taup:
     * Calculating arrival times for surface waves now works (see #1055)
     * Calculating arrivals for underside reflections now works (see #1089)

--- a/obspy/station/stationxml.py
+++ b/obspy/station/stationxml.py
@@ -17,6 +17,7 @@ import inspect
 import io
 import math
 import os
+import re
 import warnings
 
 from lxml import etree
@@ -49,7 +50,26 @@ def is_StationXML(path_or_file_object):
 
     :param path_or_file_object: File name or file like object.
     """
-    return validate_StationXML(path_or_file_object)[0]
+    if isinstance(path_or_file_object, etree._Element):
+        xmldoc = path_or_file_object
+    else:
+        try:
+            xmldoc = etree.parse(path_or_file_object)
+        except etree.XMLSyntaxError:
+            return False
+    try:
+        root = xmldoc.getroot()
+    except:
+        return False
+    # check tag of root element
+    try:
+        match = re.match(
+            r'{http://www.fdsn.org/xml/station/[0-9]+}FDSNStationXML',
+            root.tag)
+        assert match is not None
+    except:
+        return False
+    return True
 
 
 def validate_StationXML(path_or_object):


### PR DESCRIPTION
Main reason for this change is to hopefully autodetect more StationXML files that have slight schema breaches but which we still can read into an Inventory object.