### PR TITLE
Client for the IRIS Syngine Service

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,7 +47,8 @@ master:
    * Removed the dedicated client. Data can still be accessed by using the FDSN
      client.
  - obspy.clients.syngine:
-   * New client for the IRIS Syngine service.
+   * New client for the IRIS Syngine service to retrieve custom synthetic
+     seismograms.
  - obspy.imaging:
    * Experimental support for Cartopy when plotting maps. Use the `method`
      argument to functions that plot maps to select between Basemap or Cartopy.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,8 @@ master:
  - obspy.clients.neries:
    * Removed the dedicated client. Data can still be accessed by using the FDSN
      client.
+ - obspy.clients.syngine:
+   * New client for the IRIS Syngine service.
  - obspy.imaging:
    * Experimental support for Cartopy when plotting maps. Use the `method`
      argument to functions that plot maps to select between Basemap or Cartopy.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"
   # Install default dependencies
-  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator"
+  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator requests"
   # additional dependecies
   - "pip install suds-jurko"
   - "pip install pyimgur"

--- a/debian/pybuild/control
+++ b/debian/pybuild/control
@@ -22,7 +22,8 @@ Depends: python (>= 2.7),
  ${python:Depends}, python-numpy (>= 1:1.6.1), python-setuptools (>= 0.6),
  python-lxml (>= 2.1), python-matplotlib (>= 1.1.0), python-scipy (>= 0.9.0),
  python-sqlalchemy, python-suds (>= 0.4), ${shlibs:Depends},
- python-tornado, python-future (>= 0.12.4), python-decorator
+ python-tornado, python-future (>= 0.12.4), python-decorator,
+ python-requests
 Conflicts: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-db, python-obspy-earthworm, python-obspy-fissures,
  python-obspy-gse2, python-obspy-imaging, python-obspy-iris,
@@ -60,7 +61,7 @@ Depends: python3 (>= 3.2),
  ${python3:Depends}, python3-numpy (>= 1:1.6.1), python3-setuptools (>= 0.6),
  python3-lxml (>= 2.1), python3-matplotlib (>= 1.1.0), python3-scipy (>= 0.9.0),
  python3-sqlalchemy, ${shlibs:Depends}, python3-tornado,
- python3-future (>= 0.12.4), python3-decorator
+ python3-future (>= 0.12.4), python3-decorator, python3-requests
 Recommends: python-obspy-dbg (= ${binary:Version}),
  python3-mpltoolkits.basemap, python3-geographiclib,
  python3-imaging, python3-nose, python3-flake8, python3-mock, python3-gdal

--- a/debian/python_distutils/control
+++ b/debian/python_distutils/control
@@ -20,7 +20,8 @@ Depends: python (>= 2.7),
  ${python:Depends}, python-future (>= 0.12.4),
  python-numpy (>= 1:1.6.1), python-setuptools (>= 0.6), python-lxml (>= 2.1),
  python-matplotlib (>= 1.1.0), python-scipy (>= 0.9.0), python-sqlalchemy,
- python-suds (>= 0.4), ${shlibs:Depends}, python-tornado, python-decorator
+ python-suds (>= 0.4), ${shlibs:Depends}, python-tornado, python-decorator,
+ python-requests
 Conflicts: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-db, python-obspy-earthworm, python-obspy-fissures,
  python-obspy-gse2, python-obspy-imaging, python-obspy-iris,

--- a/misc/docs/DEPENDENCIES.txt
+++ b/misc/docs/DEPENDENCIES.txt
@@ -19,6 +19,7 @@ doc2dash
 ## obspy.*
 future
 decorator
+requests
 
 lxml
 numpy

--- a/misc/docs/source/packages/index.rst
+++ b/misc/docs/source/packages/index.rst
@@ -97,4 +97,5 @@ The functionality is provided through the following packages:
    obspy.clients.neic
    obspy.clients.seedlink
    obspy.clients.seishub
+   obspy.clients.syngine
    obspy.db

--- a/misc/docs/source/packages/obspy.clients.syngine.rst
+++ b/misc/docs/source/packages/obspy.clients.syngine.rst
@@ -9,7 +9,7 @@
        :toctree: autogen
        :nosignatures:
 
-       sds.Client
+       client.Client
 
     .. comment to end block
 
@@ -19,6 +19,6 @@
        :toctree: autogen
        :nosignatures:
 
-       sds
+       client
 
     .. comment to end block

--- a/misc/docs/source/packages/obspy.clients.syngine.rst
+++ b/misc/docs/source/packages/obspy.clients.syngine.rst
@@ -1,0 +1,24 @@
+.. currentmodule:: obspy.clients.syngine
+.. automodule:: obspy.clients.syngine
+
+    .. comment to end block
+
+    Classes & Functions
+    -------------------
+    .. autosummary::
+       :toctree: autogen
+       :nosignatures:
+
+       sds.Client
+
+    .. comment to end block
+
+    Modules
+    -------
+    .. autosummary::
+       :toctree: autogen
+       :nosignatures:
+
+       sds
+
+    .. comment to end block

--- a/misc/docs/source/tutorial/code_snippets/retrieving_data_from_datacenters.rst
+++ b/misc/docs/source/tutorial/code_snippets/retrieving_data_from_datacenters.rst
@@ -12,9 +12,10 @@ the documentation of the various modules.
 
     The most common use case is likely to download waveforms and event/station
     meta information. In almost all cases you will want to use the
-    :mod:`obspy.fdsn` module for this. It supports the largest number of data
-    centers and uses the most modern data formats. There are still a number of
-    reasons to choose a different module but please make sure you have one.
+    :mod:`obspy.clients.fdsn` module for this. It supports the largest number
+    of data centers and uses the most modern data formats. There are still a
+    number of reasons to choose a different module but please make sure you
+    have one.
 
 ---------------------
 The FDSN Web Services
@@ -35,8 +36,8 @@ The FDSN Web Services
     Not all data providers offer all three data types. Many offer only one or two.
 
 If you want to requests waveforms, or station/event meta information **you will
-most likely want to use the** :mod:`obspy.fdsn` **module**. It is able to
-request data from any data center implementing the `FDSN web services
+most likely want to use the** :mod:`obspy.clients.fdsn` **module**. It is able
+to request data from any data center implementing the `FDSN web services
 <https://www.fdsn.org/webservices/>`_. Example data centers include
 IRIS/ORFEUS/INGV/ETH/GFZ/RESIF/... - a curated list can be found `here
 <https://www.fdsn.org/webservices/datacenters/>`_. As a further advantage it
@@ -56,9 +57,10 @@ ArcLink
 
 ArcLink is a distributed data request protocol usable to access archived
 waveform data in the MiniSEED or SEED format and associated meta information as
-Dataless SEED files. You can use the :mod:`obspy.arclink` module to request
-data from the `EIDA <http://www.orfeus-eu.org/eida/>`_ initiative but most (or
-all) of that data can also be requested using the :mod:`obspy.fdsn` module.
+Dataless SEED files. You can use the :mod:`obspy.clients.arclink` module to
+request data from the `EIDA <http://www.orfeus-eu.org/eida/>`_ initiative but
+most (or all) of that data can also be requested using the
+:mod:`obspy.clients.fdsn` module.
 
 -----------------
 IRIS Web Services
@@ -67,25 +69,25 @@ IRIS Web Services
 **Available Data Types and Formats:** Various
 
 IRIS (in addition to FDSN web services) offers a variety of special-purpose web
-services, for some of which ObsPy has interfaces in the :mod:`obspy.iris`
-module. Use this if you require response information in the SAC poles & zeros
-or in the RESP format. If you just care about the instrument response, please
-use the :mod:`obspy.fdsn` module to request StationXML data which contains the
-same information.
+services, for some of which ObsPy has interfaces in the
+:mod:`obspy.clients.iris` module. Use this if you require response information
+in the SAC poles & zeros or in the RESP format. If you just care about the
+instrument response, please use the :mod:`obspy.clients.fdsn` module to request
+StationXML data which contains the same information.
 
 The interfaces for the calculation tools are kept around for legacy reasons;
 internal ObsPy functionality should be considered as an alternative when
 working within ObsPy:
 
-+--------------------------------------------------+--------------------------------------------------------------+
-| IRIS Web Service                                 | Equivalent ObsPy Function/Module                             |
-+==================================================+==============================================================+
-| :meth:`obspy.iris.client.Client.traveltime()`    | :mod:`obspy.taup`                                            |
-+--------------------------------------------------+--------------------------------------------------------------+
-| :meth:`obspy.iris.client.Client.distaz()`        | :mod:`obspy.core.util.geodetics`                             |
-+--------------------------------------------------+--------------------------------------------------------------+
-| :meth:`obspy.iris.client.Client.flinnengdahl()`  | :class:`obspy.core.util.geodetics.flinnengdahl.FlinnEngdahl` |
-+--------------------------------------------------+--------------------------------------------------------------+
++---------------------------------------------------------+--------------------------------------------------------------+
+| IRIS Web Service                                        | Equivalent ObsPy Function/Module                             |
++=========================================================+==============================================================+
+| :meth:`obspy.clients.iris.client.Client.traveltime()`   | :mod:`obspy.taup`                                            |
++---------------------------------------------------------+--------------------------------------------------------------+
+| :meth:`obspy.clients.iris.client.Client.distaz()`       | :mod:`obspy.geodetics`                                       |
++---------------------------------------------------------+--------------------------------------------------------------+
+| :meth:`obspy.clients.iris.client.Client.flinnengdahl()` | :class:`obspy.geodetics.flinnengdahl.FlinnEngdahl`           |
++---------------------------------------------------------+--------------------------------------------------------------+
 
 ---------------------
 Earthworm Wave Server
@@ -97,15 +99,15 @@ Earthworm Wave Server
 | Waveforms            | Custom Format                  |
 +----------------------+--------------------------------+
 
-Use the :mod:`obspy.earthworm` module to request data from the `Earthworm
-<http://www.earthwormcentral.org/>`_ data acquisition system.
+Use the :mod:`obspy.clients.earthworm` module to request data from the
+`Earthworm <http://www.earthwormcentral.org/>`_ data acquisition system.
 
 -------------------
 NERIES Web Services
 -------------------
 
 This service is largely deprecated as the data can just as well be requested
-via the :mod:`obspy.fdsn` module.
+via the :mod:`obspy.clients.fdsn` module.
 
 ----
 NEIC
@@ -119,7 +121,7 @@ NEIC
 
 The Continuous Waveform Buffer (CWB) is a repository for seismic waveform data
 that passes through the NEIC “Edge” processing system. Use the
-:mod:`obspy.neic` module to request data from it.
+:mod:`obspy.clients.neic` module to request data from it.
 
 --------
 SeedLink
@@ -131,9 +133,9 @@ SeedLink
 | Waveforms            | MiniSEED                       |
 +----------------------+--------------------------------+
 
-To connect to a real time SeedLink server, use the :mod:`obspy.seedlink`
-module. Also see the :ref:`ObsPy Tutorial <seedlink-tutorial>` for a more
-detailed introduction.
+To connect to a real time SeedLink server, use the
+:mod:`obspy.clients.seedlink` module. Also see the
+:ref:`ObsPy Tutorial <seedlink-tutorial>` for a more detailed introduction.
 
 ---------------
 Syngine Service

--- a/misc/docs/source/tutorial/code_snippets/retrieving_data_from_datacenters.rst
+++ b/misc/docs/source/tutorial/code_snippets/retrieving_data_from_datacenters.rst
@@ -134,3 +134,17 @@ SeedLink
 To connect to a real time SeedLink server, use the :mod:`obspy.seedlink`
 module. Also see the :ref:`ObsPy Tutorial <seedlink-tutorial>` for a more
 detailed introduction.
+
+---------------
+Syngine Service
+---------------
+
++----------------------+--------------------------------+
+| Available Data Types | Format                         |
++======================+================================+
+| Waveforms            | MiniSEED and zipped SAC files  |
++----------------------+--------------------------------+
+
+Use the :mod:`obspy.clients.syngine` module to download high-frequency global
+synthetic seismograms for any source receiver combination from the IRIS syngine
+service.

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -202,6 +202,13 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         if filename:
             _request_args["stream"] = True
 
+        if self._debug:
+            # Construct the same URL requests would construct.
+            from requests import PreparedRequest  # noqa
+            p = PreparedRequest()
+            p.prepare(method="GET", **_request_args)
+            print("Downloading %s ..." % p.url)
+
         if data is None:
             r = requests.get(**_request_args)
         else:

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -188,9 +188,9 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         :param params: Additional URL parameters.
         :type params: dict
         :param filename: String or file like object. Will download directly
-            to the file. If given, this function will return nothing.
+            to the file. If specified, this function will return nothing.
         :type filename: str or file-like object
-        :param data: If given, a POST request will be sent with the data in
+        :param data: If specified, a POST request will be sent with the data in
             the body of the request.
         :type data: dictionary, bytes, or file-like object
         :return: The response object assuming ``filename`` is ``None``.

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -193,7 +193,7 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         :param data: If given, a POST request will be sent with the data in
             the body of the request.
         :type data: dictionary, bytes, or file-like object
-        :return: The response object resulting in the error.
+        :return: The response object assuming ``filename`` is ``None``.
         :rtype: :class:`requests.Response`
         """
         _request_args = {"url": url,

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -171,12 +171,15 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         """
         pass
 
-    def _download(self, url, params=None, filename=None):
+    def _download(self, url, params=None, filename=None, data=None):
         """
-        Download the URL with GET and the chosen parameters.
+        Download the URL with GET or POST and the chosen parameters.
 
         Will only return if it manages to download with HTTP code 200,
         otherwise the _handle_requests_http_error() method is called.
+
+        By default it will send a GET request - if data is given it will
+        send a POST request.
 
         :param url: The URL to download from.
         :type url: str
@@ -185,6 +188,9 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         :param filename: String or file like object. Will download directly
             to the file. If given, this function will return nothing.
         :type filename: str or file-like object
+        :param data: If given, a POST request will be sent with the data in
+            the body of the request.
+        :type data: dictionary, bytes, or file-like object
         :return: The response object resulting in the error.
         :rtype: :class:`requests.Response`
         """
