### PR TITLE
Appveyor: install basemap packages via conda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,10 @@ install:
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"
   # Install default dependencies
-  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator requests"
+  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator requests basemap"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"
-  # install basemap package
-  - pip install --trusted-host 188.166.43.188 --use-wheel --no-index --find-links=http://188.166.43.188/ basemap
   # list package versions
   - "conda list"
 

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
@@ -96,15 +96,13 @@ The triggering itself mainly consists of the following two steps:
 * Calculating the characteristic function
 * Setting picks based on values of the characteristic function
 
-
-
-    ~obspy.signal.trigger.recursive_sta_lta
-    ~obspy.signal.trigger.carl_sta_trig
-    ~obspy.signal.trigger.classic_STALTA
-    ~obspy.signal.trigger.delayed_sta_lta
-    ~obspy.signal.trigger.z_detect
-    ~obspy.signal.trigger.pk_baer
-    ~obspy.signal.trigger.ar_pick
+   * ~obspy.signal.trigger.recursive_sta_lta
+   * ~obspy.signal.trigger.carl_sta_trig
+   * ~obspy.signal.trigger.classic_STALTA
+   * ~obspy.signal.trigger.delayed_sta_lta
+   * ~obspy.signal.trigger.z_detect
+   * ~obspy.signal.trigger.pk_baer
+   * ~obspy.signal.trigger.ar_pick
 
 Help for each function is available  HTML formatted or in the usual Python manner:
 
@@ -117,15 +115,13 @@ The triggering itself mainly consists of the following two steps:
 * Calculating the characteristic function
 * Setting picks based on values of the characteristic function
 
-
-
-    ~obspy.signal.trigger.recursive_sta_lta
-    ~obspy.signal.trigger.carl_sta_trig
-    ~obspy.signal.trigger.classic_STALTA
-    ~obspy.signal.trigger.delayed_sta_lta
-    ~obspy.signal.trigger.z_detect
-    ~obspy.signal.trigger.pk_baer
-    ~obspy.signal.trigger.ar_pick
+   * ~obspy.signal.trigger.recursive_sta_lta
+   * ~obspy.signal.trigger.carl_sta_trig
+   * ~obspy.signal.trigger.classic_STALTA
+   * ~obspy.signal.trigger.delayed_sta_lta
+   * ~obspy.signal.trigger.z_detect
+   * ~obspy.signal.trigger.pk_baer
+   * ~obspy.signal.trigger.ar_pick
 
 Help for each function is available  HTML formatted or in the usual Python manner:
 
@@ -154,8 +150,8 @@ Classic Sta Lta
 ===============
 
     >>> from obspy.signal.trigger import classic_sta_lta
-        >>> cft = classic_STALTA(trace.data, int(5 * df), int(10 * df))
-        >>> plot_trigger(trace, cft, 1.5, 0.5)
+    >>> cft = classic_STALTA(trace.data, int(5 * df), int(10 * df))
+    >>> plot_trigger(trace, cft, 1.5, 0.5)
 
 
     >>> cft = classic_STALTA(trace.data, int(5 * df), int(10 * df))
@@ -176,8 +172,8 @@ Recursive Sta Lta
 =================
 
     >>> from obspy.signal.trigger import recursive_STALTA
-        >>> cft = recursive_sta_lta(trace.data, int(5 * df), int(10 * df))
-        >>> plot_trigger(trace, cft, 1.2, 0.5)
+    >>> cft = recursive_sta_lta(trace.data, int(5 * df), int(10 * df))
+    >>> plot_trigger(trace, cft, 1.2, 0.5)
 
 
     >>> cft = recursive_STALTA(trace.data, int(5 * df), int(10 * df))
@@ -189,8 +185,8 @@ Carl-Sta-Trig
 =============
 
     >>> from obspy.signal.trigger import carl_STA_trig
-        >>> cft = carl_sta_trig(trace.data, int(5 * df), int(10 * df), 0.8, 0.8)
-        >>> plot_trigger(trace, cft, 20.0, -20.0)
+    >>> cft = carl_sta_trig(trace.data, int(5 * df), int(10 * df), 0.8, 0.8)
+    >>> plot_trigger(trace, cft, 20.0, -20.0)
 
 
     >>> cft = carl_STA_trig(trace.data, int(5 * df), int(10 * df), 0.8, 0.8)
@@ -202,8 +198,8 @@ Delayed Sta Lta
 ===============
 
     >>> from obspy.signal.trigger import delayed_STALTA
-        >>> cft = delayed_sta_lta(trace.data, int(5 * df), int(10 * df))
-        >>> plot_trigger(trace, cft, 5, 10)
+    >>> cft = delayed_sta_lta(trace.data, int(5 * df), int(10 * df))
+    >>> plot_trigger(trace, cft, 5, 10)
 
 
     >>> cft = delayed_STALTA(trace.data, int(5 * df), int(10 * df))


### PR DESCRIPTION
They have files for Py2.7 so we should not need this hardcoded wheel server anymore..