### PR TITLE
read_nlloc_hyp(): use GEOGRAPHIC line if no coordinate_converter is provided

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 1.0.2: (doi: 10.5281/zenodo.49636)
+ - obspy.io.nlloc:
+   * Use geographic coordinates from the NonLinLoc Hypocenter-Phase file if
+     no custom coordinate converter is provided.
  - obspy.io.sac:
    * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
      true.  If "dist" header is found, distances aren't calculated.

--- a/obspy/io/nlloc/__init__.py
+++ b/obspy/io/nlloc/__init__.py
@@ -15,11 +15,47 @@ formats.
 
 Example
 -------
+If NonLinLoc location run was performed using one of the standard projections
+available in the NonLinLoc package, it is straightforward to read a NonLinLoc
+Hypocenter-Phase file into an ObsPy :class:`~obspy.core.event.Catalog` object:
 
-First, if NonLinLoc location run was performed in some custom coordinate system
-(as opposed to WGS84 with depth in meters down), we need to set up a coordinate
-conversion function to convert from the NonLinLoc location coordinates `x`,
-`y`, `z` to longitude, latitude and depth in kilometers.
+>>> from obspy import read_events
+>>> cat = read_events("/path/to/nlloc.hyp")
+>>> print(cat)
+1 Event(s) in Catalog:
+2006-07-15T17:21:20.195670Z |  +7.737,  +51.658
+
+>>> event = cat[0]
+>>> print(event)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+Event:	2006-07-15T17:21:20.195670Z |  +7.737,  +51.658
+<BLANKLINE>
+       resource_id: ResourceIdentifier(id="smi:local/...")
+     creation_info: CreationInfo(creation_time=UTCDateTime(2013, 6, 21, ...),
+                                 version='NLLoc:v6.02.07')
+    ---------
+             picks: 5 Elements
+           origins: 1 Elements
+
+>>> origin = event.origins[0]
+>>> print(origin)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+Origin
+       resource_id: ResourceIdentifier(id="smi:local/...")
+              time: UTCDateTime(2006, 7, 15, 17, 21, 20, 1956...)
+         longitude: 51.657659...
+          latitude: 7.736781...
+             depth: 1433.5... [confidence_level=68, uncertainty=...]
+                ...
+     creation_info: CreationInfo(creation_time=UTCDateTime(2013, 6, 21, ...),
+                                 version='NLLoc:v6.02.07')
+    ---------
+          comments: 1 Elements
+          arrivals: 5 Elements
+
+
+If, instead, NonLinLoc location run was performed in some custom coordinate
+system (as opposed to WGS84 with depth in meters down), we need to set up a
+coordinate conversion function to convert from the NonLinLoc location
+coordinates `x`, `y`, `z` to longitude, latitude and depth in kilometers.
 In the example, the location run was done in Gauß-Krüger zone 4 (EPSG:31468,
 but in kilometers for coordinates) and depth in kilometers. So we have to
 convert `x` and `y` (of NonLinLoc location run) to meters (as defined in
@@ -42,8 +78,8 @@ Then, we can load the NonLinLoc Hypocenter-Phase file into an ObsPy
 function as `coordinate_converter` kwarg, which will be passed down to the
 low-level routine :func:`~obspy.io.nlloc.core.read_nlloc_hyp`.
 
->>> from obspy import read_events
->>> cat = read_events("/path/to/nlloc.hyp",
+>>> from obspy import read_events  # doctest: +SKIP
+>>> cat = read_events("/path/to/nlloc_custom.hyp",
 ...                  coordinate_converter=my_conversion)  # doctest: +SKIP
 >>> print(cat)  # doctest: +SKIP
 1 Event(s) in Catalog:
@@ -61,19 +97,18 @@ Event:  2010-05-27T16:56:24.612600Z | +48.047,  +11.646
 
 >>> origin = event.origins[0]  # doctest: +SKIP
 >>> print(origin)  # doctest: +SKIP
-    Origin
-                resource_id: ResourceIdentifier(id="smi:local/...")
-                       time: UTCDateTime(2010, 5, 27, 16, 56, 24, 612600)
-                  longitude: 11.64553754...
-                   latitude: 48.04707051...
-                      depth: 4579.4... [confidence_level=68,
- uncertainty=191.6063...]
-                        ...
-              creation_info: CreationInfo(creation_time=UTCDateTime(2014, 10,
-17, 16, 30, 8), version='NLLoc:v6.00.0')
-        ---------
-                   comments: 1 Elements
-                   arrivals: 8 Elements
+Origin
+       resource_id: ResourceIdentifier(id="smi:local/...")
+              time: UTCDateTime(2010, 5, 27, 16, 56, 24, 612600)
+         longitude: 11.64553754...
+          latitude: 48.04707051...
+             depth: 4579.4... [confidence_level=68, uncertainty=191.6063...]
+                ...
+     creation_info: CreationInfo(creation_time=UTCDateTime(2014, 10, 17,
+16, 30, 8), version='NLLoc:v6.00.0')
+    ---------
+          comments: 1 Elements
+          arrivals: 8 Elements
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -64,9 +64,8 @@ def read_nlloc_hyp(filename, coordinate_converter=None, picks=None, **kwargs):
     :param coordinate_converter: Function to convert (x, y, z)
         coordinates of NonLinLoc output to geographical coordinates and depth
         in meters (longitude, latitude, depth in kilometers).
-        If left ``None``, NonLinLoc (x, y, z) output is left unchanged (e.g. if
-        it is in geographical coordinates already like for NonLinLoc in
-        global mode).
+        If left ``None``, the geographical coordinates in the "GEOGRAPHIC" line
+        of NonLinLoc output are used.
         The function should accept three arguments x, y, z (each of type
         :class:`numpy.ndarray`) and return a tuple of three
         :class:`numpy.ndarray` (lon, lat, depth in kilometers).
@@ -138,15 +137,16 @@ def read_nlloc_hyp(filename, coordinate_converter=None, picks=None, **kwargs):
     signature, version, date, time = line.rsplit(" ", 3)
     creation_time = UTCDateTime().strptime(date + time, str("%d%b%Y%Hh%Mm%S"))
 
-    # maximum likelihood origin location info line
-    line = lines["HYPOCENTER"]
-
-    x, y, z = map(float, line.split()[1:7:2])
-
     if coordinate_converter:
-        x, y, z = coordinate_converter(x, y, z)
+        # maximum likelihood origin location in km info line
+        line = lines["HYPOCENTER"]
+        x, y, z = coordinate_converter(*map(float, line.split()[1:7:2]))
+    else:
+        # maximum likelihood origin location lon lat info line
+        line = lines["GEOGRAPHIC"]
+        x, y, z = map(float, line.split()[8:13:2])
 
-    # origin time info line
+    # maximum likelihood origin time info line
     line = lines["GEOGRAPHIC"]
 
     year, month, day, hour, minute = map(int, line.split()[1:6])

--- a/obspy/io/nlloc/tests/data/nlloc.hyp
+++ b/obspy/io/nlloc/tests/data/nlloc.hyp
@@ -1,27 +1,23 @@
-NLLOC "./nlloc.20100527.165625.grid0" "LOCATED" "Location completed."
-SIGNATURE "Megies LMU Munich   NLLoc:v6.00.0 17Oct2014 16h30m08"
-COMMENT "NonLinLoc OctTree Location"
-GRID  248 148 94  4460.1 5315.1 -0.35  0.1 0.1 0.1 PROB_DENSITY
-SEARCH OCTREE nInitial 400 nEvaluated 50008 smallestNodeSide 0.019297/0.011484/0.018359 oct_tree_integral 6.282412e-02 scatter_volume 6.282412e-02
-HYPOCENTER  x 4473.68 y 5323.28 z 4.57949  OT 24.6126  ix -1 iy -1 iz -1
-GEOGRAPHIC  OT 2010 05 27  16 56   24.6126  Lat 5323.28 Long 4473.68 Depth 4.57949
-QUALITY  Pmax 0.418427 MFmin 0.466705 MFmax 8.23868 RMS 0.0189187 Nphs 8 Gap 129.214 Dist 1.87959 Mamp  -9.9 0 Mdur  -9.9 0
-VPVSRATIO  VpVsRatio 1.82937  Npair 4  Diff 0.805
-STATISTICS  ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ 0.0043871 YY 0.0191034 YZ 0.00503624 ZZ 0.036713 EllAz1  206.782 Dip1  16.4026 Len1  0.227982 Az2  300.149 Dip2  11.2855 Len2  0.327468 Len3  3.709256e-01
-STAT_GEOG  ExpectLat 5323.29 Long 4473.68 Depth 4.59501
-TRANSFORM  NONE
-QML_OriginQuality  assocPhCt 8  usedPhCt 8  assocStaCt -1  usedStaCt 4  depthPhCt -1  stdErr 0.0189187  azGap 129.214  secAzGap 129.214  gtLevel -  minDist 1.87959 maxDist 8.35898 medDist 3.43311
-QML_OriginUncertainty  horUnc -1  minHorUnc 0.195472  maxHorUnc 0.265954  azMaxHorUnc 114.816
-FOCALMECH  Hyp  5323.28 4473.68 4.57949 Mech  0 0 0 mf  0 nObs 0
-PHASE ID Ins Cmp On Pha  FM Date     HrMn   Sec     Err  ErrMag    Coda      Amp       Per  >   TTpred    Res       Weight    StaLoc(X  Y         Z)        SDist    SAzim  RAz  RDip RQual    Tcorr 
-UH3    ?    ?    ? P      ? 20100527 1656     25.93 GAU      0.02        -1        -1        -1 >    1.2474   -0.0150    2.0540 4473.1664 5321.4733   -0.4000    1.8796 195.71 200.7 152.6  9     0.0850
-UH3    ?    ?    ? S      ? 20100527 1656      27.1 GAU      0.06        -1        -1        -1 >    2.2999    0.0195    0.4108 4473.1664 5321.4733   -0.4000    1.8796 195.71 200.6 156.4  9     0.1680
-UH2    ?    ?    ? P      ? 20100527 1656     26.04 GAU      0.03        -1        -1        -1 >    1.3698    0.0076    1.2640 4476.4043 5324.4693   -0.4000    2.9758  66.50  64.7 139.3  9     0.0500
-UH2    ?    ?    ? S      ? 20100527 1656     27.27 GAU      0.06        -1        -1        -1 >    2.5339    0.0156    0.4108 4476.4043 5324.4693   -0.4000    2.9758  66.50  63.9 144.4  9     0.1080
-UH1    ?    ?    ? P      ? 20100527 1656     26.13 GAU      0.02        -1        -1        -1 >    1.4759   -0.0085    2.0540 4472.9896 5327.1122   -0.4000    3.8905 349.85 348.8 131.0  9     0.0500
-UH1    ?    ?    ? S      ? 20100527 1656     27.46 GAU      0.03        -1        -1        -1 >    2.7386    0.0008    1.2640 4472.9896 5327.1122   -0.4000    3.8905 349.85 348.4 137.7  9     0.1080
-UH4    ?    ?    ? P      ? 20100527 1656     26.93 GAU      0.06        -1        -1        -1 >    2.1391    0.0663    0.4108 4465.4714 5321.6804   -0.4000    8.3590 258.95 258.3 106.5  9     0.1070
-UH4    ?    ?    ? S      ? 20100527 1656      28.9 GAU      0.11        -1        -1        -1 >    4.1113   -0.0299    0.1315 4465.4714 5321.6804   -0.4000    8.3590 258.95 258.1 113.1  9     0.2060
+NLLOC "./loc/rhur.20060715.172120.grid0" "LOCATED" "Location completed."
+SIGNATURE "Claudio Satriano   NLLoc:v6.02.07 21Jun2013 12h53m34"
+COMMENT "Rhur"
+GRID  105 105 55  -5 -5 -0.5  0.1 0.1 0.1 PROB_DENSITY
+SEARCH OCTREE nInitial 1000 nEvaluated 100000 smallestNodeSide 0.032500/0.032500/0.017188 oct_tree_integral 1.424956e+00 scatter_volume 1.421610e+00
+HYPOCENTER  x -0.40125 y 0.15125 z 1.43359  OT 20.1957  ix -1 iy -1 iz -1
+GEOGRAPHIC  OT 2006 07 15  17 21 20.195670  Lat 51.657659 Long 7.736781 Depth 1.43359
+QUALITY  Pmax 4.87214e+31 MFmin 27.4969 MFmax 27.5282 RMS 0.00394121 Nphs 11 Gap 156.347 Dist 0.366883 Mamp  -9.9 0 Mdur  -9.9 0
+VPVSRATIO  VpVsRatio -1  Npair 0  Diff -2e+30
+STATISTICS  ExpectX -1.32658 Y -0.0487098 Z 3.12781  CovXX 1.21008 XY 0.238028 XZ -0.486034 YY 0.648388 YZ -0.0503814 ZZ 1.33155 EllAz1  331.493 Dip1  -13.2202 Len1  1.37113 Az2  229.814 Dip2  -40.7512 Len2  1.74531 Len3  2.516878e+00
+STAT_GEOG  ExpectLat 51.655861 Long 7.723410 Depth 3.127808
+TRANSFORM  LAMBERT RefEllipsoid Clarke-1880  LatOrig 51.656300  LongOrig 7.742580  FirstStdParal 50.000000  SecondStdParal 52.000000  RotCW 0.000000
+QML_OriginQuality  assocPhCt 5  usedPhCt 5  assocStaCt -1  usedStaCt 5  depthPhCt -1  stdErr 0.00394121  azGap 156.347  secAzGap 227.423  gtLevel -  minDist 0.366883 maxDist 1.62124 medDist 0.892527
+QML_OriginUncertainty  horUnc -1  minHorUnc 1.136  maxHorUnc 1.72742  azMaxHorUnc 69.8588
+FOCALMECH  Hyp  51.657659 7.736781 1.433594 Mech  0 0 0 mf  0 nObs 0
+PHASE ID Ins Cmp On Pha  FM Date     HrMn   Sec     Err  ErrMag    Coda      Amp       Per  >   TTpred    Res       Weight    StaLoc(X  Y         Z)        SDist    SAzim  RAz  RDip RQual    Tcorr
+HM02   ?    HHZ  I P      U 20060715 1721     20.63 GAU      0.05        -1        -1        -1 >    0.4399   -0.0076    0.9958   -0.0554    0.0289    0.0000    0.3669 109.48 359.0  -1.0  0     0.0000
+HM04   ?    HHZ  I P      U 20060715 1721     20.64 GAU      0.05        -1        -1        -1 >    0.4396    0.0025    1.0009   -0.3114    0.5196    0.0000    0.3791  13.71 359.0  -1.0  0     0.0000
+HM05   ?    HHZ  I P      U 20060715 1721     20.64 GAU      0.05        -1        -1        -1 >    0.4449   -0.0009    1.0016    0.0173    0.2893    0.0000    0.4407  71.75 359.0  -1.0  0     0.0000
+HM10   ?    HHZ  I P      U 20060715 1721     20.66 GAU      0.05        -1        -1        -1 >    0.4573    0.0065    0.9970   -0.6325   -0.3537    0.0000    0.5554 204.61 359.0  -1.0  0     0.0000
+HM08   ?    HHZ  I P      U 20060715 1721     20.66 GAU      0.05        -1        -1        -1 >    0.4623   -0.0005    1.0016    0.2055   -0.0067    0.0000    0.6270 104.59 359.0  -1.0  0     0.0000
 END_PHASE
 END_NLLOC
-

--- a/obspy/io/nlloc/tests/data/nlloc.qml
+++ b/obspy/io/nlloc/tests/data/nlloc.qml
@@ -1,214 +1,167 @@
 <?xml version='1.0' encoding='utf-8'?>
 <q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
-  <eventParameters publicID="smi:local/9f6e4efc-1dec-44a5-9c75-7092507eaf25">
+  <eventParameters publicID="smi:local/f0882fec-3cdb-4f9a-9729-b41627fac8eb">
     <creationInfo>
-      <creationTime>2014-10-23T15:27:36.487786Z</creationTime>
-      <version>ObsPy 0.9.2-1209-g0e9965dae0-dirty</version>
+      <creationTime>2016-05-03T20:00:55.781589Z</creationTime>
+      <version>ObsPy 1.0.1.post0+20.gbeb9f46723.dirty</version>
     </creationInfo>
-    <event publicID="smi:local/cd1f535c-e75e-4dc6-8170-82e47cb40501">
+    <event publicID="smi:local/0eee2e6f-064b-458a-934f-c5d3105e9529">
       <creationInfo>
-        <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
-        <version>NLLoc:v6.00.0</version>
+        <creationTime>2013-06-21T12:53:34.000000Z</creationTime>
+        <version>NLLoc:v6.02.07</version>
       </creationInfo>
-      <origin publicID="smi:local/3cb10e44-6aeb-4279-8caa-235452e5c9b3">
+      <origin publicID="smi:local/a2260002-95c6-42f7-8c44-f46124355228">
         <time>
-          <value>2010-05-27T16:56:24.612600Z</value>
+          <value>2006-07-15T17:21:20.195670Z</value>
         </time>
         <latitude>
-          <value>48.0470705175</value>
-          <uncertainty>0.0012429</uncertainty>
+          <value>7.736781</value>
+          <uncertainty>0.00724156630677</uncertainty>
         </latitude>
         <longitude>
-          <value>11.6455375456</value>
-          <uncertainty>0.0015118</uncertainty>
+          <value>51.657659</value>
+          <uncertainty>0.00989286468574</uncertainty>
         </longitude>
         <depth>
-          <value>4579.49</value>
-          <uncertainty>191.606367326</uncertainty>
+          <value>1433.59</value>
+          <uncertainty>1153.92807402</uncertainty>
           <confidenceLevel>68</confidenceLevel>
         </depth>
         <depthType>from location</depthType>
         <quality>
-          <associatedPhaseCount>8</associatedPhaseCount>
-          <usedPhaseCount>8</usedPhaseCount>
+          <associatedPhaseCount>5</associatedPhaseCount>
+          <usedPhaseCount>5</usedPhaseCount>
           <associatedStationCount>-1</associatedStationCount>
-          <usedStationCount>4</usedStationCount>
+          <usedStationCount>5</usedStationCount>
           <depthPhaseCount>-1</depthPhaseCount>
-          <standardError>0.0189187</standardError>
-          <azimuthalGap>129.214</azimuthalGap>
-          <secondaryAzimuthalGap>129.214</secondaryAzimuthalGap>
+          <standardError>0.00394121</standardError>
+          <azimuthalGap>156.347</azimuthalGap>
+          <secondaryAzimuthalGap>227.423</secondaryAzimuthalGap>
           <groundTruthLevel>-</groundTruthLevel>
-          <minimumDistance>0.0169035589727</minimumDistance>
-          <maximumDistance>0.0751741131744</maximumDistance>
-          <medianDistance>0.030874699985</medianDistance>
+          <minimumDistance>0.00329945808744</minimumDistance>
+          <maximumDistance>0.0145801616038</maximumDistance>
+          <medianDistance>0.00802668814966</medianDistance>
         </quality>
-        <comment id="smi:local/93aa18a6-1ac9-4a65-b4cd-b8349ab1bc91">
-            <text>Note: Depth/Latitude/Longitude errors are calculated from covariance matrix as 1D marginal (Lon/Lat errors as great circle degrees) while OriginUncertainty min/max horizontal errors are calculated from 2D error ellipsoid and are therefore seemingly higher compared to 1D errors. Error estimates can be reconstructed from the following original NonLinLoc error statistics line:
-STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ 0.0043871 YY 0.0191034 YZ 0.00503624 ZZ 0.036713 EllAz1  206.782 Dip1  16.4026 Len1  0.227982 Az2  300.149 Dip2  11.2855 Len2  0.327468 Len3  3.709256e-01</text>
+        <comment id="smi:local/3aadb009-ca54-4843-9fc1-57f1561295a3">
+          <text>Note: Depth/Latitude/Longitude errors are calculated from covariance matrix as 1D marginal (Lon/Lat errors as great circle degrees) while OriginUncertainty min/max horizontal errors are calculated from 2D error ellipsoid and are therefore seemingly higher compared to 1D errors. Error estimates can be reconstructed from the following original NonLinLoc error statistics line:
+STATISTICS ExpectX -1.32658 Y -0.0487098 Z 3.12781  CovXX 1.21008 XY 0.238028 XZ -0.486034 YY 0.648388 YZ -0.0503814 ZZ 1.33155 EllAz1  331.493 Dip1  -13.2202 Len1  1.37113 Az2  229.814 Dip2  -40.7512 Len2  1.74531 Len3  2.516878e+00</text>
         </comment>
         <creationInfo>
-          <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
-          <version>NLLoc:v6.00.0</version>
+          <creationTime>2013-06-21T12:53:34.000000Z</creationTime>
+          <version>NLLoc:v6.02.07</version>
         </creationInfo>
         <originUncertainty>
           <preferredDescription>uncertainty ellipse</preferredDescription>
-          <minHorizontalUncertainty>195.472</minHorizontalUncertainty>
-          <maxHorizontalUncertainty>265.954</maxHorizontalUncertainty>
-          <azimuthMaxHorizontalUncertainty>114.816</azimuthMaxHorizontalUncertainty>
+          <minHorizontalUncertainty>1136.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>1727.42</maxHorizontalUncertainty>
+          <azimuthMaxHorizontalUncertainty>69.8588</azimuthMaxHorizontalUncertainty>
           <confidenceLevel>68.0</confidenceLevel>
         </originUncertainty>
-        <arrival publicID="smi:local/677a937b-4db0-4fad-8822-9d75fdb3f9c5">
-          <pickID>smi:local/d7ba3bb7-645f-4ee6-a8f4-65e0332c5025</pickID>
+        <arrival publicID="smi:local/4822394a-8dba-4b4d-b8d6-47c75d94a600">
+          <pickID>smi:local/80f620bf-5550-4fc5-b1a6-5d4394795878</pickID>
           <phase>P</phase>
-          <azimuth>200.7</azimuth>
-          <distance>0.0169036489048</distance>
+          <azimuth>359.0</azimuth>
+          <distance>0.00329961097212</distance>
           <takeoffAngle>
-            <value>152.6</value>
+            <value>-1.0</value>
           </takeoffAngle>
-          <timeResidual>-0.015</timeResidual>
-          <timeWeight>2.054</timeWeight>
+          <timeResidual>-0.0076</timeResidual>
+          <timeWeight>0.9958</timeWeight>
         </arrival>
-        <arrival publicID="smi:local/06e00087-a9c8-4ee5-a5a8-4240bcac7db8">
-          <pickID>smi:local/3a0bde89-d7e6-45ef-a08a-4b950720f7be</pickID>
-          <phase>S</phase>
-          <azimuth>200.6</azimuth>
-          <distance>0.0169036489048</distance>
-          <takeoffAngle>
-            <value>156.4</value>
-          </takeoffAngle>
-          <timeResidual>0.0195</timeResidual>
-          <timeWeight>0.4108</timeWeight>
-        </arrival>
-        <arrival publicID="smi:local/619921cf-129e-4ef8-a743-a397becd7146">
-          <pickID>smi:local/95492f79-0db4-4bba-a198-6c08db43dd83</pickID>
+        <arrival publicID="smi:local/0217b7ba-a9f7-46c8-b9c9-1c3de497a965">
+          <pickID>smi:local/804b43a8-fe67-4041-af14-be0a2ea3e493</pickID>
           <phase>P</phase>
-          <azimuth>64.7</azimuth>
-          <distance>0.0267620123489</distance>
+          <azimuth>359.0</azimuth>
+          <distance>0.00340932820804</distance>
           <takeoffAngle>
-            <value>139.3</value>
+            <value>-1.0</value>
           </takeoffAngle>
-          <timeResidual>0.0076</timeResidual>
-          <timeWeight>1.264</timeWeight>
+          <timeResidual>0.0025</timeResidual>
+          <timeWeight>1.0009</timeWeight>
         </arrival>
-        <arrival publicID="smi:local/2c5ae0cc-981d-42c5-b2ef-57ae34ba5c02">
-          <pickID>smi:local/75ca039c-bfca-41c3-8fd3-9d70341a23fe</pickID>
-          <phase>S</phase>
-          <azimuth>63.9</azimuth>
-          <distance>0.0267620123489</distance>
-          <takeoffAngle>
-            <value>144.4</value>
-          </takeoffAngle>
-          <timeResidual>0.0156</timeResidual>
-          <timeWeight>0.4108</timeWeight>
-        </arrival>
-        <arrival publicID="smi:local/44bbb2f9-76cc-4f73-9b8c-022ec9950b0b">
-          <pickID>smi:local/550537fb-922c-4742-9bcc-504c1d330480</pickID>
+        <arrival publicID="smi:local/c0778a50-dd6e-4080-9761-2aae8bbbcdab">
+          <pickID>smi:local/9254790e-4e24-415f-b7a2-a60e504f3549</pickID>
           <phase>P</phase>
-          <azimuth>348.8</azimuth>
-          <distance>0.0349881070783</distance>
+          <azimuth>359.0</azimuth>
+          <distance>0.00396331031728</distance>
           <takeoffAngle>
-            <value>131.0</value>
+            <value>-1.0</value>
           </takeoffAngle>
-          <timeResidual>-0.0085</timeResidual>
-          <timeWeight>2.054</timeWeight>
+          <timeResidual>-0.0009</timeResidual>
+          <timeWeight>1.0016</timeWeight>
         </arrival>
-        <arrival publicID="smi:local/d7b02dea-3610-4209-9fe8-ab450a159c90">
-          <pickID>smi:local/0783bf9f-6862-40a3-baeb-ed247b73ca6f</pickID>
-          <phase>S</phase>
-          <azimuth>348.4</azimuth>
-          <distance>0.0349881070783</distance>
-          <takeoffAngle>
-            <value>137.7</value>
-          </takeoffAngle>
-          <timeResidual>0.0008</timeResidual>
-          <timeWeight>1.264</timeWeight>
-        </arrival>
-        <arrival publicID="smi:local/f7d77c25-1729-4879-b014-2f4608b72844">
-          <pickID>smi:local/d6fa4a8a-6e4c-48a1-9ab9-e84b60038f4b</pickID>
+        <arrival publicID="smi:local/963aa4e6-2b6e-4978-8fcc-de9a9ec4891a">
+          <pickID>smi:local/f744786a-bc96-4476-8c5c-6f2a9a5fef54</pickID>
           <phase>P</phase>
-          <azimuth>258.3</azimuth>
-          <distance>0.0751742930387</distance>
+          <azimuth>359.0</azimuth>
+          <distance>0.00499483219927</distance>
           <takeoffAngle>
-            <value>106.5</value>
+            <value>-1.0</value>
           </takeoffAngle>
-          <timeResidual>0.0663</timeResidual>
-          <timeWeight>0.4108</timeWeight>
+          <timeResidual>0.0065</timeResidual>
+          <timeWeight>0.997</timeWeight>
         </arrival>
-        <arrival publicID="smi:local/dbeb77a9-1f2a-4d81-adb0-a1ad82713665">
-          <pickID>smi:local/b0b74d7c-bd9e-4183-abcb-5c784a53f8b0</pickID>
-          <phase>S</phase>
-          <azimuth>258.1</azimuth>
-          <distance>0.0751742930387</distance>
+        <arrival publicID="smi:local/898783bb-82eb-45e6-84d1-86ca16c536bd">
+          <pickID>smi:local/a040ecfb-0d12-4c91-9e37-463f075a2ec6</pickID>
+          <phase>P</phase>
+          <azimuth>359.0</azimuth>
+          <distance>0.00563874646911</distance>
           <takeoffAngle>
-            <value>113.1</value>
+            <value>-1.0</value>
           </takeoffAngle>
-          <timeResidual>-0.0299</timeResidual>
-          <timeWeight>0.1315</timeWeight>
+          <timeResidual>-0.0005</timeResidual>
+          <timeWeight>1.0016</timeWeight>
         </arrival>
       </origin>
-      <pick publicID="smi:local/d7ba3bb7-645f-4ee6-a8f4-65e0332c5025">
+      <pick publicID="smi:local/80f620bf-5550-4fc5-b1a6-5d4394795878">
         <time>
-          <value>2010-05-27T16:56:25.930000Z</value>
-          <uncertainty>0.02</uncertainty>
+          <value>2006-07-15T17:21:20.630000Z</value>
+          <uncertainty>0.05</uncertainty>
         </time>
-        <waveformID stationCode="UH3"></waveformID>
+        <waveformID stationCode="HM02"></waveformID>
+        <onset>impulsive</onset>
         <phaseHint>P</phaseHint>
+        <polarity>positive</polarity>
       </pick>
-      <pick publicID="smi:local/3a0bde89-d7e6-45ef-a08a-4b950720f7be">
+      <pick publicID="smi:local/804b43a8-fe67-4041-af14-be0a2ea3e493">
         <time>
-          <value>2010-05-27T16:56:27.100000Z</value>
-          <uncertainty>0.06</uncertainty>
+          <value>2006-07-15T17:21:20.640000Z</value>
+          <uncertainty>0.05</uncertainty>
         </time>
-        <waveformID stationCode="UH3"></waveformID>
-        <phaseHint>S</phaseHint>
-      </pick>
-      <pick publicID="smi:local/95492f79-0db4-4bba-a198-6c08db43dd83">
-        <time>
-          <value>2010-05-27T16:56:26.040000Z</value>
-          <uncertainty>0.03</uncertainty>
-        </time>
-        <waveformID stationCode="UH2"></waveformID>
+        <waveformID stationCode="HM04"></waveformID>
+        <onset>impulsive</onset>
         <phaseHint>P</phaseHint>
+        <polarity>positive</polarity>
       </pick>
-      <pick publicID="smi:local/75ca039c-bfca-41c3-8fd3-9d70341a23fe">
+      <pick publicID="smi:local/9254790e-4e24-415f-b7a2-a60e504f3549">
         <time>
-          <value>2010-05-27T16:56:27.270000Z</value>
-          <uncertainty>0.06</uncertainty>
+          <value>2006-07-15T17:21:20.640000Z</value>
+          <uncertainty>0.05</uncertainty>
         </time>
-        <waveformID stationCode="UH2"></waveformID>
-        <phaseHint>S</phaseHint>
-      </pick>
-      <pick publicID="smi:local/550537fb-922c-4742-9bcc-504c1d330480">
-        <time>
-          <value>2010-05-27T16:56:26.130000Z</value>
-          <uncertainty>0.02</uncertainty>
-        </time>
-        <waveformID stationCode="UH1"></waveformID>
+        <waveformID stationCode="HM05"></waveformID>
+        <onset>impulsive</onset>
         <phaseHint>P</phaseHint>
+        <polarity>positive</polarity>
       </pick>
-      <pick publicID="smi:local/0783bf9f-6862-40a3-baeb-ed247b73ca6f">
+      <pick publicID="smi:local/f744786a-bc96-4476-8c5c-6f2a9a5fef54">
         <time>
-          <value>2010-05-27T16:56:27.460000Z</value>
-          <uncertainty>0.03</uncertainty>
+          <value>2006-07-15T17:21:20.660000Z</value>
+          <uncertainty>0.05</uncertainty>
         </time>
-        <waveformID stationCode="UH1"></waveformID>
-        <phaseHint>S</phaseHint>
-      </pick>
-      <pick publicID="smi:local/d6fa4a8a-6e4c-48a1-9ab9-e84b60038f4b">
-        <time>
-          <value>2010-05-27T16:56:26.930000Z</value>
-          <uncertainty>0.06</uncertainty>
-        </time>
-        <waveformID stationCode="UH4"></waveformID>
+        <waveformID stationCode="HM10"></waveformID>
+        <onset>impulsive</onset>
         <phaseHint>P</phaseHint>
+        <polarity>positive</polarity>
       </pick>
-      <pick publicID="smi:local/b0b74d7c-bd9e-4183-abcb-5c784a53f8b0">
+      <pick publicID="smi:local/a040ecfb-0d12-4c91-9e37-463f075a2ec6">
         <time>
-          <value>2010-05-27T16:56:28.900000Z</value>
-          <uncertainty>0.11</uncertainty>
+          <value>2006-07-15T17:21:20.660000Z</value>
+          <uncertainty>0.05</uncertainty>
         </time>
-        <waveformID stationCode="UH4"></waveformID>
-        <phaseHint>S</phaseHint>
+        <waveformID stationCode="HM08"></waveformID>
+        <onset>impulsive</onset>
+        <phaseHint>P</phaseHint>
+        <polarity>positive</polarity>
       </pick>
     </event>
   </eventParameters>

--- a/obspy/io/nlloc/tests/data/nlloc_custom.hyp
+++ b/obspy/io/nlloc/tests/data/nlloc_custom.hyp
@@ -1,0 +1,27 @@
+NLLOC "./nlloc.20100527.165625.grid0" "LOCATED" "Location completed."
+SIGNATURE "Megies LMU Munich   NLLoc:v6.00.0 17Oct2014 16h30m08"
+COMMENT "NonLinLoc OctTree Location"
+GRID  248 148 94  4460.1 5315.1 -0.35  0.1 0.1 0.1 PROB_DENSITY
+SEARCH OCTREE nInitial 400 nEvaluated 50008 smallestNodeSide 0.019297/0.011484/0.018359 oct_tree_integral 6.282412e-02 scatter_volume 6.282412e-02
+HYPOCENTER  x 4473.68 y 5323.28 z 4.57949  OT 24.6126  ix -1 iy -1 iz -1
+GEOGRAPHIC  OT 2010 05 27  16 56   24.6126  Lat 5323.28 Long 4473.68 Depth 4.57949
+QUALITY  Pmax 0.418427 MFmin 0.466705 MFmax 8.23868 RMS 0.0189187 Nphs 8 Gap 129.214 Dist 1.87959 Mamp  -9.9 0 Mdur  -9.9 0
+VPVSRATIO  VpVsRatio 1.82937  Npair 4  Diff 0.805
+STATISTICS  ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ 0.0043871 YY 0.0191034 YZ 0.00503624 ZZ 0.036713 EllAz1  206.782 Dip1  16.4026 Len1  0.227982 Az2  300.149 Dip2  11.2855 Len2  0.327468 Len3  3.709256e-01
+STAT_GEOG  ExpectLat 5323.29 Long 4473.68 Depth 4.59501
+TRANSFORM  NONE
+QML_OriginQuality  assocPhCt 8  usedPhCt 8  assocStaCt -1  usedStaCt 4  depthPhCt -1  stdErr 0.0189187  azGap 129.214  secAzGap 129.214  gtLevel -  minDist 1.87959 maxDist 8.35898 medDist 3.43311
+QML_OriginUncertainty  horUnc -1  minHorUnc 0.195472  maxHorUnc 0.265954  azMaxHorUnc 114.816
+FOCALMECH  Hyp  5323.28 4473.68 4.57949 Mech  0 0 0 mf  0 nObs 0
+PHASE ID Ins Cmp On Pha  FM Date     HrMn   Sec     Err  ErrMag    Coda      Amp       Per  >   TTpred    Res       Weight    StaLoc(X  Y         Z)        SDist    SAzim  RAz  RDip RQual    Tcorr 
+UH3    ?    ?    ? P      ? 20100527 1656     25.93 GAU      0.02        -1        -1        -1 >    1.2474   -0.0150    2.0540 4473.1664 5321.4733   -0.4000    1.8796 195.71 200.7 152.6  9     0.0850
+UH3    ?    ?    ? S      ? 20100527 1656      27.1 GAU      0.06        -1        -1        -1 >    2.2999    0.0195    0.4108 4473.1664 5321.4733   -0.4000    1.8796 195.71 200.6 156.4  9     0.1680
+UH2    ?    ?    ? P      ? 20100527 1656     26.04 GAU      0.03        -1        -1        -1 >    1.3698    0.0076    1.2640 4476.4043 5324.4693   -0.4000    2.9758  66.50  64.7 139.3  9     0.0500
+UH2    ?    ?    ? S      ? 20100527 1656     27.27 GAU      0.06        -1        -1        -1 >    2.5339    0.0156    0.4108 4476.4043 5324.4693   -0.4000    2.9758  66.50  63.9 144.4  9     0.1080
+UH1    ?    ?    ? P      ? 20100527 1656     26.13 GAU      0.02        -1        -1        -1 >    1.4759   -0.0085    2.0540 4472.9896 5327.1122   -0.4000    3.8905 349.85 348.8 131.0  9     0.0500
+UH1    ?    ?    ? S      ? 20100527 1656     27.46 GAU      0.03        -1        -1        -1 >    2.7386    0.0008    1.2640 4472.9896 5327.1122   -0.4000    3.8905 349.85 348.4 137.7  9     0.1080
+UH4    ?    ?    ? P      ? 20100527 1656     26.93 GAU      0.06        -1        -1        -1 >    2.1391    0.0663    0.4108 4465.4714 5321.6804   -0.4000    8.3590 258.95 258.3 106.5  9     0.1070
+UH4    ?    ?    ? S      ? 20100527 1656      28.9 GAU      0.11        -1        -1        -1 >    4.1113   -0.0299    0.1315 4465.4714 5321.6804   -0.4000    8.3590 258.95 258.1 113.1  9     0.2060
+END_PHASE
+END_NLLOC
+

--- a/obspy/io/nlloc/tests/data/nlloc_custom.qml
+++ b/obspy/io/nlloc/tests/data/nlloc_custom.qml
@@ -1,0 +1,215 @@
+<?xml version='1.0' encoding='utf-8'?>
+<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
+  <eventParameters publicID="smi:local/9f6e4efc-1dec-44a5-9c75-7092507eaf25">
+    <creationInfo>
+      <creationTime>2014-10-23T15:27:36.487786Z</creationTime>
+      <version>ObsPy 0.9.2-1209-g0e9965dae0-dirty</version>
+    </creationInfo>
+    <event publicID="smi:local/cd1f535c-e75e-4dc6-8170-82e47cb40501">
+      <creationInfo>
+        <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
+        <version>NLLoc:v6.00.0</version>
+      </creationInfo>
+      <origin publicID="smi:local/3cb10e44-6aeb-4279-8caa-235452e5c9b3">
+        <time>
+          <value>2010-05-27T16:56:24.612600Z</value>
+        </time>
+        <latitude>
+          <value>48.0470705175</value>
+          <uncertainty>0.0012429</uncertainty>
+        </latitude>
+        <longitude>
+          <value>11.6455375456</value>
+          <uncertainty>0.0015118</uncertainty>
+        </longitude>
+        <depth>
+          <value>4579.49</value>
+          <uncertainty>191.606367326</uncertainty>
+          <confidenceLevel>68</confidenceLevel>
+        </depth>
+        <depthType>from location</depthType>
+        <quality>
+          <associatedPhaseCount>8</associatedPhaseCount>
+          <usedPhaseCount>8</usedPhaseCount>
+          <associatedStationCount>-1</associatedStationCount>
+          <usedStationCount>4</usedStationCount>
+          <depthPhaseCount>-1</depthPhaseCount>
+          <standardError>0.0189187</standardError>
+          <azimuthalGap>129.214</azimuthalGap>
+          <secondaryAzimuthalGap>129.214</secondaryAzimuthalGap>
+          <groundTruthLevel>-</groundTruthLevel>
+          <minimumDistance>0.0169035589727</minimumDistance>
+          <maximumDistance>0.0751741131744</maximumDistance>
+          <medianDistance>0.030874699985</medianDistance>
+        </quality>
+        <comment id="smi:local/93aa18a6-1ac9-4a65-b4cd-b8349ab1bc91">
+            <text>Note: Depth/Latitude/Longitude errors are calculated from covariance matrix as 1D marginal (Lon/Lat errors as great circle degrees) while OriginUncertainty min/max horizontal errors are calculated from 2D error ellipsoid and are therefore seemingly higher compared to 1D errors. Error estimates can be reconstructed from the following original NonLinLoc error statistics line:
+STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ 0.0043871 YY 0.0191034 YZ 0.00503624 ZZ 0.036713 EllAz1  206.782 Dip1  16.4026 Len1  0.227982 Az2  300.149 Dip2  11.2855 Len2  0.327468 Len3  3.709256e-01</text>
+        </comment>
+        <creationInfo>
+          <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
+          <version>NLLoc:v6.00.0</version>
+        </creationInfo>
+        <originUncertainty>
+          <preferredDescription>uncertainty ellipse</preferredDescription>
+          <minHorizontalUncertainty>195.472</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>265.954</maxHorizontalUncertainty>
+          <azimuthMaxHorizontalUncertainty>114.816</azimuthMaxHorizontalUncertainty>
+          <confidenceLevel>68.0</confidenceLevel>
+        </originUncertainty>
+        <arrival publicID="smi:local/677a937b-4db0-4fad-8822-9d75fdb3f9c5">
+          <pickID>smi:local/d7ba3bb7-645f-4ee6-a8f4-65e0332c5025</pickID>
+          <phase>P</phase>
+          <azimuth>200.7</azimuth>
+          <distance>0.0169036489048</distance>
+          <takeoffAngle>
+            <value>152.6</value>
+          </takeoffAngle>
+          <timeResidual>-0.015</timeResidual>
+          <timeWeight>2.054</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/06e00087-a9c8-4ee5-a5a8-4240bcac7db8">
+          <pickID>smi:local/3a0bde89-d7e6-45ef-a08a-4b950720f7be</pickID>
+          <phase>S</phase>
+          <azimuth>200.6</azimuth>
+          <distance>0.0169036489048</distance>
+          <takeoffAngle>
+            <value>156.4</value>
+          </takeoffAngle>
+          <timeResidual>0.0195</timeResidual>
+          <timeWeight>0.4108</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/619921cf-129e-4ef8-a743-a397becd7146">
+          <pickID>smi:local/95492f79-0db4-4bba-a198-6c08db43dd83</pickID>
+          <phase>P</phase>
+          <azimuth>64.7</azimuth>
+          <distance>0.0267620123489</distance>
+          <takeoffAngle>
+            <value>139.3</value>
+          </takeoffAngle>
+          <timeResidual>0.0076</timeResidual>
+          <timeWeight>1.264</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/2c5ae0cc-981d-42c5-b2ef-57ae34ba5c02">
+          <pickID>smi:local/75ca039c-bfca-41c3-8fd3-9d70341a23fe</pickID>
+          <phase>S</phase>
+          <azimuth>63.9</azimuth>
+          <distance>0.0267620123489</distance>
+          <takeoffAngle>
+            <value>144.4</value>
+          </takeoffAngle>
+          <timeResidual>0.0156</timeResidual>
+          <timeWeight>0.4108</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/44bbb2f9-76cc-4f73-9b8c-022ec9950b0b">
+          <pickID>smi:local/550537fb-922c-4742-9bcc-504c1d330480</pickID>
+          <phase>P</phase>
+          <azimuth>348.8</azimuth>
+          <distance>0.0349881070783</distance>
+          <takeoffAngle>
+            <value>131.0</value>
+          </takeoffAngle>
+          <timeResidual>-0.0085</timeResidual>
+          <timeWeight>2.054</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/d7b02dea-3610-4209-9fe8-ab450a159c90">
+          <pickID>smi:local/0783bf9f-6862-40a3-baeb-ed247b73ca6f</pickID>
+          <phase>S</phase>
+          <azimuth>348.4</azimuth>
+          <distance>0.0349881070783</distance>
+          <takeoffAngle>
+            <value>137.7</value>
+          </takeoffAngle>
+          <timeResidual>0.0008</timeResidual>
+          <timeWeight>1.264</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/f7d77c25-1729-4879-b014-2f4608b72844">
+          <pickID>smi:local/d6fa4a8a-6e4c-48a1-9ab9-e84b60038f4b</pickID>
+          <phase>P</phase>
+          <azimuth>258.3</azimuth>
+          <distance>0.0751742930387</distance>
+          <takeoffAngle>
+            <value>106.5</value>
+          </takeoffAngle>
+          <timeResidual>0.0663</timeResidual>
+          <timeWeight>0.4108</timeWeight>
+        </arrival>
+        <arrival publicID="smi:local/dbeb77a9-1f2a-4d81-adb0-a1ad82713665">
+          <pickID>smi:local/b0b74d7c-bd9e-4183-abcb-5c784a53f8b0</pickID>
+          <phase>S</phase>
+          <azimuth>258.1</azimuth>
+          <distance>0.0751742930387</distance>
+          <takeoffAngle>
+            <value>113.1</value>
+          </takeoffAngle>
+          <timeResidual>-0.0299</timeResidual>
+          <timeWeight>0.1315</timeWeight>
+        </arrival>
+      </origin>
+      <pick publicID="smi:local/d7ba3bb7-645f-4ee6-a8f4-65e0332c5025">
+        <time>
+          <value>2010-05-27T16:56:25.930000Z</value>
+          <uncertainty>0.02</uncertainty>
+        </time>
+        <waveformID stationCode="UH3"></waveformID>
+        <phaseHint>P</phaseHint>
+      </pick>
+      <pick publicID="smi:local/3a0bde89-d7e6-45ef-a08a-4b950720f7be">
+        <time>
+          <value>2010-05-27T16:56:27.100000Z</value>
+          <uncertainty>0.06</uncertainty>
+        </time>
+        <waveformID stationCode="UH3"></waveformID>
+        <phaseHint>S</phaseHint>
+      </pick>
+      <pick publicID="smi:local/95492f79-0db4-4bba-a198-6c08db43dd83">
+        <time>
+          <value>2010-05-27T16:56:26.040000Z</value>
+          <uncertainty>0.03</uncertainty>
+        </time>
+        <waveformID stationCode="UH2"></waveformID>
+        <phaseHint>P</phaseHint>
+      </pick>
+      <pick publicID="smi:local/75ca039c-bfca-41c3-8fd3-9d70341a23fe">
+        <time>
+          <value>2010-05-27T16:56:27.270000Z</value>
+          <uncertainty>0.06</uncertainty>
+        </time>
+        <waveformID stationCode="UH2"></waveformID>
+        <phaseHint>S</phaseHint>
+      </pick>
+      <pick publicID="smi:local/550537fb-922c-4742-9bcc-504c1d330480">
+        <time>
+          <value>2010-05-27T16:56:26.130000Z</value>
+          <uncertainty>0.02</uncertainty>
+        </time>
+        <waveformID stationCode="UH1"></waveformID>
+        <phaseHint>P</phaseHint>
+      </pick>
+      <pick publicID="smi:local/0783bf9f-6862-40a3-baeb-ed247b73ca6f">
+        <time>
+          <value>2010-05-27T16:56:27.460000Z</value>
+          <uncertainty>0.03</uncertainty>
+        </time>
+        <waveformID stationCode="UH1"></waveformID>
+        <phaseHint>S</phaseHint>
+      </pick>
+      <pick publicID="smi:local/d6fa4a8a-6e4c-48a1-9ab9-e84b60038f4b">
+        <time>
+          <value>2010-05-27T16:56:26.930000Z</value>
+          <uncertainty>0.06</uncertainty>
+        </time>
+        <waveformID stationCode="UH4"></waveformID>
+        <phaseHint>P</phaseHint>
+      </pick>
+      <pick publicID="smi:local/b0b74d7c-bd9e-4183-abcb-5c784a53f8b0">
+        <time>
+          <value>2010-05-27T16:56:28.900000Z</value>
+          <uncertainty>0.11</uncertainty>
+        </time>
+        <waveformID stationCode="UH4"></waveformID>
+        <phaseHint>S</phaseHint>
+      </pick>
+    </event>
+  </eventParameters>
+</q:quakeml>

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -46,8 +46,8 @@ class NLLOCTestCase(unittest.TestCase):
         """
         Test writing nonlinloc observations phase file.
         """
-        # load nlloc.qml QuakeML file to generate OBS file from it
-        filename = get_example_file("nlloc.qml")
+        # load nlloc_custom.qml QuakeML file to generate OBS file from it
+        filename = get_example_file("nlloc_custom.qml")
         cat = read_events(filename, "QUAKEML")
         # adjust one pick time that got cropped by nonlinloc in NLLOC HYP file
         # due to less precision in hypocenter file (that we used to create the
@@ -82,10 +82,10 @@ class NLLOCTestCase(unittest.TestCase):
         """
         Test reading nonlinloc hypocenter phase file.
         """
-        filename = get_example_file("nlloc.hyp")
+        filename = get_example_file("nlloc_custom.hyp")
         cat = read_nlloc_hyp(filename,
                              coordinate_converter=_mock_coordinate_converter)
-        with open(get_example_file("nlloc.qml"), 'rb') as tf:
+        with open(get_example_file("nlloc_custom.qml"), 'rb') as tf:
             quakeml_expected = tf.read().decode()
         with NamedTemporaryFile() as tf:
             cat.write(tf, format="QUAKEML")
@@ -116,8 +116,103 @@ class NLLOCTestCase(unittest.TestCase):
 
         compare_xml_strings(quakeml_expected, quakeml_got)
 
+    def test_read_nlloc_hyp_with_builtin_projection(self):
+        """
+        Test reading nonlinloc hyp file without a coordinate_converter.
+        """
+        cat = read_nlloc_hyp(get_example_file("nlloc.hyp"))
+        cat_expected = read_events(get_example_file("nlloc.qml"))
+
+        # test event
+        ev = cat[0]
+        ev_expected = cat_expected[0]
+        self.assertAlmostEqual(ev.creation_info.creation_time,
+                               ev_expected.creation_info.creation_time)
+
+        # test origin
+        orig = ev.origins[0]
+        orig_expected = ev_expected.origins[0]
+        self.assertAlmostEqual(orig.time, orig_expected.time)
+        self.assertAlmostEqual(orig.longitude, orig_expected.longitude)
+        self.assertAlmostEqual(orig.longitude_errors.uncertainty,
+                               orig_expected.longitude_errors.uncertainty)
+        self.assertAlmostEqual(orig.latitude, orig_expected.latitude)
+        self.assertAlmostEqual(orig.latitude_errors.uncertainty,
+                               orig_expected.latitude_errors.uncertainty)
+        self.assertAlmostEqual(orig.depth, orig_expected.depth)
+        self.assertAlmostEqual(orig.depth_errors.uncertainty,
+                               orig_expected.depth_errors.uncertainty)
+        self.assertAlmostEqual(orig.depth_errors.confidence_level,
+                               orig_expected.depth_errors.confidence_level)
+        self.assertEqual(orig.depth_type, orig_expected.depth_type)
+        self.assertEqual(orig.quality.associated_phase_count,
+                         orig_expected.quality.associated_phase_count)
+        self.assertEqual(orig.quality.used_phase_count,
+                         orig_expected.quality.used_phase_count)
+        self.assertEqual(orig.quality.associated_station_count,
+                         orig_expected.quality.associated_station_count)
+        self.assertEqual(orig.quality.used_station_count,
+                         orig_expected.quality.used_station_count)
+        self.assertAlmostEqual(orig.quality.standard_error,
+                               orig_expected.quality.standard_error)
+        self.assertAlmostEqual(orig.quality.azimuthal_gap,
+                               orig_expected.quality.azimuthal_gap)
+        self.assertAlmostEqual(orig.quality.secondary_azimuthal_gap,
+                               orig_expected.quality.secondary_azimuthal_gap)
+        self.assertEqual(orig.quality.ground_truth_level,
+                         orig_expected.quality.ground_truth_level)
+        self.assertAlmostEqual(orig.quality.minimum_distance,
+                               orig_expected.quality.minimum_distance)
+        self.assertAlmostEqual(orig.quality.maximum_distance,
+                               orig_expected.quality.maximum_distance)
+        self.assertAlmostEqual(orig.quality.median_distance,
+                               orig_expected.quality.median_distance)
+        self.assertAlmostEqual(
+          orig.origin_uncertainty.min_horizontal_uncertainty,
+          orig_expected.origin_uncertainty.min_horizontal_uncertainty)
+        self.assertAlmostEqual(
+          orig.origin_uncertainty.max_horizontal_uncertainty,
+          orig_expected.origin_uncertainty.max_horizontal_uncertainty)
+        self.assertAlmostEqual(
+          orig.origin_uncertainty.azimuth_max_horizontal_uncertainty,
+          orig_expected.origin_uncertainty.azimuth_max_horizontal_uncertainty)
+        self.assertEqual(
+          orig.origin_uncertainty.preferred_description,
+          orig_expected.origin_uncertainty.preferred_description)
+        self.assertAlmostEqual(
+          orig.origin_uncertainty.confidence_level,
+          orig_expected.origin_uncertainty.confidence_level)
+        self.assertEqual(orig.creation_info.creation_time,
+                         orig_expected.creation_info.creation_time)
+        self.assertEqual(orig.comments[0].text, orig_expected.comments[0].text)
+
+        # test a couple of arrivals
+        for n in range(2):
+            arriv = orig.arrivals[n]
+            arriv_expected = orig_expected.arrivals[n]
+            self.assertEqual(arriv.phase, arriv_expected.phase)
+            self.assertAlmostEqual(arriv.azimuth, arriv_expected.azimuth)
+            self.assertAlmostEqual(arriv.distance, arriv_expected.distance)
+            self.assertAlmostEqual(arriv.takeoff_angle,
+                                   arriv_expected.takeoff_angle)
+            self.assertAlmostEqual(arriv.time_residual,
+                                   arriv_expected.time_residual)
+            self.assertAlmostEqual(arriv.time_weight,
+                                   arriv_expected.time_weight)
+
+        # test a couple of picks
+        for n in range(2):
+            pick = ev.picks[n]
+            pick_expected = ev_expected.picks[n]
+            self.assertAlmostEqual(pick.time, pick_expected.time)
+            self.assertEqual(pick.waveform_id.station_code,
+                             pick_expected.waveform_id.station_code)
+            self.assertEqual(pick.onset, pick_expected.onset)
+            self.assertEqual(pick.phase_hint, pick_expected.phase_hint)
+            self.assertEqual(pick.polarity, pick_expected.polarity)
+
     def test_read_nlloc_hyp_via_plugin(self):
-        filename = get_example_file("nlloc.hyp")
+        filename = get_example_file("nlloc_custom.hyp")
         cat = read_events(filename)
         self.assertEqual(len(cat), 1)
         cat = read_events(filename, format="NLLOC_HYP")
@@ -125,12 +220,12 @@ class NLLOCTestCase(unittest.TestCase):
 
     def test_is_nlloc_hyp(self):
         # test positive
-        filename = get_example_file("nlloc.hyp")
+        filename = get_example_file("nlloc_custom.hyp")
         self.assertEqual(is_nlloc_hyp(filename), True)
         # test some negatives
-        for filenames in ["nlloc.qml", "nlloc.obs", "gaps.mseed",
+        for filenames in ["nlloc_custom.qml", "nlloc.obs", "gaps.mseed",
                           "BW_RJOB.xml", "QFILE-TEST-ASC.ASC", "LMOW.BHE.SAC"]:
-            filename = get_example_file("nlloc.qml")
+            filename = get_example_file("nlloc_custom.qml")
             self.assertEqual(is_nlloc_hyp(filename), False)
 
     def test_read_nlloc_with_picks(self):
@@ -138,9 +233,9 @@ class NLLOCTestCase(unittest.TestCase):
         Test correct resource ID linking when reading NLLOC_HYP file with
         providing original picks.
         """
-        picks = read_events(get_example_file("nlloc.qml"))[0].picks
+        picks = read_events(get_example_file("nlloc_custom.qml"))[0].picks
         arrivals = read_events(
-            get_example_file("nlloc.hyp"), format="NLLOC_HYP",
+            get_example_file("nlloc_custom.hyp"), format="NLLOC_HYP",
             picks=picks)[0].origins[0].arrivals
         expected = [p.resource_id for p in picks]
         got = [a.pick_id for a in arrivals]


### PR DESCRIPTION
If NonLinLoc location run was performed using one of the standard projections available in the NonLinLoc package, there is no need to provide a custom coordinate converter and the coordinates from the "GEOGRAPHIC" line are used.

- Added a test case
- Updated the doc