### PR TITLE
Missing default encoding on MacOS causing problems

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+1.0.2: (doi: 10.5281/zenodo.49636)
+ - obspy.db:
+   * Fixed a bug in obspy-indexer command line script (see #1369,
+     command line script was not working, probably since 0.10.0)
+
 1.0.1: (doi: 10.5281/zenodo.48254)
  - General:
    * Some methods might have unnecessarily upcasted float32 arrays to float64.

--- a/obspy/core/util/version.py
+++ b/obspy/core/util/version.py
@@ -124,7 +124,7 @@ def call_git_describe(abbrev=10, dirty=True,
 
 def read_release_version():
     try:
-        with io.open(VERSION_FILE, "rt") as fh:
+        with io.open(VERSION_FILE, "rt", encoding="ascii") as fh:
             version = fh.readline()
         return version.strip()
     except IOError:

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -27,6 +27,7 @@ A command-line program that indexes seismogram files into a database.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
+from future.utils import native_str
 from future import standard_library
 
 import logging
@@ -142,7 +143,7 @@ def _run_indexer(options):
             p.daemon = True
             p.start()
         # connect to database
-        engine = create_engine(options.db_uri, encoding='utf-8',
+        engine = create_engine(options.db_uri, encoding=native_str('utf-8'),
                                convert_unicode=True)
         metadata = Base.metadata
         # recreate database


### PR DESCRIPTION
This is just to keep track of problems on OS X due to a seemingly missing default system encoding, see mail on users mailing list.

http://lists.swapbytes.de/archives/obspy-users/2015-September/001824.html
http://lists.swapbytes.de/archives/obspy-users/2015-September/001797.html