### PR TITLE
Minor fixes to Stream.getGaps()/Stream.printGaps()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@
     * Correct gap/overlap time returned by Stream.getGaps() and printed
       by Stream.printGaps() which was incorrect by one time the sampling
       interval (see #1150)
+    * Stream.getGaps(): return overlaps specified in units of samples
+      as negative integers (see #1150)
   - obspy.fdsn:
     * More detailed error messages on failing requests (see #1079)
   - obspy.imaging:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,9 @@
       initializing with floating point seconds, i.e. with microseconds,
       that could lead to microseconds being off by 1 microsecond
       (see #1096)
+    * Correct gap/overlap time returned by Stream.getGaps() and printed
+      by Stream.printGaps() which was incorrect by one time the sampling
+      interval (see #1150)
   - obspy.fdsn:
     * More detailed error messages on failing requests (see #1079)
   - obspy.imaging:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -801,7 +801,7 @@ class Stream(object):
             stats = self.traces[_i].stats
             stime = stats['endtime']
             etime = self.traces[_i + 1].stats['starttime']
-            delta = etime.timestamp - stime.timestamp
+            delta = etime.timestamp - (stime.timestamp + stats.delta)
             # Check that any overlap is not larger than the trace coverage
             if delta < 0:
                 temp = self.traces[_i + 1].stats['endtime'].timestamp - \
@@ -817,12 +817,8 @@ class Stream(object):
             nsamples = int(compatibility.round_away(math.fabs(delta) *
                                                     stats['sampling_rate']))
             # skip if is equal to delta (1 / sampling rate)
-            if flag and nsamples == 1:
+            if flag and nsamples == 0:
                 continue
-            elif delta > 0:
-                nsamples -= 1
-            else:
-                nsamples += 1
             gap_list.append([stats['network'], stats['station'],
                              stats['location'], stats['channel'],
                              stime, etime, delta, nsamples])

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -816,6 +816,8 @@ class Stream(object):
             # Number of missing samples
             nsamples = int(compatibility.round_away(math.fabs(delta) *
                                                     stats['sampling_rate']))
+            if delta < 0:
+                nsamples = -nsamples
             # skip if is equal to delta (1 / sampling rate)
             if same_sampling_rate and nsamples == 0:
                 continue

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -795,9 +795,9 @@ class Stream(object):
                 continue
             # different sampling rates should always result in a gap or overlap
             if self.traces[_i].stats.delta == self.traces[_i + 1].stats.delta:
-                flag = True
+                same_sampling_rate = True
             else:
-                flag = False
+                same_sampling_rate = False
             stats = self.traces[_i].stats
             stime = stats['endtime']
             etime = self.traces[_i + 1].stats['starttime']
@@ -817,7 +817,7 @@ class Stream(object):
             nsamples = int(compatibility.round_away(math.fabs(delta) *
                                                     stats['sampling_rate']))
             # skip if is equal to delta (1 / sampling rate)
-            if flag and nsamples == 0:
+            if same_sampling_rate and nsamples == 0:
                 continue
             gap_list.append([stats['network'], stats['station'],
                              stats['location'], stats['channel'],

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -311,15 +311,15 @@ class StreamTestCase(unittest.TestCase):
             ('BW', 'BGLD', '', 'EHE',
              UTCDateTime(2008, 1, 1, 0, 0, 1, 970000),
              UTCDateTime(2008, 1, 1, 0, 0, 4, 35000),
-             2.0649999999999999, 412.0),
+             2.0599999999999999, 412.0),
             ('BW', 'BGLD', '', 'EHE',
              UTCDateTime(2008, 1, 1, 0, 0, 8, 150000),
              UTCDateTime(2008, 1, 1, 0, 0, 10, 215000),
-             2.0649999999999999, 412.0),
+             2.0599999999999999, 412.0),
             ('BW', 'BGLD', '', 'EHE',
              UTCDateTime(2008, 1, 1, 0, 0, 14, 330000),
              UTCDateTime(2008, 1, 1, 0, 0, 18, 455000),
-             4.125, 824.0)]
+             4.120, 824.0)]
         # Assert the number of gaps.
         self.assertEqual(len(mseed_gap_list), len(gap_list))
         for _i in range(len(mseed_gap_list)):


### PR DESCRIPTION
As reported by @ltrani in #1141, one-sample overlaps are currently specified as `delta = 0.0`, and one-sample gaps are specified as `delta = 2 * sampling_interval`.

To reproduce:
```python
from obspy import read, Stream
tr = read()[0]
tr_ = tr.copy()
tr.data = tr.data[:1500]
tr_.data = tr_.data[1499:]
tr_.stats.starttime += 14.99
st_one_sample_overlap = Stream([tr.copy(), tr_.copy()])
tr_.data = tr_.data[2:]
tr_.stats.starttime += 0.02
st_one_sample_gap = Stream([tr.copy(), tr_.copy()])
st_one_sample_overlap.printGaps()
st_one_sample_gap.printGaps()
```

```
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:17.990000Z 2009-08-24T00:20:17.990000Z 0.000000        1       
Total: 0 gap(s) and 1 overlap(s)
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:17.990000Z 2009-08-24T00:20:18.010000Z 0.020000        1       
Total: 1 gap(s) and 0 overlap(s)
```

This should be fixed to compute the delta time across two traces `A` and `B` as `starttime_B - (endtime_A + sampling_interval_A)`, which then gives:

```
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:18.000000Z 2009-08-24T00:20:17.990000Z -0.010000       1       
Total: 0 gap(s) and 1 overlap(s)
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:18.000000Z 2009-08-24T00:20:18.010000Z 0.010000        1       
Total: 1 gap(s) and 0 overlap(s)
```

Furthermore, overlaps specified in units of samples should be negative integers:
```
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:17.990000Z 2009-08-24T00:20:17.990000Z -0.010000       -1      
Total: 0 gap(s) and 1 overlap(s)
Source            Last Sample                 Next Sample                 Delta           Samples 
BW.RJOB..EHZ      2009-08-24T00:20:17.990000Z 2009-08-24T00:20:18.010000Z 0.010000        1       
Total: 1 gap(s) and 0 overlap(s)
```