### PR TITLE
geographiclib.geodesicline.GeodesicLine missing ArcPosition method on older geographiclib

### DIFF
--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -502,12 +502,13 @@ class TauPyModel(object):
                                           phase_list)
 
         if geodetics.HAS_GEOGRAPHICLIB:
-            arrivals = add_geo_to_arrivals(arrivals, source_latitude_in_deg,
-                                           source_longitude_in_deg,
-                                           receiver_latitude_in_deg,
-                                           receiver_longitude_in_deg,
-                                           self.model.radius_of_planet,
-                                           self.planet_flattening)
+            try:
+                arrivals = add_geo_to_arrivals(
+                    arrivals, source_latitude_in_deg, source_longitude_in_deg,
+                    receiver_latitude_in_deg, receiver_longitude_in_deg,
+                    self.model.radius_of_planet, self.planet_flattening)
+            except ImportError as e:
+                warnings.warn("ImportError: " + str(e))
         else:
             msg = "Not able to evaluate positions of pierce points. " + \
                   "Arrivals object will not be modified. " + \
@@ -561,12 +562,13 @@ class TauPyModel(object):
                                       phase_list)
 
         if geodetics.HAS_GEOGRAPHICLIB:
-            arrivals = add_geo_to_arrivals(arrivals, source_latitude_in_deg,
-                                           source_longitude_in_deg,
-                                           receiver_latitude_in_deg,
-                                           receiver_longitude_in_deg,
-                                           self.model.radius_of_planet,
-                                           self.planet_flattening)
+            try:
+                arrivals = add_geo_to_arrivals(
+                    arrivals, source_latitude_in_deg, source_longitude_in_deg,
+                    receiver_latitude_in_deg, receiver_longitude_in_deg,
+                    self.model.radius_of_planet, self.planet_flattening)
+            except ImportError as e:
+                warnings.warn("ImportError: " + str(e))
         else:
             msg = "Not able to evaluate positions of points on path. " + \
                   "Arrivals object will not be modified. " + \

--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 
+from obspy.core.util.misc import to_int_or_zero
 from .helper_classes import TimeDistGeo
 from ..geodetics import gps2dist_azimuth, kilometer2degrees
 import obspy.geodetics.base as geodetics
@@ -26,6 +27,9 @@ import obspy.geodetics.base as geodetics
 
 if geodetics.HAS_GEOGRAPHICLIB:
     from geographiclib.geodesic import Geodesic
+    import geographiclib
+    GEOGRAPHICLIB_VERSION = list(map(
+        to_int_or_zero, geographiclib.__version__.split(".")))
 
 
 def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
@@ -107,6 +111,13 @@ def add_geo_to_arrivals(arrivals, source_latitude_in_deg,
     :rtype: :class:`Arrivals`
     """
     if geodetics.HAS_GEOGRAPHICLIB:
+        if GEOGRAPHICLIB_VERSION < [1, 34]:
+            # geographiclib is not installed ...
+            # and  obspy/geodetics does not help much
+            msg = ("This functionality needs the Python module "
+                   "'geographiclib' in version 1.34 or higher (your version "
+                   "is {}).").format(geographiclib.__version__)
+            raise ImportError(msg)
         ellipsoid = Geodesic(a=radius_of_planet_in_km * 1000.0,
                              f=flattening_of_planet)
         g = ellipsoid.Inverse(source_latitude_in_deg, source_longitude_in_deg,

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -302,12 +302,14 @@ class TauPyModelTestCase(unittest.TestCase):
         This version of the test is used when geographiclib is installed
         """
         m = TauPyModel(model="iasp91")
-        arrivals = m.get_pierce_points_geo(source_depth_in_km=10.0,
-                                           source_latitude_in_deg=-45.0,
-                                           source_longitude_in_deg=-50.0,
-                                           receiver_latitude_in_deg=-80.0,
-                                           receiver_longitude_in_deg=-50.0,
-                                           phase_list=["P"])
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            arrivals = m.get_pierce_points_geo(
+                source_depth_in_km=10.0,
+                source_latitude_in_deg=-45.0,
+                source_longitude_in_deg=-50.0,
+                receiver_latitude_in_deg=-80.0,
+                receiver_longitude_in_deg=-50.0, phase_list=["P"])
         self.assertEqual(len(arrivals), 1)
         p_arr = arrivals[0]
 
@@ -535,12 +537,14 @@ class TauPyModelTestCase(unittest.TestCase):
         expected = np.genfromtxt(filename, comments='>')
 
         m = TauPyModel(model="iasp91")
-        arrivals = m.get_ray_paths_geo(source_depth_in_km=10.0,
-                                       source_latitude_in_deg=-80.0,
-                                       source_longitude_in_deg=-60.0,
-                                       receiver_latitude_in_deg=-45.0,
-                                       receiver_longitude_in_deg=-60.0,
-                                       phase_list=["P"])
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            arrivals = m.get_ray_paths_geo(
+                source_depth_in_km=10.0,
+                source_latitude_in_deg=-80.0,
+                source_longitude_in_deg=-60.0,
+                receiver_latitude_in_deg=-45.0,
+                receiver_longitude_in_deg=-60.0, phase_list=["P"])
         self.assertEqual(len(arrivals), 1)
 
         # Interpolate both paths to 100 samples and make sure they are


### PR DESCRIPTION
See e.g. http://tests.obspy.org/35761/#2.

I think it was added with geographiclib version 1.34? https://sourceforge.net/p/geographiclib/code/ci/38346a898eca56d2f9901899c21927c2040c424e?page=4#diff-22

We should at least show an information about geographiclib being too old inside `obspy.taup.taup_geo.add_geo_to_arrivals()`: https://github.com/obspy/obspy/blob/1.0.0rc2/obspy/taup/taup_geo.py#L137