### PR TITLE
trace.detrend changes data dtype 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.pyc
 *.pyd.manifest
 *.pyo
+.cache
 .DS_Store
 /.project
 /.pydevproject

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,17 @@
 1.0.x:
+ - General:
+   * Some methods might have unnecessarily upcasted float32 arrays to float64.
+	 Now methods for which it makes sense and which don't lose accuracy don't
+	 upcast float32 arrays. Integers are still upcasted. Trace.resample() will
+	 also no longer return the original dtype which might have resulted in a
+	 large loss of accuracy but it now always returns float64 arrays.
+	 (see #1302)
  - obspy.core:
-    * Trace.normalize() does no longer divide by zero in case an all-zeros
-      data trace is being used. (see #1343)
+   * Trace.normalize() does no longer divide by zero in case an all-zeros
+     data trace is being used. (see #1343)
  - obspy.clients.fdsn:
-    * Local URLs are now recognized as valid URLs. (see #1309)
-    * Some bug fixes for the mass downloader. (see #1293, #1304)
+   * Local URLs are now recognized as valid URLs. (see #1309)
+   * Some bug fixes for the mass downloader. (see #1293, #1304)
  - obspy.taup
    * fixed wrong azimuth direction for paths > 180 degrees distance (see #1289)
    * azimuth is appended to arrivals as well (see #1289)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2311,6 +2311,7 @@ class TraceTestCase(unittest.TestCase):
         include either a single or a double precision version.
         """
         tr = read()[0]
+        tr.data = tr.data[:100]
 
         # One for each common input dtype.
         tr_int32 = tr.copy()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2410,7 +2410,7 @@ class TraceTestCase(unittest.TestCase):
                                       dspline=100).data.dtype,
             np.float64)
 
-        # Tapering.
+        # Tapering. Upcast to float64 but don't change float32.
         self.assertEqual(tr_int32.copy().taper(0.05, "hann").data.dtype,
                          np.float64)
         self.assertEqual(tr_int64.copy().taper(0.05, "hann").data.dtype,
@@ -2420,13 +2420,13 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(tr_float64.copy().taper(0.05, "hann").data.dtype,
                          np.float64)
 
-        # Normalizing.
+        # Normalizing. Upcast to float64 but don't change float32.
         self.assertEqual(tr_int32.copy().normalize().data.dtype, np.float64)
         self.assertEqual(tr_int64.copy().normalize().data.dtype, np.float64)
         self.assertEqual(tr_float32.copy().normalize().data.dtype, np.float32)
         self.assertEqual(tr_float64.copy().normalize().data.dtype, np.float64)
 
-        # Differentiate
+        # Differentiate. Upcast to float64 but don't change float32.
         self.assertEqual(tr_int32.copy().differentiate().data.dtype,
                          np.float64)
         self.assertEqual(tr_int64.copy().differentiate().data.dtype,
@@ -2436,7 +2436,7 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(tr_float64.copy().differentiate().data.dtype,
                          np.float64)
 
-        # Integrate
+        # Integrate. Upcast to float64 but don't change float32.
         self.assertEqual(
             tr_int32.copy().integrate(method="cumtrapz").data.dtype,
             np.float64)
@@ -2464,7 +2464,7 @@ class TraceTestCase(unittest.TestCase):
             np.float64)
 
         # Simulation is an operation in the spectral domain so double
-        # precision is a lot more accurate so its fine here.
+        # precision is a lot more accurate so it's fine here.
         paz_remove = {'poles': [-0.037004 + 0.037016j, -0.037004 - 0.037016j,
                                 -251.33 + 0j],
                       'zeros': [0j, 0j], 'gain': 60077000.0,

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2110,7 +2110,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             warnings.warn(msg)
             return self
 
-        self.data = self.data.astype(np.float64)
+        # Convert data if it's not a floating point type.
+        if not np.issubdtype(self.data.dtype, float):
+            self.data = np.require(self.data, dtype=np.float64)
+
         self.data /= abs(norm)
 
         return self

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1615,10 +1615,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             self.filter('lowpass_cheby_2', freq=freq, maxorder=12)
 
         orig_dtype = self.data.dtype
-        new_dtype = np.float32 if orig_dtype.itemsize == 4 else np.float64
 
         # resample in the frequency domain
-        x = rfft(np.require(self.data, dtype=new_dtype))
+        x = rfft(self.data)
         x = np.insert(x, 1, 0)
         if self.stats.npts % 2 == 0:
             x = np.append(x, [0])
@@ -1655,7 +1654,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if num % 2 == 0:
             large_y = np.delete(large_y, -1)
         self.data = irfft(large_y) * (float(num) / float(self.stats.npts))
-        self.data = np.require(self.data, dtype=orig_dtype)
         self.stats.sampling_rate = sampling_rate
 
         return self

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1614,8 +1614,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             freq = self.stats.sampling_rate * 0.5 / float(factor)
             self.filter('lowpass_cheby_2', freq=freq, maxorder=12)
 
-        # resample in the frequency domain
-        x = rfft(self.data)
+        # resample in the frequency domain. Make sure the byteorder is native.
+        x = rfft(self.data.newbyteorder("="))
         x = np.insert(x, 1, 0)
         if self.stats.npts % 2 == 0:
             x = np.append(x, [0])

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1614,8 +1614,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             freq = self.stats.sampling_rate * 0.5 / float(factor)
             self.filter('lowpass_cheby_2', freq=freq, maxorder=12)
 
-        orig_dtype = self.data.dtype
-
         # resample in the frequency domain
         x = rfft(self.data)
         x = np.insert(x, 1, 0)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2044,7 +2044,12 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         else:
             taper = np.hstack((taper_sides[:wlen], np.ones(npts - 2 * wlen),
                                taper_sides[len(taper_sides) - wlen:]))
-        self.data = self.data * taper
+
+        # Convert data if it's not a floating point type.
+        if not np.issubdtype(self.data.dtype, float):
+            self.data = np.require(self.data, dtype=np.float64)
+
+        self.data *= taper
         return self
 
     @_add_processing_info

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -23,11 +23,16 @@ def simple(data):
     point of the trace
 
     :param data: Data to detrend, type numpy.ndarray.
-    :return: Detrended data.
+    :return: Detrended data. Returns the original array which has been
+        modified in-place.
     """
+    # Convert data if it's not a floating point type.
+    if not np.issubdtype(data.dtype, float):
+        data = np.require(data, dtype=np.float64)
     ndat = len(data)
     x1, x2 = data[0], data[-1]
-    return data - (x1 + np.arange(ndat) * (x2 - x1) / float(ndat - 1))
+    data -= x1 + np.arange(ndat) * (x2 - x1) / float(ndat - 1)
+    return data
 
 
 def _plotting_helper(data, fit, plot):

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -24,7 +24,8 @@ def simple(data):
 
     :param data: Data to detrend, type numpy.ndarray.
     :return: Detrended data. Returns the original array which has been
-        modified in-place.
+        modified in-place if possible but it might have to return a copy in
+        case the dtype has to be changed.
     """
     # Convert data if it's not a floating point type.
     if not np.issubdtype(data.dtype, float):

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -102,7 +102,7 @@ def polynomial(data, order, plot=False):
     """
     # Convert data if it's not a floating point type.
     if not np.issubdtype(data.dtype, float):
-        data = np.require(data, dtype=np.float32)
+        data = np.require(data, dtype=np.float64)
 
     x = np.arange(len(data))
     fit = np.polyval(np.polyfit(x, data, deg=order), x)
@@ -165,7 +165,7 @@ def spline(data, order, dspline, plot=False):
     """
     # Convert data if it's not a floating point type.
     if not np.issubdtype(data.dtype, float):
-        data = np.require(data, dtype=np.float32)
+        data = np.require(data, dtype=np.float64)
 
     x = np.arange(len(data))
     splknots = np.arange(dspline / 2.0, len(data) - dspline / 2.0 + 2,

--- a/obspy/signal/differentiate_and_integrate.py
+++ b/obspy/signal/differentiate_and_integrate.py
@@ -30,7 +30,7 @@ def integrate_cumtrapz(data, dx, **kwargs):
     # (manually adding the zero and not using `cumtrapz(..., initial=0)` is a
     # backwards compatibility fix for scipy versions < 0.11.
     ret = scipy.integrate.cumtrapz(data, dx=dx)
-    return np.concatenate([[0], ret])
+    return np.concatenate([np.array([0], dtype=ret.dtype), ret])
 
 
 def integrate_spline(data, dx, k=3, **kwargs):

--- a/obspy/signal/differentiate_and_integrate.py
+++ b/obspy/signal/differentiate_and_integrate.py
@@ -46,7 +46,9 @@ def integrate_spline(data, dx, k=3, **kwargs):
     spline = scipy.interpolate.InterpolatedUnivariateSpline(time_array, data,
                                                             k=k)
 
-    # Backport of the antiderivative() method to old scipy versions.
+    # Backport of the antiderivative() method for scipy versions < 0.13.0.
+    # Can be removed once the minimum supported version is equal or larger
+    # to this.
     if not hasattr(spline, "antiderivative"):
         from scipy.interpolate import fitpack  # NOQA
         tck = fitpack.splantider(spline._eval_args, 1)

--- a/obspy/signal/tests/test_differentiate_and_integrate.py
+++ b/obspy/signal/tests/test_differentiate_and_integrate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Tests for differentiation and integration functions.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+import numpy as np
+
+from obspy.signal.differentiate_and_integrate import (
+    integrate_cumtrapz, integrate_spline)
+
+
+class IntegrateTestCase(unittest.TestCase):
+    """
+    Test cases for the integration methods.
+    """
+    def test_cumtrapz_integration(self):
+        """
+        Test the basic and obvious cases. We are using external methods which
+        are tested extensively elsewhere.
+        """
+        np.testing.assert_allclose(
+            integrate_cumtrapz(np.ones(10), dx=1.0),
+            np.arange(10))
+
+        np.testing.assert_allclose(
+            integrate_cumtrapz(np.ones(10), dx=2.0),
+            np.arange(10) * 2.0)
+
+        np.testing.assert_allclose(
+            integrate_cumtrapz(np.ones(10), dx=0.5),
+            np.arange(10) * 0.5)
+
+        np.testing.assert_allclose(
+            integrate_cumtrapz(np.zeros(10), dx=0.5),
+            np.zeros(10))
+
+    def test_spline_integration(self):
+        """
+        Test the basic and obvious cases. We are using external methods which
+        are tested extensively elsewhere.
+        """
+        for k in (1, 2, 3):
+            np.testing.assert_allclose(
+                integrate_spline(np.ones(10), dx=1.0, k=k),
+                np.arange(10))
+
+            np.testing.assert_allclose(
+                integrate_spline(np.ones(10), dx=2.0, k=k),
+                np.arange(10) * 2.0)
+
+            np.testing.assert_allclose(
+                integrate_spline(np.ones(10), dx=0.5, k=k),
+                np.arange(10) * 0.5)
+
+            np.testing.assert_allclose(
+                integrate_spline(np.zeros(10), dx=0.5, k=k),
+                np.zeros(10))
+
+
+def suite():
+    return unittest.makeSuite(IntegrateTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
Similar to issue #256, I find that, after reading data from a Seismic Unix file, detrending changes the dtype.

For example
```
d = obspy.read('Uy_file_single.su', format='SU', byteorder='<')
print d[0].data.dtype
d[0].detrend()
print d[0].data.dtype
```

produces

```
float32
float64
```

This behavior seems a bit unexpected.  Am I missing something?

Thanks,
Ryan