### PR TITLE
Use radius stored in the model and not the defaul earth radius.

### DIFF
--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -582,11 +582,11 @@ class SeismicPhase(object):
             self.time = np.zeros(2)
             self.ray_param = np.empty(2)
 
-            self.ray_param[0] = tMod.radiusOfEarth / float(self.name[:-4])
+            self.ray_param[0] = tMod.planet_radius / float(self.name[:-4])
 
             self.dist[1] = 2 * math.pi
             self.time[1] = \
-                2 * math.pi * tMod.radiusOfEarth / float(self.name[:-4])
+                2 * math.pi * tMod.planet_radius / float(self.name[:-4])
             self.ray_param[1] = self.ray_param[0]
 
             self.minDistance = 0
@@ -1051,11 +1051,11 @@ class SeismicPhase(object):
                                                           name[0])
             takeoffAngle = np.degrees(math.asin(np.clip(
                 takeoffVelocity * arrivalRayParam /
-                (self.tMod.radiusOfEarth - self.source_depth), -1.0, 1.0)))
+                (self.tMod.planet_radius - self.source_depth), -1.0, 1.0)))
             lastLeg = self.legs[-2][0]  # very last item is "END"
             incidentAngle = np.degrees(math.asin(
                 vMod.evaluateBelow(0, lastLeg) * arrivalRayParam /
-                self.tMod.radiusOfEarth))
+                self.tMod.planet_radius))
         return Arrival(self, degrees, arrivalTime, searchDist, arrivalRayParam,
                        rayNum, name, puristName, source_depth, takeoffAngle,
                        incidentAngle)

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -154,7 +154,7 @@ class Arrivals(list):
             ax.set_xticks([])
             ax.set_yticks([])
             intp = matplotlib.cbook.simple_linear_interpolation
-            radius = self.model.radiusOfEarth
+            radius = self.model.planet_radius
             for _i, ray in enumerate(arrivals):
                 # Requires interpolation otherwise diffracted phases look
                 # funny.
@@ -429,7 +429,7 @@ class TauPyModel(object):
                                     source_longitude_in_deg,
                                     receiver_latitude_in_deg,
                                     receiver_longitude_in_deg,
-                                    self.model.radiusOfEarth,
+                                    self.model.planet_radius,
                                     self.earth_flattening)
         arrivals = self.get_travel_times(source_depth_in_km, distance_in_deg,
                                          phase_list)
@@ -474,7 +474,7 @@ class TauPyModel(object):
                                     source_longitude_in_deg,
                                     receiver_latitude_in_deg,
                                     receiver_longitude_in_deg,
-                                    self.model.radiusOfEarth,
+                                    self.model.planet_radius,
                                     self.earth_flattening)
 
         arrivals = self.get_pierce_points(source_depth_in_km, distance_in_deg,
@@ -485,7 +485,7 @@ class TauPyModel(object):
                                            source_longitude_in_deg,
                                            receiver_latitude_in_deg,
                                            receiver_longitude_in_deg,
-                                           self.model.radiusOfEarth,
+                                           self.model.planet_radius,
                                            self.earth_flattening)
         else:
             msg = "Not able to evaluate positions of pierce points. " + \
@@ -533,7 +533,7 @@ class TauPyModel(object):
                                     source_longitude_in_deg,
                                     receiver_latitude_in_deg,
                                     receiver_longitude_in_deg,
-                                    self.model.radiusOfEarth,
+                                    self.model.planet_radius,
                                     self.earth_flattening)
 
         arrivals = self.get_ray_paths(source_depth_in_km, distance_in_deg,
@@ -544,7 +544,7 @@ class TauPyModel(object):
                                            source_longitude_in_deg,
                                            receiver_latitude_in_deg,
                                            receiver_longitude_in_deg,
-                                           self.model.radiusOfEarth,
+                                           self.model.planet_radius,
                                            self.earth_flattening)
         else:
             msg = "Not able to evaluate positions of points on path. " + \

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -356,14 +356,14 @@ class TauBranch(object):
                 sLayer = sMod.getSlownessLayer(sLayerNum, self.isPWave)
                 if sLayer['topDepth'] != sLayer['botDepth']:
                     turnDepth = bullenDepthFor(sLayer, ray_param,
-                                               sMod.radiusOfEarth)
+                                               sMod.planet_radius)
                     turnSLayer = np.array([(sLayer['topP'], sLayer['topDepth'],
                                             ray_param, turnDepth)],
                                           dtype=SlownessLayer)
                     time, dist = bullenRadialSlowness(
                         turnSLayer,
                         ray_param,
-                        sMod.radiusOfEarth)
+                        sMod.planet_radius)
                     thePath[pathIndex]['p'] = ray_param
                     thePath[pathIndex]['time'] = time
                     thePath[pathIndex]['dist'] = dist