@@ -196,7 +202,11 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         if filename:
             _request_args["stream"] = True
 
-        r = requests.get(**_request_args)
+        if data is None:
+            r = requests.get(**_request_args)
+        else:
+            _request_args["data"] = data
+            r = requests.post(**_request_args)
 
         # Only accept code 200.
         if r.status_code == 200:

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -216,9 +216,8 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
             r = requests.post(**_request_args)
 
         # Only accept code 200.
-        if r.status_code == 200:
-            return r
-        self._handle_requests_http_error(r)
+        if r.status_code != 200:
+            self._handle_requests_http_error(r)
 
         # Return if nothing else happens.
         if not filename:

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -138,8 +138,10 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
                                     DEFAULT_USER_AGENT)
 
     class NewClient(WaveformClient, HTTPClient):
-        def __init__(self, user_agent=DEFAULT_USER_AGENT):
-            HTTPClient.__init__(self, user_agent=user_agent)
+        def __init__(self, user_agent=DEFAULT_USER_AGENT, debug=False,
+                     timeout=20):
+            HTTPClient.__init__(self, user_agent=user_agent, debug=debug,
+                                timeout=timeout)
 
         def _handle_requests_http_error(self, r):
             r.raise_for_status()
@@ -235,6 +237,7 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
                     if not chunk:
                         continue
                     fh.write(chunk)
+
 
 class WaveformClient(with_metaclass(ABCMeta, BaseClient)):
     """

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -50,9 +50,27 @@ class MyNewClient(WaveformClient, StationClient):
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import with_metaclass
+from future.utils import PY2, with_metaclass
 
 from abc import ABCMeta, abstractmethod
+import platform
+import sys
+
+import obspy
+
+
+# Default user agents all HTTP clients should utilize.
+if PY2:
+    platform_ = platform.platform().decode("ascii", "ignore")
+else:
+    encoding = sys.getdefaultencoding() or "UTF-8"
+    platform_ = platform.platform().encode(encoding).decode("ascii", "ignore")
+# The default User Agent that will be sent with every request.
+DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (
+    obspy.__version__, platform_, platform.python_version())
+# The user agent tests should use by default.
+DEFAULT_TESTING_USER_AGENT = "ObsPy %s (test suite) (%s, Python %s)" % (
+    obspy.__version__, platform_, platform.python_version())
 
 
 class ClientException(Exception):

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -112,7 +112,7 @@ class RemoteBaseClient(with_metaclass(ABCMeta, BaseClient)):
         :type timeout: float
         """
         self._timeout = timeout
-        BaseClient.__init__(debug=debug)
+        BaseClient.__init__(self, debug=debug)
 
     @abstractmethod
     def get_service_version(self):

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -177,8 +177,10 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         """
         Download the URL with GET or POST and the chosen parameters.
 
-        Will only return if it manages to download with HTTP code 200,
-        otherwise the _handle_requests_http_error() method is called.
+        Will call the ``_handle_requests_http_error()`` method if the response
+        comes back with an HTTP code other than 200. Returns the response
+        object if successful and ``filename`` is not given - if given it will
+        save the response to the specified file and return ``None``.
 
         By default it will send a GET request - if data is given it will
         send a POST request.

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -188,7 +188,7 @@ class HTTPClient(with_metaclass(ABCMeta, RemoteBaseClient)):
         :return: The response object resulting in the error.
         :rtype: :class:`requests.Response`
         """
-        _request_args = {"url": url
+        _request_args = {"url": url,
                          "headers": {"User-Agent": self._user_agent},
                          "params": params}
 

--- a/obspy/clients/syngine/README.txt
+++ b/obspy/clients/syngine/README.txt
@@ -1,0 +1,26 @@
+package obspy.clients.syngine
+=============================
+
+Copyright
+---------
+GNU Lesser General Public License, Version 3 (LGPLv3)
+
+Copyright (c) 2016 by:
+    * Lion Krischer
+
+
+Overview
+--------
+Syngine service client for ObsPy.
+
+Contains requests abilities that naturally integrate with the rest of ObsPy
+for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/).
+
+ObsPy is an open-source project dedicated to provide a Python framework for
+processing seismological data. It provides parsers for common file formats and
+seismological signal processing routines which allow the manipulation of
+seismological time series (see Beyreuther et al. 2010, Megies et al. 2011).
+The goal of the ObsPy project is to facilitate rapid application development
+for seismology.
+
+For more information visit http://www.obspy.org.

--- a/obspy/clients/syngine/README.txt
+++ b/obspy/clients/syngine/README.txt
@@ -14,7 +14,7 @@ Overview
 Syngine service client for ObsPy.
 
 Contains requests abilities that naturally integrate with the rest of ObsPy
-for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/).
+for the IRIS syngine service (https://ds.iris.edu/ds/products/syngine/).
 
 ObsPy is an open-source project dedicated to provide a Python framework for
 processing seismological data. It provides parsers for common file formats and
@@ -23,4 +23,4 @@ seismological time series (see Beyreuther et al. 2010, Megies et al. 2011).
 The goal of the ObsPy project is to facilitate rapid application development
 for seismology.
 
-For more information visit http://www.obspy.org.
+For more information visit https://www.obspy.org.

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -44,7 +44,7 @@ IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
     st.plot()
 
 The available parameters are explained in detail in the
-:meth:`~obspy.clients.Syngine.client.Client.get_waveforms()` method and on
+:meth:`~obspy.clients.syngine.client.Client.get_waveforms()` method and on
 the `Syngine <http://ds.iris.edu/ds/products/syngine/>`_ website.
 
 
@@ -71,20 +71,45 @@ Bulk Requests
 -------------
 
 It is also possible to send requests for multiple user-defined stations. See
-the :meth:`~obspy.clients.Syngine.client.Client.get_waveforms_bulk()` method
+the :meth:`~obspy.clients.syngine.client.Client.get_waveforms_bulk()` method
 for details. This example specifies a bunch of receiver coordinates and
 requests seismograms for all of these.
 
 >>> bulk = [{"latitude": 10.1, "longitude": 12.2, "stacode": "AA"},
-...         {"latitude": 14.5, "longitude": 154.0, "stacode": "BB"}]
+...         {"latitude": 14.5, "longitude": 10.0, "stacode": "BB"}]
 >>> st = client.get_waveforms_bulk(
 ...     model="ak135f_5s", eventid="GCMT:C201002270634A",
 ...     bulk=bulk, starttime="P-10", endtime="P+20")
 >>> print(st)  # doctest: +ELLIPSIS
-3 Trace(s) in Stream:
+6 Trace(s) in Stream:
 XX.AA.SE.MXZ | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
 XX.AA.SE.MXN | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
 XX.AA.SE.MXE | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXZ | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXN | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXE | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
+
+
+Other Useful Methods
+--------------------
+
+Use the :meth:`~obspy.clients.syngine.client.Client.get_available_models()`
+method for a list of all available methods including some meta-information.
+
+>>> client.get_available_models()  # doctest: +SKIP
+{'ak135f_1s': {'components': 'vertical only',
+  'default_components': 'Z',
+  'default_dt': '0.05',
+  'description': 'ak135 with density & Q of Montagner & Kennet(1996)',
+  'length': 1815.00690721715,
+  'max_event_depth': 750000,
+  'max_period': '~100',
+  'max_sampling_period': '0.255383',
+  'min_period': 1.04999995231628},
+ 'ak135f_2s': ...
+ ...
+ }
+
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -4,7 +4,7 @@ obspy.clients.syngine - Client for the IRIS Syngine service
 ===========================================================
 
 This module offers methods to download from the IRIS syngine service
