### PR TITLE
SAC output ignores sampling rate from Trace metadata

### DIFF
--- a/obspy/io/sac/header.py
+++ b/obspy/io/sac/header.py
@@ -22,7 +22,8 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
                   when read into sac. [required]''',
        'b': 'F    Beginning value of the independent variable. [required]',
        'e': 'F    Ending value of the independent variable. [required]',
-       'iftype': '''I    Type of file [required]:\n
+       'iftype': '''I    Type of file [required]:
+
                   * ITIME {Time series file}
                   * IRLIM {Spectral file---real and imaginary}
                   * IAMPH {Spectral file---amplitude and phase}
@@ -32,7 +33,8 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'delta': 'F    Increment between evenly spaced samples (nominal value).'
                 ' [required]',
        'odelta': 'F    Observed increment if different from nominal value.',
-       'idep': '''I    Type of dependent variable:\n
+       'idep': '''I    Type of dependent variable:
+
                   * IUNKN (Unknown)
                   * IDISP (Displacement in nm)
                   * IVEL (Velocity in nm/sec)
@@ -49,7 +51,8 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'nzmin': 'N    GMT minute.',
        'nzsec': 'N    GMT second.',
        'nzmsec': 'N    GMT millisecond.',
-       'iztype': '''I    Reference time equivalence:\n
+       'iztype': '''I    Reference time equivalence:
+
                   * IUNKN (5): Unknown
                   * IB (9): Begin time
                   * IDAY (10): Midnight of reference GMT day
@@ -115,14 +118,16 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'evel': 'F    Event elevation (meters). [not currently used]',
        'evdp': 'F    Event depth below surface (meters). [not currently used]',
        'mag': 'F    Event magnitude.',
-       'imagtyp': '''I    Magnitude type:\n
+       'imagtyp': '''I    Magnitude type:
+
                   * IMB (52): Bodywave Magnitude
                   * IMS (53): Surfacewave Magnitude
                   * IML (54): Local Magnitude
                   * IMW (55): Moment Magnitude
                   * IMD (56): Duration Magnitude
                   * IMX (57): User Defined Magnitude''',
-       'imagsrc': '''I    Source of magnitude information:\n
+       'imagsrc': '''I    Source of magnitude information:
+
                   * INEIC (National Earthquake Information Center)
                   * IPDE (Preliminary Determination of Epicenter)
                   * IISC (International Seismological Centre)
@@ -135,7 +140,8 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
                   * IJSOP (Joint Seismic Observation Program)
                   * IUSER (The individual using SAC2000)
                   * IUNKNOWN (unknown)''',
-       'ievtyp': '''I    Type of event:\n
+       'ievtyp': '''I    Type of event:
+
                   * IUNKN (Unknown)
                   * INUCL (Nuclear event)
                   * IPREN (Nuclear pre-shot event)
@@ -174,13 +180,15 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'gcarc': 'F    Station to event great circle arc length (degrees).',
        'lcalda': 'L    TRUE if DIST AZ BAZ and GCARC are to be calculated '
                  'from st event coordinates.',
-       'iqual': '''I    Quality of data [not currently used]:\n
+       'iqual': '''I    Quality of data [not currently used]:
+
                   * IGOOD (Good data)
                   * IGLCH (Glitches)
                   * IDROP (Dropouts)
                   * ILOWSN (Low signal to noise ratio)
                   * IOTHER (Other)''',
-       'isynth': '''I    Synthetic data flag [not currently used]:\n
+       'isynth': '''I    Synthetic data flag [not currently used]:
+
                   * IRLDTA (Real data)
                   * ????? (Flags for various synthetic seismogram codes)''',
        'user0': 'F    User defined variable storage area 0.',

--- a/obspy/io/sac/header.py
+++ b/obspy/io/sac/header.py
@@ -22,7 +22,7 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
                   when read into sac. [required]''',
        'b': 'F    Beginning value of the independent variable. [required]',
        'e': 'F    Ending value of the independent variable. [required]',
-       'iftype': '''I    Type of file [required]:
+       'iftype': '''I    Type of file [required]:\n
                   * ITIME {Time series file}
                   * IRLIM {Spectral file---real and imaginary}
                   * IAMPH {Spectral file---amplitude and phase}
@@ -32,7 +32,7 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'delta': 'F    Increment between evenly spaced samples (nominal value).'
                 ' [required]',
        'odelta': 'F    Observed increment if different from nominal value.',
-       'idep': '''I    Type of dependent variable:
+       'idep': '''I    Type of dependent variable:\n
                   * IUNKN (Unknown)
                   * IDISP (Displacement in nm)
                   * IVEL (Velocity in nm/sec)
@@ -49,7 +49,7 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'nzmin': 'N    GMT minute.',
        'nzsec': 'N    GMT second.',
        'nzmsec': 'N    GMT millisecond.',
