### PR TITLE
Support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,19 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy==1.8.2 scipy==0.14.0 matplotlib==1.3.1 basemap==1.0.7 flake8 future lxml sqlalchemy mock nose gdal
+  - |
+      if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == '3' ]]; then
+        NUMPY_VERSION=1.9.2
+        SCIPY_VERSION=0.16.0
+        MPL_VERSION=1.4.3
+        BASEMAP_VERSION=1.0.7
+      else
+        NUMPY_VERSION=1.8.2
+        SCIPY_VERSION=0.14.0
+        MPL_VERSION=1.3.1
+        BASEMAP_VERSION=1.0.7
+      fi
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION matplotlib=$MPL_VERSION basemap=$BASEMAP_VERSION flake8 future lxml sqlalchemy mock nose gdal
   - source activate test-environment
   # install packages not available via conda
   - pip install wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 sudo: false
 install:
   - lsb_release -a # get info on the operating system

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,11 @@ install:
         MPL_VERSION=1.3.1
         BASEMAP_VERSION=1.0.7
       fi
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION matplotlib=$MPL_VERSION basemap=$BASEMAP_VERSION flake8 future lxml sqlalchemy mock nose gdal
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION matplotlib=$MPL_VERSION basemap=$BASEMAP_VERSION flake8 future lxml sqlalchemy mock nose gdal pyproj
   - source activate test-environment
   # install packages not available via conda
   - pip install wheel
   - wget -q -O - 'https://github.com/obspy/wheelhouse/archive/master.tar.gz' | tar -C /tmp -xzf -
-  - pip install --use-wheel --no-index --find-links=/tmp/wheelhouse-master pyproj
   - pip install --use-wheel --find-links=/tmp/wheelhouse-master coveralls
   - pip install geographiclib
   # current pyimgur stable release has a py2.6 incompatibility

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ master:
  - General:
    * Requirements have been increased to reflect latest distributions:
      * Removed support for Python 2.6.
