### PR TITLE
tr.__add__ crossfade possibility

### DIFF
--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -541,7 +541,7 @@ class Trace(object):
         return st
 
     def __add__(self, trace, method=0, interpolation_samples=0,
-                fill_value=None, sanity_checks=True):
+                fill_value=None, sanity_checks=True, crossfade='sum'):
         """
         Add another Trace object to current trace.
 
@@ -728,6 +728,20 @@ class Trace(object):
                                                lt.data.dtype)
                     data = [lt.data[:-delta], interpolation,
                             rt.data[interpolation_samples:]]
+            elif method == 2: # cut in the middle
+                ldelta = delta//2
+                rdelta = delta - ldelta
+                data = [lt.data[:-ldelta], rt.data[rdelta:]]
+            elif method == 3: # sum both traces
+                if crossfade == 'box':
+                    overlap_samples = lt[-delta:] + rt[:delta]
+                elif crossfade == 'linear':
+                    fadein = np.linspace(0., 1., delta)
+                    fadeout = fadein[::-1]
+                    overlap_samples = lt[-delta:] * fadeout +\
+                                      rt[:delta] * fadein
+                data = [lt.data[:-delta], overlap_samples,
+                        rt.data[delta:]]
             else:
                 raise NotImplementedError
         elif delta < 0 and delta_endtime >= 0:

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -733,11 +733,17 @@ class Trace(object):
                 rdelta = delta - ldelta
                 data = [lt.data[:-ldelta], rt.data[rdelta:]]
             elif method == 3: # sum both traces
-                if crossfade == 'box':
+                if crossfade == 'sum':
                     overlap_samples = lt[-delta:] + rt[:delta]
                 elif crossfade == 'linear':
                     fadein = np.linspace(0., 1., delta)
                     fadeout = fadein[::-1]
+                    overlap_samples = lt[-delta:] * fadeout +\
+                                      rt[:delta] * fadein
+                elif crossfade == 'sinus':
+                    fraction = np.linspace(0., np.pi / 2., delta)
+                    fadein = np.sin(fraction)**2
+                    fadeout = np.cos(fraction)**2
                     overlap_samples = lt[-delta:] * fadeout +\
                                       rt[:delta] * fadein
                 data = [lt.data[:-delta], overlap_samples,


### PR DESCRIPTION
This PR adds the possibility to crossfade traces when adding them or just cutting them in the middle. It works well but doesn't yet test all possible Exceptions (e.g. if one trace is contained fully...). Cutting in the middle is really useful when you don't want to throw away the two traces because of boundary effects after filtering. Crossfade is especially when merging traces that have slowly changing processing parameters. I hope this didn't exist before...

![xfade](https://cloud.githubusercontent.com/assets/2597803/13900960/504efea6-ee13-11e5-99b2-b2d43bbcc46d.png)
