### PR TITLE
Some very small additions (`fig` and `plot` args)

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -922,11 +922,12 @@ class Stream(object):
             This results in a potentially worse performance but the interactive
             matplotlib view can be used properly.
             Defaults to 'fast'.
-        :param type: Type may be set to either ``'dayplot'`` in order to create
-            a one-day plot for a single Trace or ``'relative'`` to convert all
-            date/time information to a relative scale, effectively starting
-            the seismogram at 0 seconds. ``'normal'`` will produce a standard
-            plot.
+        :param type: Type may be set to either: ``'dayplot'`` to create
+            a one-day plot for a single Trace; ``'relative'`` to convert all
+            date/time information to a relative scale starting
+            the seismogram at 0 seconds; ``'normal'`` will produce the standard
+            plot; ``'section'`` to plot a set of seismograms in one coordinate
+            system shifted according to their position.
             Defaults to ``'normal'``.
         :param equal_scale: If enabled all plots are equally scaled.
             Defaults to ``True``.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -922,7 +922,7 @@ class Stream(object):
             This results in a potentially worse performance but the interactive
             matplotlib view can be used properly.
             Defaults to 'fast'.
-        :param type: Type may be set to either: ``'normal'`` to produce the 
+        :param type: Type may be set to either: ``'normal'`` to produce the
             standard plot; ``'dayplot'`` to create a one-day plot for a single
             Trace; ``'relative'`` to convert all date/time information to a
             relative scale starting the seismogram at 0 seconds; ``'section'``

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -926,8 +926,8 @@ class Stream(object):
             a one-day plot for a single Trace; ``'relative'`` to convert all
             date/time information to a relative scale starting
             the seismogram at 0 seconds; ``'normal'`` will produce the standard
-            plot; ``'section'`` to plot a set of seismograms in one coordinate
-            system shifted according to their position.
+            plot; ``'section'`` to plot all seismograms in a single
+            coordinate system shifted according to their position.
             Defaults to ``'normal'``.
         :param equal_scale: If enabled all plots are equally scaled.
             Defaults to ``True``.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -922,13 +922,13 @@ class Stream(object):
             This results in a potentially worse performance but the interactive
             matplotlib view can be used properly.
             Defaults to 'fast'.