@@ -385,14 +385,14 @@ class TauBranch(object):
             sLayer2 = sLayer[first_unmasked]
             if sLayer2['botP'] < ray_param:
                 turnDepth = bullenDepthFor(sLayer2, ray_param,
-                                           sMod.radiusOfEarth)
+                                           sMod.planet_radius)
                 turnSLayer = np.array([(sLayer2['topP'], sLayer2['topDepth'],
                                         ray_param, turnDepth)],
                                       dtype=SlownessLayer)
                 time, dist = bullenRadialSlowness(
                     turnSLayer,
                     ray_param,
-                    sMod.radiusOfEarth)
+                    sMod.planet_radius)
                 thePath[pathIndex]['p'] = ray_param
                 thePath[pathIndex]['time'] = time
                 thePath[pathIndex]['dist'] = dist

--- a/obspy/taup/tau_model.py
+++ b/obspy/taup/tau_model.py
@@ -29,7 +29,7 @@ class TauModel(object):
 
     # Depth for which tau model as constructed.
     source_depth = 0.0
-    radiusOfEarth = 6371.0
+    planet_radius = 6371.0
     # Branch with the source at its top.
     sourceBranch = 0
     # Depths that should not have reflections or phase conversions. For
@@ -42,7 +42,7 @@ class TauModel(object):
 
     def __init__(self, sMod, spherical=True, debug=False, skip_calc=False):
         self.debug = debug
-        self.radiusOfEarth = 6371.0
+        self.planet_radius = 6371.0
         # True if this is a spherical slowness model. False if flat.
         self.spherical = spherical
         # Ray parameters used to construct the tau branches. This may only be
@@ -202,7 +202,7 @@ class TauModel(object):
         if self.source_depth != 0:
             raise TauModelError("Can't depth correct a TauModel that is not "
                                 "originally for a surface source.")
-        if depth > self.radiusOfEarth:
+        if depth > self.planet_radius:
             raise TauModelError("Can't depth correct to a source deeper than "
                                 "the radius of the Earth.")
         depthCorrected = self.loadFromDepthCache(depth)
@@ -388,7 +388,7 @@ class TauModel(object):
             mohoBranch <type 'int'>
             mohoDepth <type 'float'>
             noDisconDepths <type 'list'> (of float!?)
-            radiusOfEarth <type 'float'>
+            planet_radius <type 'float'>
             ray_params <type 'numpy.ndarray'> (1D, float)
             sMod <class 'obspy.taup.slowness_model.SlownessModel'>
             sourceBranch <type 'int'>
@@ -427,7 +427,7 @@ class TauModel(object):
             maxInterpError <type 'float'>
             maxRangeInterval <type 'float'>
             minDeltaP <type 'float'>
-            radiusOfEarth <type 'float'>
+            planet_radius <type 'float'>
             slowness_tolerance <type 'float'>
             vMod <class 'obspy.taup.velocity_model.VelocityModel'>
 
@@ -444,11 +444,11 @@ class TauModel(object):
             minRadius <type 'int'>
             modelName <type 'unicode'>
             mohoDepth <type 'float'>
