### PR TITLE
read_inventory() working with "http://" but not "https://"

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 from future import standard_library
-from future.utils import python_2_unicode_compatible
+from future.utils import python_2_unicode_compatible, native_str
 
 import copy
 import fnmatch
@@ -62,7 +62,8 @@ def read_inventory(path_or_file_object=None, format=None):
     if path_or_file_object is None:
         # if no pathname or URL specified, return example catalog
         return _create_example_inventory()
-    elif "://" in path_or_file_object:
+    elif isinstance(path_or_file_object, (str, native_str)) and \
+            "://" in path_or_file_object:
         # some URL
         # extract extension if any
         suffix = \


### PR DESCRIPTION
..compare
```python
inv = read_inventory("http://examples.obspy.org/IU_ULN.xml")
inv = read_inventory("https://examples.obspy.org/IU_ULN.xml")
```

```
In [5]: inv = read_inventory("https://examples.obspy.org/IU_ULN.xml")
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-5-7bc136d385fb> in <module>()
----> 1 inv = read_inventory("https://examples.obspy.org/IU_ULN.xml")

<decorator-gen-194> in read_inventory(path_or_file_object, format)

/home/megies/git/obspy/obspy/core/util/decorator.pyc in _map_example_filename(func, *args, **kwargs)
    283                         except IOError:
    284                             pass
--> 285         return func(*args, **kwargs)
    286     return _map_example_filename
    287 

/home/megies/git/obspy/obspy/core/inventory/inventory.pyc in read_inventory(path_or_file_object, format)
     61         return _create_example_inventory()
     62     return _read_from_plugin("inventory", path_or_file_object,
---> 63                              format=format)[0]
     64 
     65 

/home/megies/git/obspy/obspy/core/util/base.pyc in _read_from_plugin(plugin_type, filename, format, **kwargs)
    426                 position = None
    427             # check format
--> 428             is_format = is_format(filename)
    429             if position is not None:
    430                 filename.seek(0, 0)

/home/megies/git/obspy/obspy/io/stationxml/core.pyc in _is_stationxml(path_or_file_object)
     66         else:
     67             try:
---> 68                 xmldoc = etree.parse(path_or_file_object)
     69             except etree.XMLSyntaxError:
     70                 return False

lxml.etree.pyx in lxml.etree.parse (src/lxml/lxml.etree.c:72517)()

parser.pxi in lxml.etree._parseDocument (src/lxml/lxml.etree.c:105979)()

parser.pxi in lxml.etree._parseDocumentFromURL (src/lxml/lxml.etree.c:106278)()

parser.pxi in lxml.etree._parseDocFromFile (src/lxml/lxml.etree.c:105277)()

parser.pxi in lxml.etree._BaseParser._parseDocFromFile (src/lxml/lxml.etree.c:100227)()

parser.pxi in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:94350)()

parser.pxi in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:95786)()

parser.pxi in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:94818)()

IOError: Error reading file 'https://examples.obspy.org/IU_ULN.xml': failed to load external entity "https://examples.obspy.org/IU_ULN.xml"
```