-(http://ds.iris.edu/ds/products/syngine/). The service is able to generate
+(https://ds.iris.edu/ds/products/syngine/). The service is able to generate
 fully three dimensional synthetics through various 1D Earth models with
 arbitrary source-receiver geometries and source mechanisms.
 
@@ -12,7 +12,7 @@ arbitrary source-receiver geometries and source mechanisms.
     The ObsPy Development Team (devs@obspy.org)
 :license:
     GNU Lesser General Public License, Version 3
-    (http://www.gnu.org/copyleft/lesser.html)
+    (https://www.gnu.org/copyleft/lesser.html)
 
 
 Basic Usage
@@ -44,7 +44,7 @@ IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
 
 The available parameters are explained in detail in the
 :meth:`~obspy.clients.syngine.client.Client.get_waveforms()` method and on
-the `Syngine <http://ds.iris.edu/ds/products/syngine/>`_ website.
+the `Syngine <https://ds.iris.edu/ds/products/syngine/>`_ website.
 
 
 The queries are quite flexible. The following uses a station name wildcard

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -112,7 +112,7 @@ method for a list of all available methods including some meta-information.
 The :func:`~obspy.clients.syngine.client.Client.get_model_info()`
 method should be used to retrieve information about a specific model.
 
->>> from obspy.client.syngine import Client
+>>> from obspy.clients.syngine import Client
 >>> c = Client()
 >>> db_info = c.get_model_info(model_name="ak135f_5s")
 >>> print(db_info.period)

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -110,6 +110,14 @@ method for a list of all available methods including some meta-information.
  ...
  }
 
+The :func:`~obspy.clients.syngine.client.Client.get_model_info()`
+method should be used to retrieve information about a specific model.
+
+>>> from obspy.client.syngine import Client
+>>> c = Client()
+>>> db_info = c.get_model_info(model_name="ak135f_5s")
+>>> print(db_info.period)
+5.125
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -23,7 +23,7 @@ First initialize a client object.
 >>> from obspy.clients.syngine import Client
 >>> client = Client()
 
-Then requests some data.
+Then request some data.
 
 >>> st = client.get_waveforms(model="ak135f_5s", network="IU", station="ANMO",
 ...                           eventid="GCMT:C201002270634A")

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -74,8 +74,8 @@ the :meth:`~obspy.clients.syngine.client.Client.get_waveforms_bulk()` method
 for details. This example specifies a bunch of receiver coordinates and
 requests seismograms for all of these.
 
->>> bulk = [{"latitude": 10.1, "longitude": 12.2, "stacode": "AA"},
-...         {"latitude": 14.5, "longitude": 10.0, "stacode": "BB"}]
+>>> bulk = [{"latitude": 10.1, "longitude": 12.2, "stationcode": "AA"},
+...         {"latitude": 14.5, "longitude": 10.0, "stationcode": "BB"}]
 >>> st = client.get_waveforms_bulk(
 ...     model="ak135f_5s", eventid="GCMT:C201002270634A",
 ...     bulk=bulk, starttime="P-10", endtime="P+20")

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-obspy.clients.syngine - Client for the IRIS Syngine Service
+obspy.clients.syngine - Client for the IRIS Syngine service
 ===========================================================
 
-Contains requests abilities that naturally integrate with the rest of ObsPy
-for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/).
+Contains request abilities that naturally integrate with the rest of ObsPy
+for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/). The
+service is able to generate fully three dimensional synthetics through
+various 1D Earth models with arbitrary source-receiver geometries and source
+mechanisms.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
@@ -13,8 +16,75 @@ for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/).
     (http://www.gnu.org/copyleft/lesser.html)
 
 
-Please see the documentation for each method for further information and
-examples.
+Basic Usage
+-----------
+
+First initialize a client object.
+
+>>> from obspy.clients.syngine import Client
+>>> client = Client()
+
+Then requests some data.
+
+>>> st = client.get_waveforms(model="ak135f_5s", network="IU", station="ANMO",
+...                           eventid="GCMT:C201002270634A")
+>>> print(st)  # doctest: +ELLIPSIS
+3 Trace(s) in Stream:
+IU.ANMO.SE.MXZ | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+IU.ANMO.SE.MXN | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+>>> st.plot()  # doctest: +SKIP
+
+.. plot::
+
+    from obspy.clients.syngine import Client
+    client = Client()
+    st = client.get_waveforms(model="ak135f_5s", network="IU", station="ANMO",
+                              eventid="GCMT:C201002270634A")
+    st.plot()
+
+The available parameters are explained in detail in the
+:meth:`~obspy.clients.Syngine.client.Client.get_waveforms()` method and on
+the `Syngine <http://ds.iris.edu/ds/products/syngine/>`_ website.
+
+
+The queries are quite flexible. The following uses a station name wildcard
+and only requests data around the P arrival. Please be a bit careful as one
+can potentially download a lot of data with a single request.
+
+>>> st = client.get_waveforms(model="ak135f_5s", network="IU", station="AN*",
+...                           eventid="GCMT:C201002270634A",
+...                           starttime="P-10", endtime="P+20")
+>>> st.plot()  # doctest: +SKIP
+
+.. plot::
+
+    from obspy.clients.syngine import Client
+    client = Client()
+    st = client.get_waveforms(model="ak135f_5s", network="IU", station="AN*",
+                              eventid="GCMT:C201002270634A",
+                              starttime="P-10", endtime="P+20")
+    st.plot()
+
+
+Bulk Requests
+-------------
+
+It is also possible to send requests for multiple user-defined stations. See
+the :meth:`~obspy.clients.Syngine.client.Client.get_waveforms_bulk()` method
+for details. This example specifies a bunch of receiver coordinates and
+requests seismograms for all of these.
+
+>>> bulk = [{"latitude": 10.1, "longitude": 12.2, "stacode": "AA"},
+...         {"latitude": 14.5, "longitude": 154.0, "stacode": "BB"}]
+>>> st = client.get_waveforms_bulk(
+...     model="ak135f_5s", eventid="GCMT:C201002270634A",
+...     bulk=bulk, starttime="P-10", endtime="P+20")
+>>> print(st)  # doctest: +ELLIPSIS
+3 Trace(s) in Stream:
+XX.AA.SE.MXZ | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
+XX.AA.SE.MXN | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
+XX.AA.SE.MXE | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+obspy.clients.syngine - Client for the IRIS Syngine Service
+===========================================================
+
+Contains requests abilities that naturally integrate with the rest of ObsPy
+for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/).
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (http://www.gnu.org/copyleft/lesser.html)
+
+
+Please see the documentation for each method for further information and
+examples.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+from future.utils import native_str
+
+from .client import Client  # NOQA
+
+__all__ = [native_str("Client")]
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod(exclude_empty=True)

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -3,11 +3,10 @@
 obspy.clients.syngine - Client for the IRIS Syngine service
 ===========================================================
 
-Contains request abilities that naturally integrate with the rest of ObsPy
-for the IRIS syngine service (http://ds.iris.edu/ds/products/syngine/). The
-service is able to generate fully three dimensional synthetics through
-various 1D Earth models with arbitrary source-receiver geometries and source
-mechanisms.
+This module offers methods to download from the IRIS syngine service
+(http://ds.iris.edu/ds/products/syngine/). The service is able to generate
+fully three dimensional synthetics through various 1D Earth models with
+arbitrary source-receiver geometries and source mechanisms.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
@@ -61,7 +60,7 @@ can potentially download a lot of data with a single request.
 
     from obspy.clients.syngine import Client
     client = Client()
-    st = client.get_waveforms(model="ak135f_5s", network="IU", station="AN*",
+    st = client.get_waveforms(model="ak135f_5s", network="IU", station="A*",
                               eventid="GCMT:C201002270634A",
                               starttime="P-10", endtime="P+20")
     st.plot()

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -235,9 +235,9 @@ class Client(WaveformClient, HTTPClient):
         time_arguments = ["origintime"]
 
         for keys, t in ((str_arguments, str),
-                       (float_arguments, float),
-                       (int_arguments, int),
-                       (time_arguments, obspy.UTCDateTime)):
+                        (float_arguments, float),
+                        (int_arguments, int),
+                        (time_arguments, obspy.UTCDateTime)):
             for key in keys:
                 value = locals()[key]
                 if value is None:
@@ -251,7 +251,6 @@ class Client(WaveformClient, HTTPClient):
                         raise ValueError("String argument '%s' must not be "
                                          "an empty string." % key)
                 params[key] = t(value)
-
 
         # These can be absolute times, relative times or phase relative times.
         # jo

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -404,13 +404,13 @@ class Client(WaveformClient, HTTPClient):
         >>> from obspy.clients.syngine import Client
         >>> c = Client()
         >>> bulk = [
-        ...     {"netcode": "IU", "stacode": "ANMO"},  # net/sta codes
-        ...     {"latitude": 47.0, "longitude": 12.1}, # coordinates
+        ...     {"networkcode": "IU", "stationcode": "ANMO"},  # net/sta codes
+        ...     {"latitude": 47.0, "longitude": 12.1},         # coordinates
         ...     {"latitude": 47.0, "longitude": 12.1,
-        ...      "netcode": "AA", "stacode": "BB",
-        ...      "loccode": "CC"},                     # optional net/sta/loc
-        ...     ["IU", "ANTO"],                        # net/sta as list
-        ...     [33.2, -123.5]                         # lat/lon as list/tuple
+        ...      "networkcode": "AA", "stationcode": "BB",
+        ...      "locationcode": "CC"},   # optional # net/sta/loc
+        ...     ["IU", "ANTO"],           # net/sta as list
+        ...     [33.2, -123.5]            # lat/lon as list/tuple
         ... ]
 
         Just pass that on to the bulk waveform method and retrieve the data.
@@ -564,6 +564,10 @@ class Client(WaveformClient, HTTPClient):
                 buf.write("{key}={value}\n".format(key=key,
                                                    value=value).encode())
 
+            _map = {"networkcode": "NETCODE",
+                    "stationcode": "STACODE",
+                    "locationcode": "LOCCODE"}
+
             # Write the bulk content.
             for item in bulk:
                 # Dictionary like items.
@@ -575,11 +579,13 @@ class Client(WaveformClient, HTTPClient):
                                 "latitude and longitude if either is given." %
                                 str(item))
                         bulk_item = "{latitude} {longitude}".format(**item)
-                        for _i in ("netcode", "stacode", "loccode"):
+                        for _i in ("networkcode", "stationcode",
+                                   "locationcode"):
                             if _i in item:
-                                bulk_item += " %s=%s" % (_i.upper(), item[_i])
-                    elif "stacode" in item and "netcode" in item:
-                        bulk_item = "{netcode} {stacode}".format(**item)
+                                bulk_item += " %s=%s" % (_map[_i], item[_i])
+                    elif "stationcode" in item and "networkcode" in item:
+                        bulk_item = "{networkcode} {stationcode}".format(
+                            **item)
                     else:
                         raise ValueError("Item '%s' in bulk is malformed." %
                                          str(item))

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -15,6 +15,7 @@ from future.builtins import *  # NOQA
 from future.utils import native_str
 
 import io
+import pprint
 
 import numpy as np
 
@@ -76,6 +77,18 @@ class Client(WaveformClient, HTTPClient):
         info.sliprate = np.array(info.sliprate, dtype=np.float64)
         return info
 
+    def get_available_models(self):
+        """
+        Get information about all available velocity models.
+        """
+        return self._download(self._get_url("models")).json()
+
+    def print_model_information(self):
+        """
+        Print information about the available models.
+        """
+        pprint.pprint(self.get_available_models())
+
     def get_service_version(self):
         """
         Get the service version of the remote syngine server.
@@ -91,8 +104,8 @@ class Client(WaveformClient, HTTPClient):
             eventid=None, sourcelatitude=None, sourcelongitude=None,
             sourcedepthinmeters=None, sourcemomenttensor=None,
             sourcedoublecouple=None, sourceforce=None, origintime=None,
-            starttime=None, endtime=None, label=None, components="ZRT",
-            units="velocity", scale=1.0, dt=None, kernelwidth=8,
+            starttime=None, endtime=None, label=None, components=None,
+            units=None, scale=None, dt=None, kernelwidth=None,
             format="miniseed"):
         """
         """

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -408,8 +408,8 @@ class Client(WaveformClient, HTTPClient):
         for example **P-10** (meaning Pwave arrival time minus 10
         seconds). If the value is a numerical value it is interpreted as an
         offset, in seconds, from the ``origintime``.
-    :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
-    :param endtime: Specifies the desired end time for the synthetic
+        :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param endtime: Specifies the desired end time for the synthetic
         trace(s). This may be specified as either:
 
         * an absolute date and time

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -29,9 +29,6 @@ class Client(WaveformClient, HTTPClient):
     """
     Client for the IRIS syngine service.
     """
-    # Caching some information.
-    __cache = {}
-
     def __init__(self, base_url="http://service.iris.edu/irisws/syngine/1",
                  user_agent=DEFAULT_USER_AGENT, debug=False, timeout=20):
         """
@@ -71,28 +68,21 @@ class Client(WaveformClient, HTTPClient):
         :rtype: :class:`obspy.core.attribdict.AttribDict`
         """
         model_name = model_name.strip().lower()
-        key = "model_" + model_name
-        self.__cache.setdefault(self._base_url, {})
-        if key not in self.__cache[self._base_url]:
-            r = self._download(self._get_url("info"),
-                               params={"model": model_name})
-            info = AttribDict(r.json())
-            # Convert slip and sliprate into a numpy array for easier handling.
-            info.slip = np.array(info.slip, dtype=np.float64)
-            info.sliprate = np.array(info.sliprate, dtype=np.float64)
-            self.__cache[self._base_url][key] = info
-        return self.__cache[self._base_url][key]
+        r = self._download(self._get_url("info"),
+                           params={"model": model_name})
+        info = AttribDict(r.json())
+        # Convert slip and sliprate into numpy arrays for easier handling.
+        info.slip = np.array(info.slip, dtype=np.float64)
+        info.sliprate = np.array(info.sliprate, dtype=np.float64)
+        return info
 
     def get_service_version(self):
         """
         Get the service version of the remote syngine server.
         """
-        self.__cache.setdefault(self._base_url, {})
-        if "version" not in self.__cache[self._base_url]:
-            r = self._download(self._get_url("version"))
-            # Decoding and what not is handled by the requests library.
-            self.__cache[self._base_url]["version"] = r.text
-        return self.__cache[self._base_url]["version"]
+        r = self._download(self._get_url("version"))
+        # Decoding and what not is handled by the requests library.
+        return r.text
 
     def get_waveforms(
             self, model, network=None, station=None,

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -193,7 +193,7 @@ class Client(WaveformClient, HTTPClient):
         """
         Request waveforms using the Syngine service.
 
-        This method is strongly tied to the actual implememtation on the
+        This method is strongly tied to the actual implementation on the
         server side. The default values and all the exception handling are
         deferred to the service. Please see `the syngine documentation
         <http://ds.iris.edu/ds/products/syngine/>`_ for more details and the
@@ -342,3 +342,131 @@ class Client(WaveformClient, HTTPClient):
         with io.BytesIO(r.content) as buf:
             st = obspy.read(buf)
         return st
+
+    def get_waveforms_bulk(
+            self, model, bulk,
+            eventid=None, sourcelatitude=None, sourcelongitude=None,
+            sourcedepthinmeters=None, sourcemomenttensor=None,
+            sourcedoublecouple=None, sourceforce=None, origintime=None,
+            starttime=None, endtime=None, label=None, components=None,
+            units=None, scale=None, dt=None, kernelwidth=None,
+            format="miniseed", filename=None):
+        """
+        Request multiple waveforms using the Syngine service at once.
+
+        This method is strongly tied to the actual implementation on the
+        server side. The default values and all the exception handling are
+        deferred to the service. Please see `the syngine documentation
+        <http://ds.iris.edu/ds/products/syngine/>`_ for more details and the
+        default values of all parameters.
+
+        This method used the POST functionalities of the syngine service.
+
+        :param model: Specify the model.
+        :type model: str
+        :param bulk: Specify the receivers to download in bulk.
+        :type bulk: list of lists, tuples, or dictionaries
+        :param eventid: Specify an event identifier in the form
+        [catalog]:[eventid]. The centroid time and location and moment
+        tensor of the solution will be used as the source.
+        :type eventid: str
+        :param sourcelatitude: Specify the source latitude.
+        :type sourcelatitude: float
+        :param sourcelongitude: Specify the source longitude.
+        :type sourcelongitude: float
+        :param sourcedepthinmeters: Specify the source depth in meters from
+        0 to 700000.
+        :type sourcedepthinmeters: float
+        :param sourcemomenttensor: Specify a source in moment tensor
+        components as a list: ``Mrr``, ``Mtt``, ``Mpp``, ``Mrt``, ``Mrp``,
+        ``Mtp`` with values in Newton meters (*Nm*).
+        :type sourcemomenttensor: list of floats
+        :param sourcedoublecouple: Specify a source as a double couple. The
+        list of values are ``strike``, ``dip``, ``rake`` [,``M0``],
+        where strike, dip and rake are in degrees and M0 is the scalar
+        seismic moment in Newton meters (Nm). If not specified, a value
+        of *1e19* will be used as the scalar moment.
+        :type sourcedoublecouple: list of floats
+        :param sourceforce: Specify a force source as a list of ``Fr``, ``Ft``,
+        ``Fp`` in units of Newtons (N).
+        :type sourceforce: list of floats
+        :param origintime: Specify the source origin time. This must be
+        specified as an absolute date and time.
+        :type origintime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param starttime: Specifies the desired start time for the synthetic
+            trace(s). This may be specified as either:
+
+        * an absolute date and time
+        * a phase-relative offset
+        * an offset from origin time in seconds
+
+        If the value is recognized as a date and time, it is interpreted
+        as an absolute time. If the value is in the form
+        ``phase[+-]offset`` it is interpreted as a phase-relative time,
+        for example **P-10** (meaning Pwave arrival time minus 10
+        seconds). If the value is a numerical value it is interpreted as an
+        offset, in seconds, from the ``origintime``.
+    :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
+    :param endtime: Specifies the desired end time for the synthetic
+        trace(s). This may be specified as either:
+
+        * an absolute date and time
+        * a phase-relative offset
+        * an offset from origin time in seconds
+
+        If the value is recognized as a date and time, it is interpreted
+        as an absolute time. If the value is in the form
+        ``phase[+-]offset`` it is interpreted as a phase-relative time,
+        for example **P-10** (meaning Pwave arrival time minus 10
+        seconds). If the value is a numerical value it is interpreted as an
+        offset, in seconds, from the ``starttime``.
+        :type endtime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param label: Specify a label to be included in file names and HTTP
+        file name suggestions.
+        :type label: str
+        :param components: Specify the orientation of the synthetic
+        seismograms as a list of any combination of ``Z`` (vertical),
+        ``N`` (north), ``E`` (east), ``R`` (radial), ``T`` (transverse)
+        :type components: str or list of strings.
+        :param units: Specify either ``displacement``, ``velocity`` or
+        ``acceleration`` for the synthetics. The length unit is meters.
+        :type units: str
+        :param scale: Specify an amplitude scaling factor. The default
+        amplitude length unit is meters.
+        :type scale: float
+        :param dt: Specify the sampling interval in seconds. Only upsampling
+        is allowed so this value must be larger than the intrinsic interval
+        of the model database.
+        :type dt: float
+        :param kernelwidth: Specify the width of the sinc kernel used for
+            resampling to requested sample interval (``dt``), relative to the
+            original sampling rate.
+        :type kernelwidth: int
+        :param format: Specify output file to be either miniSEED or a ZIP
+        archive of SAC files, either ``miniseed`` or ``saczip``.
+        :type format: str
+        :param filename: Will download directly to the given file. If given,
+        this method will return nothing.
+        :type filename: str or file-like object
+        """
+        arguments = {
+            "eventid": eventid,
+            "sourcelatitude": sourcelatitude,
+            "sourcelongitude": sourcelongitude,
+            "sourcedepthinmeters": sourcedepthinmeters,
+            "sourcemomenttensor": sourcemomenttensor,
+            "sourcedoublecouple": sourcedoublecouple,
+            "sourceforce": sourceforce,
+            "origintime": origintime,
+            "starttime": starttime,
+            "endtime": endtime,
+            "label": label,
+            "components": components,
+            "units": units,
+            "scale": scale,
+            "dt": dt,
+            "kernelwidth": kernelwidth,
+            "format": format,
+            "filename": filename}
+
+        params = self._convert_parameters(model=model, **arguments)

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -108,6 +108,114 @@ class Client(WaveformClient, HTTPClient):
             units=None, scale=None, dt=None, kernelwidth=None,
             format="miniseed"):
         """
+        Request waveforms using the Syngine service.
+
+        This method is strongly tied to the actual implememtation on the
+        server side. The default values and all the exception handling are
+        deferred to the service. Please see `the syngine documentation
+        <http://ds.iris.edu/ds/products/syngine/>`_ for more details and the
+        default values of all parameters.
+
+        :param model: Specify the model.
+        :type model: str
+        :param network: Specify a network code combined with ``station`` to
+            identify receiver coordinates of a operating station.
+        :type network: str
+        :param station: Specify a network code combined with ``network`` to
+            identify receiver coordinates of a operating station.
+        :type station: str
+        :param receiverlatitude: Specify the receiver latitude in degrees.
+        :type receiverlatitude: float
+        :param receiverlongitude: Specify the receiver longitude in degrees.
+        :type receiverlongitude: float
+        :param networkcode: Specify the network code for synthetic. Optional
+            when using ``receiverlatitude`` and ``receiverlongitude``.
+        :type networkcode: str
+        :param stationcode: Specify the station code for synthetic. Optional
+            when using ``receiverlatitude`` and ``receiverlongitude``.
+        :type stationcode: str
+        :param locationcode: Specify the location code for synthetic. Optional
+            in any usage.
+        :type locationcode: str
+        :param eventid: Specify an event identifier in the form
+            [catalog]:[eventid]. The centroid time and location and moment
+            tensor of the solution will be used as the source.
+        :type eventid: str
+        :param sourcelatitude: Specify the source latitude.
+        :type sourcelatitude: float
+        :param sourcelongitude: Specify the source longitude.
+        :type sourcelongitude: float
+        :param sourcedepthinmeters: Specify the source depth in meters from
+            0 to 700000.
+        :type sourcedepthinmeters: float
+        :param sourcemomenttensor: Specify a source in moment tensor
+            components as a list: ``Mrr``, ``Mtt``, ``Mpp``, ``Mrt``, ``Mrp``,
+            ``Mtp`` with values in Newton meters (*Nm*).
+        :type sourcemomenttensor: list of floats
+        :param sourcedoublecouple: Specify a source as a double couple. The
+            list of values are ``strike``, ``dip``, ``rake`` [,``M0``],
+            where strike, dip and rake are in degrees and M0 is the scalar
+            seismic moment in Newton meters (Nm). If not specified, a value
+            of *1e19* will be used as the scalar moment.
+        :type sourcedoublecouple: list of floats
+        :param sourceforce: Specify a force source as a list of ``Fr``, ``Ft``,
+            ``Fp`` in units of Newtons (N).
+        :type sourceforce: list of floats
+        :param origintime: Specify the source origin time. This must be
+            specified as an absolute date and time.
+        :type origintime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param starttime: Specifies the desired start time for the synthetic
+            trace(s). This may be specified as either:
+
+            * an absolute date and time
+            * a phase-relative offset
+            * an offset from origin time in seconds
+
+            If the value is recognized as a date and time, it is interpreted
+            as an absolute time. If the value is in the form
+            ``phase[+-]offset`` it is interpreted as a phase-relative time,
+            for example **P-10** (meaning Pwave arrival time minus 10
+            seconds). If the value is a numerical value it is interpreted as an
+            offset, in seconds, from the ``origintime``.
+        :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param endtime: Specifies the desired end time for the synthetic
+            trace(s). This may be specified as either:
+
+            * an absolute date and time
+            * a phase-relative offset
+            * an offset from origin time in seconds
+
+            If the value is recognized as a date and time, it is interpreted
+            as an absolute time. If the value is in the form
+            ``phase[+-]offset`` it is interpreted as a phase-relative time,
+            for example **P-10** (meaning Pwave arrival time minus 10
+            seconds). If the value is a numerical value it is interpreted as an
+            offset, in seconds, from the ``starttime``.
+        :type endtime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param label: Specify a label to be included in file names and HTTP
+            file name suggestions.
+        :type label: str
+        :param components: Specify the orientation of the synthetic
+            seismograms as a list of any combination of ``Z`` (vertical),
+            ``N`` (north), ``E`` (east), ``R`` (radial), ``T`` (transverse)
+        :type components: str or list of strings.
+        :param units: Specify either ``displacement``, ``velocity`` or
+            ``acceleration`` for the synthetics. The length unit is meters.
+        :type units: str
+        :param scale: Specify an amplitude scaling factor. The default
+            amplitude length unit is meters.
+        :type scale: float
+        :param dt: Specify the sampling interval in seconds. Only upsampling
+            is allowed so this value must be larger than the intrinsic interval
+            of the model database.
+        :type dt: float
+        :param kernelwidth: Specify the width of the sinc kernel used for
+            resampling to requested sample interval (``dt``), relative to the
+            original sampling rate.
+        :type kernelwidth: int
+        :param format: Specify output file to be either miniSEED or a ZIP
+            archive of SAC files, either ``miniseed`` or ``saczip``.
+        :type format: str
         """
         model = str(model).strip().lower()
 

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-ObsPy client for the IRIS syngine service.
+ObsPy client for the IRIS Syngine service.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
@@ -30,7 +30,7 @@ from ..base import WaveformClient, HTTPClient, DEFAULT_USER_AGENT, \
 
 class Client(WaveformClient, HTTPClient):
     """
-    Client for the IRIS syngine service.
+    Client for the IRIS Syngine service.
     """
     def __init__(self, base_url="http://service.iris.edu/irisws/syngine/1",
                  user_agent=DEFAULT_USER_AGENT, debug=False, timeout=20):
