### PR TITLE
Advanced UTCDateTime based on nanoseconds - supporting years 1-9999

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1090,6 +1090,11 @@ class UTCDateTimeTestCase(unittest.TestCase):
                          datetime.datetime(9999, 1, 1, 0, 0, 0, 500000))
         self.assertEqual(str(dt), '9999-01-01T00:00:00.500000Z')
 
+    def test_utcdatetime_from_utcdatetime(self):
+        a = UTCDateTime(1, 1, 1, 1, 1, 1, 999999)
+        self.assertEqual(UTCDateTime(a)._ns, a._ns)
+        self.assertEqual(str(UTCDateTime(a)), str(a))
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -227,6 +227,9 @@ class UTCDateTime(object):
             return
         elif len(args) == 1 and len(kwargs) == 0:
             value = args[0]
+            if isinstance(value, UTCDateTime):
+                self._ns = value._ns
+                return
             # check types
             try:
                 # got a timestamp

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -205,7 +205,6 @@ class UTCDateTime(object):
 
     .. _ISO8601:2004: https://en.wikipedia.org/wiki/ISO_8601
     """
-    timestamp = 0.0
     DEFAULT_PRECISION = 6
 
     def __init__(self, *args, **kwargs):
@@ -214,19 +213,24 @@ class UTCDateTime(object):
         """
         # set default precision
         self.precision = kwargs.pop('precision', self.DEFAULT_PRECISION)
+        # set directly to nanoseconds if given
+        ns = kwargs.pop('ns', None)
+        if ns is not None:
+            self._ns = ns
+            return
         # iso8601 flag
         iso8601 = kwargs.pop('iso8601', False) is True
         # check parameter
         if len(args) == 0 and len(kwargs) == 0:
-            # use current time if no time is given
-            self.timestamp = time.time()
+            # use current date/time if no argument is given
+            self._from_timestamp(time.time())
             return
         elif len(args) == 1 and len(kwargs) == 0:
             value = args[0]
             # check types
             try:
                 # got a timestamp
-                self.timestamp = value.__float__()
+                self._from_timestamp(value.__float__())
                 return
             except:
                 pass
@@ -247,7 +251,7 @@ class UTCDateTime(object):
                 # check for ISO8601 date string
                 if value.count("T") == 1 or iso8601:
                     try:
-                        self.timestamp = self._parse_iso_8601(value).timestamp
+                        self._from_iso8601_string(value)
                         return
                     except:
                         if iso8601:
@@ -298,7 +302,8 @@ class UTCDateTime(object):
                     self._from_datetime(dt)
                     return
                 dt = datetime.datetime.strptime(value, pattern)
-                self._from_datetime(dt, ms)
+                dt += datetime.timedelta(seconds=ms)
+                self._from_datetime(dt)
                 return
         # check for ordinal/julian date kwargs
         if 'julday' in kwargs:
@@ -322,8 +327,8 @@ class UTCDateTime(object):
         # check if seconds are given as float value
         if len(args) == 6 and isinstance(args[5], float):
             _frac, _sec = math.modf(round(args[5], 6))
-            kwargs['microsecond'] = int(round(_frac * 1e6))
             kwargs['second'] = int(_sec)
+            kwargs['microsecond'] = int(round(_frac * 1e6))
             args = args[0:5]
         dt = datetime.datetime(*args, **kwargs)
         self._from_datetime(dt)
@@ -341,32 +346,49 @@ class UTCDateTime(object):
         microsecond = kwargs.get('microsecond', self.microsecond)
         julday = kwargs.get('julday', None)
         if julday:
-            self.timestamp = UTCDateTime(year=year, julday=julday, hour=hour,
-                                         minute=minute, second=second,
-                                         microsecond=microsecond).timestamp
+            self._ns = UTCDateTime(year=year, julday=julday, hour=hour,
+                                   minute=minute, second=second,
+                                   microsecond=microsecond)._ns
         else:
-            self.timestamp = UTCDateTime(year, month, day, hour, minute,
-                                         second, microsecond).timestamp
+            self._ns = UTCDateTime(year, month, day, hour, minute,
+                                   second, microsecond)._ns
 
