### PR TITLE
Processing info attached twice

### DIFF
--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1661,6 +1661,31 @@ class TraceTestCase(unittest.TestCase):
         tr.attach_response(inv)
         tr.remove_response()
 
+    def test_processing_info_remove_response_and_sensitivity(self):
+        """
+        Tests adding processing info for remove_response() and
+        remove_sensitivity().
+
+        See #1247.
+        """
+        # remove_sensitivity() with response object attached to the trace.
+        tr = read()[0]
+        self.assertNotIn("processing", tr.stats)
+        tr.remove_sensitivity()
+        self.assertIn("processing", tr.stats)
+        self.assertEqual(len(tr.stats.processing), 1)
+        self.assertTrue(tr.stats.processing[0].endswith(
+            "remove_sensitivity(inventory=None)"))
+
+        # With passed inventory object.
+        tr = read()[0]
+        self.assertNotIn("processing", tr.stats)
+        tr.remove_sensitivity(inventory=read_inventory())
+        self.assertIn("processing", tr.stats)
+        self.assertEqual(len(tr.stats.processing), 1)
+        self.assertIn("remove_sensitivity(inventory=<obspy.core.inventory."
+                      "inventory.Inventory object ", tr.stats.processing[0])
+
     def test_processing_information(self):
         """
         Test case for the automatic processing information.
@@ -1690,7 +1715,7 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(
             "ObsPy %s: trim(endtime=None::fill_value=None::"
             "nearest_sample=True::pad=False::starttime=%s)" % (
-                __version__, str(trimming_starttime)),
+                __version__, repr(trimming_starttime)),
             pr[0])
         self.assertIn("filter", pr[1])
         self.assertIn("simulate", pr[2])

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1686,6 +1686,25 @@ class TraceTestCase(unittest.TestCase):
         self.assertIn("remove_sensitivity(inventory=<obspy.core.inventory."
                       "inventory.Inventory object ", tr.stats.processing[0])
 
+        # remove_response()
+        tr = read()[0]
+        self.assertNotIn("processing", tr.stats)
+        tr.remove_response()
+        self.assertIn("processing", tr.stats)
+        self.assertEqual(len(tr.stats.processing), 1)
+        self.assertIn("remove_response(", tr.stats.processing[0])
+        self.assertIn("inventory=None", tr.stats.processing[0])
+
+        # With passed inventory object.
+        tr = read()[0]
+        self.assertNotIn("processing", tr.stats)
+        tr.remove_response(inventory=read_inventory())
+        self.assertIn("processing", tr.stats)
+        self.assertEqual(len(tr.stats.processing), 1)
+        self.assertIn("remove_response(", tr.stats.processing[0])
+        self.assertIn("inventory=<obspy.core.inventory.inventory.Inventory "
+                      "object", tr.stats.processing[0])
+
     def test_processing_information(self):
         """
         Test case for the automatic processing information.

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2720,12 +2720,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
         # assign processed data and store processing information
         self.data = data
-        info = ":".join(["remove_response"] +
-                        [str(x) for x in (inventory, output, water_level,
-                                          pre_filt, zero_mean, taper,
-                                          taper_fraction)] +
-                        ["%s=%s" % (k, v) for k, v in kwargs.items()])
-        self._internal_add_processing_info(info)
         return self
 
     @_add_processing_info

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -221,10 +221,10 @@ def _add_processing_info(func, *args, **kwargs):
         function=func.__name__)
     arguments = []
     arguments += \
-        ["%s=%s" % (k, v) if not isinstance(v, native_str) else
+        ["%s=%s" % (k, repr(v)) if not isinstance(v, native_str) else
          "%s='%s'" % (k, v) for k, v in callargs.items()]
     arguments += \
-        ["%s=%s" % (k, v) if not isinstance(v, native_str) else
+        ["%s=%s" % (k, repr(v)) if not isinstance(v, native_str) else
          "%s='%s'" % (k, v) for k, v in kwargs_.items()]
     arguments.sort()
     info = info % "::".join(arguments)
@@ -2750,8 +2750,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         response = self._get_response(inventory)
         self.data = self.data / response.instrument_sensitivity.value
-        info = 'remove_sensitivity:inventory=%s' % inventory
-        self._internal_add_processing_info(info)
         return self
 
 


### PR DESCRIPTION
While working on #1234, I noticed that processing info is attached to Trace.stats twice, once via a decorator and once explicitly at the end of the method calls.

@krischer, I think you worked last on the processing info, I think I'll leave this to you (I guess we only need the decorator..?)..