@@ -93,7 +93,7 @@ class Client(WaveformClient, HTTPClient):
 
     def get_service_version(self):
         """
-        Get the service version of the remote syngine server.
+        Get the service version of the remote Syngine server.
         """
         r = self._download(self._get_url("version"))
         # Decoding and what not is handled by the requests library.
@@ -106,7 +106,7 @@ class Client(WaveformClient, HTTPClient):
 
         params = {"model": model}
 
-        # Error handling is mostly delegated to the actual syngine service.
+        # Error handling is mostly delegated to the actual Syngine service.
         # Here we just check that the types are compatible.
         str_arguments = ["network", "station", "networkcode", "stationcode",
                          "locationcode", "eventid", "label", "components",
@@ -153,7 +153,7 @@ class Client(WaveformClient, HTTPClient):
                 value = float(value)
             # If a string like object, attempt to parse it to a datetime
             # object, otherwise assume its a phase-relative time and let the
-            # syngine service deal with the erorr handling.
+            # Syngine service deal with the erorr handling.
             elif isinstance(value, (str, native_str)):
                 try:
                     value = obspy.UTCDateTime(value)
@@ -213,9 +213,22 @@ class Client(WaveformClient, HTTPClient):
 
         This method is strongly tied to the actual implementation on the
         server side. The default values and all the exception handling are
-        deferred to the service. Please see `the syngine documentation
+        deferred to the service. Please see `the Syngine documentation
         <http://ds.iris.edu/ds/products/syngine/>`_ for more details and the
         default values of all parameters.
+
+        .. rubric:: Example
+
+        >>> from obspy.clients.syngine import Client
+        >>> client = Client()
+        >>> st = client.get_waveforms(model="ak135f_5s", network="IU",
+        ...                           station="ANMO",
+        ...                           eventid="GCMT:C201002270634A")
+        >>> print(st)  # doctest: +ELLIPSIS
+        3 Trace(s) in Stream:
+        IU.ANMO.SE.MXZ | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXN | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
 
         :param model: Specify the model.
         :type model: str
@@ -246,15 +259,14 @@ class Client(WaveformClient, HTTPClient):
         :type sourcelatitude: float
         :param sourcelongitude: Specify the source longitude.
         :type sourcelongitude: float
-        :param sourcedepthinmeters: Specify the source depth in meters from
-            0 to 700000.
+        :param sourcedepthinmeters: Specify the source depth in meters.
         :type sourcedepthinmeters: float
         :param sourcemomenttensor: Specify a source in moment tensor
             components as a list: ``Mrr``, ``Mtt``, ``Mpp``, ``Mrt``, ``Mrp``,
             ``Mtp`` with values in Newton meters (*Nm*).
         :type sourcemomenttensor: list of floats
         :param sourcedoublecouple: Specify a source as a double couple. The
-            list of values are ``strike``, ``dip``, ``rake`` [,``M0``],
+            list of values are ``strike``, ``dip``, ``rake`` [, ``M0`` ],
             where strike, dip and rake are in degrees and M0 is the scalar
             seismic moment in Newton meters (Nm). If not specified, a value
             of *1e19* will be used as the scalar moment.
@@ -275,10 +287,10 @@ class Client(WaveformClient, HTTPClient):
             If the value is recognized as a date and time, it is interpreted
             as an absolute time. If the value is in the form
             ``phase[+-]offset`` it is interpreted as a phase-relative time,
-            for example **P-10** (meaning Pwave arrival time minus 10
+            for example ``P-10`` (meaning Pwave arrival time minus 10
             seconds). If the value is a numerical value it is interpreted as an
             offset, in seconds, from the ``origintime``.
-        :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param endtime: Specifies the desired end time for the synthetic
             trace(s). This may be specified as either:
 
@@ -289,10 +301,10 @@ class Client(WaveformClient, HTTPClient):
             If the value is recognized as a date and time, it is interpreted
             as an absolute time. If the value is in the form
             ``phase[+-]offset`` it is interpreted as a phase-relative time,
-            for example **P-10** (meaning Pwave arrival time minus 10
+            for example ``P-10`` (meaning Pwave arrival time minus 10
             seconds). If the value is a numerical value it is interpreted as an
             offset, in seconds, from the ``starttime``.
-        :type endtime::class:`~obspy.core.utcdatetime.UTCDateTime`
+        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param label: Specify a label to be included in file names and HTTP
             file name suggestions.
         :type label: str
@@ -368,103 +380,136 @@ class Client(WaveformClient, HTTPClient):
             units=None, scale=None, dt=None, kernelwidth=None,
             format="miniseed", filename=None, data=None):
         """
-        Request multiple waveforms using the Syngine service at once.
+        Request waveforms for multiple receivers simultaneously.
 
         This method is strongly tied to the actual implementation on the
         server side. The default values and all the exception handling are
-        deferred to the service. Please see `the syngine documentation
+        deferred to the service. Please see the `Syngine documentation
         <http://ds.iris.edu/ds/products/syngine/>`_ for more details and the
         default values of all parameters.
 
-        This method used the POST functionalities of the syngine service.
+        This method uses the POST functionalities of the Syngine service.
+
+
+        .. rubric:: Example
+
+        The `bulk` parameter is a list of either other lists/tuples or
+        dictionaries. Each item specifies one receiver. Items can be
+        specified in a number of different ways:
+
+        >>> from obspy.clients.syngine import Client
+        >>> c = Client()
+        >>> bulk = [
+        ...     {"netcode": "IU" ,"stacode": "ANMO"},  # net/sta codes
+        ...     {"latitude": 47.0,"longitude": 12.1},  # coordinates
+        ...     {"latitude": 47.0,"longitude": 12.1,
+        ...      "netcode": "AA", "stacode": "BB",
+        ...      "loccode": "CC"},                     # optional net/sta/loc
+        ...     ["IU", "ANTO"],                        # net/sta as list
+        ...     [33.2, -123.5]                         # lat/lon as list/tuple
+        ... ]
+
+        Just pass that on to the bulk waveform method and retrieve the data.
+
+        >>> st = c.get_waveforms_bulk(
+        ...     model="ak135f_5s", bulk=bulk, sourcelatitude=12.3,
+        ...     sourcelongitude=75.3, sourcedepthinmeters=54321,
+        ...     sourcemomenttensor=[1E19, 1E19, 1E19, 0, 0, 0],
+        ...     components="Z")
+        >>> print(st.sort())  # doctest: +ELLIPSIS
+        5 Trace(s) in Stream:
+        AA.BB.CC.MXZ    | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXZ  | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
+        IU.ANTO.SE.MXZ  | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
+        XX.S0001.SE.MXZ | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
+        XX.S0002.SE.MXZ | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
 
         :param model: Specify the model.
         :type model: str
         :param bulk: Specify the receivers to download in bulk.
         :type bulk: list of lists, tuples, or dictionaries
         :param eventid: Specify an event identifier in the form
-        [catalog]:[eventid]. The centroid time and location and moment
-        tensor of the solution will be used as the source.
+            [catalog]:[eventid]. The centroid time and location and moment
+            tensor of the solution will be used as the source.
         :type eventid: str
         :param sourcelatitude: Specify the source latitude.
         :type sourcelatitude: float
         :param sourcelongitude: Specify the source longitude.
         :type sourcelongitude: float
-        :param sourcedepthinmeters: Specify the source depth in meters from
-        0 to 700000.
+        :param sourcedepthinmeters: Specify the source depth in meters.
         :type sourcedepthinmeters: float
         :param sourcemomenttensor: Specify a source in moment tensor
-        components as a list: ``Mrr``, ``Mtt``, ``Mpp``, ``Mrt``, ``Mrp``,
-        ``Mtp`` with values in Newton meters (*Nm*).
+            components as a list: ``Mrr``, ``Mtt``, ``Mpp``, ``Mrt``, ``Mrp``,
+            ``Mtp`` with values in Newton meters (*Nm*).
         :type sourcemomenttensor: list of floats
         :param sourcedoublecouple: Specify a source as a double couple. The
-        list of values are ``strike``, ``dip``, ``rake`` [,``M0``],
-        where strike, dip and rake are in degrees and M0 is the scalar
-        seismic moment in Newton meters (Nm). If not specified, a value
-        of *1e19* will be used as the scalar moment.
+            list of values are ``strike``, ``dip``, ``rake`` [, ``M0`` ],
+            where strike, dip and rake are in degrees and M0 is the scalar
+            seismic moment in Newton meters (Nm). If not specified, a value
+            of *1e19* will be used as the scalar moment.
         :type sourcedoublecouple: list of floats
         :param sourceforce: Specify a force source as a list of ``Fr``, ``Ft``,
-        ``Fp`` in units of Newtons (N).
+            ``Fp`` in units of Newtons (N).
         :type sourceforce: list of floats
         :param origintime: Specify the source origin time. This must be
-        specified as an absolute date and time.
+            specified as an absolute date and time.
         :type origintime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param starttime: Specifies the desired start time for the synthetic
             trace(s). This may be specified as either:
 
-        * an absolute date and time
-        * a phase-relative offset
-        * an offset from origin time in seconds
+            * an absolute date and time
+            * a phase-relative offset
+            * an offset from origin time in seconds
 
-        If the value is recognized as a date and time, it is interpreted
-        as an absolute time. If the value is in the form
-        ``phase[+-]offset`` it is interpreted as a phase-relative time,
-        for example **P-10** (meaning Pwave arrival time minus 10
-        seconds). If the value is a numerical value it is interpreted as an
-        offset, in seconds, from the ``origintime``.
-        :type starttime::class:`~obspy.core.utcdatetime.UTCDateTime`
+            If the value is recognized as a date and time, it is interpreted
+            as an absolute time. If the value is in the form
+            ``phase[+-]offset`` it is interpreted as a phase-relative time,
+            for example ``P-10`` (meaning Pwave arrival time minus 10
+            seconds). If the value is a numerical value it is interpreted as an
+            offset, in seconds, from the ``origintime``.
+        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param endtime: Specifies the desired end time for the synthetic
-        trace(s). This may be specified as either:
+            trace(s). This may be specified as either:
 
-        * an absolute date and time
-        * a phase-relative offset
-        * an offset from origin time in seconds
+            * an absolute date and time
+            * a phase-relative offset
+            * an offset from origin time in seconds
 
-        If the value is recognized as a date and time, it is interpreted
-        as an absolute time. If the value is in the form
-        ``phase[+-]offset`` it is interpreted as a phase-relative time,
-        for example **P-10** (meaning Pwave arrival time minus 10
-        seconds). If the value is a numerical value it is interpreted as an
-        offset, in seconds, from the ``starttime``.
-        :type endtime::class:`~obspy.core.utcdatetime.UTCDateTime`
+            If the value is recognized as a date and time, it is interpreted
+            as an absolute time. If the value is in the form
+            ``phase[+-]offset`` it is interpreted as a phase-relative time,
+            for example ``P-10`` (meaning Pwave arrival time minus 10
+            seconds). If the value is a numerical value it is interpreted as an
+            offset, in seconds, from the ``starttime``.
+        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :param label: Specify a label to be included in file names and HTTP
-        file name suggestions.
+            file name suggestions.
         :type label: str
         :param components: Specify the orientation of the synthetic
-        seismograms as a list of any combination of ``Z`` (vertical),
-        ``N`` (north), ``E`` (east), ``R`` (radial), ``T`` (transverse)
+            seismograms as a list of any combination of ``Z`` (vertical),
+            ``N`` (north), ``E`` (east), ``R`` (radial), ``T`` (transverse)
         :type components: str or list of strings.
         :param units: Specify either ``displacement``, ``velocity`` or
-        ``acceleration`` for the synthetics. The length unit is meters.
+            ``acceleration`` for the synthetics. The length unit is meters.
         :type units: str
         :param scale: Specify an amplitude scaling factor. The default
-        amplitude length unit is meters.
+            amplitude length unit is meters.
         :type scale: float
         :param dt: Specify the sampling interval in seconds. Only upsampling
-        is allowed so this value must be larger than the intrinsic interval
-        of the model database.
+            is allowed so this value must be larger than the intrinsic interval
+            of the model database.
         :type dt: float
         :param kernelwidth: Specify the width of the sinc kernel used for
             resampling to requested sample interval (``dt``), relative to the
             original sampling rate.
         :type kernelwidth: int
         :param format: Specify output file to be either miniSEED or a ZIP
-        archive of SAC files, either ``miniseed`` or ``saczip``.
+            archive of SAC files, either ``miniseed`` or ``saczip``.
         :type format: str
         :param filename: Will download directly to the given file. If given,
-        this method will return nothing.
+            this method will return nothing.
         :type filename: str or file-like object
-        :param data: If given this will be sent directly sent to the syngine
+        :param data: If given this will be sent directly sent to the Syngine
             service as a POST payload. All other parameters except the
             ``filename`` parameter will be silently ignored. Likely not that
             useful for most people.

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -27,19 +27,24 @@ from ..base import WaveformClient, HTTPClient, DEFAULT_USER_AGENT, \
 
 class Client(WaveformClient, HTTPClient):
     """
-    FDSN Web service request client.
-
-    For details see the :meth:`~obspy.clients.fdsn.clients.Client.__init__()`
-    method.
+    Client for the IRIS syngine service.
     """
-    # Caching the database information, thus repeatedly initializing the
-    # client is cheap.
+    # Caching some information.
     __cache = {}
 
     def __init__(self, base_url="http://service.iris.edu/irisws/syngine/1",
                  user_agent=DEFAULT_USER_AGENT, debug=False, timeout=20):
         """
         Initializes a Syngine Client.
+
+        :param base_url: The base URL of the service.
+        :type base_url: str
+        :param user_agent: The user agent sent along the HTTP request.
+        :type user_agent: str
+        :param debug: Debug on/off.
+        :type debug: bool
+        :param timeout: The socket timeout.
+        :type timeout: float
         """
         HTTPClient.__init__(self, debug=debug, timeout=timeout,
                             user_agent=user_agent)
@@ -61,6 +66,9 @@ class Client(WaveformClient, HTTPClient):
         Get some information about a particular model.
 
         :param model_name: The name of the model. Case insensitive.
+        :type model_name: str
+        :returns: A dictionary with more information about any model.
+        :rtype: :class:`obspy.core.attribdict.AttribDict`
         """
         model_name = model_name.strip().lower()
         key = "model_" + model_name
@@ -76,6 +84,9 @@ class Client(WaveformClient, HTTPClient):
         return self.__cache[self._base_url][key]
 
     def get_service_version(self):
+        """
+        Get the service version of the remote syngine server.
+        """
         self.__cache.setdefault(self._base_url, {})
         if "version" not in self.__cache[self._base_url]:
             r = self._download(self._get_url("version"))

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -118,7 +118,7 @@ class Client(WaveformClient, HTTPClient):
         int_arguments = ["kernelwidth"]
         time_arguments = ["origintime"]
 
-        for keys, t in ((str_arguments, str),
+        for keys, t in ((str_arguments, native_str),
                         (float_arguments, float),
                         (int_arguments, int),
                         (time_arguments, obspy.UTCDateTime)):
@@ -159,12 +159,12 @@ class Client(WaveformClient, HTTPClient):
                 try:
                     value = obspy.UTCDateTime(value)
                 except:
-                    value = str(value)
+                    value = (value)
             # Last but not least just try to pass it to the datetime
             # constructor without catching the error.
             else:
                 value = obspy.UTCDateTime(value)
-            params[key] = value
+            params[key] = native_str(value)
 
         # These all have to be lists of floats. Otherwise it fails.
         source_mecs = ["sourcemomenttensor",

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -512,11 +512,11 @@ class Client(WaveformClient, HTTPClient):
         :param format: Specify output file to be either miniSEED or a ZIP
             archive of SAC files, either ``miniseed`` or ``saczip``.
         :type format: str
-        :param filename: Will download directly to the given file. If given,
-            this method will return nothing.
+        :param filename: Will download directly to the specified file. If
+            given, this method will return nothing.
         :type filename: str or file-like object
-        :param data: If given this will be sent directly sent to the Syngine
-            service as a POST payload. All other parameters except the
+        :param data: If specified this will be sent directly sent to the
+            Syngine service as a POST payload. All other parameters except the
             ``filename`` parameter will be silently ignored. Likely not that
             useful for most people.
         :type data: dictionary, bytes, or file-like object

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -404,11 +404,11 @@ class Client(WaveformClient, HTTPClient):
         >>> from obspy.clients.syngine import Client
         >>> c = Client()
         >>> bulk = [
-        ...     {"networkcode": "IU", "stationcode": "ANMO"},  # net/sta codes
-        ...     {"latitude": 47.0, "longitude": 12.1},         # coordinates
+        ...     {"network": "IU", "station": "ANMO"},  # net/sta codes
+        ...     {"latitude": 47.0, "longitude": 12.1}, # coordinates
         ...     {"latitude": 47.0, "longitude": 12.1,
         ...      "networkcode": "AA", "stationcode": "BB",
-        ...      "locationcode": "CC"},   # optional # net/sta/loc
+        ...      "locationcode": "CC"},   # optional net/sta/loc
         ...     ["IU", "ANTO"],           # net/sta as list
         ...     [33.2, -123.5]            # lat/lon as list/tuple
         ... ]
@@ -583,8 +583,8 @@ class Client(WaveformClient, HTTPClient):
                                    "locationcode"):
                             if _i in item:
                                 bulk_item += " %s=%s" % (_map[_i], item[_i])
-                    elif "stationcode" in item and "networkcode" in item:
-                        bulk_item = "{networkcode} {stationcode}".format(
+                    elif "station" in item and "network" in item:
+                        bulk_item = "{network} {station}".format(
                             **item)
                     else:
                         raise ValueError("Item '%s' in bulk is malformed." %

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -16,7 +16,6 @@ from future.utils import native_str
 
 import collections
 import io
-import pprint
 import zipfile
 
 import numpy as np

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -66,7 +66,7 @@ class Client(WaveformClient, HTTPClient):
 
         .. rubric:: Example
 
-        >>> from obspy.client.syngine import Client
+        >>> from obspy.clients.syngine import Client
         >>> c = Client()
         >>> db_info = c.get_model_info(model_name="ak135f_5s")
         >>> print(db_info.period)

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -93,12 +93,6 @@ class Client(WaveformClient, HTTPClient):
         """
         return self._download(self._get_url("models")).json()
 
-    def print_model_information(self):
-        """
-        Print information about the available models.
-        """
-        pprint.pprint(self.get_available_models())
-
     def get_service_version(self):
         """
         Get the service version of the remote Syngine server.

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+ObsPy client for the IRIS syngine service.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (http://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+from future.utils import native_str
+
+import numpy as np
+
+from obspy import UTCDateTime
+from obspy.core import AttribDict
+
+from ..base import WaveformClient, HTTPClient, DEFAULT_USER_AGENT, \
+    ClientHTTPException
+
+
+class Client(WaveformClient, HTTPClient):
+    """
+    FDSN Web service request client.
+
+    For details see the :meth:`~obspy.clients.fdsn.clients.Client.__init__()`
+    method.
+    """
+    # Caching the database information, thus repeatedly initializing the
+    # client is cheap.
+    __cache = {}
+
+    def __init__(self, base_url="http://service.iris.edu/irisws/syngine/1",
+                 user_agent=DEFAULT_USER_AGENT, debug=False, timeout=20):
+        """
+        Initializes a Syngine Client.
+        """
+        HTTPClient.__init__(self, user_agent=user_agent)
+        self._debug = debug
+        self._timeout = timeout
+
+        # Make sure the base_url does not end with a slash.
+        base_url = base_url.rstrip("/")
+        self._base_url = base_url
+
+    def _get_url(self, path):
+        return "/".join([self._base_url.rstrip("/"), path])
+
+    def _handle_requests_http_error(self, r):
+        msg = "HTTP code %i when downloading '%s':\n\n%s" % (
+            r.status_code, r.url, r.text)
+        raise ClientHTTPException(msg.strip())
+
+    def get_model_info(self, model_name):
+        """
+        Get some information about a particular model.
+
+        :param model_name: The name of the model. Case insensitive.
+        """
+        model_name = model_name.strip().lower()
+        key = "model_" + model_name
+        self.__cache.setdefault(self._base_url, {})
+        if key not in self.__cache[self._base_url]:
+            r = self._download(self._get_url("info"),
+                               params={"model": model_name})
+            info = AttribDict(r.json())
+            # Convert slip and sliprate into a numpy array for easier handling.
+            info.slip = np.array(info.slip, dtype=np.float64)
+            info.sliprate = np.array(info.sliprate, dtype=np.float64)
+            self.__cache[self._base_url][key] = info
+        return self.__cache[self._base_url][key]
+
+    def get_service_version(self):
+        self.__cache.setdefault(self._base_url, {})
+        if "version" not in self.__cache[self._base_url]:
+            r = self._download(self._get_url("version"))
+            # Decoding and what not is handled by the requests library.
+            self.__cache[self._base_url]["version"] = r.text
+        return self.__cache[self._base_url]["version"]
+
+    def get_waveforms(
+            self, model, network=None, station=None,
+            receiverlatitude=None, receiverlongitude=None,
+            networkcode=None, stationcode=None, locationcode=None,
+            eventid=None, sourcelatitude=None, sourcelongitude=None,
+            sourcedepthinmeters=None, sourcemomenttensor=None,
+            sourcedoublecouple=None, sourceforce=None, origintime=None,
+            starttime=None, endtime=None, label=None, components="ZRT",
+            units="velocity", scale=1.0, dt=None, kernelwidth=8,
+            format="miniseed"):
+        """
+        """
+        model = str(model).strip().lower()
+
+        # Error handling is mostly delegated to the actual syngine service.
+        # Here we just check that the types are compatible.
+        str_arguments = ["network", "station", "networkcode", "stationcode",
+                         "locationcode", "eventid", "label", "components",
+                         "units", "format"]
+        float_arguments = ["receiverlatitude", "receiverlongitude",
+                           "sourcelatitude", "sourcelongitude",
+                           "sourcedepthinmeters", "scale", "dt"]
+        int_arguments = ["kernelwidth"]
+        time_arguments = ["origintime"]
+
+        for keys, t in ((str_arguments, str),
+                       (float_arguments, float),
+                       (int_arguments, int),
+                       (time_arguments, UTCDateTime)):
+            for key in keys:
+                value = locals()[key]
+                if value is None:
+                    continue
+                locals()[key] = t(value)
+
+        # These can be absolute times, relative times or phase relative times.
+        # jo
+        temporal_bounds = ["starttime", "endtime"]
+        for key in temporal_bounds:
+            value = locals()[key]
+            if value is None:
+                continue
+            # If a number, convert to a float.
+            elif isinstance(value, (int, float)):
+                value = float(value)
+            # If a string like object, attempt to parse it to a datetime
+            # object, otherwise assume its a phase-relative time and let the
+            # syngine service deal with the erorr handling.
+            elif isinstance(value, (str, native_str)):
+                try:
+                    value = UTCDateTime(value)
+                except:
+                    value = str(value)
+            # Last but not least just try to pass it to the datetime
+            # constructor without catching the error.
+            else:
+                value = UTCDateTime(value)
+            locals()[0] = value
+
+        # These all have to be lists of floats. Otherwise it fails.
+        source_mecs = ["sourcemomenttensor",
+                       "sourcedoublecouple",
+                       "sourceforce"]
+        for key in source_mecs:
+            value = locals()[key]
+            if value is None:
+                continue
+            value = [float(_i) for _i in value]
+            locals()[key] = value
+
+        # Now simply use all arguments to construct the query.
+        all_arguments = ["model"]
+        all_arguments.extend(str_arguments)
+        all_arguments.extend(float_arguments)
+        all_arguments.extend(int_arguments )
+        all_arguments.extend(time_arguments)
+        all_arguments.extend(temporal_bounds)
+        all_arguments.extend(source_mecs)
+
+        params = {}
+        for arg in all_arguments:
+            value = locals()[arg]
+            if value is None:
+                continue
+            params[arg] = value
+
+        r = self._download(url=self._get_url("query"), params=params)
+        from IPython.core.debugger import Tracer; Tracer(colors="Linux")()

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -65,10 +65,18 @@ class Client(WaveformClient, HTTPClient):
         """
         Get some information about a particular model.
 
+        .. rubric:: Example
+
+        >>> from obspy.client.syngine import Client
+        >>> c = Client()
+        >>> db_info = c.get_model_info(model_name="ak135f_5s")
+        >>> print(db_info.period)
+        5.125
+
         :param model_name: The name of the model. Case insensitive.
         :type model_name: str
         :returns: A dictionary with more information about any model.
-        :rtype: :class:`obspy.core.attribdict.AttribDict`
+        :rtype: :class:`obspy.core.util.attribdict.AttribDict`
         """
         model_name = model_name.strip().lower()
         r = self._download(self._get_url("info"),

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -106,7 +106,7 @@ class Client(WaveformClient, HTTPClient):
             sourcedoublecouple=None, sourceforce=None, origintime=None,
             starttime=None, endtime=None, label=None, components=None,
             units=None, scale=None, dt=None, kernelwidth=None,
-            format="miniseed"):
+            format="miniseed", filename=None):
         """
         Request waveforms using the Syngine service.
 
@@ -216,6 +216,9 @@ class Client(WaveformClient, HTTPClient):
         :param format: Specify output file to be either miniSEED or a ZIP
             archive of SAC files, either ``miniseed`` or ``saczip``.
         :type format: str
+        :param filename: Will download directly to the given file. If given,
+            this method will return nothing.
+        :type filename: str or file-like object
         """
         model = model.strip().lower()
         if not model:
@@ -287,7 +290,13 @@ class Client(WaveformClient, HTTPClient):
             value = ",".join(["%g" % float(_i) for _i in value])
             params[key] = value
 
-        r = self._download(url=self._get_url("query"), params=params)
+        r = self._download(url=self._get_url("query"), params=params,
+                           filename=filename)
+
+        # A given filename will write directly to a file.
+        if filename:
+            return
+
         with io.BytesIO(r.content) as buf:
             st = obspy.read(buf)
         return st

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -299,7 +299,7 @@ class Client(WaveformClient, HTTPClient):
 
             * an absolute date and time
             * a phase-relative offset
-            * an offset from origin time in seconds
+            * an offset from start time in seconds
 
             If the value is recognized as a date and time, it is interpreted
             as an absolute time. If the value is in the form
@@ -478,7 +478,7 @@ class Client(WaveformClient, HTTPClient):
 
             * an absolute date and time
             * a phase-relative offset
-            * an offset from origin time in seconds
+            * an offset from start time in seconds
 
             If the value is recognized as a date and time, it is interpreted
             as an absolute time. If the value is in the form

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -15,7 +15,6 @@ from future.builtins import *  # NOQA
 from future.utils import native_str
 
 import collections
-import copy
 import io
 import pprint
 

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -217,7 +217,9 @@ class Client(WaveformClient, HTTPClient):
             archive of SAC files, either ``miniseed`` or ``saczip``.
         :type format: str
         """
-        model = str(model).strip().lower()
+        model = model.strip().lower()
+        if not model:
+            raise ValueError("Model must be given.")
 
         # Error handling is mostly delegated to the actual syngine service.
         # Here we just check that the types are compatible.
@@ -238,7 +240,16 @@ class Client(WaveformClient, HTTPClient):
                 value = locals()[key]
                 if value is None:
                     continue
+                value = t(value)
+                # String arguments are stripped and empty strings are not
+                # allowed.
+                if t is str:
+                    value = value.strip()
+                    if not value:
+                        raise ValueError("String argument '%s' must not be "
+                                         "an empty string." % key)
                 locals()[key] = t(value)
+
 
         # These can be absolute times, relative times or phase relative times.
         # jo

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -180,6 +180,15 @@ class Client(WaveformClient, HTTPClient):
 
         return params
 
+    def __read_to_stream(self, r, format):
+        with io.BytesIO(r.content) as buf:
+            if format == "miniseed":
+                st = obspy.read(buf)
+            elif format == "saczip":
+                raise NotImplementedError("Unknown format '%s'." % format)
+            else:
+                raise NotImplementedError("Unknown format '%s'." % format)
+        return st
 
     def get_waveforms(
             self, model, network=None, station=None,
@@ -340,9 +349,7 @@ class Client(WaveformClient, HTTPClient):
         if filename:
             return
 
-        with io.BytesIO(r.content) as buf:
-            st = obspy.read(buf)
-        return st
+        return self.__read_to_stream(r=r, format=format)
 
     def get_waveforms_bulk(
             self, model, bulk,
@@ -525,6 +532,4 @@ class Client(WaveformClient, HTTPClient):
             if filename:
                 return
 
-            with io.BytesIO(r.content) as buf:
-                st = obspy.read(buf)
-            return st
+            return self.__read_to_stream(r=r, format=format)

--- a/obspy/clients/syngine/tests/__init__.py
+++ b/obspy/clients/syngine/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+from obspy.core.util import add_doctests, add_unittests
+
+
+MODULE_NAME = "obspy.clients.syngine"
+
+
+def suite():
+    suite = unittest.TestSuite()
+    add_doctests(suite, MODULE_NAME)
+    add_unittests(suite, MODULE_NAME)
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -375,7 +375,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(len(st_bulk), 1)
         self.assertEqual(st, st_bulk)
 
-        # One last test to test a source mechanism
+        # One to test a source mechanism
         st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
                                   sourcemomenttensor=[1, 2, 3, 4, 5, 6],
                                   sourcelatitude=10, sourcelongitude=20,
@@ -384,6 +384,29 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(len(st), 1)
         st_bulk = self.c.get_waveforms_bulk(
                 model="test", bulk=[("IU", "ANMO")],
+                sourcemomenttensor=[1, 2, 3, 4, 5, 6],
+                sourcelatitude=10, sourcelongitude=20,
+                sourcedepthinmeters=100,
+                components="Z")
+        self.assertEqual(len(st_bulk), 1)
+        self.assertEqual(st, st_bulk)
+
+        # One more to test actual time values.
+        st = self.c.get_waveforms(
+            model="test", network="IU", station="ANMO",
+            origintime=obspy.UTCDateTime(2015, 1, 2, 3, 0, 5),
+            starttime=obspy.UTCDateTime(2015, 1, 2, 3, 4, 5),
+            endtime=obspy.UTCDateTime(2015, 1, 2, 3, 10, 5),
+            sourcemomenttensor=[1, 2, 3, 4, 5, 6],
+            sourcelatitude=10, sourcelongitude=20,
+            sourcedepthinmeters=100,
+            components="Z")
+        self.assertEqual(len(st), 1)
+        st_bulk = self.c.get_waveforms_bulk(
+                model="test", bulk=[("IU", "ANMO")],
+                origintime=obspy.UTCDateTime(2015, 1, 2, 3, 0, 5),
+                starttime=obspy.UTCDateTime(2015, 1, 2, 3, 4, 5),
+                endtime=obspy.UTCDateTime(2015, 1, 2, 3, 10, 5),
                 sourcemomenttensor=[1, 2, 3, 4, 5, 6],
                 sourcelatitude=10, sourcelongitude=20,
                 sourcedepthinmeters=100,

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -304,7 +304,8 @@ class ClientTestCase(unittest.TestCase):
                     [1.0, 2.0],
                     (2.0, 3.0),
                     ("AA", "BB")],
-                format="miniseed", sourcemomenttensor=[1,2,3,4,5,6])
+                format="miniseed",
+                sourcemomenttensor=[1, 2, 3, 4, 5, 6])
 
         self.assertEqual(payload[0], "\n".join([
             "model=ak135f_5s",
@@ -454,6 +455,7 @@ class ClientTestCase(unittest.TestCase):
                 model="ak135f_5s", bulk=[], data=b"1234\n5678")
 
         self.assertEqual(payload[0], b"1234\n5678")
+
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -440,6 +440,13 @@ class ClientTestCase(unittest.TestCase):
                 eventid="GCMT:C201002270634A", starttime="P-10",
                 endtime="P+10", components="Z", format="saczip")
         self.assertEqual(len(st), 1)
+        # Same with bulk request.
+        st_bulk = self.c.get_waveforms_bulk(
+                model="test", bulk=[("IU", "ANMO")],
+                eventid="GCMT:C201002270634A", components="Z",
+                format="saczip")
+        self.assertEqual(len(st_bulk), 1)
+        self.assertEqual(st, st_bulk)
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -87,7 +87,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertTrue(isinstance(models, dict))
         keys = list(models.keys())
         self.assertTrue(len(keys) > 3)
-        self.assertIn(keys, "ak135f_5s")
+        self.assertIn("ak135f_5s", keys)
         # Check random key.
         self.assertEqual(models["ak135f_5s"]["components"],
                          "vertical and horizontal")

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -434,6 +434,13 @@ class ClientTestCase(unittest.TestCase):
             st = obspy.read(buf)
             self.assertEqual(len(st), 1)
 
+    def test_reading_saczip_files(self):
+        st = self.c.get_waveforms(
+                model="test", network="IU", station="ANMO",
+                eventid="GCMT:C201002270634A", starttime="P-10",
+                endtime="P+10", components="Z", format="saczip")
+        self.assertEqual(len(st), 1)
+
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')
 

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -9,6 +9,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import unittest
 
 from obspy.core.compatibility import mock
+from obspy.core.util.misc import CatchOutput
 from obspy.clients.syngine import Client
 from obspy.clients.base import DEFAULT_TESTING_USER_AGENT
 
@@ -47,6 +48,50 @@ class ClientTestCase(unittest.TestCase):
                          'http://service.iris.edu/irisws/syngine/1/info')
         self.assertEqual(p.call_args[1]["params"],
                          {'model': 'test_model'})
+        self.assertEqual(p.call_args[1]["headers"],
+                         {'User-Agent': DEFAULT_TESTING_USER_AGENT})
+
+    def test_get_available_models_mock(self):
+        with mock.patch("requests.get") as p:
+            p.return_value = RequestsMockResponse()
+            self.c.get_available_models()
+
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         'http://service.iris.edu/irisws/syngine/1/models')
+        self.assertEqual(p.call_args[1]["params"], None)
+        self.assertEqual(p.call_args[1]["headers"],
+                         {'User-Agent': DEFAULT_TESTING_USER_AGENT})
+
+    def test_print_model_information(self):
+        with mock.patch("requests.get") as p:
+            p.return_value = RequestsMockResponse()
+            p.return_value._json = {"a": "b"}
+
+            with CatchOutput() as out:
+                self.c.print_model_information()
+
+        self.assertEqual(out.stdout, b"{'a': 'b'}\n")
+
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         'http://service.iris.edu/irisws/syngine/1/models')
+        self.assertEqual(p.call_args[1]["params"], None)
+        self.assertEqual(p.call_args[1]["headers"],
+                         {'User-Agent': DEFAULT_TESTING_USER_AGENT})
+
+    def test_get_service_version_mock(self):
+        with mock.patch("requests.get") as p:
+            p.return_value = RequestsMockResponse()
+            p.return_value.text = "1.2.3"
+            version = self.c.get_service_version()
+
+        self.assertEqual(version, "1.2.3")
+
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         'http://service.iris.edu/irisws/syngine/1/version')
+        self.assertEqual(p.call_args[1]["params"], None)
         self.assertEqual(p.call_args[1]["headers"],
                          {'User-Agent': DEFAULT_TESTING_USER_AGENT})
 

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -47,7 +47,7 @@ class ClientTestCase(unittest.TestCase):
             self.c.get_model_info("test_model")
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          'http://service.iris.edu/irisws/syngine/1/info')
         self.assertEqual(p.call_args[1]["params"],
                          {'model': 'test_model'})
@@ -60,7 +60,7 @@ class ClientTestCase(unittest.TestCase):
             self.c.get_available_models()
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          'http://service.iris.edu/irisws/syngine/1/models')
         self.assertEqual(p.call_args[1]["params"], None)
         self.assertEqual(p.call_args[1]["headers"],
@@ -77,7 +77,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(out.stdout, b"{'a': 'b'}\n")
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          'http://service.iris.edu/irisws/syngine/1/models')
         self.assertEqual(p.call_args[1]["params"], None)
         self.assertEqual(p.call_args[1]["headers"],
@@ -92,7 +92,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(version, "1.2.3")
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          'http://service.iris.edu/irisws/syngine/1/version')
         self.assertEqual(p.call_args[1]["params"], None)
         self.assertEqual(p.call_args[1]["headers"],
@@ -121,7 +121,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertTrue(isinstance(st, obspy.Stream))
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "components": "ZRT",
@@ -146,7 +146,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertTrue(isinstance(st, obspy.Stream))
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "components": "Z",
@@ -172,7 +172,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertTrue(isinstance(st, obspy.Stream))
 
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "components": "Z",
@@ -208,7 +208,7 @@ class ClientTestCase(unittest.TestCase):
             self.c.get_waveforms(model="ak135f_5s",
                                  sourcemomenttensor=[1, 2, 3, 4, 5, 6])
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "model": "ak135f_5s",
@@ -220,7 +220,7 @@ class ClientTestCase(unittest.TestCase):
             self.c.get_waveforms(model="ak135f_5s",
                                  sourcedoublecouple=[1, 2, 3, 4])
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "model": "ak135f_5s",
@@ -232,7 +232,7 @@ class ClientTestCase(unittest.TestCase):
             self.c.get_waveforms(model="ak135f_5s",
                                  sourceforce=[3.32, 4.23, 5.11])
         self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[0][0],
+        self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
             "model": "ak135f_5s",

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -18,6 +18,7 @@ from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.syngine import Client
 from obspy.clients.base import DEFAULT_TESTING_USER_AGENT, ClientHTTPException
 
+
 BASE_URL = "http://service.iris.edu/irisws/syngine/1"
 
 
@@ -63,13 +64,13 @@ class ClientTestCase(unittest.TestCase):
         """
         info = self.c.get_model_info("test")
 
-        self.assertTrue(isinstance(info, obspy.core.AttribDict))
+        self.assertIsInstance(info, obspy.core.AttribDict)
         # Check two random keys.
         self.assertEqual(info.dump_type, "displ_only")
         self.assertEqual(info.time_scheme, "newmark2")
         # Check that both arrays have been converted to numpy arrays.
-        self.assertTrue(isinstance(info.slip, np.ndarray))
-        self.assertTrue(isinstance(info.sliprate, np.ndarray))
+        self.assertIsInstance(info.slip, np.ndarray)
+        self.assertIsInstance(info.sliprate, np.ndarray)
 
     def test_get_available_models_mock(self):
         with mock.patch("requests.get") as p:
@@ -85,10 +86,9 @@ class ClientTestCase(unittest.TestCase):
 
     def test_get_available_models(self):
         models = self.c.get_available_models()
-        self.assertTrue(isinstance(models, dict))
-        keys = list(models.keys())
-        self.assertTrue(len(keys) > 3)
-        self.assertIn("ak135f_5s", keys)
+        self.assertIsInstance(models, dict)
+        self.assertGreater(len(models), 3)
+        self.assertIn("ak135f_5s", models)
         # Check random key.
         self.assertEqual(models["ak135f_5s"]["components"],
                          "vertical and horizontal")
@@ -128,7 +128,7 @@ class ClientTestCase(unittest.TestCase):
                                       components="ZRT",
                                       eventid="GCMT:M110302J")
 
-        self.assertTrue(isinstance(st, obspy.Stream))
+        self.assertIsInstance(st, obspy.Stream)
 
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[1]["url"],
@@ -153,7 +153,7 @@ class ClientTestCase(unittest.TestCase):
                                       endtime=1800.0,
                                       eventid="GCMT:M110302J")
 
-        self.assertTrue(isinstance(st, obspy.Stream))
+        self.assertIsInstance(st, obspy.Stream)
 
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[1]["url"],
@@ -179,7 +179,7 @@ class ClientTestCase(unittest.TestCase):
                                       endtime="ScS+60",
                                       eventid="GCMT:M110302J")
 
-        self.assertTrue(isinstance(st, obspy.Stream))
+        self.assertIsInstance(st, obspy.Stream)
 
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[1]["url"],
@@ -197,14 +197,14 @@ class ClientTestCase(unittest.TestCase):
 
     def test_error_handling_arguments(self):
         # Floating points value
-        self.assertRaises(ValueError, self.c.get_waveforms, model="test",
-                          receiverlatitude="a")
+        with self.assertRaises(ValueError):
+            self.c.get_waveforms(model="test", receiverlatitude="a")
         # Int.
-        self.assertRaises(ValueError, self.c.get_waveforms, model="test",
-                          kernelwidth="a")
+        with self.assertRaises(ValueError):
+            self.c.get_waveforms(model="test", kernelwidth="a")
         # Time.
-        self.assertRaises(TypeError, self.c.get_waveforms, model="test",
-                          origintime="a")
+        with self.assertRaises(TypeError):
+            self.c.get_waveforms(model="test", origintime="a")
 
     def test_source_mechanisms_mock(self):
         r = RequestsMockResponse()
@@ -251,8 +251,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_error_handling(self):
         """
-        Tests the error handling. The clients just passes on most things to
-        syngine and relies on the service for the error detection.
+        Tests the error handling. The clients just pass on most things to
+        syngine and rely on the service for the error detection.
         """
         # Wrong components.
         with self.assertRaises(ClientHTTPException) as cm:

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -322,11 +322,11 @@ class ClientTestCase(unittest.TestCase):
                     [1.0, 2.0],
                     (2.0, 3.0),
                     ("AA", "BB")],
