### PR TITLE
fix global clients.seishub skipping routine

### DIFF
--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -77,7 +77,7 @@ class Client(object):
     >>> from obspy.clients.seishub import Client
     >>>
     >>> t = UTCDateTime("2009-09-03 00:00:00")
-    >>> client = Client(timeout=2)
+    >>> client = Client(timeout=20)
     >>>
     >>> st = client.waveform.get_waveforms("BW", "RTBE", "", "EHZ", t, t + 20)
     >>> print(st)  # doctest: +ELLIPSIS
@@ -838,7 +838,7 @@ master/seishub/plugins/seismology/waveform.py
 
         .. rubric:: Example
 
-        >>> c = Client(timeout=2)
+        >>> c = Client(timeout=20)
         >>> paz = c.station.get_paz('BW.MANZ..EHZ', '20090707')
         >>> paz['zeros']
         [0j, 0j]

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -34,6 +34,27 @@ from obspy.core.util.misc import CatchOutput, get_untracked_files_from_git, \
 
 
 MATPLOTLIB_VERSION = get_matplotlib_version()
+# this dictionary contains the locations of checker routines that determine
+# whether the module's tests can be executed or not (e.g. because test server
+# is unreachable, necessary ports are blocked, etc.).
+# A checker routine should return either an empty string (tests can and will
+# be executed) or a message explaining why tests can not be executed (all
+# tests of corresponding module will be skipped).
+MODULE_TEST_SKIP_CHECKS = {
+    'clients.seishub':
+        'obspy.clients.seishub.tests.test_client._check_server_availability',
+    }
+# List of flake8 error codes to ignore. Keep it as small as possible - there
+# usually is little reason to fight flake8.
+FLAKE8_IGNORE_CODES = [
+    # E402 module level import not at top of file
+    # This is really annoying when using the standard library import hooks
+    # from the future package.
+    "E402"
+    ]
+FLAKE8_EXCLUDE_FILES = [
+    "*/__init__.py",
+    ]
 
 
 def add_unittests(testsuite, module_name):
@@ -528,11 +549,6 @@ class ImageComparison(NamedTemporaryFile):
             return msg % (e.__class__.__name__, str(e))
         return links
 
-
-FLAKE8_EXCLUDE_FILES = [
-    "*/__init__.py",
-    ]
-
 try:
     import flake8
 except ImportError:
@@ -540,15 +556,6 @@ except ImportError:
 else:
     # Only accept flake8 version >= 2.0
     HAS_FLAKE8 = flake8.__version__ >= '2'
-
-# List of flake8 error codes to ignore. Keep it as small as possible - there
-# usually is little reason to fight flake8.
-FLAKE8_IGNORE_CODES = [
-    # E402 module level import not at top of file
-    # This is really annoying when using the standard library import hooks
-    # from the future package.
-    "E402"
-]
 
 
 def check_flake8():
@@ -602,18 +609,6 @@ def check_flake8():
         report = flake8_style.check_files(files)
 
     return report, out.stdout
-
-
-# this dictionary contains the locations of checker routines that determine
-# whether the module's tests can be executed or not (e.g. because test server
-# is unreachable, necessary ports are blocked, etc.).
-# A checker routine should return either an empty string (tests can and will
-# be executed) or a message explaining why tests can not be executed (all
-# tests of corresponding module will be skipped).
-MODULE_TEST_SKIP_CHECKS = {
-    'seishub':
-        'obspy.clients.seishub.tests.test_client._check_server_availability',
-    }
 
 
 def compare_xml_strings(doc1, doc2):


### PR DESCRIPTION
This is fixing two things:
 - the one-off and fast complete-module skip-check (which is in principle available for every network module but only implemented for `seishub` so far; implemented with 5f38e2ae9235548118530d867) for `seishub` was levered out by the big rename (`seishub` becoming `clients.seishub` as viewed by `obspy-runtests`)

     - [ ] we should move the dictionary approach to something that is looked up in the respective module's `tests/__init__.py` (but not in 1.0 but later..)
 - since we have a sane skip-check (doing a simple fast server ping) for seishub, we can set normal or high timeouts in doctests, and should not reduce those for sake of test environments where those are bound to fail with timeouts

---

commit message of below commit: 


 - seishub test only work in internal LMU munich network
 - there's a single checker routine implemented by 5f38e2ae9235548118530d86
 - a single checker routine (e.g. ping a server) can be added in
   core.util.testing.MODULE_TEST_SKIP_CHECKS to determine whether a
   whole module's tests should be skipped or not, including doctests!
 - as a result, doctests should not set, e.g. a low timeout to speed up
   test skipping on slow or unreachable networks, but rather should use
   a decent timeout (to be able to pass when server is reachable) and
   add a sane skip check routine


![screenshot from 2016-02-17 23 22 25](https://cloud.githubusercontent.com/assets/1842780/13126992/5f2c8384-d5cd-11e5-8817-755355dfee62.png)

- 1st run is without connection to test server (all test, even doctests, skipped after check routine)
- 2nd run is with connection to test server