### PR TITLE
Fix bad documentation of quantity errors in event objects

### DIFF
--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -40,10 +40,58 @@ from obspy.core.util.decorator import deprecated
 
 
 class QuantityError(AttribDict):
-    uncertainty = None
-    lower_uncertainty = None
-    upper_uncertainty = None
-    confidence_level = None
+    """
+    Uncertainty information for a physical quantity.
+
+    :type uncertainty: float
+    :param uncertainty: Uncertainty as the absolute value of symmetric
+        deviation from the main value.
+    :type lower_uncertainty: float
+    :param lower_uncertainty: Uncertainty as the absolute value of deviation
+        from the main value towards smaller values.
+    :type upper_uncertainty: float
+    :param upper_uncertainty: Uncertainty as the absolute value of deviation
+        from the main value towards larger values.
+    :type confidence_level: float
+    :param confidence_level: Confidence level of the uncertainty, given in
+        percent (0-100).
+    """
+    defaults = {"uncertainty": None, "lower_uncertainty": None,
+                "upper_uncertainty": None, "confidence_level": None}
+    warn_on_non_default_key = True
+
+    def __init__(self, uncertainty=None, lower_uncertainty=None,
+                 upper_uncertainty=None, confidence_level=None):
+        super(QuantityError, self).__init__()
+        self.uncertainty = uncertainty
+        self.lower_uncertainty = lower_uncertainty
+        self.upper_uncertainty = upper_uncertainty
+        self.confidence_level = confidence_level
+
+    def __bool__(self):
+        """
+        Boolean testing for QuantityError.
+
+        QuantityError evaluates ``True`` if any of the default fields is not
+        ``None``.
+
+        >>> err = QuantityError()
+        >>> bool(err)
+        False
+        >>> err.custom_field = "spam"
+        >>> bool(err)
+        False
+        >>> err.uncertainty = 0.05
+        >>> bool(err)
+        True
+        >>> del err.custom_field
+        >>> bool(err)
+        True
+        """
+        return any([getattr(self, key) is not None for key in self.defaults])
+
+    # Python 2 compatibility
+    __nonzero__ = __bool__
 
 
 def _bool(value):
