### PR TITLE
faster and more readable array transfer function

### DIFF
--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -731,7 +731,6 @@ def get_spoint(stream, stime, etime):
                         tr.stats.sampling_rate + .5)
     return spoint, epoint
 
-
 def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     """
     Returns array transfer function as a function of wavenumber difference
@@ -763,18 +762,15 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     nkx = int(np.ceil((kxmax + kstep / 10. - kxmin) / kstep))
     nky = int(np.ceil((kymax + kstep / 10. - kymin) / kstep))
 
-    transff = np.empty((nkx, nky))
+    kxgrid,kygrid = np.meshgrid(np.linspace(kxmin, kxmax, nkx),
+                                np.linspace(kymin, kymax, nky))
 
-    for i, kx in enumerate(np.arange(kxmin, kxmax + kstep / 10., kstep)):
-        for j, ky in enumerate(np.arange(kymin, kymax + kstep / 10., kstep)):
-            _sum = 0j
-            for k in range(len(coords)):
-                _sum += np.exp(complex(0.,
-                               coords[k, 0] * kx + coords[k, 1] * ky))
-            transff[i, j] = abs(_sum) ** 2
+    ks  = np.transpose(np.vstack( (kxgrid.flatten(),kygrid.flatten()) ))
 
-    transff /= transff.max()
-    return transff
+    k_dot_r = np.einsum('ni,mi->nm',ks,coords[:,:2]) #z coordinate is not used
+    transff = np.abs(np.sum(np.exp(1j*k_dot_r), axis=1))**2/len(coords)**2
+
+    return transff.reshape(nkx,nky)
 
 
 def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
@@ -833,7 +829,6 @@ def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
 
     transff /= transff.max()
     return transff
-
 
 def dump(pow_map, apow_map, i):
     """

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -770,7 +770,7 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
 
     # z coordinate is not used
     k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2])
-    transff = np.abs(np.sum(np.exp(1j*k_dot_r), axis=1))**2/len(coords)**2
+    transff = np.abs(np.sum(np.exp(1j * k_dot_r), axis = 1)) ** 2 / len(coords) **2
 
     return transff.reshape(nkx, nky)
 

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -763,8 +763,9 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     nkx = int(np.ceil((kxmax + kstep / 10. - kxmin) / kstep))
     nky = int(np.ceil((kymax + kstep / 10. - kymin) / kstep))
 
-    kxgrid, kygrid = np.meshgrid(np.linspace(kxmin, kxmax, nkx),
-                                 np.linspace(kymin, kymax, nky), indexing='ij')
+    # careful with meshgrid indexing
+    kygrid, kxgrid = np.meshgrid(np.linspace(kymin, kymax, nky),
+                                 np.linspace(kxmin, kxmax, nkx))
 
     ks = np.transpose(np.vstack((kxgrid.flatten(), kygrid.flatten())))
 

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -731,6 +731,7 @@ def get_spoint(stream, stime, etime):
                         tr.stats.sampling_rate + .5)
     return spoint, epoint
 
+
 def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     """
     Returns array transfer function as a function of wavenumber difference
@@ -762,15 +763,16 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     nkx = int(np.ceil((kxmax + kstep / 10. - kxmin) / kstep))
     nky = int(np.ceil((kymax + kstep / 10. - kymin) / kstep))
 
-    kxgrid,kygrid = np.meshgrid(np.linspace(kxmin, kxmax, nkx),
-                                np.linspace(kymin, kymax, nky))
+    kxgrid, kygrid = np.meshgrid(np.linspace(kxmin, kxmax, nkx),
+                                 np.linspace(kymin, kymax, nky), indexing='ij')
 
-    ks  = np.transpose(np.vstack( (kxgrid.flatten(),kygrid.flatten()) ))
+    ks = np.transpose(np.vstack((kxgrid.flatten(), kygrid.flatten())))
 
-    k_dot_r = np.einsum('ni,mi->nm',ks,coords[:,:2]) #z coordinate is not used
+    # z coordinate is not used
+    k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2])
     transff = np.abs(np.sum(np.exp(1j*k_dot_r), axis=1))**2/len(coords)**2
 
-    return transff.reshape(nkx,nky)
+    return transff.reshape(nkx, nky)
 
 
 def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
@@ -829,6 +831,7 @@ def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
 
     transff /= transff.max()
     return transff
+
 
 def dump(pow_map, apow_map, i):
     """

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -770,7 +770,7 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
 
     # z coordinate is not used
     k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2])
-    transff = np.abs(np.sum(np.exp(1j * k_dot_r), axis = 1)) ** 2 / len(coords) **2
+    transff = np.abs(np.sum(np.exp(1j * k_dot_r), axis=1))**2 / len(coords)**2
 
     return transff.reshape(nkx, nky)
 


### PR DESCRIPTION
This little modification is makes the computation of the array transfer function more readable, and it is 6x faster. It uses more memory though but 2D grids are usually still ok in memory. Not sure which one you prefer. ~18ms vs 1.33s are the run times of the array example.