### PR TITLE
SAC reference time not automatically set for incomplete stats.sac header

### DIFF
--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -621,10 +621,10 @@ def validate_sac_content(hf, hi, hs, data, *tests):
                 hdr = 'b'
             elif iztype_val == 11:
                 hdr = 'o'
-            elif val == 12:
+            elif iztype_val == 12:
                 hdr = 'a'
             elif val in range(13, 23):
-                hdr = 'it'+str(val-13)
+                hdr = 'it'+str(iztype_val-13)
 
             if hi[HD.FLOATHDRS.index(hdr)] == HD.INULL:
                 msg = "Reference header '{}' for iztype '{}' not set."

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -623,7 +623,7 @@ def validate_sac_content(hf, hi, hs, data, *tests):
                 hdr = 'o'
             elif iztype_val == 12:
                 hdr = 'a'
-            elif val in range(13, 23):
+            elif iztype_val in range(13, 23):
                 hdr = 'it'+str(iztype_val-13)
 
             if hi[HD.FLOATHDRS.index(hdr)] == HD.INULL:

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1554,7 +1554,7 @@ class SACTrace(object):
                 self._hf[HD.FLOATHDRS.index('baz')] = baz
                 self._hf[HD.FLOATHDRS.index('dist')] = dist
                 self._hf[HD.FLOATHDRS.index('gcarc')] = gcarc
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError):
                 # one or more of the geographic values is None
                 if force:
                     msg = ("Not enough information to calculate distance, "

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -812,8 +812,8 @@ class CoreTestCase(unittest.TestCase):
         """
         tr = read()[0]
         o = 0.0
-        stla = 35.4
         stlo = -100.4
+        stla = 35.4
         tr.stats.sac = {'o': o, 'stla': stla, 'stlo': stlo}
 
         with NamedTemporaryFile() as tf:

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -810,11 +810,9 @@ class CoreTestCase(unittest.TestCase):
         to validity or reference time on Trace.stats.sac is properly merged
         with the Trace.stats header. Issue 1285.
         """
-        tr = read()[0]
-        o = 0.0
-        stlo = -100.4
-        stla = 35.4
-        tr.stats.sac = {'o': o, 'stla': stla, 'stlo': stlo}
+        tr = Trace(data=np.arange(30))
+        o = 10.0
+        tr.stats.sac = {'o': o}
 
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
@@ -826,8 +824,6 @@ class CoreTestCase(unittest.TestCase):
 
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)
         self.assertEqual(tr1.stats.sac.o, o)
-        self.assertEqual(tr1.stats.sac.stla, stla)
-        self.assertEqual(tr1.stats.sac.stlo, stlo)
 
 
 def suite():

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -82,8 +82,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SACXY')
-                # self.assertEqual(len(w), 1)
-                # self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
         self.assertEqual(tr, tr1)
 
@@ -623,8 +623,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, fh)
-                # self.assertEqual(len(w), 1)
-                # self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             fh.seek(0, 0)
             st2 = _read_sac_xy(fh)
 
@@ -641,8 +641,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, tf)
-                # self.assertEqual(len(w), 1)
-                # self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tf.seek(0, 0)
             st2 = _read_sac_xy(tf)
 
@@ -780,8 +780,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SAC')
-                # self.assertEqual(len(w), 1)
-                # self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 1)
+                self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
 
         # starttime made its way to SAC file
@@ -815,21 +815,22 @@ class CoreTestCase(unittest.TestCase):
         stla = 35.4
         stlo = -100.4
         tr.stats.sac = {'o': o, 'stla': stla, 'stlo': stlo}
-  
+
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SAC')
                 # should have no warnings about reftime
-                # self.assertEqual(len(w), 0)
+                self.assertEqual(len(w), 0)
             tr1 = read(tempfile)[0]
-  
+
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)
         self.assertEqual(tr1.stats.sac.o, o)
         self.assertEqual(tr1.stats.sac.stla, stla)
         self.assertEqual(tr1.stats.sac.stlo, stlo)
- 
+
+
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')
 

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -821,8 +821,7 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SAC')
-                # should have no warnings about reftime
-                self.assertEqual(len(w), 0)
+                self.assertEqual(len(w), 1)
             tr1 = read(tempfile)[0]
 
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -82,8 +82,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SACXY')
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                # self.assertEqual(len(w), 1)
+                # self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
         self.assertEqual(tr, tr1)
 
