### PR TITLE
Silencing a log warning for the clients.fdsn.mass_downloader tests

### DIFF
--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -15,6 +15,7 @@ from future.builtins import *  # NOQA
 
 import collections
 import copy
+import logging
 import os
 import shutil
 from socket import timeout as socket_timeout
@@ -2175,7 +2176,16 @@ class DownloadHelperTestCase(unittest.TestCase):
 
         patch.side_effect = side_effect
 
-        d = MassDownloader()
+        logger = logging.getLogger("obspy.clients.fdsn.mass_downloader")
+        _l = logger.level
+        logger.setLevel(logging.CRITICAL)
+
+        try:
+            d = MassDownloader()
+        finally:
+            # Make sure to not change the log-level.
+            logger.setLevel(_l)
+
         self.assertTrue(len(d._initialized_clients) > 10)
         self.assertFalse("IRIS" in d._initialized_clients)
         self.assertFalse("RESIF" in d._initialized_clients)


### PR DESCRIPTION
This just hides a test warning that manifested on Python 2.