### PR TITLE
Stream normalization

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 1.0.x:
+ - obspy.core:
+    * Trace.normalize() does no longer divide by zero in case an all-zeros
+      data trace is being used. (see #1343)
  - obspy.clients.fdsn:
     * Local URLs are now recognized as valid URLs. (see #1309)
     * Some bug fixes for the mass downloader. (see #1293, #1304)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -7,6 +7,7 @@ import math
 import os
 import unittest
 from copy import deepcopy
+import warnings
 
 import numpy as np
 import numpy.ma as ma
@@ -2202,6 +2203,90 @@ class TraceTestCase(unittest.TestCase):
                              reltol=1.5) as ic:
             tr.remove_response(pre_filt=pre_filt, output="DISP",
                                water_level=60, end_stage=None, plot=ic.name)
+
+    def test_normalize(self):
+        """
+        Tests the normalize() method on normal and edge cases.
+        """
+        # Nothing should happen with ones.
+        tr = Trace(data=np.ones(5))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.ones(5))
+
+        # 10s should be normalized to all ones.
+        tr = Trace(data=10 * np.ones(5))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.ones(5))
+
+        # Negative 10s should be normalized to negative ones.
+        tr = Trace(data=-10 * np.ones(5))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, -np.ones(5))
+
+        # 10s and a couple of 5s should be normalized to 1s and a couple of
+        # 0.5s.
+        tr = Trace(data=np.array([10.0, 10.0, 5.0, 5.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([1.0, 1.0, 0.5, 0.5]))
+
+        # Same but negative values.
+        tr = Trace(data=np.array([-10.0, -10.0, -5.0, -5.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-1.0, -1.0, -0.5, -0.5]))
+
+        # Mixed values.
+        tr = Trace(data=np.array([-10.0, -10.0, 5.0, 5.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-1.0, -1.0, 0.5, 0.5]))
+
+        # Mixed values.
+        tr = Trace(data=np.array([-10.0, 10.0, -5.0, 5.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-1.0, 1.0, -0.5, 0.5]))
+
+        # Mixed values.
+        tr = Trace(data=np.array([-10.0, -10.0, 0.0, 0.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-1.0, -1.0, 0.0, 0.0]))
+
+        # Mixed values.
+        tr = Trace(data=np.array([10.0, 10.0, 0.0, 0.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([1.0, 1.0, 0.0, 0.0]))
+
+        # Small values get larger.
+        tr = Trace(data=np.array([-0.5, 0.5, 0.1, -0.1]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-1.0, 1.0, 0.2, -0.2]))
+
+        # All zeros. Nothing should happen.
+        tr = Trace(data=np.array([-0.0, 0.0, 0.0, -0.0]))
+        tr.normalize()
+        np.testing.assert_allclose(tr.data, np.array([-0.0, 0.0, 0.0, -0.0]))
+
+        # Passing the norm specifies the division factor.
+        tr = Trace(data=np.array([10.0, 10.0, 0.0, 0.0]))
+        tr.normalize(norm=2)
+        np.testing.assert_allclose(tr.data, np.array([5.0, 5.0, 0.0, 0.0]))
+
+        # Passing the norm specifies the division factor. Nothing happens
+        # with zero.
+        tr = Trace(data=np.array([10.0, 10.0, 0.0, 0.0]))
+        tr.normalize(norm=0)
+        np.testing.assert_allclose(tr.data, np.array([10.0, 10.0, 0.0, 0.0]))
+
+        # Warning is raised for a negative norm, but the positive value is
+        # used.
+        tr = Trace(data=np.array([10.0, 10.0, 0.0, 0.0]))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            tr.normalize(norm=-2)
+
+        self.assertEqual(w[0].category, UserWarning)
+        self.assertIn("Normalizing with negative values is forbidden.",
+                      w[0].message.args[0])
+
+        np.testing.assert_allclose(tr.data, np.array([5.0, 5.0, 0.0, 0.0]))
 
 
 def suite():

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2259,9 +2259,14 @@ class TraceTestCase(unittest.TestCase):
         tr.normalize()
         np.testing.assert_allclose(tr.data, np.array([-1.0, 1.0, 0.2, -0.2]))
 
-        # All zeros. Nothing should happen.
+        # All zeros. Nothing should happen but a warning will be raised.
         tr = Trace(data=np.array([-0.0, 0.0, 0.0, -0.0]))
-        tr.normalize()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            tr.normalize()
+        self.assertEqual(w[0].category, UserWarning)
+        self.assertIn("Attempting to normalize by dividing through zero.",
+                      w[0].message.args[0])
         np.testing.assert_allclose(tr.data, np.array([-0.0, 0.0, 0.0, -0.0]))
 
         # Passing the norm specifies the division factor.
@@ -2272,7 +2277,12 @@ class TraceTestCase(unittest.TestCase):
         # Passing the norm specifies the division factor. Nothing happens
         # with zero.
         tr = Trace(data=np.array([10.0, 10.0, 0.0, 0.0]))
-        tr.normalize(norm=0)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            tr.normalize(norm=0)
+        self.assertEqual(w[0].category, UserWarning)
+        self.assertIn("Attempting to normalize by dividing through zero.",
+                      w[0].message.args[0])
         np.testing.assert_allclose(tr.data, np.array([10.0, 10.0, 0.0, 0.0]))
 
         # Warning is raised for a negative norm, but the positive value is

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2087,7 +2087,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         ObsPy ...: normalize(norm=None)
         """
         # normalize, use norm-kwarg otherwise normalize to 1
-        if norm:
+        if norm is not None:
             norm = norm
             if norm < 0:
                 msg = "Normalizing with negative values is forbidden. " + \
@@ -2095,6 +2095,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 warnings.warn(msg)
         else:
             norm = self.max()
+
+        # Don't do anything for zero norm.
+        if not norm:
+            return self
 
         self.data = self.data.astype(np.float64)
         self.data /= abs(norm)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2056,7 +2056,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :param norm: If not ``None``, trace is normalized by dividing by
             specified value ``norm`` instead of dividing by its absolute
             maximum. If a negative value is specified then its absolute value
-            is used.
+            is used. If it is zero (either through a zero array or by being
+            passed), nothing will happen and the original array will not
+            change.
 
         If ``trace.data.dtype`` was integer it is changing to float.
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2098,8 +2098,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         else:
             norm = self.max()
 
-        # Don't do anything for zero norm.
+        # Don't do anything for zero norm but raise a warning.
         if not norm:
+            msg = ("Attempting to normalize by dividing through zero. This "
+                   "is not allowed and the data will thus not be changed.")
+            warnings.warn(msg)
             return self
 
         self.data = self.data.astype(np.float64)


### PR DESCRIPTION
Hi all,
I recently had an issue with the normalization of the data in a stream object. I try to test some data recovery methods, therefore I need traces in Stream that are just filled with zeros. If I normalize the stream, all traces with just zeros on it return with 'nan' values instead of zeros. I don't know if this is intended or not, but I thought it would be plausible if it stays zero?