### PR TITLE
SEG-2 Import / Header Issue

### DIFF
--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -173,13 +173,19 @@ class SEG2(object):
 
         # Get the time information from the file header.
         # XXX: Need some more generic date/time parsers.
-        time = self.stream.stats.seg2.ACQUISITION_TIME
-        date = self.stream.stats.seg2.ACQUISITION_DATE
-        time = time.strip().split(':')
-        date = date.strip().split('/')
-        hour, minute, second = int(time[0]), int(time[1]), float(time[2])
-        day, month, year = int(date[0]), MONTHS[date[1].lower()], int(date[2])
-        self.starttime = UTCDateTime(year, month, day, hour, minute, second)
+        if "ACQUISITION_TIME" in self.stream.stats.seg2 \
+                and "ACQUISITION_DATE" in self.stream.stats.seg2:
+            time = self.stream.stats.seg2.ACQUISITION_TIME
+            date = self.stream.stats.seg2.ACQUISITION_DATE
+            time = time.strip().split(':')
+            date = date.strip().split('/')
+            hour, minute, second = int(time[0]), int(time[1]), float(time[2])
+            day, month, year = int(date[0]), MONTHS[date[1].lower()], \
+                int(date[2])
+            self.starttime = UTCDateTime(year, month, day, hour, minute,
+                                         second)
+        else:
+            self.starttime = UTCDateTime(0)
 
     def parse_next_trace(self):
         """
@@ -235,7 +241,10 @@ class SEG2(object):
                       "to a wrong starttime of the Trace. Please contact " + \
                       "the ObsPy developers with a sample file."
                 warnings.warn(msg)
-        header['calib'] = float(header['seg2']['DESCALING_FACTOR'])
+
+        if "DESCALING_FACTOR" in header["seg2"]:
+            header['calib'] = float(header['seg2']['DESCALING_FACTOR'])
+
         # Unpack the data.
         data = np.fromstring(
             self.file_pointer.read(number_of_samples_in_data_block *


### PR DESCRIPTION
Hi there,

I'm currently working on the import of Full-Wave-Sonic-Logs into Obspy. After exporting them to SEG-2 fileformat, I get the following error using `readSEG2` function:    

    >>> readSEG2('M:\\FWS Test\\SEG2\\FWS_IT_UP_test1_agc_on_600 MM.sg2')

    Traceback (most recent call last):
      File "<pyshell#60>", line 1, in <module>
        readSEG2('M:\\FWS Test\\SEG2\\FWS_IT_UP_test1_agc_on_600 MM.sg2')
      File "C:\Python27\lib\site-packages\obspy-0.10.1-py2.7-win32.egg\obspy\seg2\seg2.py", line 333,     in readSEG2
        st = seg2.readFile(filename)
      File "C:\Python27\lib\site-packages\obspy-0.10.1-py2.7-win32.egg\obspy\seg2\seg2.py", line 85, in readFile
        self.readFileDescriptorBlock()
      File "C:\Python27\lib\site-packages\obspy-0.10.1-py2.7-win32.egg\obspy\seg2\seg2.py", line 175, in readFileDescriptorBlock
        time = self.stream.stats.seg2.ACQUISITION_TIME
      File "C:\Python27\lib\site-packages\obspy-0.10.1-py2.7-win32.egg\obspy\core\util\attribdict.py", line 110, in __getattr__
        raise AttributeError(e.args[0])
    AttributeError: ACQUISITION_TIME    


It seems as if the script can't get the time information out of the header. Any kind of advice how to solve this problem would be a great help.