-    def _from_datetime(self, dt, ms=0):
+    def _get_ns(self):
+        return self.__ns
+
+    def _set_ns(self, value):
+        if not isinstance(value, int):
+            raise TypeError('nanoseconds must be set as int/long type')
+        self.__ns = value
+
+    _ns = property(_get_ns, _set_ns)
+
+    def _from_datetime(self, dt):
         """
         Use Python datetime object to set current time.
 
         :type dt: :class:`datetime.datetime`
         :param dt: Python datetime object.
-        :type ms: float
-        :param ms: extra seconds to add to current UTCDateTime object.
         """
         # see datetime.timedelta.total_seconds
         try:
             td = (dt - TIMESTAMP0)
         except TypeError:
             td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
-        self.timestamp = (td.microseconds + (td.seconds + td.days * 86400) *
-                          1000000) / 1000000.0 + ms
+        self._ns = \
+            (td.days * 60 * 60 * 24 + td.seconds) * 1000000000 + \
+            td.microseconds * 1000
 
-    @staticmethod
-    def _parse_iso_8601(value):
+    def _from_timestamp(self, value):
+        """
+        Use given timestamp to set current time.
+
+        :type value: int, float
+        :param value: Timestamp in seconds.
+        """
+        self._ns = int(round(value * 1000000000))
+
+    def _from_iso8601_string(self, value):
         """
         Parses an ISO8601:2004 date time string.
         """
@@ -447,7 +469,8 @@ class UTCDateTime(object):
         dt = datetime.datetime.strptime(date + 'T' + time,
                                         date_pattern + 'T' + time_pattern)
         # add microseconds and eventually correct time zone
-        return UTCDateTime(dt) + (float(delta) + ms)
+        dt += datetime.timedelta(seconds=float(delta) + ms)
+        self._from_datetime(dt)
 
     def _get_timestamp(self):
         """
@@ -462,7 +485,9 @@ class UTCDateTime(object):
         >>> dt.timestamp
         1222864235.123456
         """
-        return self.timestamp
+        return self._ns / 1e9
+
+    timestamp = property(_get_timestamp)
 
     def __float__(self):
         """
@@ -494,7 +519,9 @@ class UTCDateTime(object):
         """
         # datetime.utcfromtimestamp will cut off but not round
         # avoid through adding timedelta - also avoids the year 2038 problem
