### PR TITLE
private _read_XXX/_write_XXX/_is_XXX hides all docstrings of those functions in docs

### DIFF
--- a/misc/docs/source/_templates/autosummary/class.rst
+++ b/misc/docs/source/_templates/autosummary/class.rst
@@ -11,7 +11,7 @@
 
   .. autosummary::
   {% for item in attributes %}
-     ~{{ name }}.{{ item }}
+     {{ item }}
   {%- endfor %}
   {% endif %}
   {% endblock %}
@@ -39,7 +39,7 @@
     :toctree: .
     :nosignatures:
   {% for item in public_methods %}
-     ~{{ name }}.{{ item }}
+     {{ item }}
   {%- endfor %}
   {% endif %}
 
@@ -50,7 +50,7 @@
     :toctree: .
     :nosignatures:
   {% for item in private_methods %}
-     ~{{ name }}.{{ item }}
+     {{ item }}
   {%- endfor %}
   {% endif %}
 
@@ -61,7 +61,7 @@
     :toctree: .
     :nosignatures:
   {% for item in special_methods %}
-     ~{{ name }}.{{ item }}
+     {{ item }}
   {%- endfor %}
   {% endif %}
 

--- a/misc/docs/source/_templates/autosummary/module.rst
+++ b/misc/docs/source/_templates/autosummary/module.rst
@@ -7,17 +7,40 @@
    .. comment to end block
 
    {% block functions %}
-   {% if functions %}
-   .. rubric:: Functions
+
+   {% set public_functions = [] %}
+   {% set private_functions = [] %}
+   {% for m in all_functions %}
+   {% if m in functions %}
+   {% do public_functions.append(m) %}
+   {% else %}
+   {% do private_functions.append(m) %}
+   {% endif %}
+   {%- endfor %}
+
+   {% if public_functions %}
+   .. rubric:: Public Functions
 
    .. autosummary::
       :toctree: .
       :nosignatures:
 
-   {% for item in functions %}
+   {% for item in public_functions %}
       {{ item }}
    {%- endfor %}
    {% endif %}
+
+   {% if private_functions %}
+   .. rubric:: Private Functions
+
+   .. autosummary::
+     :toctree: .
+     :nosignatures:
+   {% for item in private_functions %}
+       {{ item }}
+   {%- endfor %}
+   {% endif %}
+
    {% endblock %}
 
    {% block classes %}

--- a/misc/docs/source/conf.py
+++ b/misc/docs/source/conf.py
@@ -337,3 +337,6 @@ autoclass_content = 'class'
 # 'undoc-members', 'private-members', 'special-members', 'inherited-members' an
 # 'show-inheritance'. Don't set it to anything !
 autodoc_default_flags = ['show-inheritance']
+
+# warn about *all* references where the target cannot be found
+nitpicky = True


### PR DESCRIPTION
and therefore invalidates a lot of effort put into those documentation strings - also no one knows about special options for certain read/write functions - I strongly vote against making those private - we can't cover all options over a general read/write function