### PR TITLE
Remove 0.10 deprecations

### DIFF
--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -26,7 +26,6 @@ import numpy as np
 from obspy import UTCDateTime, read
 from obspy.core.util import AttribDict, complexify_string
 from obspy.core.util.decorator import deprecated
-from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 
 
 DCID_KEY_FILE = os.path.join(os.getenv('HOME') or '', 'dcidpasswords.txt')
@@ -38,10 +37,6 @@ _INVENTORY_NS_1_0 = "http://geofon.gfz-potsdam.de/ns/Inventory/1.0/"
 _INVENTORY_NS_0_2 = "http://geofon.gfz-potsdam.de/ns/inventory/0.2/"
 
 MSG_NOPAZ = "No Poles and Zeros information returned by server."
-
-MSG_USER_REQUIRED = """Initializing a ArcLink client without the user keyword
-is deprecated! Please provide a proper user identification string such as your
-email address. Defaulting to 'ObsPy client' for now."""
 
 
 class ArcLinkException(Exception):
@@ -110,7 +105,7 @@ class Client(object):
     """
     max_status_requests = MAX_REQUESTS
 
-    def __init__(self, host="webdc.eu", port=18002, user=None,
+    def __init__(self, user, host="webdc.eu", port=18002,
                  password="", institution="Anonymous", timeout=20,
                  dcid_keys={}, dcid_key_file=None, debug=False,
                  command_delay=0, status_delay=0.5):
@@ -119,11 +114,7 @@ class Client(object):
 
         See :class:`obspy.clients.arclink.client.Client` for all parameters.
         """
-        if user is None:
-            warnings.warn(MSG_USER_REQUIRED, category=ObsPyDeprecationWarning)
-            self.user = 'ObsPy client'
-        else:
-            self.user = user
+        self.user = user
         self.password = password
         self.institution = institution
         self.command_delay = command_delay

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from obspy import UTCDateTime, read
 from obspy.core.util import AttribDict, complexify_string
-from obspy.core.util.decorator import deprecated_keywords, deprecated
+from obspy.core.util.decorator import deprecated
 from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 
 
@@ -393,7 +393,7 @@ class Client(object):
 
     def get_waveforms(self, network, station, location, channel, starttime,
                       endtime, format="MSEED", compressed=True, metadata=False,
-                      route=True, **kwargs):
+                      route=True):
         """
         Retrieves waveform data via ArcLink and returns an ObsPy Stream object.
 
@@ -443,13 +443,8 @@ class Client(object):
             st = client.get_waveforms("BW", "RJOB", "", "EH*", t - 3, t + 15)
             st.plot()
         """
-        if kwargs.get('get_paz') or kwargs.get('getCoordinates'):
-            msg = "Keywords get_paz and getCoordinates are deprecated. " + \
-                  "Please use keyword metadata instead."
-            warnings.warn(msg, ObsPyDeprecationWarning)
         # handle deprecated keywords - one must be True to enable metadata
