### PR TITLE
remove_response(..., pre_filt=None, plot=True) not working

### DIFF
--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2623,8 +2623,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             ax6 = fig.add_subplot(326, sharex=ax4)
             for ax_ in (ax1, ax2, ax3, ax4, ax5, ax6):
                 ax_.grid(zorder=-10)
-            text = 'pre_filt: [{:.3g}, {:.3g}, {:.3g}, {:.3g}]'.format(
-                *pre_filt)
+            if pre_filt is None:
+                text = 'pre_filt: None'
+            else:
+                text = 'pre_filt: [{:.3g}, {:.3g}, {:.3g}, {:.3g}]'.format(
+                    *pre_filt)
             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
                      transform=ax1.transAxes, fontsize="large", bbox=bbox,
                      zorder=5)


### PR DESCRIPTION
```python
In [5]: st.remove_response(inv, pre_filt=None, plot=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-21e4919698f0> in <module>()
----> 1 st.remove_response(inv, pre_filt=None, plot=True)

/home/megies/git/obspy/obspy/core/stream.pyc in remove_response(self, *args, **kwargs)
   3028         """
   3029         for tr in self:
-> 3030             tr.remove_response(*args, **kwargs)
   3031         return self
   3032 

<decorator-gen-153> in remove_response(self, inventory, output, water_level, pre_filt, zero_mean, taper, taper_fraction, plot, fig, **kwargs)

/home/megies/git/obspy/obspy/core/trace.pyc in _add_processing_info(func, *args, **kwargs)
    229     info = info % "::".join(arguments)
    230     self = args[0]
--> 231     result = func(*args, **kwargs)
    232     # Attach after executing the function to avoid having it attached
    233     # while the operation failed.

/home/megies/git/obspy/obspy/core/trace.pyc in remove_response(self, inventory, output, water_level, pre_filt, zero_mean, taper, taper_fraction, plot, fig, **kwargs)
   2625                 ax_.grid(zorder=-10)
   2626             text = 'pre_filt: [{:.3g}, {:.3g}, {:.3g}, {:.3g}]'.format(
-> 2627                 *pre_filt)
   2628             ax1.text(0.05, 0.1, text, ha="left", va="bottom",
   2629                      transform=ax1.transAxes, fontsize="large", bbox=bbox,

TypeError: format() argument after * must be a sequence, not NoneType
```