@@ -623,8 +623,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, fh)
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                # self.assertEqual(len(w), 1)
+                # self.assertIn('reftime', str(w[-1].message))
             fh.seek(0, 0)
             st2 = _read_sac_xy(fh)
 
@@ -641,8 +641,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, tf)
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                # self.assertEqual(len(w), 1)
+                # self.assertIn('reftime', str(w[-1].message))
             tf.seek(0, 0)
             st2 = _read_sac_xy(tf)
 
@@ -780,8 +780,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SAC')
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                # self.assertEqual(len(w), 1)
+                # self.assertIn('reftime', str(w[-1].message))
             tr1 = read(tempfile)[0]
 
         # starttime made its way to SAC file
@@ -811,9 +811,9 @@ class CoreTestCase(unittest.TestCase):
         with the Trace.stats header. Issue 1285.
         """
         tr = read()[0]
-        o = 0
-        stla = 35.45
-        stlo = -100.45
+        o = 0.0
+        stla = 35.4
+        stlo = -100.4
         tr.stats.sac = {'o': o, 'stla': stla, 'stlo': stlo}
   
         with NamedTemporaryFile() as tf:

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -804,7 +804,32 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr1.stats.sac.stla, 1.0)
         self.assertEqual(tr1.stats.sac.stlo, 2.0)
 
-
+    def test_merge_sac_obspy_headers(self):
+        """
+        Test that manually setting a set of SAC headers not related
+        to validity or reference time on Trace.stats.sac is properly merged
+        with the Trace.stats header. Issue 1285.
+        """
+        tr = read()[0]
+        o = 0
+        stla = 35.45
+        stlo = -100.45
+        tr.stats.sac = {'o': o, 'stla': stla, 'stlo': stlo}
+  
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                tr.write(tempfile, format='SAC')
+                # should have no warnings about reftime
+                # self.assertEqual(len(w), 0)
+            tr1 = read(tempfile)[0]
+  
+        self.assertEqual(tr1.stats.starttime, tr.stats.starttime)
+        self.assertEqual(tr1.stats.sac.o, o)
+        self.assertEqual(tr1.stats.sac.stla, stla)
+        self.assertEqual(tr1.stats.sac.stlo, stlo)
+ 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')
 

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -11,8 +11,10 @@ import numpy as np
 
 from obspy import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
+from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from ..sactrace import SACTrace
+from ..util import SacHeaderError
 
 
 class SACTraceTestCase(unittest.TestCase):
@@ -174,6 +176,41 @@ class SACTraceTestCase(unittest.TestCase):
         self.assertEqual(sac.nzmsec, nzmsec + 1)
         self.assertAlmostEqual(sac.b, b - 1.0e-3, 6)
         self.assertAlmostEqual(sac.t1, t1 - 1.0e-3, 5)
+
+    def test_lcalda(self):
+        """
+        Test that distances are set when geographic information is present and
+        lcalda is True, and that they're not set when geographic information
+        is missing or lcalca is false.
+        """
+        stla, stlo, evla, evlo = -35.0, 100, 42.5, -37.5
+        meters, az, baz = gps2dist_azimuth(evla, evlo, stla, stlo)
+        km = meters / 1000.0
+        gcarc = kilometer2degrees(km)
+
+        # distances are set when lcalda True and all distance values set
+        sac = SACTrace(lcalda=True, stla=stla, stlo=stlo, evla=evla, evlo=evlo)
+        self.assertAlmostEqual(sac.az, az, places=4)
+        self.assertAlmostEqual(sac.baz, baz, places=4)
+        self.assertAlmostEqual(sac.dist, km, places=4)
+        self.assertAlmostEqual(sac.gcarc, gcarc, places=4)
+        # distances are not set when lcalda False and all distance values set
+        sac = SACTrace(lcalda=False, stla=stla, stlo=stlo, evla=evla,
+                       evlo=evlo)
+        self.assertIs(sac.az, None)
+        self.assertIs(sac.baz, None)
+        self.assertIs(sac.dist, None)
+        self.assertIs(sac.gcarc, None)
+        # distances are not set when lcalda True, not all distance values set
+        sac = SACTrace(lcalda=True, stla=stla)
+        self.assertIs(sac.az, None)
+        self.assertIs(sac.baz, None)
+        self.assertIs(sac.dist, None)
+        self.assertIs(sac.gcarc, None)
+        # exception raised when set_distances is forced but not all distances
+        # values are set. NOTE: still have a problem when others are "None".
+        sac = SACTrace(lcalda=True, stla=stla)
+        self.assertRaises(SacHeaderError, sac._set_distances, force=True)
 
 
 def suite():

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -349,9 +349,8 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                 warnings.warn(msg)
             else:
                 msg = ("Invalid reference time, unrecoverable relative time"
-                      " headers.")
+                       " headers.")
                 raise SacHeaderError(msg)
-
 
         # merge some values from stats if they're missing in the SAC header
         # ObsPy issue 1204

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -288,11 +288,18 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
         header values are kept, and a minimal set of values are updated from
         the stats dictionary according to these guidelines:
         * npts, delta always come from stats
-        * If an old reftime is found and valid, the new b and e will be made
-          and properly referenced to it. If the SAC reftime is invalid, the
-          reftime will be set from stats.starttime (with micro/milliseconds
-          precision adjustments) only if an existing SAC iztype is 9 and no
-          other relative time headers are set.
+        * If a valid old reftime is found, the new b and e will be made
+          and properly referenced to it. All other old SAC headers are simply
+          carried along.
+        * If the old SAC reftime is invalid and relative time headers are set,
+          a SacHeaderError exception will be raised.
+        * If the old SAC reftime is invalid, no relative time headers are set,
+          and "b" is set, "e" is updated from stats and other old SAC headers
+          are carried along.
+        * If the old SAC reftime is invalid, no relative time headers are set,
+          and "b" is not set, the reftime will be set from stats.starttime
+          (with micro/milliseconds precision adjustments) and "b" and "e" are
+          set accordingly.
         * If 'kstnm', 'knetwk', 'kcmpnm', or 'khole' are not set, they are
           taken from 'station', 'network', 'channel', and 'location' in stats.
         If keep_sac_header is False, a new SAC header is constructed from only


### PR DESCRIPTION
I want to set the 'o' sac header in a newly created Trace. This used to work with obspy<1.0 which automatically set the reference time headers. Now reference time is only set if no sac stats entry is present.

```
In [1]: tr = read()[0]
In [2]: from obspy.io.sac import SACTrace
In [3]: tr.stats.sac = {'o': 0}
In [5]: sactr = SACTrace.from_obspy_trace(tr)
/home/richter/anaconda/lib/python2.7/site-packages/obspy/io/sac/util.py:333: UserWarning: Old header has invalid reftime.
  warnings.warn(msg)
In [6]: print sactr
/home/richter/anaconda/lib/python2.7/site-packages/obspy/io/sac/sactrace.py:1395: UserWarning: Reference time information incomplete.
  warnings.warn(msg)
Reference Time = XX/XX/XX (XXX) XX:XX:XX.XXXXXX
	iztype not set
delta      = 0.00999999977648
iftype     = itime
kcmpnm     = EHZ
knetwk     = BW
kstnm      = RJOB
lcalda     = True
leven      = True
lovrok     = True
lpspol     = False
npts       = 3000
nvhdr      = 6
o          = 0.0
```

I help myself with 

```
In [8]: from obspy.io.sac.util import obspy_to_sac_header
In [9]: tr = read()[0]
In [10]: tr.stats.sac = obspy_to_sac_header(tr.stats)
In [14]: tr.stats.sac['o'] = 0
In [15]: sactr = SACTrace.from_obspy_trace(tr)
In [16]: print sactr
Reference Time = 08/24/2009 (236) 00:20:03.000000
	iztype IB: begin time
b          = 0.0
delta      = 0.00999999977648
e          = 29.9899993297
iftype     = itime
iztype     = ib
kcmpnm     = EHZ
knetwk     = BW
kstnm      = RJOB
lcalda     = True
leven      = True
lovrok     = True
lpspol     = False
npts       = 3000
nvhdr      = 6
nzhour     = 0
nzjday     = 236
nzmin      = 20
nzmsec     = 0
nzsec      = 3
nzyear     = 2009
o          = 0.0
scale      = 1.0
```

Maybe this edge case could be handled inside io.sac?