-        :param type: Type may be set to either: ``'dayplot'`` to create
-            a one-day plot for a single Trace; ``'relative'`` to convert all
-            date/time information to a relative scale starting
-            the seismogram at 0 seconds; ``'normal'`` will produce the standard
-            plot; ``'section'`` to plot all seismograms in a single
-            coordinate system shifted according to their position.
-            Defaults to ``'normal'``.
+        :param type: Type may be set to either: ``'normal'`` to produce the 
+            standard plot; ``'dayplot'`` to create a one-day plot for a single
+            Trace; ``'relative'`` to convert all date/time information to a
+            relative scale starting the seismogram at 0 seconds; ``'section'``
+            to plot all seismograms in a single coordinate system shifted
+            according to their distance from a reference point. Defaults to
+            ``'normal'``.
         :param equal_scale: If enabled all plots are equally scaled.
             Defaults to ``True``.
         :param show: If True, show the plot interactively after plotting. This

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2401,7 +2401,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
     @_add_processing_info
     def remove_response(self, output="VEL", water_level=60, pre_filt=None,
                         zero_mean=True, taper=True, taper_fraction=0.05,
-                        plot=False, **kwargs):
+                        plot=False, fig=None, **kwargs):
         """
         Deconvolve instrument response.
 
@@ -2584,7 +2584,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             bbox = dict(boxstyle="round", fc="w", alpha=1, ec="w")
             bbox1 = dict(boxstyle="round", fc="blue", alpha=0.15)
             bbox2 = dict(boxstyle="round", fc="red", alpha=0.15)
-            fig = plt.figure(figsize=(14, 10))
+            if fig is not None:
+                fig = plt.figure(figsize=(14, 10))
             fig.suptitle(str(self))
             ax1 = fig.add_subplot(321)
             ax1b = ax1.twinx()

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2598,7 +2598,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            text = 'pre_filt: ({:.2f} {:.2f} {:.2f} {:.2f})'.format(*pre_filt)
+            text = 'pre_filt: ({:.3g} {:.3g} {:.3g} {:.3g})'.format(*pre_filt)
             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
                      transform=ax1.transAxes, fontsize="large", bbox=bbox,
                      zorder=5)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2598,7 +2598,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            text = 'pre_filt: ({:.3g} {:.3g} {:.3g} {:.3g})'.format(*pre_filt)
+            text = 'pre_filt: [{:.3g} {:.3g} {:.3g} {:.3g}]'.format(*pre_filt)
             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
                      transform=ax1.transAxes, fontsize="large", bbox=bbox,
                      zorder=5)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2584,7 +2584,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             bbox = dict(boxstyle="round", fc="w", alpha=1, ec="w")
             bbox1 = dict(boxstyle="round", fc="blue", alpha=0.15)
             bbox2 = dict(boxstyle="round", fc="red", alpha=0.15)
-            if fig is not None:
+            if fig is None:
                 fig = plt.figure(figsize=(14, 10))
             fig.suptitle(str(self))
             ax1 = fig.add_subplot(321)
@@ -2598,9 +2598,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            ax1.text(0.05, 0.1, 'pre_filt: %s' % str(pre_filt),
-                     ha="left", va="bottom", transform=ax1.transAxes,
-                     fontsize="large", bbox=bbox, zorder=5)
+            text = 'pre_filt: (%.2f %.2f %.2f %.2f)' % pre_filt
+            ax1.text(0.05, 0.1, text, ha="left", va="bottom",
+                     transform=ax1.transAxes, fontsize="large", bbox=bbox,
+                     zorder=5)
             ax1.set_ylabel("Data spectrum, raw", bbox=bbox1)
             ax1b.set_ylabel("'pre_filt' taper fraction", bbox=bbox2)
             evalresp_info = "\n".join(
@@ -2687,8 +2688,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if plot:
             ax6.plot(times, data, color="k")
             plt.subplots_adjust(wspace=0.4)
-            if plot is True:
+            if plot is True and fig is None:
                 plt.show()
+            elif plot is True and fig is not None:
+                pass
             else:
                 plt.savefig(plot)
                 plt.close(fig)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2598,7 +2598,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            text = 'pre_filt: [{:.3g} {:.3g} {:.3g} {:.3g}]'.format(*pre_filt)
+            text = 'pre_filt: [{:.3g}, {:.3g}, {:.3g}, {:.3g}]'.format(
+                *pre_filt)
             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
                      transform=ax1.transAxes, fontsize="large", bbox=bbox,
                      zorder=5)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2598,7 +2598,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            text = 'pre_filt: (%.2f %.2f %.2f %.2f)' % pre_filt
+            text = 'pre_filt: ({:.2f} {:.2f} {:.2f} {:.2f})'.format(*pre_filt)
             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
                      transform=ax1.transAxes, fontsize="large", bbox=bbox,
                      zorder=5)

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1160,8 +1160,9 @@ class WaveformPlotting(object):
                 for _i, tr in enumerate(self.stream):
                     self._tr_offsets[_i] = tr.stats.distance
             except:
-                msg = 'trace.stats.distance undefined' +\
-                      '(should be set before plotting in meters from epicenter)'
+                msg = 'trace.stats.distance undefined ' +\
+                      '(set before plotting [in m], ' +\
+                      'or use the ev_coords argument)'
                 raise ValueError(msg)
         else:
             # Define offset as degree from epicenter

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1160,7 +1160,8 @@ class WaveformPlotting(object):
                 for _i, tr in enumerate(self.stream):
                     self._tr_offsets[_i] = tr.stats.distance
             except:
-                msg = 'Define trace.stats.distance in meters to epicenter'
+                msg = 'trace.stats.distance undefined' +\
+                      '(should be set before plotting in meters from epicenter)'
                 raise ValueError(msg)
         else:
             # Define offset as degree from epicenter

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -32,7 +32,7 @@ def utlGeoKm(*args, **kwargs):
 
 def util_geo_km(orig_lon, orig_lat, lon, lat):
     """
-    Transform lon, lat to km in reference to orig_lon and orig_lat on the
+    Transform lon, lat to km with reference to orig_lon and orig_lat on the
     elliptic Earth.
 
     >>> util_geo_km(12.0, 48.0, 12.0, 48.0)

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -32,7 +32,8 @@ def utlGeoKm(*args, **kwargs):
 
 def util_geo_km(orig_lon, orig_lat, lon, lat):
     """
-    Transform lon, lat to km in reference to orig_lon and orig_lat
+    Transform lon, lat to km in reference to orig_lon and orig_lat on the
+    elliptic Earth.
 
     >>> util_geo_km(12.0, 48.0, 12.0, 48.0)
     (0.0, 0.0)


### PR DESCRIPTION
Hi all,

this PR contains, two additions to the documentation and the additional optional 'fig' argument for the trace.remove_response(plot=True) function (similar to stream.plot()).

Two points were unclear to me:
 1. What is the projection used by utl_geo_km? If it is a 'proper' projection, its name should be in the docs. Obspy could consider wrapping some library that does the proper projections and using this behing the get_geometry function of the arrays.
 2. what should be the standard function call to make plots go to screen immediately, to an external fig instance, or to a file? It could be for example three different arguments as: plot=True fig=fig fname='figure.png' ; or a single argument plot=True/fig_instance/fname .
