### PR TITLE
More compact string representation for Inventory

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -935,8 +935,7 @@ class Client(object):
             Sending institution: IRIS-DMC (IRIS-DMC)
             Contains:
                 Networks (2):
-                    GR
-                    IU
+                    GR, IU
                 Stations (2):
                     GR.GRA1 (GRAFENBERG ARRAY, BAYERN)
                     IU.ANMO (Albuquerque, New Mexico, USA)
@@ -966,13 +965,12 @@ class Client(object):
             Sending institution: IRIS-DMC (IRIS-DMC)
             Contains:
                 Networks (2):
-                    GR
-                    IU
+                    GR, IU
                 Stations (2):
                     GR.GRA1 (GRAFENBERG ARRAY, BAYERN)
                     IU.ANMO (Albuquerque, New Mexico, USA)
                 Channels (5):
-                    GR.GRA1..BHE, GR.GRA1..BHN, GR.GRA1..BHZ, IU.ANMO.00.BHZ,
+                    GR.GRA1..BHZ, GR.GRA1..BHN, GR.GRA1..BHE, IU.ANMO.00.BHZ,
                     IU.ANMO.10.BHZ
         >>> inv = client.get_stations_bulk("/tmp/request.txt") \
         ...     # doctest: +SKIP

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -381,8 +381,7 @@ class Inventory(ComparingObject):
             Sending institution: Erdbebendienst Bayern
             Contains:
                 Networks (2):
-                    GR
-                    BW
+                    BW, GR
                 Stations (2):
                     BW.RJOB (Jochberg, Bavaria, BW-Net)
                     GR.WET (Wettzell, Bavaria, GR-Net)

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -29,6 +29,7 @@ from obspy.core.util.decorator import map_example_filename
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .network import Network
+from .util import _unified_content_strings, _textwrap
 
 # Make sure this is consistent with obspy.io.stationxml! Importing it
 # from there results in hard to resolve cyclic imports.
@@ -220,17 +221,21 @@ class Inventory(ComparingObject):
         contents = self.get_contents()
         ret_str += "\tContains:\n"
         ret_str += "\t\tNetworks (%i):\n" % len(contents["networks"])
-        ret_str += "\n".join(textwrap.wrap(
-            ", ".join(contents["networks"]), initial_indent="\t\t\t",
-            subsequent_indent="\t\t\t", expand_tabs=False))
+        ret_str += "\n".join(_textwrap(
+            ", ".join(_unified_content_strings(contents["networks"])),
+            initial_indent="\t\t\t", subsequent_indent="\t\t\t",
+            expand_tabs=False))
         ret_str += "\n"
         ret_str += "\t\tStations (%i):\n" % len(contents["stations"])
-        ret_str += "\n".join(["\t\t\t%s" % _i for _i in contents["stations"]])
+        ret_str += "\n".join([
+            "\t\t\t%s" % _i
+            for _i in _unified_content_strings(contents["stations"])])
         ret_str += "\n"
         ret_str += "\t\tChannels (%i):\n" % len(contents["channels"])
-        ret_str += "\n".join(textwrap.wrap(
-            ", ".join(contents["channels"]), initial_indent="\t\t\t",
-            subsequent_indent="\t\t\t", expand_tabs=False))
+        ret_str += "\n".join(_textwrap(
+            ", ".join(_unified_content_strings(contents["channels"])),
+            initial_indent="\t\t\t", subsequent_indent="\t\t\t",
+            expand_tabs=False))
         return ret_str
 
     def _repr_pretty_(self, p, cycle):

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -203,6 +203,7 @@ class Inventory(ComparingObject):
                 content_dict.setdefault(key, [])
                 content_dict[key].extend(value)
                 content_dict[key].sort()
+        content_dict['networks'].sort()
         return content_dict
 
     def __str__(self):
@@ -219,7 +220,9 @@ class Inventory(ComparingObject):
         contents = self.get_contents()
         ret_str += "\tContains:\n"
         ret_str += "\t\tNetworks (%i):\n" % len(contents["networks"])
