### PR TITLE
test_waveform_plugins incompatible with custom plugins

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Martin van Driel
 Fabian Engels
 Sven Egdorf
 Laura Ermert
+Tom Eulenfeld
 Marc Grunberg
 Conny Hammer
 Sebastian Heimann
@@ -42,7 +43,6 @@ Bernhard Morgenstern
 Nathaniel C. Miller
 Mark P. Panning
 Celso Reyes
-Tom Richter
 Adam Ringler
 Nicolas Rothenhäusler
 Emiliano Russo

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -56,7 +56,8 @@ class WaveformPluginsTestCase(unittest.TestCase):
             if format in ['SEGY', 'SU', 'SEG2']:
                 continue
             for native_byteorder in ['<', '>']:
-                for byteorder in ['<', '>', '=']:
+                for byteorder in (['<', '>', '='] if format in
+                                  WAVEFORM_ACCEPT_BYTEORDER else [None]):
                     if format == 'SAC' and byteorder == '=':
                         # SAC file format enforces '<' or '>'
                         # byteorder on writing
@@ -77,11 +78,11 @@ class WaveformPluginsTestCase(unittest.TestCase):
                     # create waveform file with given format and byte order
                     with NamedTemporaryFile() as tf:
                         outfile = tf.name
-                        if format in WAVEFORM_ACCEPT_BYTEORDER:
+                        if byteorder is None:
+                            tr.write(outfile, format=format)
+                        else:
                             tr.write(outfile, format=format,
                                      byteorder=byteorder)
-                        else:
-                            tr.write(outfile, format=format)
                         if format == 'Q':
                             outfile += '.QHD'
                         # read in again using auto detection
@@ -146,8 +147,6 @@ class WaveformPluginsTestCase(unittest.TestCase):
                         self.assertEqual(st[0].id, ".MANZ1..EHE")
                     elif format not in ['WAV']:
                         self.assertEqual(st[0].id, "BW.MANZ1.00.EHE")
-                    if format not in WAVEFORM_ACCEPT_BYTEORDER:
-                        break
 
     def test_isFormat(self):
         """

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -166,9 +166,9 @@ class WaveformPluginsTestCase(unittest.TestCase):
         paths = {}
         all_paths = []
         for f in formats:
-            sep = os.path.sep
-            path = f.dist.location + sep + f.module_name.replace('.', sep)
-            path = path.rsplit(sep, 1)[0] + sep + 'tests' + sep + 'data'
+            path = os.path.join(f.dist.location,
+                                *f.module_name.split('.')[:-1])
+            path = os.path.join(path, 'tests', 'data')
             all_paths.append(path)
             if os.path.exists(path):
                 paths[f.name] = path

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -166,9 +166,9 @@ class WaveformPluginsTestCase(unittest.TestCase):
         paths = {}
         all_paths = []
         for f in formats:
-            path = f.dist.location + '.' + f.module_name
-            path = path.rsplit('.', 1)[0] + '.tests.data'
-            path = path.replace('.', os.path.sep)
+            sep = os.path.sep
+            path = f.dist.location + sep + f.module_name.replace('.', sep)
+            path = path.rsplit(sep, 1)[0] + sep + 'tests' + sep + 'data'
             all_paths.append(path)
             if os.path.exists(path):
                 paths[f.name] = path

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -164,13 +164,16 @@ class WaveformPluginsTestCase(unittest.TestCase):
         formats = list(formats_ep.values())
         # Get all the test directories.
         paths = {}
+        all_paths = []
         for f in formats:
             path = f.dist.location + '.' + f.module_name
             path = path.rsplit('.', 1)[0] + '.tests.data'
             path = path.replace('.', os.path.sep)
+            all_paths.append(path)
             if os.path.exists(path):
                 paths[f.name] = path
-        self.assertTrue(len(paths) > 0)
+        msg = 'Test data directories do not exist:\n    '
+        self.assertTrue(len(paths) > 0, msg + '\n    '.join(all_paths))
         # Collect all false positives.
         false_positives = []
         # Big loop over every format.

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -16,7 +16,8 @@ import numpy as np
 
 from obspy import Trace, read
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util.base import NamedTemporaryFile, _get_entry_points
+from obspy.core.util.base import (NamedTemporaryFile, _get_entry_points,
+                                  WAVEFORM_ACCEPT_BYTEORDER)
 
 
 class WaveformPluginsTestCase(unittest.TestCase):
@@ -76,7 +77,11 @@ class WaveformPluginsTestCase(unittest.TestCase):
                     # create waveform file with given format and byte order
                     with NamedTemporaryFile() as tf:
                         outfile = tf.name
-                        tr.write(outfile, format=format, byteorder=byteorder)
+                        if format in WAVEFORM_ACCEPT_BYTEORDER:
+                            tr.write(outfile, format=format,
+                                     byteorder=byteorder)
+                        else:
+                            tr.write(outfile, format=format)
                         if format == 'Q':
                             outfile += '.QHD'
                         # read in again using auto detection
@@ -141,6 +146,8 @@ class WaveformPluginsTestCase(unittest.TestCase):
                         self.assertEqual(st[0].id, ".MANZ1..EHE")
                     elif format not in ['WAV']:
                         self.assertEqual(st[0].id, "BW.MANZ1.00.EHE")
+                    if format not in WAVEFORM_ACCEPT_BYTEORDER:
+                        break
 
     def test_isFormat(self):
         """

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -162,6 +162,15 @@ class WaveformPluginsTestCase(unittest.TestCase):
         ]
         formats_ep = _get_entry_points('obspy.plugin.waveform', 'isFormat')
         formats = list(formats_ep.values())
