### PR TITLE
FDSN mass_downloader channel priorities ignore low gain.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@
  - obspy.clients.fdsn:
    * Fixing issue with location codes potentially resulting in unwanted data
      to be requested. (see #1422)
+   * Included low-gain seismometers in default channel filters in
+     mass-downloader, also included non-oriented channels by default
+     (see #1373).
  - obspy.db:
    * Fixed a bug in obspy-indexer command line script (see #1369,
      command line script was not working, probably since 0.10.0)

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -139,9 +139,11 @@ class Restrictions(object):
                  network=None, station=None, location=None, channel=None,
                  reject_channels_with_gaps=True, minimum_length=0.9,
                  sanitize=True, minimum_interstation_distance_in_m=1000,
-                 channel_priorities=("H[HL][ZNE]", "B[HL][ZNE]",
-                                     "M[HL][ZNE]", "E[HL][ZNE]",
-                                     "L[HL][ZNE]"),
+                 channel_priorities=("HH[ZNE12]", "BH[ZNE12]",
+                                     "MH[ZNE12]", "EH[ZNE12]",
+                                     "LH[ZNE12]", "HL[ZNE12]",
+                                     "BL[ZNE12]", "ML[ZNE12]",
+                                     "EL[ZNE12]", "LL[ZNE12]"),
                  location_priorities=("", "00", "10")):
         self.starttime = obspy.UTCDateTime(starttime)
         self.endtime = obspy.UTCDateTime(endtime)

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -139,9 +139,9 @@ class Restrictions(object):
                  network=None, station=None, location=None, channel=None,
                  reject_channels_with_gaps=True, minimum_length=0.9,
                  sanitize=True, minimum_interstation_distance_in_m=1000,
-                 channel_priorities=("HH[ZNE]", "BH[ZNE]",
-                                     "MH[ZNE]", "EH[ZNE]",
-                                     "LH[ZNE]"),
+                 channel_priorities=("H[HL][ZNE]", "B[HL][ZNE]",
+                                     "M[HL][ZNE]", "E[HL][ZNE]",
+                                     "L[HL][ZNE]"),
                  location_priorities=("", "00", "10")):
         self.starttime = obspy.UTCDateTime(starttime)
         self.endtime = obspy.UTCDateTime(endtime)

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -303,7 +303,8 @@ class DownloadHelpersUtilTestCase(unittest.TestCase):
         c2 = Channel("10", "SHE", time_intervals)
         c3 = Channel("00", "BHZ", time_intervals)
         c4 = Channel("", "HHE", time_intervals)
-        channels = [c1, c2, c3, c4]
+        c5 = Channel("", "ELZ", time_intervals)
+        channels = [c1, c2, c3, c4, c5]
 
         filtered_channels = filter_channel_priority(
             channels, key="channel", priorities=[


### PR DESCRIPTION
Suggested patch to [obspy.clients.fdsn.mass_downloader.restrictions](https://github.com/obspy/obspy/blob/master/obspy/clients/fdsn/mass_downloader/restrictions.py#L198) to change default channel priorities to include low-gain (\*L\*) seismometers.

I think this would help make the mass_downloader more general, so you can download all stations from a network by not setting the channel restriction.

I edited my version to change lines 198-200 to:

`                 channel_priorities=("H[HL][ZNE]", "B[HL][ZNE]",
                                     "M[HL][ZNE]", "E[HL][ZNE]",
                                     "L[HL][ZNE]"),`

Happy to make a pull request for this if you want.