-                format="saczip", sourcemomenttensor=[1,2,3,4,5,6])
+                format="miniseed", sourcemomenttensor=[1,2,3,4,5,6])
 
         self.assertEqual(payload[0], "\n".join([
             "model=ak135f_5s",
-            "format=saczip",
+            "format=miniseed",
             "sourcemomenttensor=1,2,3,4,5,6",
             "1.0 2.0",
             "2.0 3.0",
@@ -344,12 +344,12 @@ class ClientTestCase(unittest.TestCase):
                         {"latitude": 12, "longitude": 13.1, "loccode": "00"},
                         {"latitude": 12, "longitude": 13.1, "netcode": "IU",
                          "stacode": "ANMO", "loccode": "00"}],
-                    format="saczip", eventid="GCMT:C201002270634A")
+                    format="miniseed", eventid="GCMT:C201002270634A")
 
         self.assertEqual(payload[0], "\n".join([
             "model=ak135f_5s",
             "eventid=GCMT:C201002270634A",
-            "format=saczip",
+            "format=miniseed",
             "IU ANMO",
             "12 13.1",
             "12 13.1 NETCODE=IU",

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -9,6 +9,8 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import io
 import unittest
 
+import numpy as np
+
 import obspy
 from obspy.core.compatibility import mock
 from obspy.core.util.misc import CatchOutput
@@ -53,6 +55,20 @@ class ClientTestCase(unittest.TestCase):
                          {'model': 'test_model'})
         self.assertEqual(p.call_args[1]["headers"],
                          {'User-Agent': DEFAULT_TESTING_USER_AGENT})
+
+    def test_get_model_info(self):
+        """
+        Actual test for the get_model_info() method.
+        """
+        info = self.c.get_model_info("test")
+
+        self.assertTrue(isinstance(info, obspy.core.AttribDict))
+        # Check two random keys.
+        self.assertEqual(info.dump_type, "displ_only")
+        self.assertEqual(info.time_scheme, "newmark2")
+        # Check that both arrays have been converted to numpy arrays.
+        self.assertTrue(isinstance(info.slip, np.ndarray))
+        self.assertTrue(isinstance(info.sliprate, np.ndarray))
 
     def test_get_available_models_mock(self):
         with mock.patch("requests.get") as p:

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -184,6 +184,17 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["headers"],
                          {"User-Agent": DEFAULT_TESTING_USER_AGENT})
 
+    def test_error_handling_arguments(self):
+        # Floating points value
+        self.assertRaises(ValueError, self.c.get_waveforms, model="test",
+                          receiverlatitude="a")
+        # Int.
+        self.assertRaises(ValueError, self.c.get_waveforms, model="test",
+                          kernelwidth="a")
+        # Time.
+        self.assertRaises(TypeError, self.c.get_waveforms, model="test",
+                          origintime="a")
+
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')
 

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -14,7 +14,6 @@ import numpy as np
 import obspy
 from obspy.core.compatibility import mock
 from obspy.core.util.base import NamedTemporaryFile
-from obspy.core.util.misc import CatchOutput
 from obspy.clients.syngine import Client
 from obspy.clients.base import DEFAULT_TESTING_USER_AGENT, ClientHTTPException
 
@@ -92,23 +91,6 @@ class ClientTestCase(unittest.TestCase):
         # Check random key.
         self.assertEqual(models["ak135f_5s"]["components"],
                          "vertical and horizontal")
-
-    def test_print_model_information(self):
-        with mock.patch("requests.get") as p:
-            p.return_value = RequestsMockResponse()
-            p.return_value._json = {"a": "b"}
-
-            with CatchOutput() as out:
-                self.c.print_model_information()
-
-        self.assertEqual(out.stdout, b"{'a': 'b'}\n")
-
-        self.assertEqual(p.call_count, 1)
-        self.assertEqual(p.call_args[1]["url"],
-                         'http://service.iris.edu/irisws/syngine/1/models')
-        self.assertEqual(p.call_args[1]["params"], None)
-        self.assertEqual(p.call_args[1]["headers"],
-                         {'User-Agent': DEFAULT_TESTING_USER_AGENT})
 
     def test_get_service_version_mock(self):
         with mock.patch("requests.get") as p:

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -82,6 +82,16 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["headers"],
                          {'User-Agent': DEFAULT_TESTING_USER_AGENT})
 