-            radiusOfEarth <type 'float'>
+            planet_radius <type 'float'>
         """
         # a) handle simple contents
         keys = ['cmbBranch', 'cmbDepth', 'debug', 'iocbBranch', 'iocbDepth',
-                'mohoBranch', 'mohoDepth', 'noDisconDepths', 'radiusOfEarth',
+                'mohoBranch', 'mohoDepth', 'noDisconDepths', 'planet_radius',
                 'ray_params', 'sourceBranch', 'source_depth', 'spherical']
         arrays = {k: getattr(self, k) for k in keys}
         # b) handle .tauBranches
@@ -470,7 +470,7 @@ class TauModel(object):
                   (native_str('maxInterpError'), np.float_),
                   (native_str('maxRangeInterval'), np.float_),
                   (native_str('minDeltaP'), np.float_),
-                  (native_str('radiusOfEarth'), np.float_),
+                  (native_str('planet_radius'), np.float_),
                   (native_str('slowness_tolerance'), np.float_)]
         slowness_model = np.empty(shape=(), dtype=dtypes)
         for dtype in dtypes:
@@ -501,7 +501,7 @@ class TauModel(object):
                   (native_str('modelName'), np.str_,
                    len(self.sMod.vMod.modelName)),
                   (native_str('mohoDepth'), np.float_),
-                  (native_str('radiusOfEarth'), np.float_)]
+                  (native_str('planet_radius'), np.float_)]
         velocity_model = np.empty(shape=(), dtype=dtypes)
         for dtype in dtypes:
             key = dtype[0]

--- a/obspy/taup/taup_create.py
+++ b/obspy/taup/taup_create.py
@@ -57,7 +57,7 @@ class TauP_Create(object):
         if self.debug:
             print("Done reading velocity model.")
             print("Radius of model " + self.vMod.modelName + " is " +
-                  str(self.vMod.radiusOfEarth))
+                  str(self.vMod.planet_radius))
         # if self.debug:
         #    print("velocity mode: " + self.vMod)
         return self.vMod

--- a/obspy/taup/tests/test_slownessmodel.py
+++ b/obspy/taup/tests/test_slownessmodel.py
@@ -20,10 +20,10 @@ class TauPySlownessModelTestCase(unittest.TestCase):
                             DEFAULT_QP, DEFAULT_QP,
                             DEFAULT_QS, DEFAULT_QS)],
                           dtype=VelocityLayer)
-        a = create_from_vlayer(vLayer, True)
+        a = create_from_vlayer(vLayer, True, 6371.0)
         self.assertEqual(a['botP'], 1268.0)
         self.assertEqual(a['botDepth'], 31.0)
-        b = create_from_vlayer(vLayer, False)
+        b = create_from_vlayer(vLayer, False, 6371.0)
         self.assertEqual(b['topP'], 3180.5)
 
 

--- a/obspy/taup/tests/test_velocity_model.py
+++ b/obspy/taup/tests/test_velocity_model.py
@@ -28,7 +28,7 @@ class TauPyVelocityModelTestCase(unittest.TestCase):
             self.assertEqual(len(test2.layers), 129)
             self.assertEqual(len(test2), 129)
 
-            self.assertEqual(test2.radiusOfEarth, 6371.0)
+            self.assertEqual(test2.planet_radius, 6371.0)
             self.assertEqual(test2.mohoDepth, 35)
             self.assertEqual(test2.cmbDepth, 2889.0)
             self.assertEqual(test2.iocbDepth, 5153.9)

--- a/obspy/taup/velocity_model.py
+++ b/obspy/taup/velocity_model.py
@@ -17,13 +17,13 @@ from .velocity_layer import (DEFAULT_QP, DEFAULT_QS, VelocityLayer,
 
 class VelocityModel(object):
     # Some default values as class attributes [km]
-    radiusOfEarth = 6371.0
+    planet_radius = 6371.0
     default_moho = 35
     default_cmb = 2889.0
     default_iocb = 5153.9
 
     def __init__(self, modelName="unknown",
-                 radiusOfEarth=radiusOfEarth, mohoDepth=default_moho,
+                 planet_radius=planet_radius, mohoDepth=default_moho,
                  cmbDepth=default_cmb, iocbDepth=default_iocb,
                  minRadius=0.0, maxRadius=6371.0, isSpherical=True,
                  layers=None):
@@ -32,8 +32,8 @@ class VelocityModel(object):
 
         :type modelName: str
         :param modelName: name of the velocity model.
-        :type radiusOfEarth: float
-        :param radiusOfEarth: reference radius (km), usually radius of the
+        :type planet_radius: float
+        :param planet_radius: reference radius (km), usually radius of the
             Earth.
         :type mohoDepth: float
         :param mohoDepth: Depth (km) of the Moho. It can be input from
@@ -65,7 +65,7 @@ class VelocityModel(object):
         :param isSpherical: Is this a spherical model? Defaults to true.
         """
         self.modelName = modelName
-        self.radiusOfEarth = radiusOfEarth
+        self.planet_radius = planet_radius
         self.mohoDepth = mohoDepth
         self.cmbDepth = cmbDepth
         self.iocbDepth = iocbDepth
