### PR TITLE
Try to set SAC distances on SACTrace.read

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 1.0.2: (doi: 10.5281/zenodo.49636)
+ - obspy.io.sac:
+   * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
+     true.  If "dist" header is found, distances aren't calculated.
  - obspy.db:
    * Fixed a bug in obspy-indexer command line script (see #1369,
      command line script was not working, probably since 0.10.0)

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1139,7 +1139,11 @@ class SACTrace(object):
                                             byteorder=byteorder,
                                             checksize=checksize)
 
-        return cls._from_arrays(hf, hi, hs, data)
+        sac = cls._from_arrays(hf, hi, hs, data)
+        if sac.dist is None:
+            sac._set_distances()
+
+        return sac
 
     def write(self, dest, headonly=False, ascii=False, byteorder=None,
               flush_headers=True):


### PR DESCRIPTION
SAC users expect that files read in will have distances calculated/set if "lcalda" is True.  This small fix meets that expectation.  If "dist" is found, it isn't overwritten.

EDIT: notify @claudiodsf , @john-robert