### PR TITLE
Deprecation warning fixes

### DIFF
--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -596,9 +596,6 @@ class WaveformStreamIDTestCase(unittest.TestCase):
         """
         Test initialization with an invalid seed string. Should raise a
         warning.
-
-        Skipped for Python 2.5 because it does not have the catch_warnings
-        context manager.
         """
         # An invalid SEED string will issue a warning and fill the object with
         # the default values.

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -76,7 +76,6 @@ import math
 import os
 import os.path
 import sys
-import warnings
 
 import numpy as np
 
@@ -363,15 +362,13 @@ class MomentTensor:
 
         # eigen values can be zero in some cases. this is handled in the
         # following try/except.
-        with warnings.catch_warnings(record=True):
-            np_err = np.seterr(all="warn")
+        with np.errstate(all='ignore'):
             F = -eigenw_devi[0] / eigenw_devi[2]
 
             M_DC = \
                 eigenw[2] * (1 - 2 * F) * (np.outer(a3, a3) - np.outer(a2, a2))
             M_CLVD = eigenw[2] * F * (2 * np.outer(a3, a3) - np.outer(a2, a2) -
                                       np.outer(a1, a1))
-            np.seterr(**np_err)
 
         try:
             M_DC_percentage = int(round((1 - 2 * abs(F)) * 100, 6))
@@ -2707,10 +2704,8 @@ class BeachBall:
         norm_factor = max(np.abs([EWh, EWn, EWs]))
 
         # norm_factor is be zero in some cases
-        with warnings.catch_warnings(record=True):
-            np_err = np.seterr(all="warn")
+        with np.errstate(all='ignore'):
             [EWh, EWn, EWs] = [xx / norm_factor for xx in [EWh, EWn, EWs]]
-            np.seterr(**np_err)
 
         RHS = -EWs / (EWn * np.cos(phi) ** 2 + EWh * np.sin(phi) ** 2)
 

--- a/obspy/io/pde/tests/test_mchedr.py
+++ b/obspy/io/pde/tests/test_mchedr.py
@@ -326,6 +326,7 @@ Gumma, Ibaraki, Kanagawa, Miyagi, Saitama, Tochigi and Tokyo.')
         # Read file again. Avoid the (legit) warning about the already used
         # resource identifiers.
         with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always')
             catalog = read_events(filename)
             self.assertTrue(len(catalog), 1)
 

--- a/obspy/io/seg2/tests/test_seg2.py
+++ b/obspy/io/seg2/tests/test_seg2.py
@@ -9,6 +9,7 @@ from future.builtins import *  # NOQA
 import gzip
 import os
 import unittest
+import warnings
 
 import numpy as np
 
@@ -78,7 +79,11 @@ class SEG2TestCase(unittest.TestCase):
         basename = os.path.join(self.path,
                                 '20130107_103041000.CET.3c.cont.0')
         # read SEG2 data (in counts, int32)
-        st = read(basename + ".seg2.gz")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            st = read(basename + ".seg2.gz")
+        self.assertEqual(len(w), 1)
+        self.assertIn('custom', str(w[0]))
         # read reference ASCII data (in micrometer/s)
         with gzip.open(basename + ".DAT.gz", 'rb') as f:
             results = np.loadtxt(f).T

