### PR TITLE
fdsn module import problem

### DIFF
--- a/obspy/fdsn/header.py
+++ b/obspy/fdsn/header.py
@@ -11,8 +11,10 @@ Header files for the FDSN webservice.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
 import platform
+import sys
 
 from obspy import UTCDateTime, __version__
 
@@ -52,10 +54,14 @@ URL_MAPPINGS = {
 
 FDSNWS = ("dataselect", "event", "station")
 
+if PY2:
+    platform_ = platform.platform().decode("ascii", "ignore")
+else:
+    encoding = sys.getdefaultencoding() or "UTF-8"
+    platform_ = platform.platform().encode(encoding).decode("ascii", "ignore")
 # The default User Agent that will be sent with every request.
-DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (__version__,
-                                                   platform.platform(),
-                                                   platform.python_version())
+DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (
+    __version__, platform_, platform.python_version())
 
 
 # The default parameters. Different services can choose to add more. It always


### PR DESCRIPTION
Just upgraded to 0.10.2 and can't import obspy.fdsn
platform: Linux-3.13.11-100.fc19.x86_64-x86_64-with-fedora-19
python ver: 2.7.5

Python 2.7.5 (default, Nov  3 2014, 14:33:39)
[GCC 4.8.3 20140911 (Red Hat 4.8.3-7)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import obspy.fdsn
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/site-packages/obspy/fdsn/__init__.py", line 142, in <module>
    from .client import Client  # NOQA
  File "/usr/lib64/python2.7/site-packages/obspy/fdsn/client.py", line 36, in <module>
    from obspy.fdsn.header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
  File "/usr/lib64/python2.7/site-packages/obspy/fdsn/header.py", line 53, in <module>
    platform.python_version())
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 56: ordinal not in range(128)
>>>