+        # Get all the test directories.
+        paths = {}
+        for f in formats:
+            path = f.dist.location + '.' + f.module_name
+            path = path.rsplit('.', 1)[0] + '.tests.data'
+            path = path.replace('.', os.path.sep)
+            if os.path.exists(path):
+                paths[f.name] = path
+        self.assertTrue(len(paths) > 0)
         # Collect all false positives.
         false_positives = []
         # Big loop over every format.
@@ -170,17 +179,9 @@ class WaveformPluginsTestCase(unittest.TestCase):
             is_format = load_entry_point(
                 format.dist.key, 'obspy.plugin.waveform.' + format.name,
                 'isFormat')
-            # get all the test directories.
-            paths = [os.path.join(f.dist.location, 'obspy',
-                                  f.module_name.split('.')[1], 'tests', 'data')
-                     for f in formats
-                     if f.module_name.split('.')[1] !=
-                     format.module_name.split('.')[1]]
-            # Remove double paths because some modules can have two file
-            # formats.
-            paths = set(paths)
-            # Remove path if one module defines two file formats.
-            for path in paths:
+            for f, path in paths.items():
+                if format.name in paths and paths[f] == paths[format.name]:
+                    continue
                 # Collect all files found.
                 filelist = []
                 # Walk every path.

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -50,6 +50,8 @@ WAVEFORM_PREFERRED_ORDER = ['MSEED', 'SAC', 'GSE2', 'SEISAN', 'SACXY', 'GSE1',
                             'SEGY', 'SU', 'SEG2', 'WAV', 'DATAMARK', 'CSS',
                             'AH', 'PDAS', 'KINEMETRICS_EVT']
 EVENT_PREFERRED_ORDER = ['QUAKEML', 'NLLOC_HYP']
+# waveform plugins accepting a byteorder keyword
+WAVEFORM_ACCEPT_BYTEORDER = ['MSEED', 'Q', 'SAC', 'SEGY', 'SU']
 
 _sys_is_le = sys.byteorder == 'little'
 NATIVE_BYTEORDER = _sys_is_le and '<' or '>'


### PR DESCRIPTION
Custom I/O plugins register differently than native obspy.io plugins. E.g. obspyh5 registers itself with:
```
ENTRY_POINTS = {
    'obspy.plugin.waveform': ['H5 = obspyh5'],
    'obspy.plugin.waveform.H5': [
        'isFormat = obspyh5:is_obspyh5',
        'readFormat = obspyh5:readh5',
        'writeFormat = obspyh5:writeh5']}
```
The problem: test_isFormat assumes plugins to be a submodule of some other module.
Besides, plugins have to accept a `byteorder` keyword to get the  test_readAndWrite() pass.
Here is the output of `python test_waveform_plugins.py` after installing h5py and obspyh5 (`pip install obspyh5`):

```
======================================================================
ERROR: test_isFormat (__main__.WaveformPluginsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_waveform_plugins.py", line 170, in test_isFormat
    if f.module_name.split('.')[1] !=
IndexError: list index out of range

======================================================================
ERROR: test_readAndWrite (__main__.WaveformPluginsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_waveform_plugins.py", line 79, in test_readAndWrite
    tr.write(outfile, format=format, byteorder=byteorder)
  File "/home/richter/dev/obspy/obspy/core/trace.py", line 891, in write
    Stream([self]).write(filename, format, **kwargs)
  File "/home/richter/dev/obspy/obspy/core/stream.py", line 1427, in write
    write_format(self, filename, **kwargs)
  File "/home/richter/dev/obspyh5/obspyh5.py", line 193, in writeh5
    trace2group(tr, group, headonly=headonly, **kwargs)
  File "/home/richter/dev/obspyh5/obspyh5.py", line 225, in trace2group
    trace.data.dtype, **kwargs)
  File "/home/richter/anaconda/envs/obspydev/lib/python2.7/site-packages/h5py/_hl/group.py", line 103, in create_dataset
    dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)
TypeError: make_new_dset() got an unexpected keyword argument 'byteorder'
```