--- a/obspy/io/xseed/tests/test_parser.py
+++ b/obspy/io/xseed/tests/test_parser.py
@@ -349,7 +349,7 @@ class ParserTestCase(unittest.TestCase):
         """
         filename = os.path.join(self.path, 'arclink_full.seed')
         sp = Parser(filename)
-        paz = sp.getPAZ('BHE')
+        paz = sp.get_paz('BHE')
         self.assertEqual(paz['gain'], +6.00770e+07)
         self.assertEqual(paz['zeros'], [0j, 0j])
         self.assertEqual(
@@ -360,13 +360,13 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(paz['sensitivity'], +7.86576e+08)
         self.assertEqual(paz['seismometer_gain'], +1.50000E+03)
         # Raise exception for undefined channels
-        self.assertRaises(SEEDParserException, sp.getPAZ, 'EHE')
+        self.assertRaises(SEEDParserException, sp.get_paz, 'EHE')
         #
         # Do the same for another dataless file
         #
         filename = os.path.join(self.path, 'dataless.seed.BW_FURT')
         sp = Parser(filename)
-        paz = sp.getPAZ('EHE')
+        paz = sp.get_paz('EHE')
         self.assertEqual(paz['gain'], +1.00000e+00)
         self.assertEqual(paz['zeros'], [0j, 0j, 0j])
         self.assertEqual(paz['poles'], [(-4.44400e+00 + 4.44400e+00j),
@@ -375,14 +375,14 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(paz['sensitivity'], +6.71140E+08)
         self.assertEqual(paz['seismometer_gain'], 4.00000E+02)
         # Raise exception for undefined channels
-        self.assertRaises(SEEDParserException, sp.getPAZ, 'BHE')
+        self.assertRaises(SEEDParserException, sp.get_paz, 'BHE')
         # Raise UserWarning if not a Laplacian transfer function ('A').
         # Modify transfer_fuction_type on the fly
         for blk in sp.blockettes[53]:
             blk.transfer_function_types = 'X'
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("error", UserWarning)
-            self.assertRaises(UserWarning, sp.getPAZ, 'EHE')
+            self.assertRaises(UserWarning, sp.get_paz, 'EHE')
         #
         # And the same for yet another dataless file
         #
@@ -404,14 +404,14 @@ class ParserTestCase(unittest.TestCase):
         sensitivity = [+4.92360E+08, +2.20419E+06, +9.84720E+08]
         seismometer_gain = [+2.29145E+03, +1.02583E+01, +2.29145E+03]
         for i, channel in enumerate(['BHZ', 'BLZ', 'LHZ']):
-            paz = sp.getPAZ(channel)
+            paz = sp.get_paz(channel)
             self.assertEqual(paz['gain'], gain[i])
             self.assertEqual(paz['zeros'], zeros[i])
             self.assertEqual(paz['poles'], poles[i])
             self.assertEqual(paz['sensitivity'], sensitivity[i])
             self.assertEqual(paz['seismometer_gain'], seismometer_gain[i])
         sp = Parser(os.path.join(self.path, 'dataless.seed.BW_RJOB'))
-        paz = sp.getPAZ("BW.RJOB..EHZ", UTCDateTime("2007-01-01"))
+        paz = sp.get_paz("BW.RJOB..EHZ", UTCDateTime("2007-01-01"))
         result = {'gain': 1.0,
                   'poles': [(-4.444 + 4.444j), (-4.444 - 4.444j),
                             (-1.083 + 0j)],
@@ -420,7 +420,7 @@ class ParserTestCase(unittest.TestCase):
                   'zeros': [0j, 0j, 0j],
                   'digitizer_gain': 1677850.0}
         self.assertEqual(paz, result)
-        paz = sp.getPAZ("BW.RJOB..EHZ", UTCDateTime("2010-01-01"))
+        paz = sp.get_paz("BW.RJOB..EHZ", UTCDateTime("2010-01-01"))
         result = {'gain': 60077000.0,
                   'poles': [(-0.037004000000000002 + 0.037016j),
                             (-0.037004000000000002 - 0.037016j),
@@ -443,8 +443,8 @@ class ParserTestCase(unittest.TestCase):
                   'sensitivity': 2516800000.0,
                   'zeros': [0j, 0j],
                   'digitizer_gain': 1677850.0}
-        paz = sp.getPAZ(seed_id="BW.RJOB..EHZ",
-                        datetime=UTCDateTime("2010-01-01"))
+        paz = sp.get_paz(seed_id="BW.RJOB..EHZ",
+                         datetime=UTCDateTime("2010-01-01"))
         self.assertEqual(sorted(paz.items()), sorted(result.items()))
 
     def test_get_paz_from_xseed(self):
@@ -454,7 +454,7 @@ class ParserTestCase(unittest.TestCase):
         filename = os.path.join(self.path, 'dataless.seed.BW_FURT')
         sp1 = Parser(filename)
         sp2 = Parser(sp1.get_xseed())
-        paz = sp2.getPAZ('EHE')
+        paz = sp2.get_paz('EHE')
         result = {'gain': 1.00000e+00,
                   'zeros': [0j, 0j, 0j],
                   'poles': [(-4.44400e+00 + 4.44400e+00j),
@@ -631,7 +631,7 @@ class ParserTestCase(unittest.TestCase):
         parser = Parser()
         parser.read(filename)
         dt = UTCDateTime('2012-01-01')
-        parser.getPAZ('CL.AIO.00.EHZ', dt)
+        parser.get_paz('CL.AIO.00.EHZ', dt)
 
     def test_issue_361(self):
         """