@@ -252,10 +252,10 @@ class VelocityModel(object):
         :returns: True if the model is consistent.
         :raises ValueError: If the model is inconsistent.
         """
-        # Is radiusOfEarth positive?
-        if self.radiusOfEarth <= 0.0:
+        # Is planet_radius positive?
+        if self.planet_radius <= 0.0:
             raise ValueError("Radius of earth is not positive: %f" % (
-                self.radiusOfEarth, ))
+                self.planet_radius, ))
 
         # Is mohoDepth non-negative?
         if self.mohoDepth < 0.0:
@@ -371,8 +371,8 @@ class VelocityModel(object):
 
     def __str__(self):
         desc = "modelName=" + str(self.modelName) + "\n" + \
-               "\n radiusOfEarth=" + str(
-            self.radiusOfEarth) + "\n mohoDepth=" + str(self.mohoDepth) + \
+               "\n planet_radius=" + str(
+            self.planet_radius) + "\n mohoDepth=" + str(self.mohoDepth) + \
             "\n cmbDepth=" + str(self.cmbDepth) + "\n iocbDepth=" + \
             str(self.iocbDepth) + "\n minRadius=" + str(
             self.minRadius) + "\n maxRadius=" + str(self.maxRadius) + \
@@ -423,7 +423,7 @@ class VelocityModel(object):
         following assumptions:
 
         * ``modelname`` - from the filename, with ".tvel" dropped if present
-        * ``radiusOfEarth`` - the largest depth in the model
+        * ``planet_radius`` - the largest depth in the model
         * ``meanDensity`` - 5517.0
         * ``G`` - 6.67e-11
 
@@ -474,12 +474,12 @@ class VelocityModel(object):
         mask = layers['topDepth'] == layers['botDepth']
         layers = layers[~mask]
 
-        radiusOfEarth = data[-1, 0]
+        planet_radius = data[-1, 0]
         maxRadius = data[-1, 0]
         modelName = os.path.splitext(os.path.basename(filename))[0]
         # I assume that this is a whole earth model
         # so the maximum depth ==  maximum radius == earth radius.
-        return VelocityModel(modelName, radiusOfEarth, cls.default_moho,
+        return VelocityModel(modelName, planet_radius, cls.default_moho,
                              cls.default_cmb, cls.default_iocb, 0,
                              maxRadius, True, layers)
 
@@ -512,7 +512,7 @@ class VelocityModel(object):
 
         modelname - from the filename, with ".nd" dropped, if present
 
-        radiusOfEarth - the largest depth in the model
+        planet_radius - the largest depth in the model
 
         Comments are allowed. # signifies that the rest of the
         line is a comment.  If # is the first character in a line, the line is
@@ -602,12 +602,12 @@ class VelocityModel(object):
         mask = layers['topDepth'] == layers['botDepth']
         layers = layers[~mask]
 
-        radiusOfEarth = data[-1, 0]
+        planet_radius = data[-1, 0]
         maxRadius = data[-1, 0]
         modelName = os.path.splitext(os.path.basename(filename))[0]
         # I assume that this is a whole earth model
         # so the maximum depth ==  maximum radius == earth radius.
-        return VelocityModel(modelName, radiusOfEarth, moho_depth,
+        return VelocityModel(modelName, planet_radius, moho_depth,
                              cmb_depth, iocb_depth, 0,
                              maxRadius, True, layers)
 
@@ -624,13 +624,13 @@ class VelocityModel(object):
         layers, e.g., oceans.
         """
         MOHO_MIN = 65.0
-        CMB_MIN = self.radiusOfEarth
-        IOCB_MIN = self.radiusOfEarth - 100.0
+        CMB_MIN = self.planet_radius
+        IOCB_MIN = self.planet_radius - 100.0
 
         changeMade = False
         tempMohoDepth = 0.0
-        tempCmbDepth = self.radiusOfEarth
-        tempIocbDepth = self.radiusOfEarth
+        tempCmbDepth = self.planet_radius
+        tempIocbDepth = self.planet_radius
 
         above = self.layers[:-1]
         below = self.layers[1:]
@@ -670,5 +670,5 @@ class VelocityModel(object):
         self.cmbDepth = tempCmbDepth
         self.iocbDepth = (tempIocbDepth
                           if tempCmbDepth != tempIocbDepth
-                          else self.radiusOfEarth)
+                          else self.planet_radius)
         return changeMade


### PR DESCRIPTION
This is just a simple search-and-replace change but `obspy.taup` now uses the radius within each model and not the default radius. I tried it with some slightly different radius models and it seems to work.

I'll add some tests once #1189 is merged and I can rebase on top of it so don't merge before that!