### PR TITLE
First successful read the docs build

### DIFF
--- a/misc/docs/source/conf.py
+++ b/misc/docs/source/conf.py
@@ -13,6 +13,9 @@ import sphinx_bootstrap_theme
 
 import obspy
 
+
+READ_THE_DOCS = os.environ.get('READTHEDOCS', None) == 'True'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -183,6 +186,8 @@ html_context = {
     # Whether to use local files or files on ObsPy servers
     'use_local_assets': True,
 }
+if READ_THE_DOCS:
+    html_context['use_local_assets'] = False
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()


### PR DESCRIPTION
Last aspect that needed fixing was that we rely on the `Makefile` structure for docs building (mostly downloading header bar from docs.obspy.org during building, but Read The Docs only runs a basic `sphinx-build` so anything needed during the build has to be in `conf.py`. [See this docs entry for introducing RTD-only tweaks into conf.py](https://read-the-docs.readthedocs.org/en/latest/faq.html#how-do-i-change-behavior-for-read-the-docs):

![screenshot from 2015-09-22 14 28 21](https://cloud.githubusercontent.com/assets/1842780/10017358/52ece1ec-6136-11e5-9747-d23ca80060c9.png)

[First successful RTD build](https://readthedocs.org/projects/obspy/builds/3342256/).. and [the output](http://obspy.readthedocs.org/en/rtd/):

![screenshot from 2015-09-22 14 32 36](https://cloud.githubusercontent.com/assets/1842780/10017433/d0bbf52c-6136-11e5-94a2-95a27dd61911.png)