-        return TIMESTAMP0 + datetime.timedelta(seconds=self.timestamp)
+        dt = datetime.timedelta(seconds=self._ns // 1000000000,
+                                microseconds=self._ns % 1000000000 // 1000)
+        return TIMESTAMP0 + dt
 
     datetime = property(_get_datetime)
 
@@ -511,7 +538,7 @@ class UTCDateTime(object):
         >>> dt.date
         datetime.date(2008, 10, 1)
         """
-        return self._get_datetime().date()
+        return self.datetime.date()
 
     date = property(_get_date)
 
@@ -528,7 +555,7 @@ class UTCDateTime(object):
         >>> dt.year
         2012
         """
-        return self._get_datetime().year
+        return self.datetime.year
 
     def _set_year(self, value):
         """
@@ -562,7 +589,7 @@ class UTCDateTime(object):
         >>> dt.month
         2
         """
-        return self._get_datetime().month
+        return self.datetime.month
 
     def _set_month(self, value):
         """
@@ -595,7 +622,7 @@ class UTCDateTime(object):
         >>> dt.day
         11
         """
-        return self._get_datetime().day
+        return self.datetime.day
 
     def _set_day(self, value):
         """
@@ -629,7 +656,7 @@ class UTCDateTime(object):
         >>> dt.weekday
         2
         """
-        return self._get_datetime().weekday()
+        return self.datetime.weekday()
 
     weekday = property(_get_weekday)
 
@@ -646,7 +673,7 @@ class UTCDateTime(object):
         >>> dt.time
         datetime.time(12, 30, 35, 45020)
         """
-        return self._get_datetime().time()
+        return self.datetime.time()
 
     time = property(_get_time)
 
@@ -663,7 +690,7 @@ class UTCDateTime(object):
         >>> dt.hour
         10
         """
-        return self._get_datetime().hour
+        return self.datetime.hour
 
     def _set_hour(self, value):
         """
@@ -696,7 +723,7 @@ class UTCDateTime(object):
         >>> dt.minute
         11
         """
-        return self._get_datetime().minute
+        return self.datetime.minute
 
     def _set_minute(self, value):
         """
@@ -729,7 +756,7 @@ class UTCDateTime(object):
         >>> dt.second
         12
         """
-        return self._get_datetime().second
+        return self.datetime.second
 
     def _set_second(self, value):
         """
@@ -745,7 +772,7 @@ class UTCDateTime(object):
         >>> dt
         UTCDateTime(2012, 2, 11, 10, 11, 20)
         """
-        self.timestamp += value - self.second
+        self._set(second=value)
 
     second = property(_get_second, _set_second)
 
@@ -762,7 +789,7 @@ class UTCDateTime(object):
         >>> dt.microsecond
         345234
         """
-        return self._get_datetime().microsecond
+        return int(self._ns % 1000000000 // 1000)
 
     def _set_microsecond(self, value):
         """
@@ -821,7 +848,7 @@ class UTCDateTime(object):
 
         :rtype: time.struct_time
         """
-        return self._get_datetime().timetuple()
+        return self.datetime.timetuple()
 
     def utctimetuple(self):
         """
@@ -829,7 +856,7 @@ class UTCDateTime(object):
 
         :rtype: time.struct_time
         """
-        return self._get_datetime().utctimetuple()
+        return self.datetime.utctimetuple()
 
     def __add__(self, value):
         """
@@ -853,11 +880,12 @@ class UTCDateTime(object):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
                      86400) * 1000000) / 1000000.0
+
         elif isinstance(value, UTCDateTime):
             msg = ("unsupported operand type(s) for +: 'UTCDateTime' and "
                    "'UTCDateTime'")
             raise TypeError(msg)
-        return UTCDateTime(self.timestamp + value)
+        return UTCDateTime(ns=self._ns + int(round(value * 1e9)))
 
     def __sub__(self, value):
         """
@@ -882,12 +910,12 @@ class UTCDateTime(object):
         86400.0
         """
         if isinstance(value, UTCDateTime):
-            return round(self.timestamp - value.timestamp, self.__precision)
+            return round((self._ns - value._ns) / 1e9, self.__precision)
         elif isinstance(value, datetime.timedelta):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
                      86400) * 1000000) / 1000000.0
-        return UTCDateTime(self.timestamp - value)
+        return UTCDateTime(ns=self._ns - int(round(value * 1e9)))
 
     def __str__(self):
         """
@@ -901,8 +929,12 @@ class UTCDateTime(object):
         >>> str(dt)
         '2008-10-01T12:30:35.045020Z'
         """
-        return "%s%sZ" % (self.strftime('%Y-%m-%dT%H:%M:%S'),
-                          (self.__ms_pattern % (abs(self.timestamp % 1)))[1:])
+        dt = self.datetime
+        pattern = "%%.%dlf" % (self.precision)
+        ns = pattern % ((self._ns % 1000000000) / 1e9)
+        return "%04d-%02d-%02dT%02d:%02d:%02d.%sZ" % (
+            dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
+            ns[2:self.precision + 2])
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
@@ -1102,7 +1134,7 @@ class UTCDateTime(object):
         """
         Returns a representation of UTCDatetime object.
         """
-        return 'UTCDateTime' + self._get_datetime().__repr__()[17:]
+        return 'UTCDateTime' + self.datetime.__repr__()[17:]
 
     def __abs__(self):
         """
@@ -1135,7 +1167,7 @@ class UTCDateTime(object):
         See methods :meth:`~datetime.datetime.strftime()` and
         :meth:`~datetime.datetime.strptime()` for more information.
         """
-        return self._get_datetime().strftime(format)
+        return self.datetime.strftime(format)
 
     @staticmethod
     def strptime(date_string, format):