-        ret_str += "\n".join(["\t\t\t%s" % _i for _i in contents["networks"]])
+        ret_str += "\n".join(textwrap.wrap(
+            ", ".join(contents["networks"]), initial_indent="\t\t\t",
+            subsequent_indent="\t\t\t", expand_tabs=False))
         ret_str += "\n"
         ret_str += "\t\tStations (%i):\n" % len(contents["stations"])
         ret_str += "\n".join(["\t\t\t%s" % _i for _i in contents["stations"]])

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -21,7 +21,7 @@ import warnings
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .station import Station
-from .util import BaseNode
+from .util import BaseNode, _unified_content_strings, _textwrap
 
 
 @python_2_unicode_compatible
@@ -137,9 +137,10 @@ class Network(BaseNode):
             for _i in _unified_content_strings(contents["stations"])])
         ret += "\n"
         ret += "\t\tChannels (%i):\n" % len(contents["channels"])
-        ret += "\n".join(textwrap.wrap(", ".join(
-            contents["channels"]), initial_indent="\t\t\t",
-            subsequent_indent="\t\t\t", expand_tabs=False))
+        ret += "\n".join(_textwrap(", ".join(
+            _unified_content_strings(contents["channels"])),
+            initial_indent="\t\t\t", subsequent_indent="\t\t\t",
+            expand_tabs=False))
         return ret
 
     def _repr_pretty_(self, p, cycle):

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -16,7 +16,6 @@ from future.utils import python_2_unicode_compatible
 
 import copy
 import fnmatch
-import textwrap
 import warnings
 
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
@@ -133,7 +132,9 @@ class Network(BaseNode):
         contents = self.get_contents()
         ret += "\tContains:\n"
         ret += "\t\tStations (%i):\n" % len(contents["stations"])