@@ -131,8 +179,9 @@ def _event_type_class_factory(class_name, class_attributes=[],
         ValueError: Setting attribute "some_letters" failed. ...
 
     If you pass ``ATTRIBUTE_HAS_ERRORS`` as the third tuple item for the
-    class_attributes, an error QuantityError will be be created that will be
-    named like the attribute with "_errors" appended.
+    class_attributes, a error (type
+    :class:`~obspy.core.event.base.QuantityError`) will be be created that will
+    be named like the attribute with "_errors" appended.
 
         >>> assert(hasattr(test_event, "some_error_quantity_errors"))
         >>> test_event.some_error_quantity_errors  # doctest: +ELLIPSIS
@@ -218,11 +267,11 @@ def _event_type_class_factory(class_name, class_attributes=[],
                 repr_str = value.__repr__()
                 # Print any associated errors.
                 error_key = key + "_errors"
-                if hasattr(self, error_key) and\
-                   _bool(getattr(self, error_key)):
+                if self.get(error_key, False):
                     err_items = sorted(getattr(self, error_key).items())
                     repr_str += " [%s]" % ', '.join(
-                        [str(k) + "=" + str(v) for k, v in err_items])
+                        sorted([str(k) + "=" + str(v) for k, v in err_items
+                                if v is not None]))
                 return repr_str
 
             # Case 2: Short representation for small objects. Will just print a
@@ -872,28 +921,28 @@ class CompositeTime(__CompositeTime):
 
     :type year: int
     :param year: Year or range of years of the event's focal time.
-    :type year_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type year_errors: :class:`~obspy.core.event.base.QuantityError`
     :param year_errors: AttribDict containing error quantities.
     :type month: int
     :param month: Month or range of months of the event’s focal time.
-    :type month_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type month_errors: :class:`~obspy.core.event.base.QuantityError`
     :param month_errors: AttribDict containing error quantities.
     :type day: int
     :param day: Day or range of days of the event’s focal time.
-    :type day_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type day_errors: :class:`~obspy.core.event.base.QuantityError`
     :param day_errors: AttribDict containing error quantities.
     :type hour: int
     :param hour: Hour or range of hours of the event’s focal time.
-    :type hour_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type hour_errors: :class:`~obspy.core.event.base.QuantityError`
     :param hour_errors: AttribDict containing error quantities.
     :type minute: int
     :param minute: Minute or range of minutes of the event’s focal time.
-    :type minute_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type minute_errors: :class:`~obspy.core.event.base.QuantityError`
     :param minute_errors: AttribDict containing error quantities.
     :type second: float
     :param second: Second and fraction of seconds or range of seconds with
         fraction of the event’s focal time.
-    :type second_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type second_errors: :class:`~obspy.core.event.base.QuantityError`
     :param second_errors: AttribDict containing error quantities.
 
     >>> print(CompositeTime(2011, 1, 1))

--- a/obspy/core/event/magnitude.py
+++ b/obspy/core/event/magnitude.py
@@ -63,7 +63,7 @@ class Magnitude(__Magnitude):
     :param mag: Resulting magnitude value from combining values of type
         :class:`~obspy.core.event.StationMagnitude`. If no estimations are
         available, this value can represent the reported magnitude.
-    :type mag_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type mag_errors: :class:`~obspy.core.event.base.QuantityError`
     :param mag_errors: AttribDict containing error quantities.
     :type magnitude_type: str, optional
     :param magnitude_type: Describes the type of magnitude. This is a free-text
@@ -156,7 +156,7 @@ class StationMagnitude(__StationMagnitude):
         StationMagnitude has an associated :class:`~obspy.core.event.Origin`.
     :type mag: float
     :param mag: Estimated magnitude.
-    :type mag_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type mag_errors: :class:`~obspy.core.event.base.QuantityError`
     :param mag_errors: AttribDict containing error quantities.
     :type station_magnitude_type: str, optional
     :param station_magnitude_type: See :class:`~obspy.core.event.Magnitude`
@@ -266,7 +266,7 @@ class Amplitude(__Amplitude):
         here. For clarity, using the optional unit attribute is highly
         encouraged.
     :type generic_amplitude_errors:
-        :class:`~obspy.core.util.attribdict.AttribDict`
+        :class:`~obspy.core.event.base.QuantityError`
     :param generic_amplitude_errors: AttribDict containing error quantities.
     :type type: str, optional
     :param type: Describes the type of amplitude using the nomenclature from
@@ -331,7 +331,7 @@ class Amplitude(__Amplitude):
         the waveform stream referenced by ``waveform_id``.
     :type scaling_time: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
     :param scaling_time: Scaling time for amplitude measurement.
-    :type scaling_time_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type scaling_time_errors: :class:`~obspy.core.event.base.QuantityError`
     :param scaling_time_errors: AttribDict containing error quantities.
     :type magnitude_hint: str, optional
     :param magnitude_hint: Type of magnitude the amplitude measurement is used

--- a/obspy/core/event/origin.py
+++ b/obspy/core/event/origin.py
@@ -194,17 +194,17 @@ class Origin(__Origin):
         `resource_id` attribute in case it is not specified will be skipped.
     :type time: :class:`~obspy.core.utcdatetime.UTCDateTime`
     :param time: Focal time.
-    :type time_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type time_errors: :class:`~obspy.core.event.base.QuantityError`
     :param time_errors: AttribDict containing error quantities.
     :type longitude: float
     :param longitude: Hypocenter longitude, with respect to the World Geodetic
         System 1984 (WGS84) reference system. Unit: deg
-    :type longitude_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type longitude_errors: :class:`~obspy.core.event.base.QuantityError`
     :param longitude_errors: AttribDict containing error quantities.
     :type latitude: float
     :param latitude: Hypocenter latitude, with respect to the WGS84 reference
         system. Unit: deg
-    :type latitude_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type latitude_errors: :class:`~obspy.core.event.base.QuantityError`
     :param latitude_errors: AttribDict containing error quantities.
     :type depth: float, optional
     :param depth: Depth of hypocenter with respect to the nominal sea level
@@ -214,7 +214,7 @@ class Origin(__Origin):
         As an example, GSE2.0, defines depth with respect to the local surface.
         If event data is converted from other formats to QuakeML, depth values
         may have to be modified accordingly. Unit: m
-    :type depth_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type depth_errors: :class:`~obspy.core.event.base.QuantityError`
     :param depth_errors: AttribDict containing error quantities.
     :type depth_type: str, optional
     :param depth_type: Type of depth determination. Allowed values are the
@@ -312,6 +312,7 @@ class Origin(__Origin):
     >>> origin.resource_id = 'smi:ch.ethz.sed/origin/37465'
     >>> origin.time = UTCDateTime(0)
     >>> origin.latitude = 12
+    >>> origin.latitude_errors.uncertainty = 0.01
     >>> origin.latitude_errors.confidence_level = 95.0
     >>> origin.longitude = 42
     >>> origin.depth_type = 'from location'
@@ -320,7 +321,7 @@ class Origin(__Origin):
         resource_id: ResourceIdentifier(id="smi:ch.ethz.sed/...")
                time: UTCDateTime(1970, 1, 1, 0, 0)
           longitude: 42.0
-           latitude: 12.0 [confidence_level=95.0]
+           latitude: 12.0 [confidence_level=95.0, uncertainty=0.01]
          depth_type: ...'from location'
 
     .. note::
@@ -362,7 +363,7 @@ class Pick(__Pick):
         `resource_id` attribute in case it is not specified will be skipped.
     :type time: :class:`~obspy.core.utcdatetime.UTCDateTime`
     :param time: Observed onset time of signal (“pick time”).
-    :type time_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type time_errors: :class:`~obspy.core.event.base.QuantityError`
     :param time_errors: AttribDict containing error quantities.
     :type waveform_id: :class:`~obspy.core.event.WaveformStreamID`
     :param waveform_id: Identifies the waveform stream.
@@ -376,12 +377,12 @@ class Pick(__Pick):
     :param horizontal_slowness: Observed horizontal slowness of the signal.
         Most relevant in array measurements. Unit: s·deg^(−1)
     :type horizontal_slowness_errors:
-        :class:`~obspy.core.util.attribdict.AttribDict`
+        :class:`~obspy.core.event.base.QuantityError`
     :param horizontal_slowness_errors: AttribDict containing error quantities.
     :type backazimuth: float, optional
     :param backazimuth: Observed backazimuth of the signal. Most relevant in
         array measurements. Unit: deg
-    :type backazimuth_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type backazimuth_errors: :class:`~obspy.core.event.base.QuantityError`
     :param backazimuth_errors: AttribDict containing error quantities.
     :type slowness_method_id: :class:`~obspy.core.event.ResourceIdentifier`,
         optional
@@ -491,7 +492,7 @@ class Arrival(__Arrival):
     :type takeoff_angle: float, optional
     :param takeoff_angle: Angle of emerging ray at the source, measured against
         the downward normal direction. Unit: deg
-    :type takeoff_angle_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type takeoff_angle_errors: :class:`~obspy.core.event.base.QuantityError`
     :param takeoff_angle_errors: AttribDict containing error quantities.
     :type time_residual: float, optional
     :param time_residual: Residual between observed and expected arrival time

--- a/obspy/core/event/source.py
+++ b/obspy/core/event/source.py
@@ -49,18 +49,18 @@ class Axis(__Axis):
     :param azimuth: Azimuth of eigenvector of moment tensor expressed in
         principal-axes system. Measured clockwise from South-North direction at
         epicenter. Unit: deg
-    :type azimuth_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type azimuth_errors: :class:`~obspy.core.event.base.QuantityError`
     :param azimuth_errors: AttribDict containing error quantities.
     :type plunge: float
     :param plunge: Plunge of eigenvector of moment tensor expressed in
         principal-axes system. Measured against downward vertical direction at
         epicenter. Unit: deg
-    :type plunge_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type plunge_errors: :class:`~obspy.core.event.base.QuantityError`
     :param plunge_errors: AttribDict containing error quantities.
     :type length: float
     :param length: Eigenvalue of moment tensor expressed in principal-axes
         system. Unit: Nm
-    :type length_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type length_errors: :class:`~obspy.core.event.base.QuantityError`
     :param length_errors: AttribDict containing error quantities.
 
     .. note::
@@ -85,15 +85,15 @@ class NodalPlane(__NodalPlane):
 
     :type strike: float
     :param strike: Strike angle of nodal plane. Unit: deg
-    :type strike_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type strike_errors: :class:`~obspy.core.event.base.QuantityError`
     :param strike_errors: AttribDict containing error quantities.
     :type dip: float
     :param dip: Dip angle of nodal plane. Unit: deg
-    :type dip_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type dip_errors: :class:`~obspy.core.event.base.QuantityError`
     :param dip_errors: AttribDict containing error quantities.
     :type rake: float
     :param rake: Rake angle of nodal plane. Unit: deg
-    :type rake_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type rake_errors: :class:`~obspy.core.event.base.QuantityError`
     :param rake_errors: AttribDict containing error quantities.
 
     .. note::
@@ -180,27 +180,27 @@ class Tensor(__Tensor):
 
     :type m_rr: float
     :param m_rr: Moment-tensor element Mrr. Unit: Nm
-    :type m_rr_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_rr_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_rr_errors: AttribDict containing error quantities.
     :type m_tt: float
     :param m_tt: Moment-tensor element Mtt. Unit: Nm
-    :type m_tt_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_tt_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_tt_errors: AttribDict containing error quantities.
     :type m_pp: float
     :param m_pp: Moment-tensor element Mpp. Unit: Nm
-    :type m_pp_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_pp_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_pp_errors: AttribDict containing error quantities.
     :type m_rt: float
     :param m_rt: Moment-tensor element Mrt. Unit: Nm
-    :type m_rt_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_rt_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_rt_errors: AttribDict containing error quantities.
     :type m_rp: float
     :param m_rp: Moment-tensor element Mrp. Unit: Nm
-    :type m_rp_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_rp_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_rp_errors: AttribDict containing error quantities.
     :type m_tp: float
     :param m_tp: Moment-tensor element Mtp. Unit: Nm
-    :type m_tp_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type m_tp_errors: :class:`~obspy.core.event.base.QuantityError`
     :param m_tp_errors: AttribDict containing error quantities.
 
     .. note::
@@ -289,7 +289,7 @@ class MomentTensor(__MomentTensor):
     :type scalar_moment: float, optional
     :param scalar_moment: Scalar moment as derived in moment tensor inversion.
         Unit: Nm
-    :type scalar_moment_errors: :class:`~obspy.core.util.attribdict.AttribDict`
+    :type scalar_moment_errors: :class:`~obspy.core.event.base.QuantityError`
     :param scalar_moment_errors: AttribDict containing error quantities.
     :type tensor: :class:`~obspy.core.event.Tensor`, optional
     :param tensor: Tensor object holding the moment tensor elements.

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -17,6 +17,7 @@ from obspy.core.event import (Catalog, Comment, CreationInfo, Event, Origin,
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util.base import get_basemap_version, get_cartopy_version
 from obspy.core.util.testing import ImageComparison
+from obspy.core.event.base import QuantityError
 
 BASEMAP_VERSION = get_basemap_version()
 
@@ -846,6 +847,26 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             {})
 
 
+class BaseTestCase(unittest.TestCase):
+    """
+    Test suite for obspy.core.event.base.
+    """
+    def test_quantity_error_warn_on_non_default_key(self):
+        """
+        """
+        err = QuantityError()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            err.uncertainty = 0.01
+            err.lower_uncertainty = 0.1
+            err.upper_uncertainty = 0.02
+            err.confidence_level = 80
+            self.assertEqual(len(w), 0)
+            # setting a typoed or custom field should warn!
+            err.confidence_levle = 80
+            self.assertEqual(len(w), 1)
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(CatalogTestCase, 'test'))
@@ -855,6 +876,7 @@ def suite():
     suite.addTest(unittest.makeSuite(OriginTestCase, 'test'))
     suite.addTest(unittest.makeSuite(WaveformStreamIDTestCase, 'test'))
     suite.addTest(unittest.makeSuite(ResourceIdentifierTestCase, 'test'))
