### PR TITLE
add convenience method and property to UTCDateTime to get matplotlib datetime float representation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,10 @@
 master:
  - obspy.core
    * Stream/Trace.write() can now autodetect file format from file extension.
- - obspy.clients.fdsn
+   * New convenience property `.matplotlib_date` for `UTCDateTime` objects to
+     get matplotlib datetime float representation (which can be used in
+     time-based matplotlib axes, e.g. by Stream.plot()).
+ - obspy.clients.fdsn:
    * The mass downloader now has `exclude_networks` and `exclude_stations`
      arguments to not download certain pieces of data. (see #1305)
    * The mass downloader can now download stations that are part of a given

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1003,6 +1003,19 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(UTCDateTime('2015-07-03-06-42-1.5123'),
                          UTCDateTime(2015, 7, 3, 6, 42, 1, 512300))
 
+    def test_matplotlib_date(self):
+        """
+        Test convenience method and property for conversion to matplotlib
+        datetime float numbers.
+        """
+        for t_, expected in zip(
+                ("1986-05-02T13:44:12.567890Z", "2009-08-24T00:20:07.700000Z",
+                 "2026-11-27T03:12:45.4"),
+                (725128.5723676839, 733643.0139780092, 739947.1338587963)):
+            t = UTCDateTime(t_)
+            np.testing.assert_almost_equal(
+                t.matplotlib_date, expected, decimal=8)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -1455,6 +1455,23 @@ class UTCDateTime(object):
             self.datetime.replace(hour=0, minute=0, second=0, microsecond=0))
         return timedelta.total_seconds() / 3600.0
 
+    @property
+    def matplotlib_date(self):
+        """
+        Maplotlib date number representation.
+
+        Useful for plotting on matplotlib time-based axes, like created by e.g.
+        :meth:`obspy.core.stream.Stream.plot()`.
+
+        >>> t = UTCDateTime("2009-08-24T00:20:07.700000Z")
+        >>> t.matplotlib_date
+        733643.0139780092
+
+        :rtype: float
+        """
+        from matplotlib.dates import date2num
+        return date2num(self.datetime)
+
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
..for plotting on matplotlib time axes.

This adds a method `UTCDateTime.to_matplotlib()` and a property `UTCDateTime.mpl` for even shorter notation.