### PR TITLE
mseed recordanalyzer: always displays blockette information of first record

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@
  - obspy.db:
    * Fixed a bug in obspy-indexer command line script (see #1369,
      command line script was not working, probably since 0.10.0)
+ - obspy.io.mseed:
+   * Fixed a bug in obspy-mseed-recordanalyzer (see #1386)
 
 1.0.1: (doi: 10.5281/zenodo.48254)
  - General:

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -45,6 +45,7 @@ Alberto Michelini
 Bernhard Morgenstern
 Nathaniel C. Miller
 Mark P. Panning
+Giovanni Rapagnani
 Celso Reyes
 Adam Ringler
 Nicolas Rothenhäusler

--- a/obspy/io/mseed/scripts/recordanalyzer.py
+++ b/obspy/io/mseed/scripts/recordanalyzer.py
@@ -220,7 +220,7 @@ class RecordAnalyser(object):
             if cur_blkt_offset >= self.fixed_header['Beginning of data']:
                 break
             # Seek to the offset.
-            self.file.seek(cur_blkt_offset, 0)
+            self.file.seek(self.record_offset + cur_blkt_offset, 0)
             # Unpack the first two values. This is always the blockette type
             # and the beginning of the next blockette.
             encoding = native_str('%s2H' % self.endian)

--- a/obspy/io/mseed/tests/test_recordanalyzer.py
+++ b/obspy/io/mseed/tests/test_recordanalyzer.py
@@ -15,7 +15,7 @@ class RecordAnalyserTestCase(unittest.TestCase):
     def setUp(self):
         self.test_file = os.path.join(os.path.dirname(__file__),
                                       'data',
-                                      'test.mseed')
+                                      'timingquality.mseed')
 
     def test_default_record(self):
         with CatchOutput() as out:
@@ -27,32 +27,34 @@ Record Offset: 0 byte
 Header Endianness: Big Endian
 
 FIXED SECTION OF DATA HEADER
-	Sequence number: 1
-	Data header/quality indicator: R
-	Station identifier code: HGN
-	Location identifier: 00
-	Channel identifier: BHZ
-	Network code: NL
-	Record start time: 2003-05-29T02:13:22.043400Z
-	Number of samples: 5980
-	Sample rate factor: 32760
-	Sample rate multiplier: 64717
+	Sequence number: 763445
+	Data header/quality indicator: D
+	Station identifier code: BGLD
+	Location identifier: 
+	Channel identifier: EHE
+	Network code: BW
+	Record start time: 2007-12-31T23:59:59.915000Z
+	Number of samples: 412
+	Sample rate factor: 200
+	Sample rate multiplier: 1
 	Activity flags: 0
 	I/O and clock flags: 0
 	Data quality flags: 0
 	Number of blockettes that follow: 2
-	Time correction: 0
-	Beginning of data: 128
+	Time correction: -1500
+	Beginning of data: 64
 	First blockette: 48
 
 BLOCKETTES
-	1000:	Encoding Format: 11
+	1000:	Encoding Format: 10
 		Word Order: 1
-		Data Record Length: 12
-	100:	Sampling Rate: 40.0
+		Data Record Length: 9
+	1001:	Timing quality: 55
+		mu_sec: 0
+		Frame count: -73
 
 CALCULATED VALUES
-	Corrected Starttime: 2003-05-29T02:13:22.043400Z
+	Corrected Starttime: 2007-12-31T23:59:59.765000Z
 
 ''' % (self.test_file,)  # noqa
         self.assertEqual(expected.encode('utf-8'),
@@ -64,36 +66,38 @@ CALCULATED VALUES
 
         expected = '''FILE: %s
 Record Number: 1
-Record Offset: 4096 byte
+Record Offset: 512 byte
 Header Endianness: Big Endian
 
 FIXED SECTION OF DATA HEADER
-	Sequence number: 2
-	Data header/quality indicator: R
-	Station identifier code: HGN
-	Location identifier: 00
-	Channel identifier: BHZ
-	Network code: NL
-	Record start time: 2003-05-29T02:15:51.543400Z
-	Number of samples: 5967
-	Sample rate factor: 32760
-	Sample rate multiplier: 64717
+	Sequence number: 763446
+	Data header/quality indicator: D
+	Station identifier code: BGLD
+	Location identifier: 
+	Channel identifier: EHE
+	Network code: BW
+	Record start time: 2008-01-01T00:00:01.975000Z
+	Number of samples: 412
+	Sample rate factor: 200
+	Sample rate multiplier: 1
 	Activity flags: 0
 	I/O and clock flags: 0
 	Data quality flags: 0
 	Number of blockettes that follow: 2
-	Time correction: 0
-	Beginning of data: 128
+	Time correction: -1500
+	Beginning of data: 64
 	First blockette: 48
 
 BLOCKETTES
-	1000:	Encoding Format: 11
+	1000:	Encoding Format: 10
 		Word Order: 1
-		Data Record Length: 12
-	100:	Sampling Rate: 40.0
+		Data Record Length: 9
+	1001:	Timing quality: 70
+		mu_sec: 0
+		Frame count: -73
 
 CALCULATED VALUES
-	Corrected Starttime: 2003-05-29T02:15:51.543400Z
+	Corrected Starttime: 2008-01-01T00:00:01.825000Z
 
 ''' % (self.test_file,)  # noqa
         self.assertEqual(expected.encode('utf-8'),


### PR DESCRIPTION
Obspy version 1.0.1-1~wheezy, Debian Wheezy, installed from obspy .deb repository

The file demo.mseed in attachment contains 2 miniseed records of 512 bytes. First one has bloquette 1001 with timing quality set to 10 and second one has bloquette 1001 with timing quality set to  20.

Using recordanalyzer.py to display the timing quality of both records will always show "Timing quality: 10".

The bug is in function  `def _get_blockettes(self)`  where a seek is done from the beginning of the file, but the seek displacement you pass is a value which is the offset of the bloquette relative to the position of the analyzed record. In the seek displacement you forgot to take into account the position of the record with respect to the beginning of the file. Patch is attached.



[demo.mseed.zip](https://github.com/obspy/obspy/files/238686/demo.mseed.zip)
[recordanalyzer_patch.txt](https://github.com/obspy/obspy/files/238687/recordanalyzer_patch.txt)
