### PR TITLE
decorators mangling call syntax in API docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
         flake8
         future
         lxml
+        decorator
         sqlalchemy
         mock
         nose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"
   # Install default dependencies
-  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal"
+  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator"
   # additional dependecies
   - "pip install suds-jurko"
   - "pip install pyimgur"

--- a/debian/pybuild/control
+++ b/debian/pybuild/control
@@ -22,7 +22,7 @@ Depends: python (>= 2.7),
  ${python:Depends}, python-numpy (>= 1:1.6.1), python-setuptools (>= 0.6),
  python-lxml (>= 2.1), python-matplotlib (>= 1.1.0), python-scipy (>= 0.9.0),
  python-sqlalchemy, python-suds (>= 0.4), ${shlibs:Depends},
- python-tornado, python-future (>= 0.12.4)
+ python-tornado, python-future (>= 0.12.4), python-decorator
 Conflicts: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-db, python-obspy-earthworm, python-obspy-fissures,
  python-obspy-gse2, python-obspy-imaging, python-obspy-iris,
@@ -60,7 +60,7 @@ Depends: python3 (>= 3.2),
  ${python3:Depends}, python3-numpy (>= 1:1.6.1), python3-setuptools (>= 0.6),
  python3-lxml (>= 2.1), python3-matplotlib (>= 1.1.0), python3-scipy (>= 0.9.0),
  python3-sqlalchemy, ${shlibs:Depends}, python3-tornado,
- python3-future (>= 0.12.4)
+ python3-future (>= 0.12.4), python3-decorator
 Recommends: python-obspy-dbg (= ${binary:Version}),
  python3-mpltoolkits.basemap, python3-geographiclib,
  python3-imaging, python3-nose, python3-flake8, python3-mock, python3-gdal

--- a/debian/python_distutils/control
+++ b/debian/python_distutils/control
@@ -20,7 +20,7 @@ Depends: python (>= 2.7),
  ${python:Depends}, python-future (>= 0.12.4),
  python-numpy (>= 1:1.6.1), python-setuptools (>= 0.6), python-lxml (>= 2.1),
  python-matplotlib (>= 1.1.0), python-scipy (>= 0.9.0), python-sqlalchemy,
- python-suds (>= 0.4), ${shlibs:Depends}, python-tornado
+ python-suds (>= 0.4), ${shlibs:Depends}, python-tornado, python-decorator
 Conflicts: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-db, python-obspy-earthworm, python-obspy-fissures,
  python-obspy-gse2, python-obspy-imaging, python-obspy-iris,

--- a/misc/docs/DEPENDENCIES.txt
+++ b/misc/docs/DEPENDENCIES.txt
@@ -18,6 +18,7 @@ doc2dash
 # ObsPy Library
 ## obspy.*
 future
+decorator
 
 lxml
 numpy

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1594,7 +1594,7 @@ class TraceTestCase(unittest.TestCase):
         tr.resample(400)
         tr.differentiate()
         tr.integrate()
-        tr.taper()
+        tr.taper(max_percentage=0.1)
 
     def test_issue_695(self):
         x = np.zeros(12)

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -13,7 +13,6 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import functools
 import inspect
 import os
 import socket
@@ -23,6 +22,7 @@ import warnings
 import zipfile
 
 import numpy as np
+from decorator import decorator
 
 from obspy.core.util import get_example_file
 from obspy.core.util.base import NamedTemporaryFile
@@ -33,208 +33,193 @@ def deprecated(warning_msg=None):
     """
     This is a decorator which can be used to mark functions as deprecated.
 
+    .. note::
+        Actually, this is not a decorator itself but a decorator factory,
+        returning the correct decorator for the specified options. It can be
+        used just like a decorator.
+
     It will result in a warning being emitted when the function is used.
     """
