### PR TITLE
appveyor: install basemap via conda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,10 @@ install:
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"
   # Install default dependencies
-  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator requests"
+  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy flake8 mock nose gdal decorator requests basemap"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"
-  # install basemap package
-  - pip install --trusted-host 188.166.43.188 --use-wheel --no-index --find-links=http://188.166.43.188/ basemap
   # list package versions
   - "conda list"
 


### PR DESCRIPTION
They have files for Py2.7 so we should not need this hardcoded wheel server anymore..