### PR TITLE
Fix arclink decryption

### DIFF
--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -182,7 +182,7 @@ class Client(object):
         b_buffer = (buffer + '\r\n').encode()
         self._client.write(b_buffer)
         if self.debug:
-            print(b'>>> ' + b_buffer)
+            print('>>> ' + buffer)
 
     def _read_ln(self, value=b''):
         line = self._client.read_until(value + b'\r\n', self.timeout)
@@ -191,7 +191,7 @@ class Client(object):
             msg = "Timeout waiting for expected %s, got %s"
             raise ArcLinkException(msg % (value, line.decode()))
         if self.debug:
-            print(b'... ' + line)
+            print('... ' + line.decode())
         return line
 
     def _hello(self):

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -573,7 +573,7 @@ class ClientTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             # Dataless SEED
-            client.saveResponse(tempfile, 'BW', 'MANZ', '', 'EHZ', start, end)
+            client.save_response(tempfile, 'BW', 'MANZ', '', 'EHZ', start, end)
             with open(tempfile, 'rb') as fp:
                 self.assertEqual(fp.read(8), b"000001V ")
 
@@ -583,7 +583,7 @@ class ClientTestCase(unittest.TestCase):
         start = UTCDateTime(2008, 1, 1)
         end = start + 1
         # Dataless SEED
-        client.saveResponse(file_object, 'BW', 'MANZ', '', 'EHZ', start, end)
+        client.save_response(file_object, 'BW', 'MANZ', '', 'EHZ', start, end)
         file_object.seek(0, 0)
         self.assertEqual(file_object.read(8), b"000001V ")
 


### PR DESCRIPTION
- fixes #1347
- added a PyCrypto fallback/alternative for M2Crypto - the latter is incredible difficult to install on Windows & py3k - M2Crypto is still the default method - however we should really consider to switch that out wich PyCrypto
- can't fix/adapt decrypt test suite as long the given ArcLink test node is not running properly - currently one can login with any credentials and no data is encrypted ...