-       'iztype': '''I    Reference time equivalence:
+       'iztype': '''I    Reference time equivalence:\n
                   * IUNKN (5): Unknown
                   * IB (9): Begin time
                   * IDAY (10): Midnight of reference GMT day
@@ -115,14 +115,14 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'evel': 'F    Event elevation (meters). [not currently used]',
        'evdp': 'F    Event depth below surface (meters). [not currently used]',
        'mag': 'F    Event magnitude.',
-       'imagtyp': '''I    Magnitude type:
+       'imagtyp': '''I    Magnitude type:\n
                   * IMB (52): Bodywave Magnitude
                   * IMS (53): Surfacewave Magnitude
                   * IML (54): Local Magnitude
                   * IMW (55): Moment Magnitude
                   * IMD (56): Duration Magnitude
                   * IMX (57): User Defined Magnitude''',
-       'imagsrc': '''I    Source of magnitude information:
+       'imagsrc': '''I    Source of magnitude information:\n
                   * INEIC (National Earthquake Information Center)
                   * IPDE (Preliminary Determination of Epicenter)
                   * IISC (International Seismological Centre)
@@ -135,7 +135,7 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
                   * IJSOP (Joint Seismic Observation Program)
                   * IUSER (The individual using SAC2000)
                   * IUNKNOWN (unknown)''',
-       'ievtyp': '''I    Type of event:
+       'ievtyp': '''I    Type of event:\n
                   * IUNKN (Unknown)
                   * INUCL (Nuclear event)
                   * IPREN (Nuclear pre-shot event)
@@ -174,13 +174,13 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'gcarc': 'F    Station to event great circle arc length (degrees).',
        'lcalda': 'L    TRUE if DIST AZ BAZ and GCARC are to be calculated '
                  'from st event coordinates.',
-       'iqual': '''I    Quality of data [not currently used]:
+       'iqual': '''I    Quality of data [not currently used]:\n
                   * IGOOD (Good data)
                   * IGLCH (Glitches)
                   * IDROP (Dropouts)
                   * ILOWSN (Low signal to noise ratio)
                   * IOTHER (Other)''',
-       'isynth': '''I    Synthetic data flag [not currently used]:
+       'isynth': '''I    Synthetic data flag [not currently used]:\n
                   * IRLDTA (Real data)
                   * ????? (Flags for various synthetic seismogram codes)''',
        'user0': 'F    User defined variable storage area 0.',

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -831,8 +831,6 @@ class CoreTestCase(unittest.TestCase):
         in the SAC file.
         """
         tr = read(self.file, format='SAC')[0]
-        npts = tr.stats.sac.npts
-        delta = tr.stats.sac.delta
         tr.decimate(2)
         with NamedTemporaryFile() as tf:
             tempfile = tf.name

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -842,8 +842,6 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr1.stats.sac.delta, tr.stats.sac.delta * 2)
 
 
-
-
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')
 

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -825,6 +825,24 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)
         self.assertEqual(tr1.stats.sac.o, o)
 
+    def test_decimate_resample(self):
+        """
+        Test that ObsPy Trace resampling and decimation is properly reflected
+        in the SAC file.
+        """
+        tr = read(self.file, format='SAC')[0]
+        npts = tr.stats.sac.npts
+        delta = tr.stats.sac.delta
+        tr.decimate(2)
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            tr.write(tempfile, format='SAC')
+            tr1 = read(tempfile)[0]
+        self.assertEqual(tr1.stats.sac.npts, tr.stats.sac.npts / 2)
+        self.assertEqual(tr1.stats.sac.delta, tr.stats.sac.delta * 2)
+
+
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -365,7 +365,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                 header.update(nztimes)
                 header['b'] = microsecond * 1e-6
                 header['e'] = header['b'] +\
-                    (header['npts'] - 1) * header['delta']
+                    (stats['npts'] - 1) * stats['delta']
 
             msg = "Old header has invalid reftime."
             warnings.warn(msg)
@@ -396,7 +396,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
         header['b'] = microsecond * 1e-6
 
         # we now have correct b, npts, delta, and nz times
-        header['e'] = header['b'] + (header['npts'] - 1) * header['delta']
+        header['e'] = header['b'] + (stats['npts'] - 1) * stats['delta']
 
         header['scale'] = stats.get('calib', HD.FNULL)
 
@@ -412,6 +412,10 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
     header['leven'] = 1
     header['lovrok'] = 1
     header['iftype'] = 1
+
+    # ObsPy issue #1317
+    header['npts'] = stats['npts']
+    header['delta'] = stats['delta']
 
     return header
 


### PR DESCRIPTION
When using the trace.decimate() function in v.1.0.0 on .SAC formatted traces, the new sampling rate isn't updated in the trace metadata. I've tried to work around it by decimating, then forcing the trace to update the stats with the new sampling rate using trace.stats.update. This does work for the current instance, however, when writing the trace out as a .SAC, the old sampling rate is written into the stats.

