### PR TITLE
Raise Exception when filtering masked array and fill masked values with nan

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,11 @@
    * Added workaround for numpy issue where many FFTs of various lengths fill
      a cache that never gets cleared, effectively creating a memory leak
      (see #1424).
+   * Trace.filter and Stream.filter don't work on masked arrays anymore because
+     it produced unpredictable results due to the un-initialized data-chunk.
+     The uninitialized masked gap is now also initialized to np.nan in case
+     of floating point data which and a consistent fill value in case of
+     integer data. (see #1363)
  - obspy.clients.fdsn:
    * Fixing issue with location codes potentially resulting in unwanted data
      to be requested. (see #1422)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2055,6 +2055,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                         simulate_sensitivity=simulate_sensitivity, **kwargs)
         return self
 
+    @raise_if_masked
     def filter(self, type, **options):
         """
         Filter the data of all traces in the Stream.

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1379,6 +1379,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         return self
 
     @_add_processing_info
+    @raise_if_masked
     def filter(self, type, **options):
         """
         Filter the data of the current trace.

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -153,6 +153,11 @@ def create_empty_data_chunk(delta, dtype, fill_value=None):
         dtype = native_str(dtype)
     if fill_value is None:
         temp = np.ma.masked_all(delta, dtype=np.dtype(dtype))
+        # fill with nan if float number and otherwise with a very small number
+        if issubclass(temp.data.dtype.type, np.integer):
+            temp.data[:] = np.iinfo(temp.data.dtype).min
+        else:
+            temp.data[:] = np.nan
     elif (isinstance(fill_value, list) or isinstance(fill_value, tuple)) \
             and len(fill_value) == 2:
         # if two values are supplied use these as samples bordering to our data


### PR DESCRIPTION
This PR fixes a little issue that occured when involuntarily filtering masked data. This is not a well defined operation that should throw an Exception. I therefore added the raise_if_masked decorator to the filter functions in trace and stream. I also set all masked values to `np.nan` instead of `empty` now to avoid random behaviour due to unset data values.