+    def test_get_available_models(self):
+        models = self.c.get_available_models()
+        self.assertTrue(isinstance(models, dict))
+        keys = list(models.keys())
+        self.assertTrue(len(keys) > 3)
+        self.assertIn(keys, "ak135f_5s")
+        # Check random key.
+        self.assertEqual(models["ak135f_5s"]["components"],
+                         "vertical and horizontal")
+
     def test_print_model_information(self):
         with mock.patch("requests.get") as p:
             p.return_value = RequestsMockResponse()

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -443,9 +443,10 @@ class ClientTestCase(unittest.TestCase):
         # Same with bulk request.
         st_bulk = self.c.get_waveforms_bulk(
                 model="test", bulk=[("IU", "ANMO")],
-                eventid="GCMT:C201002270634A", components="Z",
-                format="saczip")
+                eventid="GCMT:C201002270634A", starttime="P-10",
+                endtime="P+10", components="Z", format="saczip")
         self.assertEqual(len(st_bulk), 1)
+
         self.assertEqual(st, st_bulk)
 
 def suite():

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -356,6 +356,33 @@ class ClientTestCase(unittest.TestCase):
             "12 13.1 LOCCODE=00",
             "12 13.1 NETCODE=IU STACODE=ANMO LOCCODE=00\n"]))
 