-        metadata = metadata or kwargs.get('get_paz', False) or \
-            kwargs.get('getCoordinates', False)
+        metadata = metadata
         file_stream = io.BytesIO()
         self.save_waveforms(file_stream, network, station, location, channel,
                             starttime, endtime, format=format,
@@ -776,9 +771,8 @@ class Client(object):
     def getMetadata(self, *args, **kwargs):
         return self.get_metadata(*args, **kwargs)
 
-    @deprecated_keywords({'get_paz': None, 'getCoordinates': None})
-    def get_metadata(self, network, station, location, channel, starttime=None,
-                     endtime=None, time=None, route=True):
+    def get_metadata(self, network, station, location, channel, time,
+                     route=True):
         """
         Returns poles, zeros, normalization factor and sensitivity and station
         coordinates for a single channel at a given time.
@@ -815,17 +809,7 @@ class Client(object):
         'coordinates': AttribDict({'latitude': 49.9862, 'elevation': 635.0,
                                    'longitude': 12.1083})}
         """
-        # XXX: deprecation handling
-        if starttime and endtime:
-            # warn if old scheme
-            msg = "The 'starttime' and 'endtime' keywords will be " + \
-                "deprecated. Please use 'time' instead."
-            warnings.warn(msg, category=ObsPyDeprecationWarning)
-        elif starttime and not endtime:
-            # use a single starttime as time keyword
-            time = starttime
-            endtime = time + 0.00001
-        elif not time:
+        if not time:
             # if not temporal keyword is given raise an exception
             raise ValueError("keyword 'time' is required")
         else:
@@ -936,8 +920,8 @@ class Client(object):
     def getPAZ(self, *args, **kwargs):
         return self.get_paz(*args, **kwargs)
 
-    def get_paz(self, network, station, location, channel, starttime=None,
-                endtime=None, time=None, route=True):
+    def get_paz(self, network, station, location, channel, time,
+                route=True):
         """
         Returns poles, zeros, normalization factor and sensitivity for a
         single channel at a given time.
@@ -972,18 +956,7 @@ class Client(object):
                     'name': 'LMU:STS-2/N/g=1500',
                     'normalization_factor': 60077000.0})
         """
-        # XXX: deprecation handling
-        if starttime and endtime:
-            # warn if old scheme
-            msg = "The 'starttime' and 'endtime' keywords will be " + \
-                "deprecated. Please use 'time' instead. Be aware that the" + \
-                "result of get_paz() will differ using the 'time' keyword."
-            warnings.warn(msg, category=ObsPyDeprecationWarning)
-        elif starttime and not endtime:
-            # use a single starttime as time keyword
-            time = starttime
-            endtime = time + 0.00001
-        elif not time:
+        if not time:
             # if not temporal keyword is given raise an exception
             raise ValueError("keyword 'time' is required")
         else:

--- a/obspy/clients/seedlink/slpacket.py
+++ b/obspy/clients/seedlink/slpacket.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from obspy.core.compatibility import from_buffer
 from obspy.core.trace import Trace
-from obspy.core.util.decorator import deprecated_keywords
 from obspy.io.mseed.headers import clibmseed
 from obspy.io.mseed.util import (_convert_msr_to_dict,
                                  _ctypes_array_2_numpy_array,
@@ -73,7 +72,6 @@ class SLPacket(object):
     ERRORSIGNATURE = b"ERROR\r\n"
     ENDSIGNATURE = b"END"
 
-    @deprecated_keywords({'bytes': 'data'})
     def __init__(self, data=None, offset=None):
         if data is None or offset is None:
             return

--- a/obspy/clients/seishub/tests/test_client.py
+++ b/obspy/clients/seishub/tests/test_client.py
@@ -15,7 +15,6 @@ with standard_library.hooks():
 
 from obspy.core import AttribDict, UTCDateTime
 from obspy.clients.seishub import Client
-from obspy.io.xseed.utils import SEEDParserException
 
 
 TESTSERVER = "http://teide.geophysik.uni-muenchen.de:8080"
@@ -245,27 +244,6 @@ class ClientTestCase(unittest.TestCase):
                              'elevation': 500.0,
                              'longitude': 11.636093000000001})
         self.assertEqual(st[0].stats.coordinates, result)
