### PR TITLE
Enhance Trace.times() (more output options)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,13 @@ master:
    * New convenience property `.matplotlib_date` for `UTCDateTime` objects to
      get matplotlib datetime float representation (which can be used in
      time-based matplotlib axes, e.g. by Stream.plot()).
+   * Trace.times() has new options `type` and `reftime` to support fetching an
+     array of sampletimes in various different timing varieties ("relative":
+     the old default, float relative to trace starttime or `reftime` in
+     seconds; "utcdatetime": absolute times as UTCDateTime objects;
+     "timestamp": array of float POSIX timestamps, compare
+     `UTCDateTime.timestamp`; "matplotlib": array of float matplotlib dates,
+     useful for plotting on matplotlib time axes; see #1307)
  - obspy.clients.fdsn:
    * The mass downloader now has `exclude_networks` and `exclude_stations`
      arguments to not download certain pieces of data. (see #1305)

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
@@ -130,3 +130,14 @@ Plot & Color Options
 Various options are available to change the appearance of the waveform plot.
 Please see :meth:`~obspy.core.stream.Stream.plot` method for all possible
 options.
+
+--------------------------------
+Custom Plotting using Matplotlib
+--------------------------------
+
+Custom plots can be done using matplotlib, like shown in this minimalistic
+example (see http://matplotlib.org/gallery.html for more advanced plotting
+examples):
+
+.. plot:: tutorial/code_snippets/waveform_plotting_tutorial_7.py
+   :include-source:

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_7.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_7.py
@@ -1,0 +1,12 @@
+import matplotlib.pyplot as plt
+from obspy import read
+
+st = read()
+tr = st[0]
+
+fig = plt.figure()
+ax = fig.add_subplot(1, 1, 1)
+ax.plot(tr.times("matplotlib"), tr.data, "b-")
+ax.xaxis_date()
+fig.autofmt_xdate()
+plt.show()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1379,6 +1379,7 @@ class TraceTestCase(unittest.TestCase):
         """
         tr = Trace(data=np.ones(100))
         tr.stats.sampling_rate = 20
+        delta = tr.stats.delta
         start = UTCDateTime(2000, 1, 1, 0, 0, 0, 0)
         tr.stats.starttime = start
         tm = tr.times()
@@ -1387,6 +1388,35 @@ class TraceTestCase(unittest.TestCase):
         tr.data[30:40] = np.ma.masked
         tm = tr.times()
         self.assertTrue(np.alltrue(tr.data.mask == tm.mask))
+        # test relative with reftime
+        tr.data = np.ones(100)
+        shift = 9.5
+        reftime = start - shift
+        got = tr.times(reftime=reftime)
+        self.assertEqual(len(got), tr.stats.npts)
+        expected = np.arange(shift, shift + 4.5 * delta, delta)
+        np.testing.assert_allclose(got[:5], expected, rtol=1e-8)
+        # test other options
+        got = tr.times("utcdatetime")
+        expected = np.array([
+            UTCDateTime(2000, 1, 1, 0, 0),
+            UTCDateTime(2000, 1, 1, 0, 0, 0, 50000),
+            UTCDateTime(2000, 1, 1, 0, 0, 0, 100000),
+            UTCDateTime(2000, 1, 1, 0, 0, 0, 150000),
+            UTCDateTime(2000, 1, 1, 0, 0, 0, 200000)], dtype=UTCDateTime)
+        self.assertTrue(isinstance(got[0], UTCDateTime))
+        np.testing.assert_allclose(
+            [t_.timestamp for t_ in got[:5]],
+            [t_.timestamp for t_ in expected], rtol=1e-17)
+        got = tr.times("timestamp")
+        expected = np.arange(0, 4.5 * delta, delta) + 946684800.0
+        np.testing.assert_allclose(got[:5], expected, rtol=1e-17)
+        got = tr.times("matplotlib")
+        expected = np.array([
+            730120.00000000000000000000, 730120.00000057870056480169,
+            730120.00000115740112960339, 730120.00000173610169440508,
+            730120.00000231480225920677])
+        np.testing.assert_allclose(got[:5], expected, rtol=1e-17)
 
     def test_modulo_operation(self):
         """

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2372,6 +2372,33 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             plotting with absolute time on axes, see :mod:`matplotlib.dates`
             and :func:`matplotlib.dates.date2num`, ``type="matplotlib"``)
 
+        >>> from obspy import read, UTCDateTime
+        >>> tr = read()[0]
+
+        >>> tr.times()
+        array([  0.00000000e+00,   1.00000000e-02,   2.00000000e-02, ...,
+                 2.99700000e+01,   2.99800000e+01,   2.99900000e+01])
+
+        >>> tr.times(reftime=UTCDateTime("2009-01-01T00"))
+        array([ 20305203.  ,  20305203.01,  20305203.02, ...,  20305232.97,
+                20305232.98,  20305232.99])
+
+        >>> tr.times("utcdatetime")
+        array([UTCDateTime(2009, 8, 24, 0, 20, 3),
+               UTCDateTime(2009, 8, 24, 0, 20, 3, 10000),
+               UTCDateTime(2009, 8, 24, 0, 20, 3, 20000), ...,
+               UTCDateTime(2009, 8, 24, 0, 20, 32, 970000),
+               UTCDateTime(2009, 8, 24, 0, 20, 32, 980000),
+               UTCDateTime(2009, 8, 24, 0, 20, 32, 990000)], dtype=object)
+
+        >>> tr.times("timestamp")
+        array([  1.25107320e+09,   1.25107320e+09,   1.25107320e+09, ...,
+                 1.25107323e+09,   1.25107323e+09,   1.25107323e+09])
+
+        >>> tr.times("matplotlib")
+        array([ 733643.01392361,  733643.01392373,  733643.01392384, ...,
+                733643.01427049,  733643.0142706 ,  733643.01427072])
+
         :type type: str
         :param type: Determines type of returned time array, see above for
             valid values.

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2353,7 +2353,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
         return self
 
-    def times(self, type="relative"):
+    def times(self, type="relative", reftime=None):
         """
         For convenient plotting compute a NumPy array with timing information
         of all samples in the Trace.
@@ -2361,7 +2361,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         Time can be either:
 
           * seconds relative to ``trace.stats.starttime``
-            (``type="relative"``)
+            (``type="relative"``) or to ``reftime``
           * absolute time as
             :class:`~obspy.core.utcdatetime.UTCDateTime` objects
             (``type="utcdatetime"``)
@@ -2375,6 +2375,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type type: str
         :param type: Determines type of returned time array, see above for
             valid values.
+        :type reftime: obspy.core.utcdatetime.UTCDateTime
+        :param reftime: When using a relative timing, the time used as the
+            reference for the zero point, i.e., the first sample will be at
+            ``trace.stats.starttime - reftime`` (in seconds).
         :rtype: :class:`~numpy.ndarray` or :class:`~numpy.ma.MaskedArray`
         :returns: An array of time samples in an :class:`~numpy.ndarray` if
             the trace doesn't have any gaps or a :class:`~numpy.ma.MaskedArray`
@@ -2385,7 +2389,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         time_array = np.arange(self.stats.npts)
         time_array = time_array / self.stats.sampling_rate
         if type == "relative":
-            pass
+            if reftime is not None:
+                time_array += (self.stats.starttime - reftime)
         elif type == "timestamp":
             time_array = time_array + self.stats.starttime.timestamp
         elif type == "utcdatetime":

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2383,7 +2383,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         array([ 20305203.  ,  20305203.01,  20305203.02, ...,  20305232.97,
                 20305232.98,  20305232.99])
 
-        >>> tr.times("utcdatetime")
+        >>> tr.times("utcdatetime")  # doctest: +SKIP
         array([UTCDateTime(2009, 8, 24, 0, 20, 3),
                UTCDateTime(2009, 8, 24, 0, 20, 3, 10000),
                UTCDateTime(2009, 8, 24, 0, 20, 3, 20000), ...,


### PR DESCRIPTION
First and foremost intended for convenient plotting in matplotlib axes with a
time axis..

```python
import matplotlib.pyplot as plt
from obspy import read

tr = read()[0]
plt.plot(tr.times(type="matplotlib"), tr.data)
fig = plt.gcf()
fig.autofmt_xdate()
fig.axes[0].xaxis_date()
plt.show()
```

Still needs ..
 * [x] tests
 * [x] mention in "plotting waveforms" tutorial page
 * [x] changelog