### PR TITLE
SAC file truncated to zero on write if an invalid header field is set

### DIFF
--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -514,7 +514,8 @@ def dict_to_header_arrays(header=None, byteorder='='):
                     #                                          'strict')
                     hs[HD.STRHDRS.index(hdr)] = value
             else:
-                raise ValueError("Unrecognized header name: {}.".format(hdr))
+                msg = "Unrecognized header name: {}. Ignored.".format(hdr)
+                warnings.warn(msg)
 
     return hf, hi, hs
 

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -839,6 +839,29 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr1.stats.sac.npts, tr.stats.sac.npts / 2)
         self.assertEqual(tr1.stats.sac.delta, tr.stats.sac.delta * 2)
 
+    def test_invalid_header_field(self):
+        """
+        Given a SAC file on disk, when it is read and an invalid header is
+        appended to the stats.sac dictionary, then the invalid header should be
+        ignored (user given a warning) and the written file should be the same
+        as the original.
+        """
+        tr = read(self.file, format='SAC')[0]
+
+        with io.BytesIO() as buf:
+            tr.write(buf, format='SAC')
+            buf.seek(0, 0)
+
+            tr.stats.sac.AAA = 10.
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                with io.BytesIO() as buf1:
+                    tr.write(buf1, format='SAC')
+                    self.assertIn('Ignored', str(w[-1].message))
+                    buf1.seek(0, 0)
+
+                    self.assertEqual(buf.read(), buf1.read())
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')


### PR DESCRIPTION
Here's a test code:

```python
from obspy import read

tr = read('trace.sac')[0]
tr.stats.sac.AAA = 10.
tr.write('trace.sac', format='SAC')
```

which gives:
```
ValueError: Unrecognized header name: AAA.
```

And truncates to zero `trace.sac`.

I think that setting an invalid header field should be tested in order to prevent future regressions.