-
-    def test_get_paz_call_change(self):
-        t = UTCDateTime("2012-05-10")
-        c = self.client
-        datas = []
-        result = AttribDict(
-            {'gain': 1.0, 'poles': [0j],
-             'sensitivity': 6319100000000.0, 'digitizer_gain': 1000000.0,
-             'seismometer_gain': 6319100.0, 'zeros': [0j]})
-        # test that the old/deprecated call syntax is still working
-        self.assertRaises(SEEDParserException, c.station.get_paz, "BW", "RLAS",
-                          t)
-        datas.append(c.station.get_paz("BW", "RLAS", t, "", "BJZ"))
-        datas.append(c.station.get_paz("BW", "RLAS", t, "", channel="BJZ"))
-        datas.append(c.station.get_paz("BW", "RLAS", t, location="",
-                                       channel="BJZ"))
-        datas.append(c.station.get_paz("BW", "RLAS", t, channel="BJZ",
-                                       location=""))
-        datas.append(c.station.get_paz("BW", "RLAS", t, channel="BJZ"))
-        for data in datas:
-            self.assertEqual(data, result)
 
     def test_localcache(self):
         """

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -34,9 +34,8 @@ from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
                                   _read_from_plugin)
-from obspy.core.util.decorator import (deprecated_keywords, deprecated,
-                                       map_example_filename, raise_if_masked,
-                                       uncompress_file)
+from obspy.core.util.decorator import (deprecated, map_example_filename,
+                                       raise_if_masked, uncompress_file)
 from obspy.core.util.misc import get_window_times
 
 
@@ -2322,7 +2321,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         return [tr.max() for tr in self]
 
-    @deprecated_keywords({'type': 'method'})
     def differentiate(self, method='gradient'):
         """
         Differentiate all traces with respect to time.
@@ -2353,7 +2351,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             tr.differentiate(method=method)
         return self
 
-    @deprecated_keywords({'type': 'method'})
     def integrate(self, method='cumtrapz', **options):
         """
         Integrate all traces with respect to time.

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2075,7 +2075,7 @@ class StreamTestCase(unittest.TestCase):
         st = read()
         p = Parser("/path/to/dataless.seed.BW_RJOB")
         kwargs = dict(seedresp={'filename': p, 'units': "DIS"},
-                      pre_filt=(1, 2, 50, 60), waterlevel=60)
+                      pre_filt=(1, 2, 50, 60), water_level=60)
         st.simulate(**kwargs)
         for tr in st:
             tr.stats.processing.pop()

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -26,8 +26,7 @@ from obspy.core import compatibility
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict, create_empty_data_chunk
 from obspy.core.util.base import _get_function_from_entry_point
-from obspy.core.util.decorator import (deprecated_keywords, raise_if_masked,
-                                       skip_if_no_data)
+from obspy.core.util.decorator import raise_if_masked, skip_if_no_data
 from obspy.core.util.misc import flat_not_masked_contiguous, get_window_times
 
 
@@ -1780,7 +1779,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         return self.data.std()
 
     @skip_if_no_data
-    @deprecated_keywords({'type': 'method'})
     @_add_processing_info
     def differentiate(self, method='gradient', **options):
         """
@@ -1816,7 +1814,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         return self
 
     @skip_if_no_data
