### PR TITLE
Beamforming tutorial is not outdated!

### DIFF
--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis.rst
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis.rst
@@ -2,13 +2,10 @@
 Beamforming - FK Analysis
 =========================
 
-.. warning::
-    This example is outdated. The `sonic` routine was replaced by
-    :func:`obspy.signal.array_analysis.array_processing`.
-
 The following code shows how to do an FK Analysis with ObsPy. The data are from
 the blasting of the AGFA skyscraper in Munich. We execute
-:func:`~obspy.signal.array_analysis.sonic` using the following settings:
+:func:`~obspy.signal.array_analysis.array_processing` using the following
+settings:
 
 * The slowness grid is set to corner values of -3.0 to 3.0 s/km with a step
   fraction of ``sl_s = 0.03``.
@@ -24,10 +21,10 @@ the blasting of the AGFA skyscraper in Munich. We execute
 The output will be stored in ``out``.
 
 The second half shows how to plot the output. We use the output
-``out`` produced by :func:`~obspy.signal.array_analysis.sonic`, which are
-:class:`numpy ndarrays <numpy.ndarray>` containing timestamp, relative power,
-absolute power, backazimuth, slowness. The colorbar corresponds to relative
-power.
+``out`` produced by :func:`~obspy.signal.array_analysis.array_processing`,
+which are :class:`numpy ndarrays <numpy.ndarray>` containing timestamp,
+relative power, absolute power, backazimuth, slowness. The colorbar corresponds
+to relative power.
 
 .. plot:: tutorial/code_snippets/beamforming_fk_analysis_1.py
    :include-source:

--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
@@ -69,7 +69,7 @@ st[4].stats.coordinates = AttribDict({
 paz1hz = corn_freq_2_paz(1.0, damp=0.707)
 st.simulate(paz_remove='self', paz_simulate=paz1hz)
 
-# Execute sonic
+# Execute array_processing
 kwargs = dict(
     # slowness grid: X min, X max, Y min, Y max, Slow Step
     sll_x=-3.0, slm_x=3.0, sll_y=-3.0, slm_y=3.0, sl_s=0.03,


### PR DESCRIPTION
The beamforming tutorial [here]( http://docs.obspy.org/tutorial/code_snippets/beamforming_fk_analysis.html) warns that it is outdated, but actually the code works perfectly with ObsPy 1.0.0, since calls to `sonic()` have been correctly replaced with calls to `array_processing()`.

The warning should therefore be removed and all the remaining references to `sonic()` (including one in code comments) corrected.
