### PR TITLE
Suggestion: add set operations to Domain and Restrictions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ master:
  - obspy.clients.fdsn
    * The mass downloader now has `exclude_networks` and `exclude_stations`
      arguments to not download certain pieces of data. (see #1305)
+   * The mass downloader can now download station that are part of a given
+     inventory object.
 
 1.0.0: (doi: 10.5281/zenodo.46151)
  - General:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,7 @@
 master:
- - ...
+ - obspy.clients.fdsn
+   * The mass downloader now has `exclude_networks` and `exclude_stations`
+     arguments to not download certain pieces of data. (see #1305)
 
 1.0.0: (doi: 10.5281/zenodo.46151)
  - General:

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -1103,6 +1103,13 @@ class ClientDownloadHelper(object):
                 if skip_station:
                     continue
 
+                # If an inventory is given, only keep stations part of the
+                # inventory.
+                if self.restrictions.limit_stations_to_inventory is not None \
+                        and (network.code, station.code) not in \
+                        self.restrictions.limit_stations_to_inventory:
+                    continue
+
                 # Skip the station if it is not in the desired domain.
                 if needs_filtering is True and \
                         not self.domain.is_in_domain(station.latitude,

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -21,11 +21,13 @@ with standard_library.hooks():
 
 import collections
 import copy
+import fnmatch
 from multiprocessing.pool import ThreadPool
-import numpy as np
 import os
 import time
 import timeit
+
+import numpy as np
 
 import obspy
 from obspy.core.util import Enum
@@ -1082,7 +1084,25 @@ class ClientDownloadHelper(object):
                      for _i in self.restrictions]
 
         for network in inv:
+            # Skip network if so desired.
+            skip_network = False
+            for pattern in self.restrictions.exclude_networks:
+                if fnmatch.fnmatch(network.code, pattern):
+                    skip_network = True
+                    break
+            if skip_network:
+                continue
+
             for station in network:
+                # Skip station if so desired.
+                skip_station = False
+                for pattern in self.restrictions.exclude_stations:
+                    if fnmatch.fnmatch(station.code, pattern):
+                        skip_station = True
+                        break
+                if skip_station:
+                    continue
+
                 # Skip the station if it is not in the desired domain.
                 if needs_filtering is True and \
                         not self.domain.is_in_domain(station.latitude,

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -75,6 +75,32 @@ class Restrictions(object):
     ...     # Guard against the same station having different names.
     ...     minimum_interstation_distance_in_m=100.0)
 
+    The ``network``, ``station``, ``location``, and ``channel`` codes are
+    directly passed to the `station` service of each fdsn-ws implementation
+    and can thus take comma separated string lists as arguments, i.e.
+
+    .. code-block:: python
+
+        restrictions = Restrictions(
+            ...
+            network="BW,G?", station="A*,B*",
+            ...
+            )
+
+    Not all fdsn-ws implementations support the direct exclusion of network
+    or station codes. The ``exclude_networks`` and ``exclude_stations``
+    arguments should thus be used for that purpose to ensure compatibility
+    across all data providers, e.g.
+
+    .. code-block:: python
+
+        restrictions = Restrictions(
+            ...
+            network="B*,G*", station="A*, B*",
+            exclude_networks=["BW", "GR"],
+            exclude_stations=["AL??", "*O"],
+            ...
+            )
 
     :param starttime: The start time of the data to be downloaded.
     :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
@@ -103,6 +129,12 @@ class Restrictions(object):
     :type location: str
     :param channel: The channel code. Can contain wildcards.
     :type channel: str
+    :param exclude_network: A list of potentially wildcarded networks that
+        should not be downloaded.
+    :type exclude_network: list of str
+    :param exclude_stations: A list of potentially wildcarded stations that
+        should not be downloaded.
+    :type exclude_stations: list of str
     :param reject_channels_with_gaps: If True (default), MiniSEED files with
         gaps and/or overlaps will be rejected.
     :type reject_channels_with_gaps: bool
@@ -134,6 +166,7 @@ class Restrictions(object):
                  station_starttime=None, station_endtime=None,
                  chunklength_in_sec=None,
                  network=None, station=None, location=None, channel=None,
+                 exclude_networks=tuple(), exclude_stations=tuple(),
                  reject_channels_with_gaps=True, minimum_length=0.9,
                  sanitize=True, minimum_interstation_distance_in_m=1000,
                  channel_priorities=("HH[ZNE]", "BH[ZNE]",
@@ -157,6 +190,8 @@ class Restrictions(object):
         self.station = station
         self.location = location
         self.channel = channel
+        self.exclude_networks = exclude_networks
+        self.exclude_stations = exclude_stations
         self.reject_channels_with_gaps = reject_channels_with_gaps
         self.minimum_length = minimum_length
         self.sanitize = bool(sanitize)

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -145,9 +145,9 @@ class Restrictions(object):
     :type location: str
     :param channel: The channel code. Can contain wildcards.
     :type channel: str
-    :param exclude_network: A list of potentially wildcarded networks that
+    :param exclude_networks: A list of potentially wildcarded networks that
         should not be downloaded.
-    :type exclude_network: list of str
+    :type exclude_networks: list of str
     :param exclude_stations: A list of potentially wildcarded stations that
         should not be downloaded.
     :type exclude_stations: list of str

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -102,6 +102,22 @@ class Restrictions(object):
             ...
             )
 
+    It is also possible to restrict the downloaded stations to stations part of
+    an existing inventory object which can originate from a StationXML file or
+    from other sources. It will only keep stations that are part of the
+    inventory object. Channels are still selected dynamically based on the
+    other restrictions. Keep in mind that all other restrictions still apply -
+    passing an inventory will just further restrict the possibly downloaded
+    data.
+
+    .. code-block:: python
+
+        restrictions = Restrictions(
+            ...
+            limit_stations_to_inventory=inv,
+            ...
+            )
+
     :param starttime: The start time of the data to be downloaded.
     :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
     :param endtime: The end time of the data.
@@ -135,6 +151,12 @@ class Restrictions(object):
     :param exclude_stations: A list of potentially wildcarded stations that
         should not be downloaded.
     :type exclude_stations: list of str
+    :param limit_stations_to_inventory: If given, only stations part of the
+        this inventory object will be downloaded. All other restrictions
+        still apply - this just serves to further limit the set of stations
+        to download.
+    :type limit_stations_to_inventory:
+        :class:`~obspy.core.inventory.inventory.Inventory`
     :param reject_channels_with_gaps: If True (default), MiniSEED files with
         gaps and/or overlaps will be rejected.
     :type reject_channels_with_gaps: bool
@@ -167,6 +189,7 @@ class Restrictions(object):
                  chunklength_in_sec=None,
                  network=None, station=None, location=None, channel=None,
                  exclude_networks=tuple(), exclude_stations=tuple(),
+                 limit_stations_to_inventory=None,
                  reject_channels_with_gaps=True, minimum_length=0.9,
                  sanitize=True, minimum_interstation_distance_in_m=1000,
                  channel_priorities=("HH[ZNE]", "BH[ZNE]",
@@ -199,6 +222,16 @@ class Restrictions(object):
         self.location_priorities = location_priorities
         self.minimum_interstation_distance_in_m = \
             float(minimum_interstation_distance_in_m)
+
+        # Further restrict the possibly downloaded networks and station to
+        # the one in the given inventory.
+        if limit_stations_to_inventory is not None:
+            self.limit_stations_to_inventory = set()
+            for net in limit_stations_to_inventory:
+                for sta in net:
+                    self.limit_stations_to_inventory.add((net.code, sta.code))
+        else:
+            self.limit_stations_to_inventory = None
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2089,6 +2089,120 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
             os.path.join(self.data, "channel_level_fdsn.txt"))
         c.get_availability()
 
+    def test_excluding_networks_and_stations(self):
+        """
+        Tests the excluding of networks and stations.
+        """
+        # Default
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGL"), ("AK", "BWN"), ("AZ", "BZN")],
+                         sorted(c.stations.keys()))
+
+        # Excluding things that don't exists does not do anything.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_networks=["Z*", "ZNB", "[XYZ]?"],
+            exclude_stations=["A*", "[CD]?", "ZNF"]
+        )
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGL"), ("AK", "BWN"), ("AZ", "BZN")],
+                         sorted(c.stations.keys()))
+
+        # Simple network exclude.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_networks=["AK"])
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AZ", "BZN")],
+                         sorted(c.stations.keys()))
+
+        # Wildcarded network exclude.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_networks=["?K"])
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AZ", "BZN")],
+                         sorted(c.stations.keys()))
+
+        # Multiple network excludes
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_networks=["AK", "AZ"])
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([], sorted(c.stations.keys()))
+
+        # Simple station exclude.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_stations=["BAGL"]
+        )
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BWN"), ("AZ", "BZN")],
+                         sorted(c.stations.keys()))
+
+        # Wildcarded station exclude.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_stations=["[AB]?N"]
+        )
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGL")],
+                         sorted(c.stations.keys()))
+
+        # Multiple excludes.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            exclude_stations=["BWN", "BZN"]
+        )
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "channel_level_fdsn.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGL")],
+                         sorted(c.stations.keys()))
+
     def test_parse_miniseed_filenames(self):
         """
         Tests the MiniSEED filename parsing of the helper objects.

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -174,6 +174,24 @@ class RestrictionsTestCase(unittest.TestCase):
         Restrictions(starttime=start, endtime=start + 10,
                      station_starttime=start, station_endtime=start + 10)
 
+    def test_inventory_parsing(self):
+        """
+        Test the inventory parsing if an inventory is given.
+        """
+        # Nothing is given.
+        r = Restrictions(starttime=obspy.UTCDateTime(2011, 1, 1),
+                         endtime=obspy.UTCDateTime(2011, 2, 1))
+        self.assertIs(r.limit_stations_to_inventory, None)
+
+        # An inventory object is given.
+        inv = obspy.read_inventory(os.path.join(
+            self.data, "channel_level_fdsn.txt"))
+        r = Restrictions(starttime=obspy.UTCDateTime(2011, 1, 1),
+                         endtime=obspy.UTCDateTime(2011, 2, 1),
+                         limit_stations_to_inventory=inv)
+        self.assertEqual({("AK", "BAGL"), ("AK", "BWN"), ("AZ", "BZN")},
+                         r.limit_stations_to_inventory)
+
 
 class DownloadHelpersUtilTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
1. Add union and difference operations in `Domain`.

2. Add rejecting argument to `Restrictions`, e.g. `network_reject`.

Especially the second one.

And pass an `Inventory` object directly to `mass_dowload`  as the argument?