@@ -1165,7 +1197,7 @@ class UTCDateTime(object):
         >>> dt.timetz()
         datetime.time(12, 30, 35, 45020)
         """
-        return self._get_datetime().timetz()
+        return self.datetime.timetz()
 
     def utcoffset(self):
         """
@@ -1176,7 +1208,7 @@ class UTCDateTime(object):
         >>> dt = UTCDateTime(2008, 10, 1, 12, 30, 35, 45020)
         >>> dt.utcoffset()
         """
-        return self._get_datetime().utcoffset()
+        return self.datetime.utcoffset()
 
     def dst(self):
         """
@@ -1187,7 +1219,7 @@ class UTCDateTime(object):
         >>> dt = UTCDateTime(2008, 10, 1, 12, 30, 35, 45020)
         >>> dt.dst()
         """
-        return self._get_datetime().dst()
+        return self.datetime.dst()
 
     def tzname(self):
         """
@@ -1198,7 +1230,7 @@ class UTCDateTime(object):
         >>> dt = UTCDateTime(2008, 10, 1, 12, 30, 35, 45020)
         >>> dt.tzname()
         """
-        return self._get_datetime().tzname()
+        return self.datetime.tzname()
 
     def ctime(self):
         """
@@ -1209,7 +1241,7 @@ class UTCDateTime(object):
         >>> UTCDateTime(2002, 12, 4, 20, 30, 40).ctime()
         'Wed Dec  4 20:30:40 2002'
         """
-        return self._get_datetime().ctime()
+        return self.datetime.ctime()
 
     def isoweekday(self):
         """
@@ -1225,7 +1257,7 @@ class UTCDateTime(object):
         >>> dt.isoweekday()
         3
         """
-        return self._get_datetime().isoweekday()
+        return self.datetime.isoweekday()
 
     def isocalendar(self):
         """
@@ -1241,7 +1273,7 @@ class UTCDateTime(object):
         >>> dt.isocalendar()
         (2008, 40, 3)
         """
-        return self._get_datetime().isocalendar()
+        return self.datetime.isocalendar()
 
     def isoformat(self, sep="T"):
         """
@@ -1262,7 +1294,7 @@ class UTCDateTime(object):
         >>> dt.isoformat()
         '2008-10-01T00:00:00'
         """
-        return self._get_datetime().isoformat(sep=native_str(sep))
+        return self.datetime.isoformat(sep=native_str(sep))
 
     def format_fissures(self):
         """
@@ -1343,7 +1375,7 @@ class UTCDateTime(object):
         temp = "%04d,%03d" % (self.year, self.julday)
         if self.time == datetime.time(0):
             return temp
-        temp += ",%02d" % self.hour
+        temp += ",%02d" % (self.hour)
         if self.microsecond:
             return temp + ":%02d:%02d.%04d" % (self.minute, self.second,
                                                self.microsecond // 100)
@@ -1413,7 +1445,6 @@ class UTCDateTime(object):
             12
         """
         self.__precision = int(value)
-        self.__ms_pattern = "%%0.%df" % (self.__precision)
 
     precision = property(_get_precision, _set_precision)
 
@@ -1431,7 +1462,7 @@ class UTCDateTime(object):
         >>> dt.toordinal()
         734503
         """
-        return self._get_datetime().toordinal()
+        return self.datetime.toordinal()
 
     @staticmethod
     def now():

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -376,8 +376,7 @@ class UTCDateTime(object):
         except TypeError:
             td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
         self._ns = \
-            (td.days * 60 * 60 * 24 + td.seconds) * 1000000000 + \
-            td.microseconds * 1000
+            (td.days * 86400 + td.seconds) * 10**9 + td.microseconds * 1000
 
     def _from_timestamp(self, value):
         """
@@ -386,7 +385,7 @@ class UTCDateTime(object):
         :type value: int, float
         :param value: Timestamp in seconds.
         """
-        self._ns = int(round(value * 1000000000))
+        self._ns = int(round(value * 10**9))
 
     def _from_iso8601_string(self, value):
         """
@@ -519,8 +518,8 @@ class UTCDateTime(object):
         """
         # datetime.utcfromtimestamp will cut off but not round
         # avoid through adding timedelta - also avoids the year 2038 problem
-        dt = datetime.timedelta(seconds=self._ns // 1000000000,
-                                microseconds=self._ns % 1000000000 // 1000)
+        dt = datetime.timedelta(seconds=self._ns // 10**9,
+                                microseconds=self._ns % 10**9 // 1000)
         return TIMESTAMP0 + dt
 
     datetime = property(_get_datetime)
@@ -789,7 +788,7 @@ class UTCDateTime(object):
         >>> dt.microsecond
         345234
         """
-        return int(self._ns % 1000000000 // 1000)
+        return int(self._ns % 10**9 // 1000)
 
     def _set_microsecond(self, value):
         """
@@ -879,8 +878,7 @@ class UTCDateTime(object):
         if isinstance(value, datetime.timedelta):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
-                     86400) * 1000000) / 1000000.0
-
+                     86400) * 10**6) / 1e6
         elif isinstance(value, UTCDateTime):
             msg = ("unsupported operand type(s) for +: 'UTCDateTime' and "
                    "'UTCDateTime'")
