### PR TITLE
Pass correct types to mpl's date2num.

### DIFF
--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -159,8 +159,11 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
 
     if any([isinstance(c, (datetime.datetime, UTCDateTime)) for c in color]):
         datetimeplot = True
-        color = [np.isfinite(float(t)) and date2num(t) or np.nan
-                 for t in color]
+        color = [
+            (np.isfinite(float(t)) and
+             date2num(getattr(t, 'datetime', t)) or
+             np.nan)
+            for t in color]
     else:
         datetimeplot = False
 
@@ -477,7 +480,7 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
 
     if isinstance(color[0], (datetime.datetime, UTCDateTime)):
         datetimeplot = True
-        color = [date2num(t) for t in color]
+        color = [date2num(getattr(t, 'datetime', t)) for t in color]
     else:
         datetimeplot = False
 

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -98,8 +98,8 @@ def parse_file_to_dict(data_dict, samp_int_dict, file, counter, format=None,
     for tr in stream:
         _id = tr.getId()
         data_dict.setdefault(_id, [])
-        data_dict[_id].append([date2num(tr.stats.starttime),
-                               date2num(tr.stats.endtime)])
+        data_dict[_id].append([date2num(tr.stats.starttime.datetime),
+                               date2num(tr.stats.endtime.datetime)])
         try:
             samp_int_dict.setdefault(_id, [])
             samp_int_dict[_id].\
@@ -255,27 +255,26 @@ def main(argv=None):
 
     # Plot vertical lines if option 'event_times' was specified
     if args.event_time:
-        times = map(date2num, args.event_time)
+        times = [date2num(t.datetime) for t in args.event_time]
         for time in times:
             ax.axvline(time, color='k')
     # Deprecated version (don't plot twice)
     if args.event_times and not args.event_time:
         times = args.event_times.split(',')
-        times = map(UTCDateTime, times)
-        times = map(date2num, times)
+        times = [date2num(UTCDateTime(t).datetime) for t in times]
         for time in times:
             ax.axvline(time, color='k')
 
     if args.start_time:
-        args.start_time = date2num(args.start_time)
+        args.start_time = date2num(args.start_time.datetime)
     elif args.starttime:
         # Deprecated version
-        args.start_time = date2num(args.starttime)
+        args.start_time = date2num(args.starttime.datetime)
     if args.end_time:
-        args.end_time = date2num(args.end_time)
+        args.end_time = date2num(args.end_time.datetime)
     elif args.endtime:
         # Deprecated version
-        args.end_time = date2num(args.endtime)
+        args.end_time = date2num(args.endtime.datetime)
 
     # Generate dictionary containing nested lists of start and end times per
     # station

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -693,7 +693,7 @@ class WaveformPlotting(object):
                 # convert seconds of relative sample times to days and add
                 # start time of trace.
                 x_values = ((trace.times() / SECONDS_PER_DAY) +
-                            date2num(trace.stats.starttime))
+                            date2num(trace.stats.starttime.datetime))
             ax.plot(x_values, trace.data, color=self.color,
                     linewidth=self.linewidth, linestyle=self.linestyle)
         # Write to self.ids
@@ -1430,7 +1430,7 @@ class WaveformPlotting(object):
             if self.type == 'relative':
                 return t - self.reftime
             else:
-                return date2num(t)
+                return date2num(t.datetime)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The expected input is a `datetime.datetime` object. Passing in `UTCDateTime` used to work only because there were checks for `datetime.date`. The soon-to-be-release 1.5.0 swaps that test for `datetime.datetime`, which this is not, so conversions are treated as if no times were provided.

Testing with 1.5.0rc1 seems to be fine other than this one thing.