-    def deprecated_(func):
-        @functools.wraps(func)
-        def new_func(*args, **kwargs):
-            if 'deprecated' in str(func.__doc__).lower():
-                msg = func.__doc__
-            elif warning_msg:
-                msg = warning_msg
-            else:
-                msg = "Call to deprecated function %s." % func.__name__
-            warnings.warn(msg, category=ObsPyDeprecationWarning)
-            return func(*args, **kwargs)
-
-        new_func.__name__ = func.__name__
-        new_func.__doc__ = func.__doc__
-        new_func.__dict__.update(func.__dict__)
-        return new_func
-    return deprecated_
+    @decorator
+    def _deprecated(func, *args, **kwargs):
+        if 'deprecated' in str(func.__doc__).lower():
+            msg = func.__doc__
+        elif warning_msg:
+            msg = warning_msg
+        else:
+            msg = "Call to deprecated function %s." % func.__name__
+        warnings.warn(msg, category=ObsPyDeprecationWarning)
+        return func(*args, **kwargs)
+    return _deprecated
 
 
 def deprecated_keywords(keywords):
     """
     Decorator for marking keywords as deprecated.
 
+    .. note::
+        Actually, this is not a decorator itself but a decorator factory,
+        returning the correct decorator for the specified options. It can be
+        used just like a decorator.
+
     :type keywords: dict
     :param keywords: old/new keyword names as key/value pairs.
     """
-    def fdec(func):
-        fname = func.__name__
-        msg = "Deprecated keyword %s in %s() call - please use %s instead."
-        msg2 = "Deprecated keyword %s in %s() call - ignoring."
-        msg3 = ("Conflicting deprecated keywords (%s) in %s() call"
-                " - please use new '%s' keyword instead.")
+    msg = "Deprecated keyword %s in %s() call - please use %s instead."
+    msg2 = "Deprecated keyword %s in %s() call - ignoring."
+    msg3 = ("Conflicting deprecated keywords (%s) in %s() call"
+            " - please use new '%s' keyword instead.")
 
-        @functools.wraps(func)
-        def echo_func(*args, **kwargs):
-            # check if multiple deprecated keywords get mapped to the same new
-            # keyword
-            new_keyword_appearance_counts = dict.fromkeys(keywords.values(), 0)
-            for key, new_key in keywords.items():
-                if key in kwargs:
-                    new_keyword_appearance_counts[new_key] += 1
-            for key_ in keywords.values():
-                if new_keyword_appearance_counts[key_] > 1:
-                    conflicting_keys = ", ".join(
-                        [old_key for old_key, new_key in keywords.items()
-                         if new_key == key_])
-                    raise Exception(msg3 % (conflicting_keys, fname, new_key))
-            # map deprecated keywords to new keywords
-            for kw in kwargs.keys():
-                if kw in keywords:
-                    nkw = keywords[kw]
-                    if nkw is None:
-                        warnings.warn(msg2 % (kw, fname),
-                                      category=ObsPyDeprecationWarning)
-                    else:
-                        warnings.warn(msg % (kw, fname, nkw),
-                                      category=ObsPyDeprecationWarning)
-                        kwargs[nkw] = kwargs[kw]
-                    del(kwargs[kw])
-            return func(*args, **kwargs)
-        return echo_func
-
-    return fdec
+    @decorator
+    def _deprecated_keywords(func, *args, **kwargs):
+        # check if multiple deprecated keywords get mapped to the same new
+        # keyword
+        new_keyword_appearance_counts = dict.fromkeys(keywords.values(), 0)
+        for key, new_key in keywords.items():
+            if key in kwargs:
+                new_keyword_appearance_counts[new_key] += 1
+        for key_ in keywords.values():
+            if new_keyword_appearance_counts[key_] > 1:
+                conflicting_keys = ", ".join(
+                    [old_key for old_key, new_key in keywords.items()
+                     if new_key == key_])
+                raise Exception(msg3 % (conflicting_keys, fname, new_key))
+        # map deprecated keywords to new keywords
+        for kw in kwargs.keys():
+            if kw in keywords:
+                nkw = keywords[kw]
+                if nkw is None:
+                    warnings.warn(msg2 % (kw, fname),
+                                  category=ObsPyDeprecationWarning)
+                else:
+                    warnings.warn(msg % (kw, fname, nkw),
+                                  category=ObsPyDeprecationWarning)
+                    kwargs[nkw] = kwargs[kw]
+                del(kwargs[kw])
+        return func(*args, **kwargs)
+    return _deprecated_keywords
 
 
-def skip_on_network_error(func):
+@decorator
+def skip_on_network_error(func, *args, **kwargs):
     """
     Decorator for unittest to mark test routines that fail with certain network
     errors (e.g. timeouts) as "skipped" rather than "Error".
     """
