### PR TITLE
ResourceIdentifier: compare equal to string with its ID

### DIFF
--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -889,7 +889,10 @@ class ResourceIdentifier(object):
         Both the object and it's id can still be independently used as
         dictionary keys.
         """
-        return self.id.__hash__()
+        # "Salt" the hash with a string so the hash of the object and a
+        # string identical to the id can both be used as individual
+        # dictionary keys.
+        return hash("RESOURCE_ID") + self.id.__hash__()
 
     def regenerate_uuid(self):
         """

--- a/obspy/core/event.py
+++ b/obspy/core/event.py
@@ -870,6 +870,8 @@ class ResourceIdentifier(object):
         return 'ResourceIdentifier(id="%s")' % self.id
 
     def __eq__(self, other):
+        if self.id == other:
+            return True
         if not isinstance(other, ResourceIdentifier):
             return False
         if self.id == other.id:


### PR DESCRIPTION
I think `ResourceIdentifier` objects should compare equal to a string that matches their internal ID string, right now they only compare equal to other RID objects:

![screenshot from 2016-01-22 12 38 34](https://cloud.githubusercontent.com/assets/1842780/12509784/421db8c6-c105-11e5-81c3-34e57dfd424a.png)
