### PR TITLE
add option "append=False" to writing MiniSEED files

### DIFF
--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -446,7 +446,8 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
 
 
 def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
-                 sequence_number=None, flush=True, verbose=0, **_kwargs):
+                 sequence_number=None, flush=True, verbose=0, append=False,
+                 **_kwargs):
     """
     Write Mini-SEED file from a Stream object.
 
@@ -488,6 +489,10 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
     :type verbose: int, optional
     :param verbose: Controls verbosity, a value of ``0`` will result in no
         diagnostic output.
+    :type append: bool
+    :param append: Whether to append to the file if it exists, or overwrite
+        (default). Only has an effect if a filename is supplied (in contrast to
+        a file-like object)
 
     .. note::
         The ``reclen``, ``encoding``, ``byteorder`` and ``sequence_count``
@@ -763,7 +768,8 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
 
     # Open filehandler or use an existing file like object.
     if not hasattr(filename, 'write'):
-        f = open(filename, 'wb')
+        filemode = "a" if append else "w"
+        f = open(filename, filemode + 'b')
     else:
         f = filename
 


### PR DESCRIPTION
This PR would add an option `append=False` to `_write_mseed()`, in order to append to existing files rather than overwrite them. One use case is e.g. adding missing data to a data archive (e.g. via SDS client).

```python
from obspy import read

filename = "/tmp/mseed_append.mseed"

st = read()

st[0].write(filename, format="MSEED")
st[1].write(filename, format="MSEED", append=True)
st[2].write(filename, format="MSEED", append=True)
st[1].write(filename, format="MSEED", append=True)
st[2].write(filename, format="MSEED", append=True)

print(read(filename))
```
```
5 Trace(s) in Stream:
BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHN | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHN | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
```

The same could be achieved by manually opening the target file in append mode..
```python
from obspy import read

filename = "/tmp/mseed_append.mseed"

st = read()

st[0].write(filename, format="MSEED")
with open(filename, "ab") as fh:
    st[1].write(fh, format="MSEED")
    st[2].write(fh, format="MSEED")
    st[1].write(fh, format="MSEED")
    st[2].write(fh, format="MSEED")

print(read(filename))
```
.. but a canonical kwarg for this might still be good to have, I think.

No tests yet, wanted to hear feedback/opinions first.

(The same could be implemented for a series of other formats, I think.)