### PR TITLE
fix some try/excepts in seishub client

### DIFF
--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -363,16 +363,9 @@ master/seishub/plugins/seismology/waveform.py
         :rtype: list
         :return: List of containing network ids.
         """
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getNetworkIds'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['network']) for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_network_ids'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['network']) for node in root.getchildren()]
+        url = '/seismology/waveform/getNetworkIds'
+        root = self.client._objectify(url, **kwargs)
+        return [str(node['network']) for node in root.getchildren()]
 
     @deprecated("'getStationIds' has been renamed to 'get_station_ids'. "
                 "Use that instead.")  # noqa
@@ -392,16 +385,9 @@ master/seishub/plugins/seismology/waveform.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getStationIds'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['station']) for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_station_ids'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['station']) for node in root.getchildren()]
+        url = '/seismology/waveform/getStationIds'
+        root = self.client._objectify(url, **kwargs)
+        return [str(node['station']) for node in root.getchildren()]
 
     @deprecated("'getLocationIds' has been renamed to 'get_location_ids'. Use "
                 "that instead.")  # noqa
@@ -423,16 +409,9 @@ master/seishub/plugins/seismology/waveform.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getLocationIds'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['location']) for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_location_ids'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['location']) for node in root.getchildren()]
+        url = '/seismology/waveform/getLocationIds'
+        root = self.client._objectify(url, **kwargs)
+        return [str(node['location']) for node in root.getchildren()]
 
     @deprecated("'getChannelIds' has been renamed to 'get_channel_ids'. Use "
                 "that instead.")  # noqa
@@ -457,16 +436,9 @@ master/seishub/plugins/seismology/waveform.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getChannelIds'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['channel']) for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_channel_ids'
-            root = self.client._objectify(url, **kwargs)
-            return [str(node['channel']) for node in root.getchildren()]
+        url = '/seismology/waveform/getChannelIds'
+        root = self.client._objectify(url, **kwargs)
+        return [str(node['channel']) for node in root.getchildren()]
 
     @deprecated("'getLatency' has been renamed to 'get_latency'. Use "
                 "that instead.")  # noqa
@@ -493,18 +465,10 @@ master/seishub/plugins/seismology/waveform.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getLatency'
-            root = self.client._objectify(url, **kwargs)
-            return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                    for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_latency'
-            root = self.client._objectify(url, **kwargs)
-            return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                    for node in root.getchildren()]
+        url = '/seismology/waveform/getLatency'
+        root = self.client._objectify(url, **kwargs)
+        return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
+                for node in root.getchildren()]
 
     @deprecated("'getWaveform' has been renamed to 'get_waveforms'. "
                 "Use that instead.")  # noqa
@@ -570,14 +534,8 @@ master/seishub/plugins/seismology/waveform.py
         kwargs['starttime'] = trim_start - delta
         kwargs['endtime'] = trim_end + delta
 
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getWaveform'
-            data = self.client._fetch(url, **kwargs)
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_waveforms'
-            data = self.client._fetch(url, **kwargs)
+        url = '/seismology/waveform/getWaveform'
+        data = self.client._fetch(url, **kwargs)
         if not data:
             raise Exception("No waveform data available")
         # unpickle
@@ -649,14 +607,8 @@ master/seishub/plugins/seismology/waveform.py
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
 
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getPreview'
-            data = self.client._fetch(url, **kwargs)
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_previews'
-            data = self.client._fetch(url, **kwargs)
+        url = '/seismology/waveform/getPreview'
+        data = self.client._fetch(url, **kwargs)
         if not data:
             raise Exception("No waveform data available")
         # unpickle
@@ -690,14 +642,8 @@ master/seishub/plugins/seismology/waveform.py
         if 'trace_ids' in kwargs:
             if isinstance(kwargs['trace_ids'], list):
                 kwargs['trace_ids'] = ','.join(kwargs['trace_ids'])
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/waveform/getPreview'
-            data = self.client._fetch(url, **kwargs)
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/waveform/get_previews_by_ids'
-            data = self.client._fetch(url, **kwargs)
+        url = '/seismology/waveform/getPreview'
+        data = self.client._fetch(url, **kwargs)
         if not data:
             raise Exception("No waveform data available")
         # unpickle
@@ -739,18 +685,10 @@ master/seishub/plugins/seismology/waveform.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/station/getList'
-            root = self.client._objectify(url, **kwargs)
-            return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                    for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/station/get_list'
-            root = self.client._objectify(url, **kwargs)
-            return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                    for node in root.getchildren()]
+        url = '/seismology/station/getList'
+        root = self.client._objectify(url, **kwargs)
+        return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
+                for node in root.getchildren()]
 
     @deprecated("'getCoordinates' has been renamed to 'get_coordinates'. Use "
                 "that instead.")  # noqa
@@ -935,18 +873,10 @@ master/seishub/plugins/seismology/event.py
         for key, value in locals().items():
             if key not in ["self", "kwargs"]:
                 kwargs[key] = value
-        # server side obspy < 0.11
-        try:
-            url = '/seismology/event/getList'
-            root = self.client._objectify(url, **kwargs)
-            results = [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                       for node in root.getchildren()]
-        # server side obspy >= 0.11
-        except:
-            url = '/seismology/event/get_list'
-            root = self.client._objectify(url, **kwargs)
-            results = [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                       for node in root.getchildren()]
+        url = '/seismology/event/getList'
+        root = self.client._objectify(url, **kwargs)
+        results = [dict(((k, v.pyval) for k, v in node.__dict__.items()))
+                   for node in root.getchildren()]
         for res in results:
             res['resource_name'] = str(res['resource_name'])
         if limit == len(results) or \


### PR DESCRIPTION
During the big rename (see #999) API endpoints for seishub server were accidentally changed in dff4079 and ed2440e. This was fixed by da7a045, but in a partially wrong way doing a try/except for two naming versions of API endpoints, while API endpoints in seishub server actually never changed.

The only problem with this is that in some cases this will yield misleading and wrong error messages: It masked the real error and showed a wrong error resulting from trying to reach a non-existing API endpoint.

See API endpoints in current seishub.plugins.seismology master (barsch/seishub.plugins.seismology@07c21903d3281f63e156d36e4a4ef):

```
$ pygrep mapping_url
station.py
176:    mapping_url = '/seismology/station/getStationIds'
199:    mapping_url = '/seismology/station/getList'

waveform.py
115:    mapping_url = '/seismology/waveform/getNetworkIds'
132:    mapping_url = '/seismology/waveform/getStationIds'
152:    mapping_url = '/seismology/waveform/getLocationIds'
176:    mapping_url = '/seismology/waveform/getChannelIds'
202:    mapping_url = '/seismology/waveform/getLatency'
241:    mapping_url = '/seismology/waveform/getWaveformPath'
307:    mapping_url = '/seismology/waveform/getWaveform'
456:    mapping_url = '/seismology/waveform/getPreview'

event.py
35:    mapping_url = '/seismology/event/getList'
128:    mapping_url = '/seismology/event/plotBeachball'
```

Tests run fine, see http://tests.obspy.org/39487/.