-    @deprecated_keywords({'type': 'method'})
     @_add_processing_info
     def integrate(self, method="cumtrapz", **options):
         """

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -26,8 +26,6 @@ from subprocess import STDOUT, CalledProcessError, check_output
 
 import numpy as np
 
-from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
-
 
 # The following dictionary maps the first character of the channel_id to the
 # lowest sampling rate this so called Band Code should be used for according
@@ -262,121 +260,6 @@ def get_untracked_files_from_git():
     except (OSError, CalledProcessError):
         return None
     return files
-
-
-def wrap_long_string(string, line_length=79, prefix="",
-                     special_first_prefix=None, assumed_tab_width=8,
-                     sloppy=False):
-    """
-    Reformat a long string, wrapping it to a specified length.
-
-    :type string: str
-    :param string: Input string to wrap
-    :type line_length: int
-    :param line_length: total target length of each line, including the
-        prefix if specified
-    :type prefix: str, optional
-    :param prefix: common prefix used to start the line (e.g. some spaces,
-        tabs for indentation)
-    :type special_first_prefix: str, optional
-    :param special_first_prefix: special prefix to use on the first line,
-        instead of the general prefix
-    :type assumed_tab_width: int
-    :param assumed_tab_width: if the prefix strings include tabs the line
-        length can not be computed exactly. assume a tab in general is
-        equivalent to this many spaces.
-    :type sloppy: bool
-    :param sloppy: Controls the behavior when a single word without spaces is
-        to long to fit on a single line. Default (False) is to allow a single
-        line to be longer than the specified line length. If set to True,
-        Long words will be force-hyphenated to fit the line.
-
-    .. deprecated:: 0.10.0
-        The wrap_long_string function is deprecated. Please use the textwrap
-        module from the standard library instead.
-
-    .. rubric:: Examples
-
-    >>> string = ("Retrieve an event based on the unique origin "
-    ...           "ID numbers assigned by the IRIS DMC")
-    >>> print(wrap_long_string(string, prefix="\t*\t > ",
-    ...                        line_length=50))  # doctest: +SKIP
-            *        > Retrieve an event based on
-            *        > the unique origin ID numbers
-            *        > assigned by the IRIS DMC
-    >>> print(wrap_long_string(string, prefix="\t* ",
-    ...                        line_length=70))  # doctest: +SKIP
-            * Retrieve an event based on the unique origin ID
-            * numbers assigned by the IRIS DMC
-    >>> print(wrap_long_string(string, prefix="\t \t  > ",
-    ...                        special_first_prefix="\t*\t",
-    ...                        line_length=50))  # doctest: +SKIP
-            *        Retrieve an event based on
-                     > the unique origin ID numbers
-                     > assigned by the IRIS DMC
-    >>> problem_string = ("Retrieve_an_event_based_on_the_unique "
-    ...                   "origin ID numbers assigned by the IRIS DMC")
-    >>> print(wrap_long_string(problem_string, prefix="\t\t",
-    ...                        line_length=40, sloppy=True))  # doctest: +SKIP
-                    Retrieve_an_event_based_on_the_unique
-                    origin ID
-                    numbers
-                    assigned by
-                    the IRIS DMC
-    >>> print(wrap_long_string(problem_string, prefix="\t\t",
-    ...                        line_length=40))  # doctest: +SKIP
-                    Retrieve_an_event_base\
-                    d_on_the_unique origin
-                    ID numbers assigned by
-                    the IRIS DMC
-    """
-
-    warnings.warn('The wrap_long_string function is deprecated. Please use '
-                  'the textwrap module from the standard library instead.',
-                  ObsPyDeprecationWarning)
-
-    def text_width_for_prefix(line_length, prefix):
-        text_width = line_length - len(prefix) - \
-            (assumed_tab_width - 1) * prefix.count("\t")
-        return text_width
-
-    lines = []
-    if special_first_prefix is not None:
-        text_width = text_width_for_prefix(line_length, special_first_prefix)
-    else:
-        text_width = text_width_for_prefix(line_length, prefix)
-
-    while len(string) > text_width:
-        ind = string.rfind(" ", 0, text_width)
-        # no suitable place to split found
-        if ind < 1:
-            # sloppy: search to right for space to split at
-            if sloppy:
-                ind = string.find(" ", text_width)
-                if ind == -1:
-                    ind = len(string) - 1
-                part = string[:ind]
-                string = string[ind + 1:]
-            # not sloppy: force hyphenate
-            else:
-                ind = text_width - 2
-                part = string[:ind] + "\\"
-                string = string[ind:]
-        # found a suitable place to split
-        else:
-            part = string[:ind]
-            string = string[ind + 1:]
-        # need to use special first line prefix?
-        if special_first_prefix is not None and not lines:
-            line = special_first_prefix + part
-        else:
-            line = prefix + part
-        lines.append(line)
-        # need to set default text width, just in case we had a different
-        # text width for the first line
-        text_width = text_width_for_prefix(line_length, prefix)
-    lines.append(prefix + string)
-    return "\n".join(lines)
 
 
 @contextmanager

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -33,7 +33,7 @@ import logging
 import multiprocessing
 import select
 import sys
-from argparse import SUPPRESS, ArgumentParser
+from argparse import ArgumentParser
 
 with standard_library.hooks():
     import http.server
@@ -42,7 +42,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm.session import sessionmaker
 
 from obspy import __version__
-from obspy.core.util.base import _get_deprecated_argument_action
 from obspy.db.db import Base
 from obspy.db.indexer import WaveformFileCrawler, worker
 from obspy.db.util import parse_mapping_data
@@ -243,25 +242,6 @@ Default path option is 'data=*.*'.""")
     parser.add_argument(
         '-p', '--port', type=int, default=0,
         help="Port number. If not given a free port will be picked.")
