### PR TITLE
Unsafe figure opening/closing in tests (in ImageComparison, and also doctests)

### DIFF
--- a/obspy/imaging/tests/test_beachball.py
+++ b/obspy/imaging/tests/test_beachball.py
@@ -226,6 +226,10 @@ class BeachballTestCase(unittest.TestCase):
               [150, 87, 1]]
 
         # Initialize figure
+        try:
+            plt.close("all")
+        except:
+            pass
         fig = plt.figure(figsize=(6, 6), dpi=300)
         ax = fig.add_subplot(111, aspect='equal')
 
@@ -245,7 +249,8 @@ class BeachballTestCase(unittest.TestCase):
         # set the x and y limits and save the output
         ax.axis([-120, 120, -120, 120])
         # create and compare image
-        with ImageComparison(self.path, 'bb_collection.png') as ic:
+        with ImageComparison(self.path, 'bb_collection.png',
+                             plt_close_all_enter=False) as ic:
             fig.savefig(ic.name)
 
     def collection_aspect(self, axis, filename_width, filename_width_height):
@@ -256,6 +261,10 @@ class BeachballTestCase(unittest.TestCase):
 
         # Test passing only a width
         # Initialize figure
+        try:
+            plt.close("all")
+        except:
+            pass
         fig = plt.figure()
         ax = fig.add_subplot(111)
         # add the beachball (a collection of two patches) to the axis
@@ -266,7 +275,8 @@ class BeachballTestCase(unittest.TestCase):
         # set the x and y limits
         ax.axis(axis)
         # create and compare image
-        with ImageComparison(self.path, filename_width) as ic:
+        with ImageComparison(self.path, filename_width,
+                             plt_close_all_enter=False) as ic:
             fig.savefig(ic.name)
 
         # Test passing a width and a height
@@ -281,7 +291,8 @@ class BeachballTestCase(unittest.TestCase):
         # set the x and y limits and save the output
         ax.axis(axis)
         # create and compare image
-        with ImageComparison(self.path, filename_width_height) as ic:
+        with ImageComparison(self.path, filename_width_height,
+                             plt_close_all_enter=False) as ic:
             fig.savefig(ic.name)
 
     def test_collection_aspect_x(self):

--- a/obspy/signal/_sosfilt.py
+++ b/obspy/signal/_sosfilt.py
@@ -463,6 +463,8 @@ def _sosfilt(sos, x, axis=-1, zi=None):
     >>> x[0] = 1.
     >>> y_tf = signal.lfilter(b, a, x)
     >>> y_sos = _sosfilt(sos, x)
+    >>> plt.figure()  # doctest: +ELLIPSIS
+    <matplotlib.figure.Figure object at 0x...>
     >>> plt.plot(y_tf, 'r', label='TF')  # doctest: +ELLIPSIS
     [<matplotlib.lines.Line2D object at ...>]
     >>> plt.plot(y_sos, 'k', label='SOS')  # doctest: +ELLIPSIS

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -456,7 +456,8 @@ class PsdTestCase(unittest.TestCase):
         #     matches (like above):
         ppsd.calculate_histogram(**stack_criteria_list[1])
         with ImageComparison(self.path_images,
-                             'ppsd_restricted_stack.png') as ic:
+                             'ppsd_restricted_stack.png',
+                             plt_close_all_exit=False) as ic:
             fig = ppsd.plot(show=False, **plot_kwargs)
             # some matplotlib/Python version combinations lack the left-most
             # tick/label "Jan 2015". Try to circumvent and get the (otherwise
@@ -476,7 +477,9 @@ class PsdTestCase(unittest.TestCase):
         try:
             with ImageComparison(self.path_images,
                                  'ppsd_restricted_stack.png',
-                                 adjust_tolerance=False) as ic:
+                                 adjust_tolerance=False,
+                                 plt_close_all_enter=False,
+                                 plt_close_all_exit=False) as ic:
                 # rms of the valid comparison above is ~31,
                 # rms of the invalid comparison we test here is ~36
                 if MATPLOTLIB_VERSION == [1, 1, 1]:
@@ -497,7 +500,8 @@ class PsdTestCase(unittest.TestCase):
         #     image test should pass agin:
         ppsd.calculate_histogram(**stack_criteria_list[1])
         with ImageComparison(self.path_images,
-                             'ppsd_restricted_stack.png') as ic:
+                             'ppsd_restricted_stack.png',
+                             plt_close_all_enter=False) as ic:
             ppsd._plot_histogram(fig=fig, draw=True)
             _t = np.geterr()
             np.seterr(under="ignore")


### PR DESCRIPTION
I suspect that some stray CI fails (e.g. https://travis-ci.org/obspy/obspy/jobs/109439831#L661; some simple plot command stumbling into an Axes3D instance) come from unclean handling of figure-closing in image tests. In principle ImageComparison should only call `plt.close()` on exit if figure is not closed by the used plotting routine already (see #1250). On the other hand it's probably safest to just always close all figures on exit.. (see also #1156).

We could control this by..
 * having some kwarg `close_figure` in `ImageComparison` init
 * setting some attribute on the `ImageComparison` while in its context
 * ..