@@ -641,15 +641,15 @@ class ParserTestCase(unittest.TestCase):
         parser = Parser()
         parser.read(filename)
         # 1 - G.SPB..BHZ - no Laplace transform - works
-        parser.getPAZ('G.SPB..BHZ')
+        parser.get_paz('G.SPB..BHZ')
         # 2 - G.SPB.00.BHZ - raises exception because of multiple results
-        self.assertRaises(SEEDParserException, parser.getPAZ, 'G.SPB.00.BHZ')
+        self.assertRaises(SEEDParserException, parser.get_paz, 'G.SPB.00.BHZ')
         # 3 - G.SPB.00.BHZ with datetime - no Laplace transform - works
         dt = UTCDateTime('2007-01-01')
-        parser.getPAZ('G.SPB.00.BHZ', dt)
+        parser.get_paz('G.SPB.00.BHZ', dt)
         # 4 - G.SPB.00.BHZ with later datetime works
         dt = UTCDateTime('2012-01-01')
-        parser.getPAZ('G.SPB.00.BHZ', dt)
+        parser.get_paz('G.SPB.00.BHZ', dt)
 
     def test_split_stations_dataless_to_xseed(self):
         """

--- a/obspy/io/y/tests/test_core.py
+++ b/obspy/io/y/tests/test_core.py
@@ -5,6 +5,7 @@ from future.builtins import *  # NOQA
 
 import os
 import unittest
+import warnings
 
 from obspy.io.y.core import _is_y, _read_y
 
@@ -50,7 +51,11 @@ class CoreTestCase(unittest.TestCase):
         Test faulty Y file containing non ASCII chars in TAG_STATION_INFO.
         """
         testfile = os.path.join(self.path, 'data', 'YAZRSPE.20100119.060433')
-        st = _read_y(testfile)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            st = _read_y(testfile)
+        self.assertEqual(len(w), 1)
+        self.assertIn('Invalid', str(w[0]))
         self.assertEqual(len(st), 1)
         tr = st[0]
         self.assertEqual(len(tr), 16976)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -197,7 +197,7 @@ class PPSD(object):
     >>> ppsd = PPSD(tr.stats, paz)
     >>> print(ppsd.id)
     BW.RJOB..EHZ
-    >>> print(ppsd.times)
+    >>> print(ppsd.times_processed)
     []
 
     Now we could add data to the probabilistic psd (all processing like

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -19,6 +19,7 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime, read, read_inventory
 from obspy.core import Stats
 from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.core.util.testing import (
     ImageComparison, ImageComparisonException, MATPLOTLIB_VERSION)
 from obspy.io.xseed import Parser
@@ -336,8 +337,18 @@ class PsdTestCase(unittest.TestCase):
         # (also test various means of initialization, basically testing the
         #  decorator that maps the deprecated keywords)
         for metadata in [parser, inv, resp]:
-            ppsd = PPSD(st[0].stats, paz=metadata)
-            ppsd = PPSD(st[0].stats, parser=metadata)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                ppsd = PPSD(st[0].stats, paz=metadata)
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, ObsPyDeprecationWarning)
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                ppsd = PPSD(st[0].stats, parser=metadata)
+            self.assertEqual(len(w), 1)
+            self.assertIs(w[0].category, ObsPyDeprecationWarning)
+
             ppsd = PPSD(st[0].stats, metadata)
             ppsd.add(st)
             # commented code to generate the test data:

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -185,7 +185,7 @@ class PsdTestCase(unittest.TestCase):
         ppsd = _get_ppsd()
         # read results and compare
         result_hist = np.load(file_histogram)
-        self.assertEqual(len(ppsd.times), 4)
+        self.assertEqual(len(ppsd.times_processed), 4)
         self.assertEqual(ppsd.nfft, 65536)
         self.assertEqual(ppsd.nlap, 49152)
         np.testing.assert_array_equal(ppsd.current_histogram, result_hist)
@@ -217,14 +217,14 @@ class PsdTestCase(unittest.TestCase):
             ppsd.save_npz(filename)
             ppsd_loaded = PPSD.load_npz(filename)
             ppsd_loaded.calculate_histogram()