+    def test_get_waveforms(self):
+        """
+        Test get_waveforms() by actually downloading some things.
+
+        Use the 'test' model which does not produce useful seismograms but
+        is quick to test.
+        """
+        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+                                  eventid="GCMT:C201002270634A",
+                                  components="Z")
+        self.assertEqual(len(st), 1)
+
+        # Test phase relative times. This tests that everything is correctly
+        # encoded and what not.
+        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+                                  eventid="GCMT:C201002270634A",
+                                  starttime="P-10", endtime="P+20",
+                                  components="Z")
+        self.assertEqual(len(st), 1)
+
+        # One last test to test a source mechanism
+        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+                                  sourcemomenttensor=[1, 2, 3, 4, 5, 6],
+                                  sourcelatitude=10, sourcelongitude=20,
+                                  sourcedepthinmeters=100,
+                                  components="Z")
+        self.assertEqual(len(st), 1)
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -195,6 +195,49 @@ class ClientTestCase(unittest.TestCase):
         self.assertRaises(TypeError, self.c.get_waveforms, model="test",
                           origintime="a")
 
+    def test_source_mechanisms_mock(self):
+        r = RequestsMockResponse()
+        with io.BytesIO() as buf:
+            obspy.read()[0].write(buf, format="mseed")
+            buf.seek(0, 0)
+            r.content = buf.read()
+
+        with mock.patch("requests.get") as p:
+            p.return_value = r
+            st = self.c.get_waveforms(model="ak135f_5s",
+                                      sourcemomenttensor=[1, 2, 3, 4, 5, 6])
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         "http://service.iris.edu/irisws/syngine/1/query")
+        self.assertEqual(p.call_args[1]["params"], {
+            "model": "ak135f_5s",
+            "format": "miniseed",
+            "sourcemomenttensor": "1,2,3,4,5,6"})
+
+        with mock.patch("requests.get") as p:
+            p.return_value = r
+            st = self.c.get_waveforms(model="ak135f_5s",
+                                      sourcedoublecouple=[1, 2, 3, 4])
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         "http://service.iris.edu/irisws/syngine/1/query")
+        self.assertEqual(p.call_args[1]["params"], {
+            "model": "ak135f_5s",
+            "format": "miniseed",
+            "sourcedoublecouple": "1,2,3,4"})
+
+        with mock.patch("requests.get") as p:
+            p.return_value = r
+            st = self.c.get_waveforms(model="ak135f_5s",
+                                      sourceforce=[3.32, 4.23, 5.11])
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         "http://service.iris.edu/irisws/syngine/1/query")
+        self.assertEqual(p.call_args[1]["params"], {
+            "model": "ak135f_5s",
+            "format": "miniseed",
+            "sourceforce": "3.32,4.23,5.11"})
+
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')
 

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -24,6 +24,7 @@ class RequestsMockResponse(object):
         self.content = b""
         self.status_code = 200
         self._json = {}