-        ret += "\n".join(["\t\t\t%s" % _i for _i in contents["stations"]])
+        ret += "\n".join([
+            "\t\t\t%s" % _i
+            for _i in _unified_content_strings(contents["stations"])])
         ret += "\n"
         ret += "\t\tChannels (%i):\n" % len(contents["channels"])
         ret += "\n".join(textwrap.wrap(", ".join(

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -23,7 +23,8 @@ import numpy as np
 from obspy import UTCDateTime
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
-from .util import BaseNode, Equipment, Operator, Distance, Latitude, Longitude
+from .util import (BaseNode, Equipment, Operator, Distance, Latitude,
+                   Longitude, _unified_content_strings, _textwrap)
 
 
 @python_2_unicode_compatible
@@ -167,9 +168,10 @@ class Station(BaseNode):
             historical_code="historical Code: %s " % self.historical_code if
             self.historical_code else "")
         ret += "\tAvailable Channels:\n"
-        ret += "\n".join(textwrap.wrap(
-            ", ".join(contents["channels"]), initial_indent="\t\t",
-            subsequent_indent="\t\t", expand_tabs=False))
+        ret += "\n".join(_textwrap(
+            ", ".join(_unified_content_strings(contents["channels"])),
+            initial_indent="\t\t", subsequent_indent="\t\t",
+            expand_tabs=False))
         return ret
 
     def _repr_pretty_(self, p, cycle):

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -16,7 +16,6 @@ from future.utils import python_2_unicode_compatible
 
 import copy
 import fnmatch
-import textwrap
 import warnings
 
 import numpy as np

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -773,7 +773,7 @@ class Angle(FloatWithUncertaintiesFixedUnit):
 
 
 def _unified_content_strings(contents):
-    contents_unique = sorted(set(contents), cmp=_cmp_seed_ids)
+    contents_unique = sorted(set(contents), key=_seed_id_keyfunction)
     contents_counts = [
         (item, contents.count(item)) for item in contents_unique]
     items = [item if count == 1 else "{} ({}x)".format(item, count)
@@ -803,43 +803,49 @@ def _textwrap(text, *args, **kwargs):
     return InventoryTextWrapper(*args, **kwargs).wrap(text)
 
 
-def _cmp_seed_ids(x, y):
+def _seed_id_keyfunction(x):
     """
-    cmp-like function to compare two (partial) SEED IDs
+    Keyfunction to use in sorting two (partial) SEED IDs
 
     Assumes that the last (or only) "."-separated part is a channel code.
     Assumes the last character is a the component code and sorts it
     "Z"-"N"-"E"-others_lexical.
     """
-    if x.count(".") != y.count("."):
-        raise ValueError()
+    # for comparison we build a list of 5 SEED code pieces:
+    # [network, station, location, band+instrument, component]
+    # with partial codes (i.e. not 4 fields after splitting at dots),
+    # we go with the following assumptions (these seem a bit random, but that's
+    # what can be encountered in string representations of the Inventory object
+    # hierarchy):
+    #  - no dot means network code only (e.g. "IU")
+    #  - one dot means network.station code only (e.g. "IU.ANMO")
+    #  - two dots means station.location.channel code only (e.g. "ANMO.10.BHZ")
+    #  - three dots: full SEED ID (e.g. "IU.ANMO.10.BHZ")
+    #  - more dots: sort after any of the previous, plain lexical sort
+    # if no "." in the string: assume it's a network code
+    number_of_dots = x.count(".")
     x = x.upper()
-    y = y.upper()
-    if "." in x:
-        x_chunks = x.split(".")
-        y_chunks = y.split(".")
-        x_chunks = x_chunks[:-1] + [x_chunks[-1][:-1], x_chunks[-1][-1]]
-        y_chunks = y_chunks[:-1] + [y_chunks[-1][:-1], y_chunks[-1][-1]]
+    if number_of_dots == 0:
+        x = [x] + [""] * 4
+    elif number_of_dots == 1:
+        x = x.split(".") + [""] * 3
+    elif number_of_dots in (2, 3):
+        x = x.split(".")
+        if number_of_dots == 2:
+            x = [""] + x
+        # split channel code into band+instrument code and component code
+        x = x[:-1] + [x[-1][:-1], x[-1] and x[-1][-1] or '']
+        # special comparison for component code, convert "ZNE" to integers
+        # which compare less than any character
+        comp = "ZNE".find(x[-1])
+        if comp >= 0:
+            x[-1] = comp
+    # all other cases, just leave the upper case string, it will compare
+    # greater than any of the split lists
     else:
-        # append a fake empty component code, so that the rest of the logic
-        # can be the same
-        x_chunks = [x, ""]
-        y_chunks = [y, ""]
-    # just a normal comparison by SEED ID parts up to the last item
-    # (== component code)
-    for x_, y_ in zip(x_chunks[:-1], y_chunks[:-1]):
-        result = cmp(x_, y_)
-        if result:
-            return result
-    # special comparison for component code
-    x_ = x_chunks[-1]
-    y_ = y_chunks[-1]
-    component_sorter = "ENZ"
-    result = -cmp(component_sorter.find(x_), component_sorter.find(y_))
-    if result:
-        return result
-    # if neither of both component codes is in Z/N/E, just do a lexical sort
-    return cmp(x_, y_)
+        pass
+
+    return x
 
 
 if __name__ == '__main__':

--- a/obspy/io/kml/tests/data/inventory.kml
+++ b/obspy/io/kml/tests/data/inventory.kml
@@ -42,10 +42,10 @@
 			GR.FUR (Fuerstenfeldbruck, Bavaria, GR-Net)
 			GR.WET (Wettzell, Bavaria, GR-Net)
 		Channels (21):
-			GR.FUR..HHZ, GR.FUR..HHN, GR.FUR..HHE, GR.FUR..BHZ, GR.FUR..BHN,
-			GR.FUR..BHE, GR.FUR..LHZ, GR.FUR..LHN, GR.FUR..LHE, GR.FUR..VHZ,
-			GR.FUR..VHN, GR.FUR..VHE, GR.WET..HHZ, GR.WET..HHN, GR.WET..HHE,
-			GR.WET..BHZ, GR.WET..BHN, GR.WET..BHE, GR.WET..LHZ, GR.WET..LHN,
+			GR.FUR..BHZ, GR.FUR..BHN, GR.FUR..BHE, GR.FUR..HHZ, GR.FUR..HHN,
+			GR.FUR..HHE, GR.FUR..LHZ, GR.FUR..LHN, GR.FUR..LHE, GR.FUR..VHZ,
+			GR.FUR..VHN, GR.FUR..VHE, GR.WET..BHZ, GR.WET..BHN, GR.WET..BHE,
+			GR.WET..HHZ, GR.WET..HHN, GR.WET..HHE, GR.WET..LHZ, GR.WET..LHN,
 			GR.WET..LHE</description>
       <Style>
         <ListStyle>
@@ -68,8 +68,8 @@
 	Access: None 
 	Latitude: 48.16, Longitude: 11.28, Elevation: 565.0 m
 	Available Channels:
-		FUR..HHZ, FUR..HHN, FUR..HHE, FUR..BHZ, FUR..BHN, FUR..BHE,
-		FUR..LHZ, FUR..LHN, FUR..LHE, FUR..VHZ, FUR..VHN, FUR..VHE</description>
+		FUR..BHZ, FUR..BHN, FUR..BHE, FUR..HHZ, FUR..HHN, FUR..HHE, FUR..LHZ
+		FUR..LHN, FUR..LHE, FUR..VHZ, FUR..VHN, FUR..VHE</description>
         <TimeSpan>
           <begin>2006-12-16T00:00:00.000000Z</begin>
         </TimeSpan>
@@ -88,8 +88,8 @@
 	Access: None 
 	Latitude: 49.14, Longitude: 12.88, Elevation: 613.0 m
 	Available Channels:
-		WET..HHZ, WET..HHN, WET..HHE, WET..BHZ, WET..BHN, WET..BHE,
-		WET..LHZ, WET..LHN, WET..LHE</description>
+		WET..BHZ, WET..BHN, WET..BHE, WET..HHZ, WET..HHN, WET..HHE, WET..LHZ
+		WET..LHN, WET..LHE</description>
         <TimeSpan>
           <begin>2007-02-02T00:00:00.000000Z</begin>
         </TimeSpan>
@@ -104,13 +104,9 @@
 	Access: UNKNOWN
 	Contains:
 		Stations (3):
-			BW.RJOB (Jochberg, Bavaria, BW-Net)
-			BW.RJOB (Jochberg, Bavaria, BW-Net)
-			BW.RJOB (Jochberg, Bavaria, BW-Net)
+			BW.RJOB (Jochberg, Bavaria, BW-Net) (3x)
 		Channels (9):
-			BW.RJOB..EHZ, BW.RJOB..EHN, BW.RJOB..EHE, BW.RJOB..EHZ,
-			BW.RJOB..EHN, BW.RJOB..EHE, BW.RJOB..EHZ, BW.RJOB..EHN,
-			BW.RJOB..EHE</description>
+			BW.RJOB..EHZ (3x), BW.RJOB..EHN (3x), BW.RJOB..EHE (3x)</description>
       <Style>
         <ListStyle>
           <listItemType>check</listItemType>

--- a/obspy/io/stationtxt/__init__.py
+++ b/obspy/io/stationtxt/__init__.py
@@ -29,15 +29,13 @@ Inventory created at ...
     Sending institution: None
     Contains:
         Networks (2):
-            AK
-            AZ
+            AK, AZ
         Stations (3):
             AK.BAGL ()
             AK.BWN ()
             AZ.BZN ()
         Channels (6):
-            AK.BAGL..LHZ, AK.BWN..LHZ, AK.BWN..LHZ, AZ.BZN..LHZ, AZ.BZN..LHZ,
-            AZ.BZN..LHZ
+            AK.BAGL..LHZ, AK.BWN..LHZ (2x), AZ.BZN..LHZ (3x)
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)


### PR DESCRIPTION
 * multiple network codes per line
 * combine identical items and give count in brackets
 * lexical sort, sort component Z-N-E-others

Makes the following..
```
>>> print(inventory)
Inventory created at 2016-05-20T08:57:08.088722Z
	Created by: ObsPy 1.0.1.post0+114.g18bcd8f57b.obspy.master
		    https://www.obspy.org
	Sending institution: IRIS-DMC (IRIS-DMC)
	Contains:
		Networks (26):
			1A
			1A
			1B
			1B
			1C
			1D
			1D
			1E
			1E
			1F
			2A
			2B
			2C
			2D
			2G
			3A
			3C
			3C
			3D
			3E
			3F
			3F
			4A
			4A
			4E
			IU
		Stations (5):
			IU.ANMO (Albuquerque, New Mexico, USA)
			IU.ANMO (Albuquerque, New Mexico, USA)
			IU.ANMO (Albuquerque, New Mexico, USA)
			IU.ANMO (Albuquerque, New Mexico, USA)
			IU.ANMO (Albuquerque, New Mexico, USA)
		Channels (233):
			IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1,
			IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1,
			IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1,
			IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH1,
			IU.ANMO.10.BH1, IU.ANMO.10.BH1, IU.ANMO.10.BH2, IU.ANMO.10.BH2,
			IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2,
			IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2,
			IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2,
			IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2, IU.ANMO.10.BH2,
			IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ,
			IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ,
			IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ,
			IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ, IU.ANMO.10.BHZ,
			IU.ANMO.10.BHZ, IU.ANMO.10.EH1, IU.ANMO.10.EH2, IU.ANMO.10.EHZ,
			IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1,
			IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1,
			IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1,
			IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH1,
			IU.ANMO.10.HH1, IU.ANMO.10.HH1, IU.ANMO.10.HH2, IU.ANMO.10.HH2,
			IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2,
			IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2,
			IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2,
			IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2, IU.ANMO.10.HH2,
			IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ,
			IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ,
			IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ,
			IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ, IU.ANMO.10.HHZ,
			IU.ANMO.10.HHZ, IU.ANMO.10.LDI, IU.ANMO.10.LDO, IU.ANMO.10.LDO,
			IU.ANMO.10.LDO, IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1,
			IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1,
			IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1,
			IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1,
			IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH1, IU.ANMO.10.LH2,
			IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2,
			IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2,
			IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2,
			IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2, IU.ANMO.10.LH2,
			IU.ANMO.10.LH2, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ,
			IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ,
			IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ,
			IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LHZ,
			IU.ANMO.10.LHZ, IU.ANMO.10.LHZ, IU.ANMO.10.LWD, IU.ANMO.10.LWS,
			IU.ANMO.10.UDI, IU.ANMO.10.UWD, IU.ANMO.10.UWS, IU.ANMO.10.VDI,
			IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1,
			IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1,
			IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1,
			IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH1,
			IU.ANMO.10.VH1, IU.ANMO.10.VH1, IU.ANMO.10.VH2, IU.ANMO.10.VH2,
			IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2,
			IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2,
			IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2,
			IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2, IU.ANMO.10.VH2,
			IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ,
			IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ,
			IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ,
			IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ, IU.ANMO.10.VHZ,
			IU.ANMO.10.VHZ, IU.ANMO.10.VM1, IU.ANMO.10.VM2, IU.ANMO.10.VMU,
			IU.ANMO.10.VMV, IU.ANMO.10.VMW, IU.ANMO.10.VMZ, IU.ANMO.10.VWD,
			IU.ANMO.10.VWS
```
become:
```
>>> print(inventory)
Inventory created at 2016-05-20T08:57:08.000000Z
	Created by: ObsPy 1.0.1.post0+114.g18bcd8f57b.obspy.master
		    https://www.obspy.org
	Sending institution: IRIS-DMC (IRIS-DMC)
	Contains:
		Networks (26):
			1A (2x), 1B (2x), 1C, 1D (2x), 1E (2x), 1F, 2A, 2B, 2C, 2D, 2G, 3A
			3C (2x), 3D, 3E, 3F (2x), 4A (2x), 4E, IU
		Stations (5):
			IU.ANMO (Albuquerque, New Mexico, USA) (5x)
		Channels (233):
			IU.ANMO.10.BHZ (17x), IU.ANMO.10.BH1 (18x), IU.ANMO.10.BH2 (18x), 
			IU.ANMO.10.EHZ, IU.ANMO.10.EH1, IU.ANMO.10.EH2, 
			IU.ANMO.10.HHZ (17x), IU.ANMO.10.HH1 (18x), IU.ANMO.10.HH2 (18x), 
			IU.ANMO.10.LDI, IU.ANMO.10.LDO (3x), IU.ANMO.10.LHZ (17x), 
			IU.ANMO.10.LH1 (18x), IU.ANMO.10.LH2 (18x), IU.ANMO.10.LWD, 
			IU.ANMO.10.LWS, IU.ANMO.10.UDI, IU.ANMO.10.UWD, IU.ANMO.10.UWS, 
			IU.ANMO.10.VDI, IU.ANMO.10.VHZ (17x), IU.ANMO.10.VH1 (18x), 
			IU.ANMO.10.VH2 (18x), IU.ANMO.10.VMZ, IU.ANMO.10.VM1, 
			IU.ANMO.10.VM2, IU.ANMO.10.VMU, IU.ANMO.10.VMV, IU.ANMO.10.VMW, 
			IU.ANMO.10.VWD, IU.ANMO.10.VWS
```