-            self.assertEqual(len(ppsd_loaded.times), 4)
+            self.assertEqual(len(ppsd_loaded.times_processed), 4)
             self.assertEqual(ppsd_loaded.nfft, 65536)
             self.assertEqual(ppsd_loaded.nlap, 49152)
             np.testing.assert_array_equal(ppsd_loaded.current_histogram,
                                           result_hist)
-            np.testing.assert_array_equal(ppsd_loaded.spec_bins,
+            np.testing.assert_array_equal(ppsd_loaded.db_bin_edges,
                                           binning['spec_bins'])
-            np.testing.assert_array_equal(ppsd_loaded.period_bins,
+            np.testing.assert_array_equal(ppsd_loaded.period_bin_centers,
                                           binning['period_bins'])
 
     def test_ppsd_w_iris(self):

--- a/obspy/taup/taup.py
+++ b/obspy/taup/taup.py
@@ -133,6 +133,7 @@ def travelTimePlot(min_degree=0, max_degree=360, npoints=1000,  # noqa
     # Loop over all degrees.
     for degree in degrees:
         with warnings.catch_warnings(record=True):
+            warnings.simplefilter('always')
             tt = getTravelTimes(degree, depth, model, phase_list=phases)
         # Mirror if necessary.
         if degree > 180:

--- a/obspy/taup/tests/test_obspy_taup_wrapper.py
+++ b/obspy/taup/tests/test_obspy_taup_wrapper.py
@@ -8,6 +8,7 @@ from future.builtins import *  # NOQA
 
 import os
 import unittest
+import warnings
 
 from obspy.taup.taup import getTravelTimes
 
@@ -30,7 +31,9 @@ class ObsPyTauPWrapperTestCase(unittest.TestCase):
             data = fp.readlines()
 
         # 1
-        tt = getTravelTimes(delta=52.474, depth=611.0, model='ak135')[:16]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tt = getTravelTimes(delta=52.474, depth=611.0, model='ak135')[:16]
         lines = data[5:21]
         self.assertEqual(len(tt), len(lines))
         # check calculated tt against original
@@ -46,7 +49,9 @@ class ObsPyTauPWrapperTestCase(unittest.TestCase):
             self.assertAlmostEqual(item['dT/dD'], float(parts[3]), 1)
 
         # 2
-        tt = getTravelTimes(delta=50.0, depth=300.0, model='ak135')[:17]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tt = getTravelTimes(delta=50.0, depth=300.0, model='ak135')[:17]
         lines = data[26:43]
         self.assertEqual(len(tt), len(lines))
         # check calculated tt against original
@@ -69,7 +74,9 @@ class ObsPyTauPWrapperTestCase(unittest.TestCase):
             data = fp.readlines()
 
         # 1
-        tt = getTravelTimes(delta=52.474, depth=611.0, model='iasp91')[:16]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tt = getTravelTimes(delta=52.474, depth=611.0, model='iasp91')[:16]
         lines = data[5:21]
         self.assertEqual(len(tt), len(lines))
         # check calculated tt against original
@@ -83,7 +90,9 @@ class ObsPyTauPWrapperTestCase(unittest.TestCase):
             self.assertAlmostEqual(item['dT/dD'], float(parts[3]), 1)
 
         # 2
-        tt = getTravelTimes(delta=50.0, depth=300.0, model='iasp91')[:19]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tt = getTravelTimes(delta=50.0, depth=300.0, model='iasp91')[:19]
         lines = data[26:45]
         self.assertEqual(len(tt), len(lines))
         # check calculated tt against original
@@ -104,12 +113,14 @@ class ObsPyTauPWrapperTestCase(unittest.TestCase):
 
         See #728 for more details.
         """
-        tt_1 = getTravelTimes(delta=100, depth=0, model="ak135")
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            tt_1 = getTravelTimes(delta=100, depth=0, model="ak135")
 
-        # Some other calculation in between.
-        getTravelTimes(delta=100, depth=200, model="ak135")
+            # Some other calculation in between.
+            getTravelTimes(delta=100, depth=200, model="ak135")
 
-        tt_2 = getTravelTimes(delta=100, depth=0, model="ak135")
+            tt_2 = getTravelTimes(delta=100, depth=0, model="ak135")
 
         # Both should be equal if everything is alright.
         self.assertEqual(tt_1, tt_2)


### PR DESCRIPTION
These seem to only show up if you run in verbose mode _and_ you request a single module at a time.

However, there are still [a few](https://gist.github.com/QuLogic/eea6d576866297a72f4a) I can't fix because I don't really know about those modules.