### PR TITLE
TauP depth caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,6 @@ install:
         requests
   - source activate test-environment
   # install packages not available via conda
-  - pip install cachetools
   - pip install coveralls
   # 2015/02/16 - Temporary workaround. Remove limitation once installing
   # geographiclib works again.

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ install:
         requests
   - source activate test-environment
   # install packages not available via conda
+  - pip install cachetools
   - pip install coveralls
   # 2015/02/16 - Temporary workaround. Remove limitation once installing
   # geographiclib works again.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -139,6 +139,8 @@ master:
      surface waves (see #986.)
    * Fix incorrect branch splitting which also caused issues for extremely
      shallow phases (see #1057.)
+   * Proper cache for model splits resulting in much faster calculations if
+     the source depth is repeatedly the same (see #1248).
 
 0.10.x:
   - obspy.core:

--- a/obspy/taup/slowness_model.py
+++ b/obspy/taup/slowness_model.py
@@ -527,16 +527,16 @@ class SlownessModel(object):
         """
         Find depth corresponding to a slowness p between two velocity layers.
 
-        Here, slowness is defined as ``(6731-depth) / velocity``, and sometimes
-        called ray parameter. Both the top and the bottom velocity layers are
-        included. We also check to see if the slowness is less than the bottom
-        slowness of these layers but greater than the top slowness of the next
-        deeper layer. This corresponds to a total reflection. In this case a
-        check needs to be made to see if this is an S wave reflecting off of a
-        fluid layer, use P velocity below in this case. We assume that slowness
-        is monotonic within these layers and therefore there is only one depth
-        with the given slowness. This means we return the first depth that we
-        find.
+        Here, slowness is defined as ``(radius_of_planet-depth) / velocity``,
+        and sometimes called ray parameter. Both the top and the bottom
+        velocity layers are included. We also check to see if the slowness is
+        less than the bottom slowness of these layers but greater than the top
+        slowness of the next deeper layer. This corresponds to a total
+        reflection. In this case a check needs to be made to see if this is an
+        S wave reflecting off of a fluid layer, use P velocity below in this
+        case. We assume that slowness is monotonic within these layers and
+        therefore there is only one depth with the given slowness. This means
+        we return the first depth that we find.
 
         :param p: Slowness (aka ray parameter) to find, in s/km.
         :type p: float
@@ -619,10 +619,9 @@ class SlownessModel(object):
                   "shouldn't be allowed to happen!")
             # noinspection PyUnboundLocalVariable
             return vel_layer.getBotDepth()
-
         raise SlownessModelError(
             "slowness p=" + str(p) +
-            "is not contained within the specified layers." +
+            " is not contained within the specified layers." +
             " top_critical_layer=" + str(top_critical_layer) +
             " bot_critical_layer=" + str(bot_critical_layer))
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -309,14 +309,11 @@ class TauPyModel(object):
         :param cache: An object to use to cache models split at source depths.
             Generating results requires splitting a model at the source depth,
             which may be expensive. The cache allows faster calculation when
-            multiple results are requested for the same source depth. If the
-            `cachetools`_ package is available, then you may supply a mutable
-            mapping or one of its cache implementations, otherwise the LRUCache
-            with maximum size of 128 will be used. If the `cachetools`_ package
-            is not available or ``False`` is specified, then no cache will be
+            multiple results are requested for the same source depth. The
+            dictionary must be ordered, otherwise the LRU cache will not
+            behave correctly. If ``False`` is specified, then no cache will be
             used.
-        :type cache: :class:`cachetools.Cache` or
-            :class:`collections.MutableMapping` or `bool`
+        :type cache: :class:`collections.OrderedDict` or bool
 
         Usage:
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -291,7 +291,8 @@ class TauPyModel(object):
     Representation of a seismic model and methods for ray paths through it.
     """
 
-    def __init__(self, model="iasp91", verbose=False, planet_flattening=0.0):
+    def __init__(self, model="iasp91", verbose=False, planet_flattening=0.0,
+                 cache=None):
         """
         Loads an already created TauPy model.
 
@@ -305,6 +306,17 @@ class TauPyModel(object):
             longitudes) to epicentral distances - the actual traveltime and
             raypath calculations are performed on a spherical planet.
         :type planet_flattening: float
+        :param cache: An object to use to cache models split at source depths.
+            Generating results requires splitting a model at the source depth,
+            which may be expensive. The cache allows faster calculation when
+            multiple results are requested for the same source depth. If the
+            `cachetools`_ package is available, then you may supply a mutable
+            mapping or one of its cache implementations, otherwise the LRUCache
+            with maximum size of 128 will be used. If the `cachetools`_ package
+            is not available or ``False`` is specified, then no cache will be
+            used.
+        :type cache: :class:`cachetools.Cache` or
+            :class:`collections.MutableMapping` or `bool`
 
         Usage:
 
@@ -318,7 +330,7 @@ class TauPyModel(object):
         2
         """
         self.verbose = verbose
-        self.model = TauModel.from_file(model)
+        self.model = TauModel.from_file(model, cache=cache)
         self.planet_flattening = planet_flattening
 
     def get_travel_times(self, source_depth_in_km, distance_in_degree=None,


### PR DESCRIPTION
It's the PR you've been waiting for... and I mean that literally, since the CIs seem to have been taking forever lately.

This implements the depth cache using [cachetools](https://pythonhosted.org/cachetools/), if available. Otherwise, no cache is used. Using cachetools allows some flexibility in the caching algorithm that the user can tweak for specific use cases. There is also a `functools.lru_cache` in the standard library, but it's 3-only. I have a solution that would fall back to that partially implemented too that could be added here if I figure out one last bug with it.

Locally, the taup tests with caching are about 50% of the original runtime, so fingers crossed that we get some reasonable speedup on the CIs.