### PR TITLE
fdsn.client.Client.get_events(): add units for mindepth and maxdepth

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -341,11 +341,11 @@ class Client(object):
             of degrees from the geographic point defined by the latitude and
             longitude parameters.
         :type mindepth: float, optional
-        :param mindepth: Limit to events with depth more than the specified
-            minimum.
+        :param mindepth: Limit to events with depth, in kilometers, larger than
+            the specified minimum.
         :type maxdepth: float, optional
-        :param maxdepth: Limit to events with depth less than the specified
-            maximum.
+        :param maxdepth: Limit to events with depth, in kilometers, smaller
+            than the specified maximum.
         :type minmagnitude: float, optional
         :param minmagnitude: Limit to events with a magnitude larger than the
             specified minimum.


### PR DESCRIPTION
ObsPy 1.0.0

In `fdsn.client.Client.get_events()`, unit for `mindepth` and `maxdepth` should be documented.
This is in kilometers, as for the FDSN-WS specification: http://www.fdsn.org/webservices/FDSN-WS-Specifications-1.1.pdf
