### PR TITLE
Function arguments which expect tuple are error prone with silent failures.

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -107,10 +107,10 @@ ObsPy knows of and combine it into one data set.
         # Only HH or BH channels. If a station has HH channels, those will be
         # downloaded, otherwise the BH. Nothing will be downloaded if it has
         # neither. You can add more/less patterns if you like.
-        channel_priorities=("HH[ZNE]", "BH[ZNE]"),
+        channel_priorities=["HH[ZNE]", "BH[ZNE]"],
         # Location codes are arbitrary and there is no rule as to which
         # location is best. Same logic as for the previous setting.
-        location_priorities=("", "00", "10"))
+        location_priorities=["", "00", "10"])
 
     # No specified providers will result in all known ones being queried.
     mdl = MassDownloader()

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -12,6 +12,9 @@ Non-geographical restrictions and constraints for the mass downloader.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import native_str
+
+import collections
 
 import obspy
 
@@ -160,8 +163,23 @@ class Restrictions(object):
         self.reject_channels_with_gaps = reject_channels_with_gaps
         self.minimum_length = minimum_length
         self.sanitize = bool(sanitize)
+
+        # These must be iterables, but not strings.
+        if not isinstance(channel_priorities, collections.Iterable) \
+                or isinstance(channel_priorities, (str, native_str)):
+            msg = "'channel_priorities' must be a list or other iterable " \
+                  "container."
+            raise TypeError(msg)
+
+        if not isinstance(location_priorities, collections.Iterable) \
+                or isinstance(location_priorities, (str, native_str)):
+            msg = "'location_priorities' must be a list or other iterable " \
+                  "container."
+            raise TypeError(msg)
+
         self.channel_priorities = channel_priorities
         self.location_priorities = location_priorities
+
         self.minimum_interstation_distance_in_m = \
             float(minimum_interstation_distance_in_m)
 

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -39,10 +39,10 @@ class Restrictions(object):
     ...     # Only HH or BH channels. If a station has HH channels,
     ...     # those will be downloaded, otherwise the BH. Nothing will be
     ...     # downloaded if it has neither.
-    ...     channel_priorities=("HH[ZNE]", "BH[ZNE]"),
+    ...     channel_priorities=["HH[ZNE]", "BH[ZNE]"],
     ...     # Location codes are arbitrary and there is no rule as to which
     ...     # location is best.
-    ...     location_priorities=("", "00", "10"))
+    ...     location_priorities=["", "00", "10"])
 
 
     And the restrictions for downloading a noise data set might look similar to

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -12,6 +12,7 @@ The obspy.clients.fdsn.download_helpers test suite.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import native_str
 
 import collections
 import copy
@@ -107,6 +108,112 @@ class RestrictionsTestCase(unittest.TestCase):
         super(RestrictionsTestCase, self).__init__(*args, **kwargs)
         self.path = os.path.dirname(__file__)
         self.data = os.path.join(self.path, "data")
+
+    def test_passing_string_as_priority_list_raises(self):
+        """
+        Users reported errors as they used "tuples" with single items as
+        priority lists. Python semantics mean that a "tuple" without a comma
+        is not tuple. Thus '("HH[NEZ")' is actually just a string which is
+        not what the users expected. Thus this should raise an exception.
+        """
+        start = obspy.UTCDateTime(2014, 1, 1)
+        end = start + 10
+
+        # Test for the channel_priorities key.
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         channel_priorities="HHE")
+        self.assertEqual(e.exception.args[0],
+                         "'channel_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         channel_priorities=("HHE"))
+        self.assertEqual(e.exception.args[0],
+                         "'channel_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         channel_priorities=native_str("HHE"))
+        self.assertEqual(e.exception.args[0],
+                         "'channel_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         channel_priorities=(native_str("HHE")))
+        self.assertEqual(e.exception.args[0],
+                         "'channel_priorities' must be a list or other "
+                         "iterable container.")
+
+        # And for the location priorities key.
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         location_priorities="00")
+        self.assertEqual(e.exception.args[0],
+                         "'location_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         location_priorities=("00"))
+        self.assertEqual(e.exception.args[0],
+                         "'location_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         location_priorities=native_str("00"))
+        self.assertEqual(e.exception.args[0],
+                         "'location_priorities' must be a list or other "
+                         "iterable container.")
+
+        with self.assertRaises(TypeError) as e:
+            Restrictions(starttime=start, endtime=end,
+                         location_priorities=(native_str("00")))
+        self.assertEqual(e.exception.args[0],
+                         "'location_priorities' must be a list or other "
+                         "iterable container.")
+
+        # All other valid things should of course still work.
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=("HHE",))
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=["HHE"])
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=("HHE", "BHE"))
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=["HHE", "BHE"])
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=(native_str("HHE"),))
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=[native_str("HHE")])
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=(native_str("HHE"),
+                                         native_str("BHE")))
+        Restrictions(starttime=start, endtime=end,
+                     channel_priorities=[native_str("HHE"),
+                                         native_str("BHE")])
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=("00",))
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=["00"])
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=("00", "10"))
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=["00", "10"])
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=(native_str("00"),))
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=[native_str("00")])
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=(native_str("00"),
+                                          native_str("10")))
+        Restrictions(starttime=start, endtime=end,
+                     location_priorities=[native_str("00"),
+                                          native_str("10")])
 
     def test_restrictions_object(self):
         """


### PR DESCRIPTION
The crux is that a tuple with a single item requires a comma after the item
```
type(('ex'))
<type 'str'>
type(('ex',))
<type 'tuple'>
```
If a function expects a tuple, but is passes a single iterable in () without a trailing comma, the single iterable is iterated over instead of the single item.
Examples:
GOOD: `fdsn.mass_downloader.Restrictions(... ,channel_priorities=("LH[ZNE]",), ...)`
GOOD:`fdsn.mass_downloader.Restrictions(... ,channel_priorities=("LH[ZNE]","BH[ZNE]"), ...)`
BAD:`fdsn.mass_downloader.Restrictions(... ,channel_priorities=("LH[ZNE]"), ...)`
        Iterates over string e.g.  Z,H,[,...

btw: the same thing happens with taup when using e.g. `phase_list = ('PKKP')` it starts looking for 'P', 'K', 'K', 'P' .