### PR TITLE
build docs for PRs

### DIFF
--- a/misc/scripts/build-docs.sh
+++ b/misc/scripts/build-docs.sh
@@ -1,1 +1,0 @@
-../docs/build-docs.sh

--- a/misc/scripts/docs_buildbot/build-docs.sh
+++ b/misc/scripts/docs_buildbot/build-docs.sh
@@ -1,0 +1,1 @@
+../../docs/build-docs.sh

--- a/misc/scripts/docs_buildbot/remove_old_pull_request_docs.py
+++ b/misc/scripts/docs_buildbot/remove_old_pull_request_docs.py
@@ -1,0 +1,66 @@
+import glob
+import os
+import requests
+import shutil
+from obspy import UTCDateTime
+
+
+DIRECTORY = "/home/obspy/htdocs/docs/pull_requests"
+
+
+try:
+    # github API token with "repo.status" access right
+    token = os.environ["OBSPY_COMMIT_STATUS_TOKEN"]
+except KeyError:
+    headers = None
+else:
+    headers = {"Authorization": "token {}".format(token)}
+
+
+# without using pagination we only get the last 100 pulls,
+# but this should be enough
+data = requests.get(
+    "https://api.github.com/repos/obspy/obspy/pulls",
+    params={"state": "closed", "sort": "updated", "direction": "desc",
+            "per_page": 100},
+    headers=headers)
+try:
+    assert data.ok
+except:
+    print(data.json())
+    raise
+
+now = UTCDateTime()
+# delete everything belonging to pull requests that have been closed for more
+# than two weeks
+time_threshold = now - 14 * 24 * 3600
+# any files older than this will be deleted no matter what
+time_threshold_hard = (now - 365 * 24 * 3600).timestamp
+
+
+def delete(path):
+    try:
+        if os.path.isfile(file_):
+            os.remove(file_)
+        elif os.path.isdir(file_):
+            shutil.rmtree(file_)
+    except Exception as e:
+        print("Failed to remove '{}' ({}).".format(file_, str(e)))
+
+
+for d in data.json():
+    # extract the pieces we need from the PR data
+    number = d['number']
+    time = UTCDateTime(d['closed_at'])
+
+    # still pretty freshly closed, so leave it alone
+    if time > time_threshold:
+        continue
+
+    for file_ in glob.glob(
+            os.path.join(DIRECTORY, str(number) + "*")):
+        delete(file_)
+
+for file_ in glob.glob(os.path.join(DIRECTORY, "*")):
+    if os.stat(file_).st_mtime < time_threshold_hard:
+        delete(file_)

--- a/misc/scripts/docs_buildbot/update-docs-pr.sh
+++ b/misc/scripts/docs_buildbot/update-docs-pr.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+cd $HOME
+anaconda3/bin/python update_pull_request_metadata.py
+for FILE in `ls pull_request_docs/*.todo 2> /dev/null`
+do
+    PR=${FILE##*/}
+    PR=${PR%.*}
+    bash $HOME/update-docs.sh -p $PR
+    STATUS=`echo $?`
+    echo $STATUS
+    if [ ! "$STATUS" = "-1" ]
+    then
+        touch $HOME/pull_request_docs/${PR}.done
+        rm $HOME/pull_request_docs/${PR}.todo
+    fi
+    cp $HOME/update-docs-pr/log.txt $HOME/pull_request_docs/${PR}.log
+    cp $HOME/update-docs-pr/log.txt $HOME/htdocs/docs/pull_requests/${PR}.log
+done

--- a/misc/scripts/docs_buildbot/update_pull_request_metadata.py
+++ b/misc/scripts/docs_buildbot/update_pull_request_metadata.py
@@ -1,0 +1,64 @@
+import os
+import requests
+from obspy import UTCDateTime
+
+
+try:
+    # github API token with "repo.status" access right
+    token = os.environ["OBSPY_COMMIT_STATUS_TOKEN"]
+except KeyError:
+    headers = None
+else:
+    headers = {"Authorization": "token {}".format(token)}
+
+
+data = requests.get(
+    "https://api.github.com/repos/obspy/obspy/pulls",
+    params={"state": "open", "sort": "created", "direction": "desc",
+            "per_page": 100},
+    headers=headers)
+try:
+    assert data.ok
+except:
+    print(data.json())
+    raise
+data = data.json()
+
+for d in data:
+    # extract the pieces we need from the PR data
+    number = d['number']
+    fork = d['head']['user']['login']
+    branch = d['head']['ref']
+    commit = d['head']['sha']
+    # need to figure out time of last push from commit details.. -_-
+    url = "https://api.github.com/repos/{fork}/obspy/git/commits/{hash}"
+    url = url.format(fork=fork, hash=commit)
+    commit_data = requests.get(url, headers=headers)
+    try:
+        assert commit_data.ok
+    except:
+        print(commit_data.json())
+        raise
+    commit_data = commit_data.json()
+    time = int(UTCDateTime(commit_data['committer']['date']).timestamp)
+
+    filename = os.path.join("pull_request_docs", str(number))
+    filename_todo = filename + ".todo"
+    filename_done = filename + ".done"
+
+    # create new stub file if it doesn't exist
+    if not os.path.exists(filename):
+        with open(filename, "wb") as fh:
+            fh.write("{}\n{}\n".format(fork, branch).encode("UTF-8"))
+
+    # update access/modify time of file
+    os.utime(filename, (time, time))
+
+    # check if nothing needs to be done..
+    if os.path.exists(filename_done):
+        time_done = UTCDateTime(os.stat(filename_done).st_atime)
+        if time_done > time:
+            continue
+    # ..otherwise touch the .todo file
+    with open(filename_todo, "wb"):
+        pass

--- a/misc/scripts/docs_buildbot/update_pull_request_status.py
+++ b/misc/scripts/docs_buildbot/update_pull_request_status.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import requests
+
+# github API token with "repo.status" access right
+token = os.environ["OBSPY_COMMIT_STATUS_TOKEN"]
+
+commit = sys.argv[1]
+status = sys.argv[2]
+target_url = sys.argv[3]
+
+if status == "success":
+    description = "Check out Pull Request docs build here:"
+elif status in ["error", "failure"]:
+    description = "Log for failed Pull Request docs build here:"
+else:
+    raise ValueError("Invalid status: {}".format(status))
+
+url = "https://api.github.com/repos/obspy/obspy/statuses/{}".format(commit)
+headers = {"Authorization": "token {}".format(token)}
+data = {"state": status, "context": "docs-buildbot",
+        "description": description, "target_url": target_url}
+r = requests.post(url, json=data, headers=headers)
+
+try:
+    assert r.ok
+except:
+    print(r.json())


### PR DESCRIPTION
With the new Anaconda Python setup we have on our docs buildbot it would be rather unproblematic to have multiple builds running at the same time (in separate environments). I think it might be a good idea to have a cronjob running that frequently checks for updated PRs (using github API) and builds docs for them. This might especially help to judge the docs part of PRs by external contributors that do not build the docs locally for checking (for us and for them).

(A speedup of docs build time would certainly help for this one. E.g. by making client module images static and not request data via network -- at least for known to fail modules.)

Opinions? I think I'm gonna work on this when I find some time.