@@ -914,7 +912,7 @@ class UTCDateTime(object):
         elif isinstance(value, datetime.timedelta):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
-                     86400) * 1000000) / 1000000.0
+                     86400) * 10**6) / 1e6
         return UTCDateTime(ns=self._ns - int(round(value * 1e9)))
 
     def __str__(self):
@@ -931,7 +929,7 @@ class UTCDateTime(object):
         """
         dt = self.datetime
         pattern = "%%.%dlf" % (self.precision)
-        ns = pattern % ((self._ns % 1000000000) / 1e9)
+        ns = pattern % ((self._ns % 10**9) / 1e9)
         return "%04d-%02d-%02dT%02d:%02d:%02d.%sZ" % (
             dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
             ns[2:self.precision + 2])

--- a/obspy/io/gcf/libgcf.py
+++ b/obspy/io/gcf/libgcf.py
@@ -68,8 +68,9 @@ def decode_date_time(data):
     Bits 0-16 contain the number of seconds since midnight,
     and bits 17-31 the number of days since 17th November 1989.
     """
-    days = data >> 17
-    secs = data & 0x1FFFF
+    # prevent numpy array
+    days = int(data >> 17)
+    secs = int(data & 0x1FFFF)
     starttime = UTCDateTime('1989-11-17') + days * 86400 + secs
     return starttime
 

--- a/obspy/io/zmap/__init__.py
+++ b/obspy/io/zmap/__init__.py
@@ -22,8 +22,8 @@ mechanisms including format autodetection.
 >>> cat = read_events('/path/to/zmap_events.txt')
 >>> print(cat)
 2 Event(s) in Catalog:
-2012-04-04T14:21:42.299999Z | +41.818,  +79.689 | 4.4 None
-2012-04-04T14:21:42.299999Z | +41.822,  +79.684 | 5.1 None
+2012-04-04T14:21:42.300000Z | +41.818,  +79.689 | 4.4 None
+2012-04-04T14:21:42.300000Z | +41.822,  +79.684 | 5.1 None
 >>> cat.write('example.txt', format='ZMAP')  # doctest: +SKIP
 
 

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -383,18 +383,26 @@ class TriggerTestCase(unittest.TestCase):
             # two warnings get raised
             self.assertEqual(len(w), 2)
         # check floats in resulting dictionary separately
