### PR TITLE
make sure no imports from obspy set matplotlib backend

### DIFF
--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -21,8 +21,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import matplotlib.pyplot as plt
-
 from obspy.core.event.header import (
     EventType, EventTypeCertainty, EventDescriptionType)
 from obspy.imaging.source import plot_radiation_pattern, _setup_figure_and_axes
@@ -276,6 +274,7 @@ class Event(__Event):
             cat = read_events("/path/to/CMTSOLUTION")
             cat.plot(kind=[['global'], ['p_sphere', 'p_quiver']])
         """
+        import matplotlib.pyplot as plt
         try:
             fm = self.preferred_focal_mechanism() or self.focal_mechanisms[0]
             mtensor = fm.moment_tensor.tensor

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -19,7 +19,6 @@ import warnings
 from copy import copy, deepcopy
 
 import numpy as np
-import matplotlib.pyplot as plt
 from decorator import decorator
 
 from obspy.core import compatibility
@@ -2558,6 +2557,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         from obspy.core.inventory import PolynomialResponseStage
         from obspy.signal.invsim import (cosine_taper, cosine_sac_taper,
                                          invert_spectrum)
+        if plot:
+            import matplotlib.pyplot as plt
+
         if (isinstance(inventory, (str, native_str)) and
                 inventory.upper() in ("DISP", "VEL", "ACC")):
             from obspy.core.util.deprecation_helpers import \

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -34,7 +34,6 @@ import sys
 import warnings
 
 import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib import path as mplpath
 from matplotlib import collections, patches, transforms
 from decorator import decorator
@@ -251,6 +250,7 @@ def beachball(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     :param fig: Give an existing figure instance to plot into. New Figure if
         set to ``None``.
     """
+    import matplotlib.pyplot as plt
     plot_width = width * 0.95
 
     # plot the figure

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -17,7 +17,6 @@ import datetime
 import warnings
 
 import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
 from matplotlib.colors import Normalize
@@ -162,6 +161,7 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
         are problematic, but e.g. one station plot (without colorbar) and one
         event plot (with colorbar) together should work well.
     """
+    import matplotlib.pyplot as plt
     min_color = min(color)
     max_color = max(color)
 
@@ -536,6 +536,7 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
         projections. Some arguments may be ignored if you choose one of the
         built-in ``projection`` choices.
     """
+    import matplotlib.pyplot as plt
     min_color = min(color)
     max_color = max(color)
 

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -17,8 +17,8 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA @UnusedWildImport
 
 import numpy as np
-import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # NOQA
+from matplotlib.cm import get_cmap
 
 from obspy.core.util.base import get_matplotlib_version
 from obspy.core.event.source import farfield
@@ -43,6 +43,7 @@ def _setup_figure_and_axes(kind, fig=None, subplot_size=4.0):
         plotting options for each axes (see
         :meth:`obspy.core.event.event.Event.plot`, parameter `kind`).
     """
+    import matplotlib.pyplot as plt
     # make 2d layout of kind parameter
     if isinstance(kind[0], (list, tuple)):
         nrows = len(kind)
@@ -104,6 +105,7 @@ def plot_radiation_pattern(
         used to do further customization of the plot before showing it.
     :returns: Matplotlib figure or None (if `kind` is "mayavi" or "vtk")
     """
+    import matplotlib.pyplot as plt
 
     # reoorder all moment tensors to NED and RTP convention
     # name : COMPONENT              : NED sign and index