+     * Added support for Python 3.5.
      * matplotlib >= 1.1.0 is now required.
      * numpy >= 1.6.1 is now required
      * scipy >= 0.9.0 is now required

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -1331,14 +1331,14 @@ class UTCDateTime(object):
         2008,275,00:30
         """
         if not compact:
-            if not self.time:
+            if self.time == datetime.time(0):
                 return "%04d,%03d" % (self.year, self.julday)
             return "%04d,%03d,%02d:%02d:%02d.%04d" % (self.year, self.julday,
                                                       self.hour, self.minute,
                                                       self.second,
                                                       self.microsecond // 100)
         temp = "%04d,%03d" % (self.year, self.julday)
-        if not self.time:
+        if self.time == datetime.time(0):
             return temp
         temp += ",%02d" % self.hour
         if self.microsecond:

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -263,7 +263,14 @@ def map_example_filename(arg_kwarg_name):
             # check args
             else:
                 try:
-                    ind = inspect.getargspec(func).args.index(arg_kwarg_name)
+                    inspected_args = [
+                        p.name
+                        for p in inspect.signature(func).parameters.values()
+                    ]
+                except AttributeError:
+                    inspected_args = inspect.getargspec(func).args
+                try:
+                    ind = inspected_args.index(arg_kwarg_name)
                 except ValueError:
                     pass
                 else:

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -49,7 +49,7 @@ class Enum(object):
         >>> units.xxx  # doctest: +ELLIPSIS
         Traceback (most recent call last):
         ...
-        KeyError: 'xxx'
+        AttributeError: 'xxx'
 
     Changing enum values will not work:
 
@@ -99,8 +99,11 @@ class Enum(object):
             return self._Enum__replace[key.lower()]
         return self.__enums.__getitem__(key.lower())
 
-    __getattr__ = get
-    __getitem__ = get
+    def __getattr__(self, name):
+        try:
+            return self.get(name)
+        except KeyError:
+            raise AttributeError("'%s'" % (name, ))
 
     def __setattr__(self, name, value):
         if name == '_Enum__enums':
@@ -111,6 +114,7 @@ class Enum(object):
             return
         raise NotImplementedError
 
+    __getitem__ = get
     __setitem__ = __setattr__
 
     def __contains__(self, value):

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -177,7 +177,6 @@ def _read_ndk(filename, *args, **kwargs):  # @UnusedVariable
             prev_line = next_line
         if len(data) > prev_line + 1:
             yield data[prev_line + 1:]
-        raise StopIteration
 
     # Use one Flinn Engdahl object for all region determinations.
     fe = FlinnEngdahl()

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -17,6 +17,7 @@ except ImportError:
     has_GDAL = False
 else:
     has_GDAL = True
+    no_filecmp = gdal.VersionInfo() >= '2000000'
 
 
 SHAPEFILE_SUFFIXES = (".shp", ".shx", ".dbf", ".prj")
@@ -37,8 +38,9 @@ class ShapefileTestCase(unittest.TestCase):
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("catalog" + suffix))
                 self.assertTrue(
-                    filecmp.cmp("catalog" + suffix,
-                                self.catalog_shape_basename + suffix),
+                    no_filecmp or filecmp.cmp(
+                        "catalog" + suffix,
+                        self.catalog_shape_basename + suffix),
                     msg="%s not binary equal." % ("catalog" + suffix))
 
     @unittest.skipIf(not has_GDAL, "GDAL not installed")
@@ -49,8 +51,9 @@ class ShapefileTestCase(unittest.TestCase):
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("catalog" + suffix))
                 self.assertTrue(
-                    filecmp.cmp("catalog" + suffix,
-                                self.catalog_shape_basename + suffix),
+                    no_filecmp or filecmp.cmp(
+                        "catalog" + suffix,
+                        self.catalog_shape_basename + suffix),
                     msg="%s not binary equal." % ("catalog" + suffix))
 
     @unittest.skipIf(not has_GDAL, "GDAL not installed")
@@ -61,8 +64,9 @@ class ShapefileTestCase(unittest.TestCase):
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("inventory" + suffix))
                 self.assertTrue(
-                    filecmp.cmp("inventory" + suffix,
-                                self.inventory_shape_basename + suffix),
+                    no_filecmp or filecmp.cmp(
+                        "inventory" + suffix,
+                        self.inventory_shape_basename + suffix),
                     msg="%s not binary equal." % ("inventory" + suffix))
 
     @unittest.skipIf(not has_GDAL, "GDAL not installed")
@@ -73,8 +77,9 @@ class ShapefileTestCase(unittest.TestCase):
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("inventory" + suffix))
                 self.assertTrue(
-                    filecmp.cmp("inventory" + suffix,
-                                self.inventory_shape_basename + suffix),
+                    no_filecmp or filecmp.cmp(
+                        "inventory" + suffix,
+                        self.inventory_shape_basename + suffix),
                     msg="%s not binary equal." % ("inventory" + suffix))
 
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -24,7 +24,7 @@ from .taup_time import TauP_Time
 # Pretty paired colors. Reorder to have saturated colors first and remove
 # some colors at the end.
 cmap = plt.get_cmap('Paired', lut=12)
-COLORS = ['#%02x%02x%02x' % tuple(col * 255 for col in cmap(i)[:3])
+COLORS = ['#%02x%02x%02x' % tuple(int(col * 255) for col in cmap(i)[:3])
           for i in range(12)]
 COLORS = COLORS[1:][::2][:-1] + COLORS[::2][:-1]
 


### PR DESCRIPTION
Since we don't have a `pyproj` wheel for 3.5, I installed it from conda, but then the 3.3 package doesn't like our pinned NumPy version. Should we just bump NumPy for all of 3.x (`pyproj` is available in conda for newer NumPy)?

The four remaining failures are due to changes in GDAL 2.0.0 which is the only available version for 3.5. I suspect there is some change to a version field in the `.dbf` file (other files from the test are unchanged). @megies How do you think we should proceed to fix the test? I am not really familiar with the shapefile format to decide.