-    @functools.wraps(func)
-    def new_func(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        ###################################################
-        # add more except clauses like this to add other
-        # network errors that should be skipped
-        except socket.timeout as e:
-            if str(e) == "timed out":
-                raise unittest.SkipTest(str(e))
-        ###################################################
-        except socket.error as e:
-            if str(e) == "[Errno 110] Connection timed out":
-                raise unittest.SkipTest(str(e))
-        # general except to be able to generally reraise
-        except Exception as e:
-            raise
-    return new_func
+    try:
+        return func(*args, **kwargs)
+    ###################################################
+    # add more except clauses like this to add other
+    # network errors that should be skipped
+    except socket.timeout as e:
+        if str(e) == "timed out":
+            raise unittest.SkipTest(str(e))
+    ###################################################
+    except socket.error as e:
+        if str(e) == "[Errno 110] Connection timed out":
+            raise unittest.SkipTest(str(e))
+    # general except to be able to generally reraise
+    except Exception as e:
+        raise
 
 
-def uncompress_file(func):
+@decorator
+def uncompress_file(func, filename, *args, **kwargs):
     """
     Decorator used for temporary uncompressing file if .gz or .bz2 archive.
     """
-    def wrapped_func(filename, *args, **kwargs):
-        if not isinstance(filename, (str, native_str)):
-            return func(filename, *args, **kwargs)
-        elif not os.path.exists(filename):
-            msg = "File not found '%s'" % (filename)
-            raise IOError(msg)
-        # check if we got a compressed file or archive
-        obj_list = []
-        if tarfile.is_tarfile(filename):
-            try:
-                # reading with transparent compression
-                with tarfile.open(filename, 'r|*') as tar:
-                    for tarinfo in tar:
-                        # only handle regular files
-                        if not tarinfo.isfile():
-                            continue
-                        data = tar.extractfile(tarinfo).read()
-                        obj_list.append(data)
-            except:
-                pass
-        elif zipfile.is_zipfile(filename):
-            try:
-                zip = zipfile.ZipFile(filename)
-                obj_list = [zip.read(name) for name in zip.namelist()]
-            except:
-                pass
-        elif filename.endswith('.bz2'):
-            # bz2 module
-            try:
-                import bz2
-                with open(filename, 'rb') as fp:
-                    obj_list.append(bz2.decompress(fp.read()))
-            except:
-                pass
-        elif filename.endswith('.gz'):
-            # gzip module
-            try:
-                import gzip
-                with gzip.open(filename, 'rb') as fp:
-                    obj_list.append(fp.read())
-            except:
-                pass
-        # handle results
-        if obj_list:
-            # write results to temporary files
-            result = None
-            for obj in obj_list:
-                with NamedTemporaryFile() as tempfile:
-                    tempfile._fileobj.write(obj)
-                    stream = func(tempfile.name, *args, **kwargs)
-                    # just add other stream objects to first stream
-                    if result is None:
-                        result = stream
-                    else:
-                        result += stream
-        else:
-            # no compressions
-            result = func(filename, *args, **kwargs)
-        return result
-    return wrapped_func
+    if not isinstance(filename, (str, native_str)):
+        return func(filename, *args, **kwargs)
+    elif not os.path.exists(filename):
+        msg = "File not found '%s'" % (filename)
+        raise IOError(msg)
+    # check if we got a compressed file or archive
+    obj_list = []
+    if tarfile.is_tarfile(filename):
+        try:
+            # reading with transparent compression
+            with tarfile.open(filename, 'r|*') as tar:
+                for tarinfo in tar:
+                    # only handle regular files
+                    if not tarinfo.isfile():
+                        continue
+                    data = tar.extractfile(tarinfo).read()
+                    obj_list.append(data)
+        except:
+            pass
+    elif zipfile.is_zipfile(filename):
+        try:
+            zip = zipfile.ZipFile(filename)
+            obj_list = [zip.read(name) for name in zip.namelist()]
+        except:
+            pass
+    elif filename.endswith('.bz2'):
+        # bz2 module
+        try:
+            import bz2
+            with open(filename, 'rb') as fp:
+                obj_list.append(bz2.decompress(fp.read()))
+        except:
+            pass
+    elif filename.endswith('.gz'):
+        # gzip module
+        try:
+            import gzip
+            with gzip.open(filename, 'rb') as fp:
+                obj_list.append(fp.read())
+        except:
+            pass
+    # handle results
+    if obj_list:
+        # write results to temporary files
+        result = None
+        for obj in obj_list:
+            with NamedTemporaryFile() as tempfile:
+                tempfile._fileobj.write(obj)
+                stream = func(tempfile.name, *args, **kwargs)
+                # just add other stream objects to first stream
+                if result is None:
+                    result = stream
+                else:
+                    result += stream
+    else:
+        # no compressions
+        result = func(filename, *args, **kwargs)
+    return result
 
 
-def raise_if_masked(func):
+@decorator
+def raise_if_masked(func, *args, **kwargs):
     """
     Raises if the first argument (self in case of methods) is a Trace with
     masked values or a Stream containing a Trace with masked values.
     """
-    @functools.wraps(func)
-    def new_func(*args, **kwargs):
-        arrays = []
-        # first arg seems to be a Stream
-        if hasattr(args[0], "traces"):
-            arrays = [tr.data for tr in args[0]]
-        # first arg seems to be a Trace
-        if hasattr(args[0], "data") and isinstance(args[0].data, np.ndarray):
-            arrays = [args[0].data]
-        for arr in arrays:
-            if np.ma.is_masked(arr):
-                msg = "Trace with masked values found. This is not " + \
-                      "supported for this operation. Try the split() " + \
-                      "method on Trace/Stream to produce a Stream with " + \
-                      "unmasked Traces."
-                raise NotImplementedError(msg)
-        return func(*args, **kwargs)
-
-    new_func.__name__ = func.__name__
-    new_func.__doc__ = func.__doc__
-    new_func.__dict__.update(func.__dict__)
-    return new_func
+    arrays = []
+    # first arg seems to be a Stream
+    if hasattr(args[0], "traces"):
+        arrays = [tr.data for tr in args[0]]
+    # first arg seems to be a Trace
+    if hasattr(args[0], "data") and isinstance(args[0].data, np.ndarray):
+        arrays = [args[0].data]
+    for arr in arrays:
+        if np.ma.is_masked(arr):
+            msg = "Trace with masked values found. This is not " + \
+                  "supported for this operation. Try the split() " + \
+                  "method on Trace/Stream to produce a Stream with " + \
+                  "unmasked Traces."
+            raise NotImplementedError(msg)
+    return func(*args, **kwargs)
 
 
-def skip_if_no_data(func):
+@decorator
+def skip_if_no_data(func, *args, **kwargs):
     """
     Does nothing if the first argument (self in case of methods) is a Trace
     with no data in it.
     """
-    @functools.wraps(func)
-    def new_func(*args, **kwargs):
-        if not args[0]:
-            return
-        return func(*args, **kwargs)
-
-    new_func.__name__ = func.__name__
-    new_func.__doc__ = func.__doc__
-    new_func.__dict__.update(func.__dict__)
-    return new_func
+    if not args[0]:
+        return
+    return func(*args, **kwargs)
 
 
 def map_example_filename(arg_kwarg_name):
@@ -243,57 +228,54 @@ def map_example_filename(arg_kwarg_name):
     of the specified name with the correct file path. If the pattern is not
     encountered nothing is done.
 
+    .. note::
+        Actually, this is not a decorator itself but a decorator factory,
+        returning the correct decorator for the specified options. It can be
+        used just like a decorator.
+
     :type arg_kwarg_name: str
     :param arg_kwarg_name: name of the arg/kwarg that should be (tried) to map
     """
-    def deprecated_(func):
-        @functools.wraps(func)
-        def new_func(*args, **kwargs):
-            prefix = '/path/to/'
-            # check kwargs
-            if arg_kwarg_name in kwargs:
-                if isinstance(kwargs[arg_kwarg_name], (str, native_str)):
-                    if kwargs[arg_kwarg_name].startswith(prefix):
+    @decorator
+    def _map_example_filename(func, *args, **kwargs):
+        prefix = '/path/to/'
+        # check kwargs
+        if arg_kwarg_name in kwargs:
+            if isinstance(kwargs[arg_kwarg_name], (str, native_str)):
+                if kwargs[arg_kwarg_name].startswith(prefix):
+                    try:
+                        kwargs[arg_kwarg_name] = \
+                            get_example_file(kwargs[arg_kwarg_name][9:])
+                    # file not found by get_example_file:
+                    except IOError:
+                        pass
+        # check args
+        else:
+            try:
+                inspected_args = [
+                    p.name
+                    for p in inspect.signature(func).parameters.values()
+                ]
+            except AttributeError:
+                inspected_args = inspect.getargspec(func).args
+            try:
+                ind = inspected_args.index(arg_kwarg_name)
+            except ValueError:
+                pass
+            else:
+                if ind < len(args) and isinstance(args[ind], (str,
+                                                              native_str)):
+                    # need to check length of args from inspect
+                    if args[ind].startswith(prefix):
                         try:
-                            kwargs[arg_kwarg_name] = \
-                                get_example_file(kwargs[arg_kwarg_name][9:])
+                            args = list(args)
+                            args[ind] = get_example_file(args[ind][9:])
+                            args = tuple(args)
                         # file not found by get_example_file:
                         except IOError:
                             pass
-            # check args
-            else:
-                try:
-                    inspected_args = [
-                        p.name
-                        for p in inspect.signature(func).parameters.values()
-                    ]
-                except AttributeError:
-                    inspected_args = inspect.getargspec(func).args
-                try:
-                    ind = inspected_args.index(arg_kwarg_name)
-                except ValueError:
-                    pass
-                else:
-                    if ind < len(args) and isinstance(args[ind], (str,
-                                                                  native_str)):
-                        # need to check length of args from inspect
-                        if args[ind].startswith(prefix):
-                            try:
-                                args = list(args)
-                                args[ind] = get_example_file(args[ind][9:])
-                                args = tuple(args)
-                            # file not found by get_example_file:
-                            except IOError:
-                                pass
-            return func(*args, **kwargs)
-
-        new_func.__name__ = func.__name__
-        new_func.__doc__ = func.__doc__
-        new_func.__dict__.update(func.__dict__)
-        return new_func
-        # reset warning filter settings
-        warnings.filters.pop(0)
-    return deprecated_
+        return func(*args, **kwargs)
+    return _map_example_filename
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ INSTALL_REQUIRES = [
     'matplotlib>=1.1.0',
     'lxml',
     'setuptools',
-    'sqlalchemy']
+    'sqlalchemy',
+    'decorator']
 EXTRAS_REQUIRE = {
     'tests': ['flake8>=2', 'pyimgur'],
     'arclink': ['m2crypto'],


### PR DESCRIPTION
We really need to fix the mangled call syntax in API docs for decorated function/method calls...

![screenshot from 2015-05-20 15 50 41](https://cloud.githubusercontent.com/assets/1842780/7727275/0ec118a2-ff08-11e4-8767-687613b9e7f3.png)
![screenshot from 2015-05-20 15 50 13](https://cloud.githubusercontent.com/assets/1842780/7727276/0ec31116-ff08-11e4-9e98-6759d5e8ac24.png)
