### PR TITLE
taup: Fix initialization of Axes.

### DIFF
--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -150,8 +150,8 @@ class Arrivals(list):
             if not ax:
                 plt.figure(figsize=(10, 10))
                 ax = plt.subplot(111, polar=True)
-            ax.set_theta_zero_location('N')
-            ax.set_theta_direction(-1)
+                ax.set_theta_zero_location('N')
+                ax.set_theta_direction(-1)
             ax.set_xticks([])
             ax.set_yticks([])
             intp = matplotlib.cbook.simple_linear_interpolation


### PR DESCRIPTION
The direction/origin should only be set if the Axes is created in the function.

This should fix the body wave example in the documentation, where the S waves overlap the P waves because the second Axes is reset in the taup `plot` method.