### PR TITLE
Minor bug in triggering: last occurence of characteristic function falling gelow off threshold is missed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,9 @@
   - obspy.signal:
     * Bug fixed within rotate.rotate2ZNE(). Additionally it can now also
       perform the inverse rotation (see #1061).
+    * Bug fixed in triggering. When using option `max_len_delete` and a trigger
+      occurred right before the end of data, one trigger was potentially lost
+      (see #1145 for details).
   - obspy.station:
     * Plotting responses across multiple channels is more robust now in
       presence of some strange channels (e.g. with zero sampling rate,

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -112,7 +112,8 @@ class TriggerTestCase(unittest.TestCase):
         # check that max_len_delete drops the picks
         picks_del = triggerOnset(cft, 1.5, 1.0, max_len=50,
                                  max_len_delete=True)
-        np.testing.assert_array_equal(picks_del, on_of[np.array([0, 1, 5, 6])])
+        np.testing.assert_array_equal(
+            picks_del, on_of[np.array([0, 1, 5, 6, 7])])
         #
         # set True for visual understanding the tests
         if False:  # pragma: no cover

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -346,7 +346,11 @@ def triggerOnset(charfct, thres1, thres2, max_len=9e99, max_len_delete=False):
     #
     on = deque([ind1[0]])
     of = deque([-1])
-    of.extend(ind2[np.diff(ind2) > 1].tolist())
+    # determine the indices where charfct falls below off-threshold
+    ind2_ = np.empty_like(ind2, dtype=bool)
+    ind2_[:-1] = np.diff(ind2) > 1
+    ind2_[-1] = False
+    of.extend(ind2[ind2_].tolist())
     on.extend(ind1[np.where(np.diff(ind1) > 1)[0] + 1].tolist())
     # include last pick if trigger is on or drop it
     if max_len_delete:

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -349,7 +349,8 @@ def triggerOnset(charfct, thres1, thres2, max_len=9e99, max_len_delete=False):
     # determine the indices where charfct falls below off-threshold
     ind2_ = np.empty_like(ind2, dtype=bool)
     ind2_[:-1] = np.diff(ind2) > 1
-    ind2_[-1] = False
+    # last occurence is missed by the diff, add it manually
+    ind2_[-1] = True
     of.extend(ind2[ind2_].tolist())
     on.extend(ind1[np.where(np.diff(ind1) > 1)[0] + 1].tolist())
     # include last pick if trigger is on or drop it


### PR DESCRIPTION
First discovered by @petrrr, by switching to numpy 1.10. Numpy 1.10 is now showing a warning when a boolean index array gets expanded to match the shape of the array that is being indexed.

See posts on numpy mailing list:
https://mail.scipy.org/pipermail/numpy-discussion/2015-August/073467.html

```
obspy/signal/tests/test_trigger.py /home/megies/git/obspy/obspy/signal/trigger.py:349: VisibleDeprecationWarning: boolean index did not match indexed array along dimension 0; dimension is 3395 but corresponding boolean dimension is 3394
  of.extend(ind2[np.diff(ind2) > 1].tolist())
```

The `np.diff()` can't make use of the last item, so the last time the trigger's characteristic function is falling below the off-threshold was not used. We have to add that last item by hand.

I'm not sure if this glitch actually had a negative impact right now, though. My feeling is that this only has an influence in extreme edge cases, namely when the last time the characteristic function falls below the off-threshold is actually closely preceeded by an exceedance of the on-threshold. Even then, with `max_len_delete=False` (default) my guess is that the length of that trigger might be wrong, and that only with `max_len_delete=True` this could actually lead to a missed trigger.. but the code is not easy to read..

(btw.. numpy is also working around `DeprecationWarning`s not shown by default on Python nowadays.. ;-))