### PR TITLE
Allow overriding Python interpreter used for documentation

### DIFF
--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
+PYTHON        = python
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -52,7 +53,7 @@ clean:
 	@rm -rf $(BUILDDIR)/*
 	@rm -rf source/packages/autogen/obspy.*
 	@rm -rf source/pep8/*
-	@python make_assets.py -c -f
+	@$(PYTHON) make_assets.py -c -f
 
 coverage:
 	@coverage run --rcfile=.coveragerc -m obspy.scripts.runtests -q --all
@@ -65,20 +66,20 @@ coverager:
 	@coverage xml --rcfile=.coveragerc -o $(BUILDDIR)/html/coverage.xml
 
 c_coverage:
-	@python make_c_coverage.py $(BUILDDIR)/html/c_coverage
+	@$(PYTHON) make_c_coverage.py $(BUILDDIR)/html/c_coverage
 
 pep8:
-	@python make_pep8.py 1
+	@$(PYTHON) make_pep8.py 1
 	@pep8 --show-source source/tutorial; echo
 
 citations:
-	@python make_citations.py
+	@$(PYTHON) make_citations.py
 
 credits:
-	@python make_credits.py
+	@$(PYTHON) make_credits.py
 
 assets:
-	@python make_assets.py
+	@$(PYTHON) make_assets.py
 
 html: assets credits citations
 	if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi

--- a/misc/docs/source/tutorial/code_snippets/xcorr_pick_correction.py
+++ b/misc/docs/source/tutorial/code_snippets/xcorr_pick_correction.py
@@ -5,8 +5,9 @@ from obspy.signal.cross_correlation import xcorr_pick_correction
 
 
 # read example data of two small earthquakes
-st1 = obspy.read("https://examples.obspy.org/BW.UH1..EHZ.D.2010.147.a.slist.gz")
-st2 = obspy.read("https://examples.obspy.org/BW.UH1..EHZ.D.2010.147.b.slist.gz")
+path = "https://examples.obspy.org/BW.UH1..EHZ.D.2010.147.%s.slist.gz"
+st1 = obspy.read(path % ("a", ))
+st2 = obspy.read(path % ("b", ))
 # select the single traces to use in correlation.
 # to avoid artifacts from preprocessing there should be some data left and
 # right of the short time window actually used in the correlation.


### PR DESCRIPTION
Running `make <target>` always uses `python`, but on anything but conda, `python` is always `python2`, in accordance with the PEP. That means you can't run, e.g., `make pep8` with Python 3.