+    suite.addTest(unittest.makeSuite(BaseTestCase, 'test'))
     return suite
 
 

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -14,6 +14,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 
 import collections
 import copy
+import warnings
 
 
 class AttribDict(collections.MutableMapping):
@@ -43,6 +44,7 @@ class AttribDict(collections.MutableMapping):
     """
     defaults = {}
     readonly = []
+    warn_on_non_default_key = False
 
     def __init__(self, *args, **kwargs):
         """
@@ -80,6 +82,10 @@ class AttribDict(collections.MutableMapping):
         if key in self.readonly:
             msg = 'Attribute "%s" in %s object is read only!'
             raise AttributeError(msg % (key, self.__class__.__name__))
+        if self.warn_on_non_default_key and key not in self.defaults:
+            msg = ('Setting attribute "{}" which is not a default attribute '
+                   '("{}").').format(key, '", "'.join(self.defaults.keys()))
+            warnings.warn(msg)
 
         if isinstance(value, collections.Mapping) and \
            not isinstance(value, AttribDict):


### PR DESCRIPTION
Also improved class structure for QuantityError, and warning on setting a non-expected attribute (I think we should do this for all Event-type objects -- quite a few times I've seen people wondering why they're setting some attribute wasn't working, just to find out that it was just a typo in the attribute name).