+
     def json(self):
         return self._json
 
@@ -204,8 +205,8 @@ class ClientTestCase(unittest.TestCase):
 
         with mock.patch("requests.get") as p:
             p.return_value = r
-            st = self.c.get_waveforms(model="ak135f_5s",
-                                      sourcemomenttensor=[1, 2, 3, 4, 5, 6])
+            self.c.get_waveforms(model="ak135f_5s",
+                                 sourcemomenttensor=[1, 2, 3, 4, 5, 6])
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[0][0],
                          "http://service.iris.edu/irisws/syngine/1/query")
@@ -216,8 +217,8 @@ class ClientTestCase(unittest.TestCase):
 
         with mock.patch("requests.get") as p:
             p.return_value = r
-            st = self.c.get_waveforms(model="ak135f_5s",
-                                      sourcedoublecouple=[1, 2, 3, 4])
+            self.c.get_waveforms(model="ak135f_5s",
+                                 sourcedoublecouple=[1, 2, 3, 4])
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[0][0],
                          "http://service.iris.edu/irisws/syngine/1/query")
@@ -228,8 +229,8 @@ class ClientTestCase(unittest.TestCase):
 
         with mock.patch("requests.get") as p:
             p.return_value = r
-            st = self.c.get_waveforms(model="ak135f_5s",
-                                      sourceforce=[3.32, 4.23, 5.11])
+            self.c.get_waveforms(model="ak135f_5s",
+                                 sourceforce=[3.32, 4.23, 5.11])
         self.assertEqual(p.call_count, 1)
         self.assertEqual(p.call_args[0][0],
                          "http://service.iris.edu/irisws/syngine/1/query")
@@ -237,6 +238,7 @@ class ClientTestCase(unittest.TestCase):
             "model": "ak135f_5s",
             "format": "miniseed",
             "sourceforce": "3.32,4.23,5.11"})
+
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -15,7 +15,7 @@ import obspy
 from obspy.core.compatibility import mock
 from obspy.core.util.misc import CatchOutput
 from obspy.clients.syngine import Client
-from obspy.clients.base import DEFAULT_TESTING_USER_AGENT
+from obspy.clients.base import DEFAULT_TESTING_USER_AGENT, ClientHTTPException
 
 BASE_URL = "http://service.iris.edu/irisws/syngine/1"
 
@@ -264,6 +264,21 @@ class ClientTestCase(unittest.TestCase):
             "model": "ak135f_5s",
             "format": "miniseed",
             "sourceforce": "3.32,4.23,5.11"})
+
+    def test_error_handling(self):
+        """
+        Tests the error handling. The clients just passes on most things to
+        syngine and relies on the service for the error detection.
+        """
+        # Wrong components.
+        with self.assertRaises(ClientHTTPException) as cm:
+            self.c.get_waveforms(
+                model="ak135f_5s", eventid="GCMT:C201002270634A",
+                station="ANMO", network="IU", components="ABC")
+
+        msg = cm.exception.args[0]
+        self.assertIn("HTTP code 400 when", msg)
+        self.assertIn("Unrecognized component", msg)
 
 
 def suite():

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -358,7 +358,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_get_waveforms(self):
         """
-        Test get_waveforms() by actually downloading some things.
+        Test get_waveforms() and get_waveforms_bulk() by actually downloading
+        some things.
 
         Use the 'test' model which does not produce useful seismograms but
         is quick to test.
@@ -367,6 +368,13 @@ class ClientTestCase(unittest.TestCase):
                                   eventid="GCMT:C201002270634A",
                                   components="Z")
         self.assertEqual(len(st), 1)
+        # Download exactly the same with a bulk request and check the result
+        # is the same!
+        st_bulk = self.c.get_waveforms_bulk(
+                model="test", bulk=[("IU", "ANMO")],
+                eventid="GCMT:C201002270634A", components="Z")
+        self.assertEqual(len(st_bulk), 1)
+        self.assertEqual(st, st_bulk)
 
         # Test phase relative times. This tests that everything is correctly
         # encoded and what not.
@@ -375,6 +383,12 @@ class ClientTestCase(unittest.TestCase):
                                   starttime="P-10", endtime="P+20",
                                   components="Z")
         self.assertEqual(len(st), 1)
+        st_bulk = self.c.get_waveforms_bulk(
+                model="test", bulk=[("IU", "ANMO")],
+                starttime="P-10", endtime="P+20",
+                eventid="GCMT:C201002270634A", components="Z")
+        self.assertEqual(len(st_bulk), 1)
+        self.assertEqual(st, st_bulk)
 
         # One last test to test a source mechanism
         st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
@@ -383,6 +397,15 @@ class ClientTestCase(unittest.TestCase):
                                   sourcedepthinmeters=100,
                                   components="Z")
         self.assertEqual(len(st), 1)
+        st_bulk = self.c.get_waveforms_bulk(
+                model="test", bulk=[("IU", "ANMO")],
+                sourcemomenttensor=[1, 2, 3, 4, 5, 6],
+                sourcelatitude=10, sourcelongitude=20,
+                sourcedepthinmeters=100,
+                components="Z")
+        self.assertEqual(len(st_bulk), 1)
+        self.assertEqual(st, st_bulk)
+
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -321,13 +321,17 @@ class ClientTestCase(unittest.TestCase):
             p.side_effect = side_effect
             self.c.get_waveforms_bulk(
                     model="ak135f_5s", bulk=[
-                        {"netcode": "IU", "stacode": "ANMO"},
+                        {"networkcode": "IU", "stationcode": "ANMO"},
                         {"latitude": 12, "longitude": 13.1},
-                        {"latitude": 12, "longitude": 13.1, "netcode": "IU"},
-                        {"latitude": 12, "longitude": 13.1, "stacode": "ANMO"},
-                        {"latitude": 12, "longitude": 13.1, "loccode": "00"},
-                        {"latitude": 12, "longitude": 13.1, "netcode": "IU",
-                         "stacode": "ANMO", "loccode": "00"}],
+                        {"latitude": 12, "longitude": 13.1,
+                         "networkcode": "IU"},
+                        {"latitude": 12, "longitude": 13.1,
+                         "stationcode": "ANMO"},
+                        {"latitude": 12, "longitude": 13.1,
+                         "locationcode": "00"},
+                        {"latitude": 12, "longitude": 13.1,
+                         "networkcode": "IU", "stationcode": "ANMO",
+                         "locationcode": "00"}],
                     format="miniseed", eventid="GCMT:C201002270634A")
 
         self.assertEqual(payload[0], "\n".join([

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -5,6 +5,7 @@ The obspy.clients.syngine test suite.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
+from future.utils import native_str
 
 import io
 import unittest
@@ -158,12 +159,12 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "components": "Z",
-            "endtime": 1800.0,
-            "eventid": "GCMT:M110302J",
-            "format": "miniseed",
-            "model": "ak135f_5s",
-            "network": "_GSN"})
+            "components": native_str("Z"),
+            "endtime": native_str(1800.0),
+            "eventid": native_str("GCMT:M110302J"),
+            "format": native_str("miniseed"),
+            "model": native_str("ak135f_5s"),
+            "network": native_str("_GSN")})
         self.assertEqual(p.call_args[1]["headers"],
                          {"User-Agent": DEFAULT_TESTING_USER_AGENT})
 
@@ -184,13 +185,13 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "components": "Z",
-            "starttime": "P-10",
-            "endtime": "ScS+60",
-            "eventid": "GCMT:M110302J",
-            "format": "miniseed",
-            "model": "ak135f_5s",
-            "network": "_GSN"})
+            "components": native_str("Z"),
+            "starttime": native_str("P-10"),
+            "endtime": native_str("ScS+60"),
+            "eventid": native_str("GCMT:M110302J"),
+            "format": native_str("miniseed"),
+            "model": native_str("ak135f_5s"),
+            "network": native_str("_GSN")})
         self.assertEqual(p.call_args[1]["headers"],
                          {"User-Agent": DEFAULT_TESTING_USER_AGENT})
 
@@ -220,8 +221,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": "ak135f_5s",
-            "format": "miniseed",
+            "model": native_str("ak135f_5s"),
+            "format": native_str("miniseed"),
             "sourcemomenttensor": "1,2,3,4,5,6"})
 
         with mock.patch("requests.get") as p:
@@ -232,8 +233,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": "ak135f_5s",
-            "format": "miniseed",
+            "model": native_str("ak135f_5s"),
+            "format": native_str("miniseed"),
             "sourcedoublecouple": "1,2,3,4"})
 
         with mock.patch("requests.get") as p:
@@ -244,8 +245,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": "ak135f_5s",
-            "format": "miniseed",
+            "model": native_str("ak135f_5s"),
+            "format": native_str("miniseed"),
             "sourceforce": "3.32,4.23,5.11"})
 
     def test_error_handling(self):

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+The obspy.clients.syngine test suite.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA @UnusedWildImport
+
+import unittest
+
+from obspy.core.compatibility import mock
+from obspy.clients.syngine import Client
+from obspy.clients.base import DEFAULT_TESTING_USER_AGENT
+
+BASE_URL = "http://service.iris.edu/irisws/syngine/1"
+
+
+class RequestsMockResponse(object):
+    def __init__(self):
+        self.text = ""
+        self.content = b""
+        self.status_code = 200
+        self._json = {}
+    def json(self):
+        return self._json
+
+
+class ClientTestCase(unittest.TestCase):
+    """
+    Test cases for obspy.clients.iris.client.Client.
+    """
+    c = Client(user_agent=DEFAULT_TESTING_USER_AGENT)
+
+    def test_get_model_info_mock(self):
+        """
+        Mock test for the get_model_info() method.
+        """
+        with mock.patch("requests.get") as p:
+            r = RequestsMockResponse()
+            r._json["slip"] = [0.0, 1.0, 2.0]
+            r._json["sliprate"] = [0.0, 1.0, 2.0]
+            p.return_value = r
+            self.c.get_model_info("test_model")
+
+        self.assertEqual(p.call_count, 1)
+        self.assertEqual(p.call_args[0][0],
+                         'http://service.iris.edu/irisws/syngine/1/info')
+        self.assertEqual(p.call_args[1]["params"],
+                         {'model': 'test_model'})
+        self.assertEqual(p.call_args[1]["headers"],
+                         {'User-Agent': DEFAULT_TESTING_USER_AGENT})
+
+
+def suite():
+    return unittest.makeSuite(ClientTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -321,7 +321,7 @@ class ClientTestCase(unittest.TestCase):
             p.side_effect = side_effect
             self.c.get_waveforms_bulk(
                     model="ak135f_5s", bulk=[
-                        {"networkcode": "IU", "stationcode": "ANMO"},
+                        {"network": "IU", "station": "ANMO"},
                         {"latitude": 12, "longitude": 13.1},
                         {"latitude": 12, "longitude": 13.1,
                          "networkcode": "IU"},

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -41,7 +41,7 @@ DEFAULT_MODULES = ['clients.filesystem', 'core', 'db', 'geodetics', 'imaging',
                    'signal', 'taup']
 NETWORK_MODULES = ['clients.arclink', 'clients.earthworm', 'clients.fdsn',
                    'clients.iris', 'clients.neic', 'clients.seedlink',
-                   'clients.seishub']
+                   'clients.seishub', 'clients.syngine']
 ALL_MODULES = DEFAULT_MODULES + NETWORK_MODULES
 
 # default order of automatic format detection

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ INSTALL_REQUIRES = [
     'lxml',
     'setuptools',
     'sqlalchemy',
-    'decorator']
+    'decorator',
+    'requests']
 EXTRAS_REQUIRE = {
     'tests': ['flake8>=2', 'pyimgur'],
     'arclink': ['m2crypto'],


### PR DESCRIPTION
This PR adds a new client `obspy.clients.syngine` to provide an interface with the [IRIS Syngine](http://service.iris.edu/irisws/syngine/1) service. It supports the full service including GET and POST requests and corresponding ObsPy methods.

Tests should be fairly comprehensive and are mix of mock and actual network tests that download stuff.

### Usage Examples

```python
>>> from obspy.clients.syngine import Client
>>> client = Client()

>>> st = client.get_waveforms(model="ak135f_5s", network="IU", station="ANMO",
                              eventid="GCMT:C201002270634A")
>>> print(st)
3 Trace(s) in Stream:
IU.ANMO.SE.MXZ | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
IU.ANMO.SE.MXN | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
```

```python
>>> bulk = [{"latitude": 10.1, "longitude": 12.2, "stacode": "AA"},
...         {"latitude": 14.5, "longitude": 10.0, "stacode": "BB"}]
>>> st = client.get_waveforms_bulk(
...     model="ak135f_5s", eventid="GCMT:C201002270634A",
...     bulk=bulk, starttime="P-10", endtime="P+20")
>>> print(st)  
6 Trace(s) in Stream:
XX.AA.SE.MXZ | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
XX.AA.SE.MXN | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
XX.AA.SE.MXE | 2010-02-27T06:48:11.500000Z - ... | 4.0 Hz, 120 samples
XX.BB.SE.MXZ | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
XX.BB.SE.MXN | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
XX.BB.SE.MXE | 2010-02-27T06:48:15.250000Z - ... | 4.0 Hz, 120 samples
```

### Additional Things

* This PR introduces a new dependency to ObsPy: The [requests](http://docs.python-requests.org) module. It is one of the most used Python modules and thus should prove no problem to packaging people. I think we should base all future (and potentially) existing HTTP clients on the `requests` library - it just makes things much simpler.
* (@jkmacc-LANL) It also continues ideas from #1212 and introduces two new mix-in classes `RemoteBaseClient` (a base class for all remote clients) and `HTTPClient` (a base class for all clients downloading over HTTP). The later also contains actual downloading methods so it does not have to be reimplemented in each client. The Syngine client is based on these.