### PR TITLE
Iterative reading of SEG-Y and SU files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,10 @@ master:
      white background.
  - obspy.io.css
     * Read support for NNSA KB Core format waveform data. (see #1332)
+ - obspy.io.segy:
+    * Iterative reading of large SEG-Y and SU files with
+	  `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.
+	  (see #1400).
  - obspy.scripts:
    * obspy-scan command line script now also plots and prints overlaps
      alongside gaps (see #1366)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,13 +16,13 @@ master:
      arguments to not download certain pieces of data. (see #1305)
    * The mass downloader can now download stations that are part of a given
      inventory object.
- - obspy.css
-    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.imaging.cm
    * new colormap: viridis_white. This is a modification of viridis that
      goes to white instead of yellow but remains perceptually uniform. It
      is especially useful for printing when an image should merge with the
      white background.
+ - obspy.io.css
+    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.scripts:
    * obspy-scan command line script now also plots and prints overlaps
      alongside gaps (see #1366)

--- a/obspy/io/segy/__init__.py
+++ b/obspy/io/segy/__init__.py
@@ -29,7 +29,7 @@ file formats usually used in observatories (GSE2, MiniSEED, ...). The
 of ObsPy are therefore not fully suited to handle them. Nonetheless they work
 well enough if some potential problems are kept in mind.
 
-SEG Y files can be read in three different ways that have different
+SEG Y files can be read in four different ways that have different
 advantages/disadvantages. Most of the following also applies to SU files with
 some changes (keep in mind that SU files have no file wide headers).
 
@@ -37,6 +37,9 @@ some changes (keep in mind that SU files have no file wide headers).
 2. Using the :mod:`obspy.io.segy` specific
    :func:`obspy.io.segy.core._read_segy` function.
 3. Using the internal :func:`obspy.io.segy.segy._read_segy` function.
+4. Some SEG-Y files are too large to be read into memory. The
+   :func:`obspy.io.segy.segy.iread_segy` function reads a large file trace
+   by trace circumventing this problem.
 
 Reading using methods 1 and 2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,6 +127,21 @@ tab completion, but data are read directly from the disk when it is accessed:
 >>> segy = _read_segy(filename, headonly=True)
 >>> print(len(segy.traces[0].data))
 2001
+
+
+Iteratively reading a file using method 4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a file is too big to be read into memory in one go (as all the other
+methods do), read the file trace by trace using the
+:func:`obspy.io.segy.segy.iread_segy` function:
+
+>>> from obspy.io.segy.segy import iread_segy
+>>> for trace in iread_segy(filename):
+...    # Do something meaningful.
+...    print(round(trace.data.sum() * 1E9))
+-5.0
+
 
 Writing
 -------

--- a/obspy/io/segy/__init__.py
+++ b/obspy/io/segy/__init__.py
@@ -139,8 +139,8 @@ methods do), read the file trace by trace using the
 >>> from obspy.io.segy.segy import iread_segy
 >>> for trace in iread_segy(filename):
 ...    # Do something meaningful.
-...    print(round(trace.data.sum() * 1E9))
--5.0
+...    print(int(trace.data.sum() * 1E9))
+-5
 
 
 Writing

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -190,59 +190,13 @@ def _read_segy(filename, headonly=False, byteorder=None,
     stream.stats.endian = endian
     stream.stats.textual_file_header_encoding = \
         textual_file_header_encoding
-    # Loop over all traces.
+
+    # Convert traces to ObsPy Trace objects.
     for tr in segy_object.traces:
-        # Create new Trace object for every segy trace and append to the Stream
-        # object.
-        trace = Trace()
-        stream.append(trace)
-        # skip data if headonly is set
-        if headonly:
-            trace.stats.npts = tr.npts
-        else:
-            trace.data = tr.data
-        trace.stats.segy = AttribDict()
-        # If all values will be unpacked create a normal dictionary.
-        if unpack_trace_headers:
-            # Add the trace header as a new attrib dictionary.
-            header = AttribDict()
-            for key, value in tr.header.__dict__.items():
-                setattr(header, key, value)
-        # Otherwise use the LazyTraceHeaderAttribDict.
-        else:
-            # Add the trace header as a new lazy attrib dictionary.
-            header = LazyTraceHeaderAttribDict(tr.header.unpacked_header,
-                                               tr.header.endian)
-        trace.stats.segy.trace_header = header
-        # The sampling rate should be set for every trace. It is a sample
-        # interval in microseconds. The only sanity check is that is should be
-        # larger than 0.
-        tr_header = trace.stats.segy.trace_header
-        if tr_header.sample_interval_in_ms_for_this_trace > 0:
-            trace.stats.delta = \
-                float(tr.header.sample_interval_in_ms_for_this_trace) / \
-                1E6
-        # If the year is not zero, calculate the start time. The end time is
-        # then calculated from the start time and the sampling rate.
-        if tr_header.year_data_recorded > 0:
-            year = tr_header.year_data_recorded
-            # The SEG Y rev 0 standard specifies the year to be a 4 digit
-            # number.  Before that it was unclear if it should be a 2 or 4
-            # digit number. Old or wrong software might still write 2 digit
-            # years. Every number <30 will be mapped to 2000-2029 and every
-            # number between 30 and 99 will be mapped to 1930-1999.
-            if year < 100:
-                if year < 30:
-                    year += 2000
-                else:
-                    year += 1900
-            julday = tr_header.day_of_year
-            hour = tr_header.hour_of_day
-            minute = tr_header.minute_of_hour
-            second = tr_header.second_of_minute
-            trace.stats.starttime = UTCDateTime(
-                year=year, julday=julday, hour=hour, minute=minute,
-                second=second)
+        stream.append(tr.to_obspy_trace(
+            headonly=headonly,
+            unpack_trace_headers=unpack_trace_headers))
+
     return stream
 
 

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -913,6 +913,26 @@ def iread_segy(file, endian=None, textual_header_encoding=None,
     """
     Iteratively read a SEG-Y field and yield single ObsPy Traces.
 
+    The function iteratively loops over the whole file and yields single
+    ObsPy Traces. The next Trace will be read after the current loop has
+    finished - this function is thus suitable for reading arbitrarily large
+    SEG-Y files without running into memory problems.
+
+    >>> from obspy.core.util import get_example_file
+    >>> filename = get_example_file("00001034.sgy_first_trace")
+    >>> from obspy.io.segy.segy import iread_segy
+    >>> for tr in iread_segy(filename):
+    ...     # Each Trace's stats attribute will have references to the file
+    ...     # headers and some more information.
+    ...     tf = tr.stats.segy.textual_file_header
+    ...     bf = tr.stats.segy.binary_file_header
+    ...     tfe = tr.stats.segy.textual_file_header_encoding
+    ...     de = tr.stats.segy.data_encoding
+    ...     e = tr.stats.segy.endian
+    ...     # Also do something meaningful with each Trace.
+    ...     print(int(tr.data.sum() * 1E9))
+    -5
+
     :param file: Open file like object or a string which will be assumed to be
         a filename.
     :type endian: str
@@ -978,6 +998,23 @@ def _internal_iread_segy(file, endian=None, textual_header_encoding=None,
 def iread_su(file, endian=None, unpack_headers=False, headonly=False):
     """
     Iteratively read a SU field and yield single ObsPy Traces.
+
+    The function iteratively loops over the whole file and yields single
+    ObsPy Traces. The next Trace will be read after the current loop has
+    finished - this function is thus suitable for reading arbitrarily large
+    SU files without running into memory problems.
+
+    >>> from obspy.core.util import get_example_file
+    >>> filename = get_example_file("1.su_first_trace")
+    >>> from obspy.io.segy.segy import iread_su
+    >>> for tr in iread_su(filename):
+    ...     # Each Trace's stats attribute will have some file-wide
+    ...     # information.
+    ...     de = tr.stats.su.data_encoding
+    ...     e = tr.stats.su.endian
+    ...     # Also do something meaningful with each Trace.
+    ...     print(int(tr.data.sum()))
+    -26121
 
     :param file: Open file like object or a string which will be assumed to be
         a filename.

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -126,7 +126,8 @@ class SEGYFile(object):
         self._read_headers()
         # Read the actual traces.
         if read_traces:
-            self._read_traces(unpack_headers=unpack_headers, headonly=headonly)
+            [i for i in self._read_traces(
+                unpack_headers=unpack_headers, headonly=headonly)]
 
     def __str__(self):
         """
@@ -943,15 +944,18 @@ def iread_segy(file, endian=None, textual_header_encoding=None,
                 yield tr
             return
     # Otherwise just read it.
-    for tr in _internal_iread_segy(file, endian=endian,
-                                   textual_header_encoding=textual_header_encoding,
-                                   unpack_headers=unpack_headers,
-                                   headonly=headonly):
+    for tr in _internal_iread_segy(
+            file, endian=endian,
+            textual_header_encoding=textual_header_encoding,
+            unpack_headers=unpack_headers, headonly=headonly):
         yield tr
 
 
 def _internal_iread_segy(file, endian=None, textual_header_encoding=None,
                          unpack_headers=False, headonly=False):
+    """
+    Iteratively read a SEG-Y field and yield single ObsPy Traces.
+    """
     segy_file =  SEGYFile(
         file, endian=endian, textual_header_encoding=textual_header_encoding,
         unpack_headers=unpack_headers, headonly=headonly, read_traces=False)

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -956,7 +956,7 @@ def _internal_iread_segy(file, endian=None, textual_header_encoding=None,
     """
     Iteratively read a SEG-Y field and yield single ObsPy Traces.
     """
-    segy_file =  SEGYFile(
+    segy_file = SEGYFile(
         file, endian=endian, textual_header_encoding=textual_header_encoding,
         unpack_headers=unpack_headers, headonly=headonly, read_traces=False)
     for trace in segy_file._read_traces(unpack_headers=unpack_headers,
@@ -971,6 +971,7 @@ def _internal_iread_segy(file, endian=None, textual_header_encoding=None,
             segy_file.textual_header_encoding.upper()
         tr.stats.segy.data_encoding = trace.data_encoding
         tr.stats.segy.endian = trace.endian
+        tr.stats._format = "SEGY"
         yield tr
 
 

--- a/obspy/io/segy/tests/test_su.py
+++ b/obspy/io/segy/tests/test_su.py
@@ -12,8 +12,9 @@ import unittest
 
 import numpy as np
 
+import obspy
 from obspy.core.util import NamedTemporaryFile
-from obspy.io.segy.segy import SEGYTraceReadingError, _read_su
+from obspy.io.segy.segy import SEGYTraceReadingError, _read_su, iread_su
 
 
 class SUTestCase(unittest.TestCase):
@@ -122,6 +123,21 @@ class SUTestCase(unittest.TestCase):
             data = fp.read()
         st = _read_su(io.BytesIO(data))
         self.assertEqual(len(st.traces[0].data), 8000)
+
+    def test_iterative_reading(self):
+        """
+        Tests iterative reading.
+        """
+        # Read normally.
+        filename = os.path.join(self.path, '1.su_first_trace')
+        st = obspy.read(filename, unpack_trace_headers=True)
+
+        # Read iterative.
+        ist = [_i for _i in iread_su(filename, unpack_headers=True)]
+
+        del ist[0].stats.su.data_encoding
+
+        self.assertEqual(st.traces, ist)
 
 
 def suite():


### PR DESCRIPTION
Hi,

I guess this is not an issue per se, but I am new to the geosciences and I need some help (my config: Windows 8, Anaconda Python3.4, ObsPy 1.0.1, VisualStudio C++).

I am trying to read a SEG-Y file corresponding to a 2D line with 1.5M traces and getting out of memory in less than 2 min. Will the entire file contents always be read into memory? Is there some kind of workaround? Should I be doing it differently?

If I have lines with almost 16GB each, then the only way possible to go through it would be to have a computer with a huge amount of RAM?

Thanks in advance

