### PR TITLE
Fix SAC reftime and file mode warnings

### DIFF
--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -267,7 +267,6 @@ def write_sac(dest, hf, hi, hs, data=None, byteorder=None):
     Write the header and (optionally) data arrays to a SAC binary file.
 
     :param dest: Full path or File-like object to SAC binary file on disk.
-        If data is None, file mode should be 'wb+'.
     :type dest: str or file
     :param hf: SAC float header array
     :type hf: :class:`numpy.ndarray` of floats
@@ -293,9 +292,8 @@ def write_sac(dest, hf, hi, hs, data=None, byteorder=None):
     existing binary file with data in it.
 
     """
-    # this function is a hot mess.  clean up the logic.
-
     # deal with file name versus File-like object, and file mode
+    # file open modes in Python: http://stackoverflow.com/a/23566951/745557
     if data is None:
         # file exists, just modify it (don't start from scratch)
         fmode = 'rb+'
@@ -327,12 +325,6 @@ def write_sac(dest, hf, hi, hs, data=None, byteorder=None):
         is_file_name = False
     except IOError:
         raise SacIOError("Cannot open file: " + dest)
-
-    if data is None and f.mode != 'rb+':
-        # msg = "File mode must be 'wb+' for data=None."
-        # raise ValueError(msg)
-        msg = "Writing header-only file. Use 'wb+' file mode to update header."
-        warnings.warn(msg)
 
     # TODO: make sure all data have the same/desired byte order
 
@@ -380,6 +372,7 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
     """
     # TODO: fix prodigious use of file open/close for "with" statements.
 
+    # file open modes in Python: http://stackoverflow.com/a/23566951/745557
     if data is None:
         # file exists, just modify it (don't start from scratch)
         fmode = 'r+'
@@ -395,10 +388,6 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
     except TypeError:
         f = dest
         is_file_name = False
-
-    if data is None and f.mode != 'r+':
-        msg = "Writing header-only file. Use 'wb+' file mode to update header."
-        warnings.warn(msg)
 
     try:
         np.savetxt(f, np.reshape(hf, (14, 5)), fmt=native_str("%#15.7g"),

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -10,6 +10,7 @@ import copy
 import io
 import os
 import unittest
+import warnings
 
 import numpy as np
 
@@ -78,7 +79,11 @@ class CoreTestCase(unittest.TestCase):
         tr = read(self.filexy, format='SACXY')[0]
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            tr.write(tempfile, format='SACXY')
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                tr.write(tempfile, format='SACXY')
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
         self.assertEqual(tr, tr1)
 
@@ -615,7 +620,11 @@ class CoreTestCase(unittest.TestCase):
         st = _read_sac_xy(self.filexy)
 
         with io.BytesIO() as fh:
-            _write_sac_xy(st, fh)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                _write_sac_xy(st, fh)
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             fh.seek(0, 0)
             st2 = _read_sac_xy(fh)
 
@@ -629,7 +638,11 @@ class CoreTestCase(unittest.TestCase):
         st = _read_sac_xy(self.filexy)
 
         with NamedTemporaryFile() as tf:
-            _write_sac_xy(st, tf)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                _write_sac_xy(st, tf)
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tf.seek(0, 0)
             st2 = _read_sac_xy(tf)
 
@@ -764,7 +777,11 @@ class CoreTestCase(unittest.TestCase):
 
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            tr.write(tempfile, format='SAC')
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                tr.write(tempfile, format='SAC')
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
 
         # starttime made its way to SAC file


### PR DESCRIPTION
Fix SAC module warnings detailed in #1242 .  

* invalid reftime warnings are caught in the tests, and the warnings themselves are tested
* the file mode warnings are removed from the offending sac module functions.  Users are responsible for understanding the implications of file modes.