@@ -187,6 +189,7 @@ def _plot_radiation_pattern_sphere(
         outwards.
     :param type: 'P' or 'S' (P or S wave).
     """
+    import matplotlib.pyplot as plt
     type = type.upper()
     if type not in ("P", "S"):
         msg = ("type must be 'P' or 'S'")
@@ -221,12 +224,12 @@ def _plot_radiation_pattern_sphere(
     if is_p_wave:
         disp = farfield(ned_mt, points, type="P")
         magn = np.sum(disp * points, axis=0)
-        cmap = plt.get_cmap('bwr')
+        cmap = get_cmap('bwr')
         norm = plt.Normalize(-1, 1)
     else:
         disp = farfield(ned_mt, points, type="S")
         magn = np.sqrt(np.sum(disp * disp, axis=0))
-        cmap = plt.get_cmap('Greens')
+        cmap = get_cmap('Greens')
         norm = plt.Normalize(0, 1)
     magn /= np.max(np.abs(magn))
 
@@ -267,6 +270,7 @@ def _plot_radiation_pattern_quiver(ax3d, ned_mt, type):
     :type type: str
     :param type: 'P' or 'S' (P or S wave).
     """
+    import matplotlib.pyplot as plt
     if MATPLOTLIB_VERSION < [1, 4]:
         msg = ("Matplotlib 3D quiver plot needs matplotlib version >= 1.4.")
         raise ImportError(msg)
@@ -286,14 +290,14 @@ def _plot_radiation_pattern_quiver(ax3d, ned_mt, type):
         # normalized magnitude:
         magn = np.sum(disp * points, axis=0)
         magn /= np.max(np.abs(magn))
-        cmap = plt.get_cmap('bwr')
+        cmap = get_cmap('bwr')
     else:
         # get radiation pattern
         disp = farfield(ned_mt, points, type="S")
         # normalized magnitude (positive only):
         magn = np.sqrt(np.sum(disp * disp, axis=0))
         magn /= np.max(np.abs(magn))
-        cmap = plt.get_cmap('Greens')
+        cmap = get_cmap('Greens')
 
     # plot
     # there is a mlab3d bug that quiver vector colors and lengths
@@ -327,8 +331,9 @@ def _plot_beachball(ax2d, rtp_mt):
     :param ax2d: matplotlib Axes3D object
     :param rtp_mt: moment tensor in RTP convention
     """
+    import matplotlib.pyplot as plt
     norm = plt.Normalize(-1., 1.)
-    cmap = plt.get_cmap('bwr')
+    cmap = get_cmap('bwr')
     bball = beach(rtp_mt, xy=(0, 0), width=50, facecolor=cmap(norm(0.7)),
                   bgcolor=cmap(norm(-0.7)))
 

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -23,7 +23,6 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import math as M
 
 import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib import mlab
 from matplotlib.colors import Normalize
 
@@ -103,6 +102,7 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
         percentages of the amplitude range (linear or logarithmic depending
         on option `dbscale`) are clipped.
     """
+    import matplotlib.pyplot as plt
     # enforce float for samp_rate
     samp_rate = float(samp_rate)
 

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -29,10 +29,10 @@ from datetime import datetime
 from dateutil.rrule import MINUTELY, SECONDLY
 
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
-from matplotlib.dates import AutoDateLocator, date2num
 import matplotlib.lines as mlines
+import matplotlib.patches as patches
+from matplotlib.cm import get_cmap
+from matplotlib.dates import AutoDateLocator, date2num
 from matplotlib.path import Path
 from matplotlib.ticker import MaxNLocator, ScalarFormatter
 import scipy.signal as signal
@@ -222,6 +222,7 @@ class WaveformPlotting(object):
         Destructor closes the figure instance if it has been created by the
         class.
         """
+        import matplotlib.pyplot as plt
         if self.kwargs.get('fig', None) is None and \
                 not self.kwargs.get('handle'):
             plt.close()
@@ -270,6 +271,7 @@ class WaveformPlotting(object):
         'm' = magenta, 'y' = yellow, 'k' = black, 'w' = white) and gray shades
         can be given as a string encoding a float in the 0-1 range.
         """
+        import matplotlib.pyplot as plt
         # Setup the figure if not passed explicitly.
         if not self.fig_obj:
             self.__setup_figure()
@@ -805,6 +807,7 @@ class WaveformPlotting(object):
         """
         Goes through all axes in pyplot and sets time ticks on the x axis.
         """
+        import matplotlib.pyplot as plt
         self.fig.subplots_adjust(hspace=0)
         # Loop over all but last axes.
         for ax in self.axis[:-1]:
@@ -826,6 +829,7 @@ class WaveformPlotting(object):
     def __plot_set_y_ticks(self, *args, **kwargs):  # @UnusedVariable
         """
         """
+        import matplotlib.pyplot as plt
         if self.equal_scale:
             ylims = np.vstack([ax.get_ylim() for ax in self.axis])
             yranges = np.diff(ylims).flatten()
@@ -1098,6 +1102,7 @@ class WaveformPlotting(object):
         """
         Plots multiple waveforms as a record section on a single plot.
         """
+        import matplotlib.pyplot as plt
         # Initialise data and plot
         self.__sect_init_traces()
         ax, lines = self.__sect_init_plot()
@@ -1287,7 +1292,7 @@ class WaveformPlotting(object):
             self.sect_color = self.color
             return
 
-        cmap = plt.get_cmap('Paired', lut=len(colors))
+        cmap = get_cmap('Paired', lut=len(colors))
         self.sect_color = {k: cmap(i) for i, k in enumerate(sorted(colors))}
 
     def __sect_offset_to_fraction(self, offset):
@@ -1384,6 +1389,7 @@ class WaveformPlotting(object):
         """
         The design and look of the whole plot to be produced.
         """
+        import matplotlib.pyplot as plt
         # Setup figure and axes
         self.fig = plt.figure(num=None, dpi=self.dpi,
                               figsize=(float(self.width) / self.dpi,

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -15,7 +15,6 @@ from future.builtins import *  # NOQA
 
 import numpy as np
 from scipy.interpolate import LSQUnivariateSpline
-import matplotlib.pyplot as plt
 
 
 def simple(data):
@@ -32,6 +31,7 @@ def simple(data):
 
 
 def _plotting_helper(data, fit, plot):
+    import matplotlib.pyplot as plt
     fig, axes = plt.subplots(2, 1, figsize=(8, 5))
     plt.subplots_adjust(hspace=0)
     axes[0].plot(data, color="k", label="Original Data")

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -15,7 +15,6 @@ from future.builtins import *  # NOQA
 
 import numpy as np
 import scipy.interpolate
-import matplotlib.pyplot as plt
 
 from obspy.signal.headers import clibsignal
 
@@ -380,6 +379,7 @@ def plot_lanczos_windows(a, filename=None):
         from obspy.signal.interpolation import plot_lanczos_windows
         plot_lanczos_windows(a=20)
     """
+    import matplotlib.pyplot as plt
     x_max = 1024.0 - 0.5
     n = 2 ** 15
     x = np.linspace(-x_max, x_max, n)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -31,7 +31,6 @@ import pickle
 import warnings
 
 import numpy as np
-import matplotlib.pyplot as plt
 from matplotlib import mlab
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.dates import date2num
@@ -1540,6 +1539,7 @@ class PPSD(object):
         :param xaxis_frequency: If set to `True`, the x axis will be frequency
             in Hertz as opposed to the default of period in seconds.
         """
+        import matplotlib.pyplot as plt
         self.__check_histogram()
         fig = plt.figure()
         fig.ppsd = AttribDict()
@@ -1655,6 +1655,7 @@ class PPSD(object):
         :meth:`plot()` call, so this routine can only be used to update with
         data from a new stack.
         """
+        import matplotlib.pyplot as plt
         ax = fig.axes[0]
         xlim = ax.get_xlim()
         if "quadmesh" in fig.ppsd:
@@ -1722,6 +1723,7 @@ class PPSD(object):
         :type filename: str, optional
         :param filename: Name of output file
         """
+        import matplotlib.pyplot as plt
         fig = plt.figure()
         ax = fig.add_subplot(111)
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -11,7 +11,7 @@ import copy
 import warnings
 
 import matplotlib.cbook
-import matplotlib.pyplot as plt
+from matplotlib.cm import get_cmap
 import matplotlib.text
 import numpy as np
 
@@ -26,7 +26,7 @@ import obspy.geodetics.base as geodetics
 
 # Pretty paired colors. Reorder to have saturated colors first and remove
 # some colors at the end.
-cmap = plt.get_cmap('Paired', lut=12)
+cmap = get_cmap('Paired', lut=12)
 COLORS = ['#%02x%02x%02x' % tuple(int(col * 255) for col in cmap(i)[:3])
           for i in range(12)]
 COLORS = COLORS[1:][::2][:-1] + COLORS[::2][:-1]
@@ -128,6 +128,7 @@ class Arrivals(list):
         :returns: The (possibly created) axes instance.
         :rtype: :class:`matplotlib.axes.Axes`
         """
+        import matplotlib.pyplot as plt
         arrivals = []
         for _i in self:
             if _i.path is None:


### PR DESCRIPTION
Otherwise on some systems e.g. `$ obspy-runtests ...` errors out (and our `MatplotlibBackend` context manager / backend switcher becomes pretty much useless internally) because it can't set "AGG" mpl backend.