-        self.assertAlmostEqual(trig[0].pop('duration'), 3.9600000381469727)
-        self.assertAlmostEqual(trig[1].pop('duration'), 1.9900000095367432)
-        self.assertAlmostEqual(trig[2].pop('duration'), 1.9200000762939453)
-        self.assertAlmostEqual(trig[3].pop('duration'), 3.9200000762939453)
-        self.assertAlmostEqual(trig[0]['similarity'].pop('UH1'), 0.94149447384)
-        self.assertAlmostEqual(trig[0]['similarity'].pop('UH3'), 1)
-        self.assertAlmostEqual(trig[1]['similarity'].pop('UH1'), 0.65228204570)
-        self.assertAlmostEqual(trig[1]['similarity'].pop('UH3'), 0.72679293429)
-        self.assertAlmostEqual(trig[2]['similarity'].pop('UH1'), 0.89404458774)
-        self.assertAlmostEqual(trig[2]['similarity'].pop('UH3'), 0.74581409371)
-        self.assertAlmostEqual(trig[3]['similarity'].pop('UH1'), 1)
-        self.assertAlmostEqual(trig[3]['similarity'].pop('UH3'), 1)
+        self.assertAlmostEqual(trig[0].pop('duration'), 3.96, places=6)
+        self.assertAlmostEqual(trig[1].pop('duration'), 1.99, places=6)
+        self.assertAlmostEqual(trig[2].pop('duration'), 1.92, places=6)
+        self.assertAlmostEqual(trig[3].pop('duration'), 3.92, places=6)
+        self.assertAlmostEqual(trig[0]['similarity'].pop('UH1'),
+                               0.94149447384, places=6)
+        self.assertAlmostEqual(trig[0]['similarity'].pop('UH3'), 1,
+                               places=6)
+        self.assertAlmostEqual(trig[1]['similarity'].pop('UH1'),
+                               0.65228204570, places=6)
+        self.assertAlmostEqual(trig[1]['similarity'].pop('UH3'),
+                               0.72679293429, places=6)
+        self.assertAlmostEqual(trig[2]['similarity'].pop('UH1'),
+                               0.89404458774, places=6)
+        self.assertAlmostEqual(trig[2]['similarity'].pop('UH3'),
+                               0.74581409371, places=6)
+        self.assertAlmostEqual(trig[3]['similarity'].pop('UH1'), 1,
+                               places=6)
+        self.assertAlmostEqual(trig[3]['similarity'].pop('UH3'), 1,
+                               places=6)
         remaining_results = \
             [{'coincidence_sum': 4.0,
               'similarity': {},


### PR DESCRIPTION
While trying to fix #1318 I run accross the following issue:

```
Python 2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)]

>>> import datetime
>>> datetime.datetime(1,1,1,0,0,0,1)
datetime.datetime(1, 1, 1, 0, 0, 0, 1)
>>> print(datetime.datetime(1, 1, 1, 0, 0, 0, 1))
0001-01-01 00:00:00.000001
```

so microseconds support in Python datetime has been massively improved, unfortunately our current UTCDateTime implementation does not reflect that

```
>>> from obspy import UTCDateTime
>>> UTCDateTime(1,1,1,0,0,0,1)
0001-01-01T00:00:00.000000Z 
>>> UTCDateTime(1,1,1,0,0,0,1).timestamp
-62135596800.0
```

It boils down to floating point precision errors - as usual

```
>>> -62135596800.000001
-62135596800.0
>>> "%.8lf" % -62135596800.000001
'-62135596800.00000000'
```

NumPy is no help either (no `np.float128` on Windows):

```
>>> import numpy as np
>>> np.float64(-62135596800.000001)
-62135596800.0
>>> "%.8lf" % np.float64(-62135596800.000001)
'-62135596800.00000000'
```

In order to solve that issue I had a look into the following concepts:
- switch back to `datetime.datetime` instead of `float` timestamp within the UTCDateTime class - unfortunatly we loose the option to set a precision and we are bound to microseconds
- use `decimal.Decimal` instead -> working with decimal is a pain, see also http://legacy.python.org/dev/peps/pep-0410/ and https://mail.python.org/pipermail/python-dev/2012-February/116837.html
- http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html - again converting back to datetime/timestamp is a pain

... but I decided to use a `long` to store nanoseconds instead of microseconds (timestamp) in the `UTCDateTime` class, this enables some really nice features, such as support form year 1 to 9999 and precision down to nanoseconds while being not much slower than the previous implementation - and I'm sure there is room for improvement - and more important: keeping the current UTCDateTime API as it is.

See https://github.com/obspy/obspy/blob/new_utcdatetime/obspy/core/tests/test_utcdatetime.py#L989-L1068.

Comments? Ideas? Is nanoseconds enough?

This PR fixes #1318 and #1008 .