-
-    # Deprecated arguments
-    action = _get_deprecated_argument_action(
-        '--check_duplicates', '--check-duplicates', real_action='store_true')
-    parser.add_argument('--check_duplicates', nargs=0,
-                        action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action(
-        '--drop_database', '--drop-database', real_action='store_true')
-    parser.add_argument('--drop_database', nargs=0,
-                        action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action('--mapping_file',
-                                             '--mapping-file')
-    parser.add_argument('--mapping_file', action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action(
-        '--run_once', '--run-once', real_action='store_true')
-    parser.add_argument('--run_once', nargs=0, action=action, help=SUPPRESS)
 
     args = parser.parse_args(argv)
     # set level of verbosity

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -122,7 +122,8 @@ def _run_indexer(options):
             return
         # prepare map file
         if options.mapping_file:
-            data = open(options.mapping_file, 'r').readlines()
+            with open(options.mapping_file, 'r') as f:
+                data = f.readlines()
             mappings = parse_mapping_data(data)
             logging.info("Parsed %d lines from mapping file %s" %
                          (len(data), options.mapping_file))

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -4698,7 +4698,6 @@ def main(argv=None):
                               RawDescriptionHelpFormatter,
                               RawTextHelpFormatter,
                               SUPPRESS)
-        from obspy.core.util.base import _get_deprecated_argument_action
 
         parser = ArgumentParser(prog='obspy-mopad',
                                 formatter_class=RawDescriptionHelpFormatter,
@@ -4817,19 +4816,6 @@ The 'source mechanism' as a comma-separated list of length:
             action='store_true',
             help='if isotropic part shall be considered for plotting '
                  '[%(default)s]')
-
-        # Deprecated arguments
-
-        action = _get_deprecated_argument_action('--show_1fp', '--show-1fp')
-        group_show.add_argument(
-            '--show_1fp', dest='GMT_show_1FP', action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--show_isotropic_part', '--show-isotropic-part',
-            real_action='store_true')
-        group_show.add_argument(
-            '--show_isotropic_part', dest='GMT_plot_isotropic_part', nargs=0,
-            action=action, help=SUPPRESS)
 
         parser_gmt.set_defaults(call=_call_gmt, build=_build_gmt_dict)
 
@@ -4986,68 +4972,6 @@ The 'source mechanism' as a comma-separated list of length:
             help='if isotropic part shall be considered for plotting '
                  '[%(default)s]')
 
-        # Deprecated arguments
-        action = _get_deprecated_argument_action(
-            '--basis_vectors', '--basis-vectors', real_action='store_true')
-        group_misc.add_argument(
-            '--basis_vectors', dest='plot_show_basis_axes', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--full_sphere', '--full-sphere', real_action='store_true')
-        group_misc.add_argument(
-            '--full_sphere', dest='plot_full_sphere', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--input_system', '--input-system')
-        group_misc.add_argument(
-            '--input_system', dest='plot_input_system',
-            type=caps, choices=ALLOWED_BASES, default='NED',
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--lines_only', '--lines-only', real_action='store_true')
-        group_misc.add_argument(
-            '--lines_only', dest='plot_only_lines', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action('--output_file',
-                                                 '--output-file')
-        group_misc.add_argument(
-            '--output_file', dest='plot_outfile', action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--pa_system', '--pa-system', real_action='store_true')
-        group_misc.add_argument(
-            '--pa_system', dest='plot_pa_plot', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--pressure_colour', '--pressure-colour')
-        group_misc.add_argument(
-            '--pressure_colour', dest='plot_pressure_colour',
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--show1fp', '--show-1fp', real_action='store_true')
-        group_misc.add_argument(
-            '--show1fp', dest='plot_show_1faultplane', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action(
-            '--show_isotropic_part', '--show-isotropic-part',
-            real_action='store_true')
-        group_misc.add_argument(
-            '--show_isotropic_part', dest='plot_isotropic_part', nargs=0,
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action('--tension_colour',
-                                                 '--tension-colour')
-        group_misc.add_argument(
-            '--tension_colour', dest='plot_tension_colour',
-            action=action, help=SUPPRESS)
-
         parser_plot.set_defaults(call=_call_plot, build=_build_plot_dict)
 
         # decompose
@@ -5161,21 +5085,6 @@ The 'source mechanism' as a comma-separated list of length:
             type=int, choices=[20, 21, 31], default=20,
             help='integer key to choose the type of decomposition - 20: '
                  'ISO+DC+CLVD ; 21: ISO+major DC+ minor DC ; 31: ISO + 3 DCs')
-
-        # Deprecated arguments
-        action = _get_deprecated_argument_action('--input_system',
-                                                 '--input-system')
-        group_system.add_argument(
-            '--input_system', dest='decomp_in_system',
-            type=caps, choices=ALLOWED_BASES, default='NED',
-            action=action, help=SUPPRESS)
-
-        action = _get_deprecated_argument_action('--output_system',
-                                                 '--output-system')
-        group_system.add_argument(
-            '--output_system', dest='decomp_out_system',
-            type=caps, choices=ALLOWED_BASES, default='NED',
-            action=action, help=SUPPRESS)
 
         parser_decompose.set_defaults(call=_call_decompose,
                                       build=_build_decompose_dict)

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -35,12 +35,12 @@ from future.builtins import *  # NOQA
 import os
 import sys
 import warnings
-from argparse import SUPPRESS, ArgumentParser, RawDescriptionHelpFormatter
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import numpy as np
 
 from obspy import UTCDateTime, __version__, read
-from obspy.core.util.base import ENTRY_POINTS, _get_deprecated_argument_action
+from obspy.core.util.base import ENTRY_POINTS
 from obspy.core.util.misc import MatplotlibBackend
 from obspy.imaging.util import ObsPyAutoDateFormatter, \
     decimal_seconds_format_date_first_tick
@@ -209,31 +209,6 @@ def main(argv=None):
     parser.add_argument('paths', nargs='*',
                         help='Files or directories to scan.')
 
-    # Deprecated arguments
-    action = _get_deprecated_argument_action('--endtime', '--end-time')
-    parser.add_argument('--endtime', type=UTCDateTime,
-                        action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action('--event-times', '--event-time')
-    parser.add_argument('--event-times', action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action('--ids', '--id')
-    parser.add_argument('--ids', action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action(
-        '--nox', '--no-x', real_action='store_true')
-    parser.add_argument('--nox', dest='no_x', nargs=0,
-                        action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action(
-        '--nogaps', '--no-gaps', real_action='store_true')
-    parser.add_argument('--nogaps', dest='no_gaps', nargs=0,
-                        action=action, help=SUPPRESS)
-
-    action = _get_deprecated_argument_action('--starttime', '--start-time')
-    parser.add_argument('--starttime', type=UTCDateTime,
-                        action=action, help=SUPPRESS)
-
     args = parser.parse_args(argv)
 
     if args.output is not None:
@@ -258,28 +233,16 @@ def main(argv=None):
     fig = plt.figure()
     ax = fig.add_subplot(111)
 
-    # Plot vertical lines if option 'event_times' was specified
+    # Plot vertical lines if option 'event_time' was specified
     if args.event_time:
         times = [date2num(t.datetime) for t in args.event_time]
-        for time in times:
-            ax.axvline(time, color='k')
-    # Deprecated version (don't plot twice)
-    if args.event_times and not args.event_time:
-        times = args.event_times.split(',')
-        times = [date2num(UTCDateTime(t).datetime) for t in times]
         for time in times:
             ax.axvline(time, color='k')
 
     if args.start_time:
         args.start_time = date2num(args.start_time.datetime)
-    elif args.starttime:
-        # Deprecated version
-        args.start_time = date2num(args.starttime.datetime)
     if args.end_time:
         args.end_time = date2num(args.end_time.datetime)
-    elif args.endtime:
-        # Deprecated version
-        args.end_time = date2num(args.endtime.datetime)
 
     # Generate dictionary containing nested lists of start and end times per
     # station
@@ -299,9 +262,6 @@ def main(argv=None):
     if args.write:
         write_npz(args.write, data, samp_int)
 
-    # Handle deprecated argument
-    if args.ids and not args.id:
-        args.id = args.ids.split(',')
     # either use ids specified by user or use ids based on what data we have
     # parsed
     ids = args.id or list(data.keys())

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -40,7 +40,6 @@ import scipy.signal as signal
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.util import create_empty_data_chunk
 from obspy.geodetics import FlinnEngdahl, kilometer2degrees, locations2degrees
-from obspy.core.util.decorator import deprecated_keywords
 from obspy.imaging.util import (ObsPyAutoDateFormatter, _id_key, _timestring)
 
 
@@ -398,7 +397,6 @@ class WaveformPlotting(object):
         ax.set_xlim(xmin, xmax)
         self._draw_overlap_axvspan_legend()
 
-    @deprecated_keywords({'swap_time_axis': None})
     def plot_day(self, *args, **kwargs):
         """
         Extend the seismogram.

--- a/obspy/io/xseed/scripts/dataless2xseed.py
+++ b/obspy/io/xseed/scripts/dataless2xseed.py
@@ -9,11 +9,10 @@ from future.builtins import *  # NOQA
 
 import os
 import sys
-from argparse import SUPPRESS, ArgumentParser
+from argparse import ArgumentParser
 from glob import glob
 
 from obspy import __version__
-from obspy.core.util.base import _get_deprecated_argument_action
 from obspy.io.xseed.parser import Parser
 
 
@@ -87,11 +86,6 @@ def main(argv=None):
     parser.add_argument('-x', '--xml-version', dest='version', default=1.1,
                         help='XML-SEED version, 1.0 or 1.1', type=float)
     parser.add_argument('files', nargs='+', help='files to process')
-
-    # Deprecated arguments
-    action = _get_deprecated_argument_action('-v', '--xml-version')
-    parser.add_argument('-v', dest='version', default=1.1, type=float,
-                        action=action, help=SUPPRESS)
 
     args = parser.parse_args(argv)
 

--- a/obspy/scripts/print.py
+++ b/obspy/scripts/print.py
@@ -7,10 +7,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-from argparse import SUPPRESS, ArgumentParser
+from argparse import ArgumentParser
 
 from obspy import Stream, __version__, read
-from obspy.core.util.base import ENTRY_POINTS, _get_deprecated_argument_action
+from obspy.core.util.base import ENTRY_POINTS
 
 
 def main(argv=None):
@@ -27,12 +27,6 @@ def main(argv=None):
                         help='Switch on printing of gap information.')
     parser.add_argument('files', nargs='+',
                         help='Files to process.')
-
-    # Deprecated arguments
-    action = _get_deprecated_argument_action(
-        '--nomerge', '--no-merge', real_action='store_false')
-    parser.add_argument('--nomerge', nargs=0, action=action, dest='merge',
-                        help=SUPPRESS)
 
     args = parser.parse_args(argv)
 

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -436,7 +436,7 @@ def simulate_seismometer(
         remove_sensitivity=True, simulate_sensitivity=True, water_level=600.0,
         zero_mean=True, taper=True, taper_fraction=0.05, pre_filt=None,
         seedresp=None, nfft_pow2=False, pitsasim=True, sacsim=False,
-        shsim=False, **_kwargs):
+        shsim=False):
     """
     Simulate/Correct seismometer.
 


### PR DESCRIPTION
The re-routing is currently keeping some things around that shouldn't be necessary, since they were deprecated in 0.10.x already.

This is just a note of those changes; if it passes and there are no other issues, I'd probably just fast-forward #1039 to include these changes as well.