### PR TITLE
fix some bugs in obspy-scan

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,10 @@
       (see #1096)
   - obspy.fdsn:
     * More detailed error messages on failing requests (see #1079)
+  - obspy.imaging:
+    * fix some bugs in `obspy-scan` (see #1138)
+  - obspy.io.zmap
+    * Add support for time values with sub-second precision (see #1093)
   - obspy.mseed:
     * Blockette 100 is now only written for Traces that need it. Previously
       it was written or not for all Traces, depending on whether the last
@@ -40,8 +44,6 @@
   - obspy.taup:
     * Calculating arrival times for surface waves now works (see #1055)
     * Calculating arrivals for underside reflections now works (see #1089)
-  - obspy.io.zmap
-    * Add support for time values with sub-second precision (see #1093)
 
 0.10.2: (doi: 10.5281/zenodo.17641)
  - obspy.core:


### PR DESCRIPTION
 - sorting or restricting data (to given start/end time) was only
   changing the data list but not the sampling rate list, potentially
   leading to exceptions and/or misinterpreted data regarding gaps / gap
   length (in my case to an empty plot when `--start-time` was
   specified)
 - in case of invalid sampling_rates the length of data and sampling
   rate lists could have diverged, potentially leading to exceptions
   and/or misinterpreted data regarding gaps / gap length
 - `--end-time` command line option was only usable in combination with
   `--start-time` due to a misformed `if` clause