### PR TITLE
unable to read large mseed file

### DIFF
--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -374,7 +374,7 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
         verbose = 0
 
     lil = clibmseed.readMSEEDBuffer(
-        bfr_np, buflen, selections, C.c_int8(unpack_data),
+        bfr_np, C.c_ulonglong(buflen), selections, C.c_int8(unpack_data),
         reclen, C.c_int8(verbose), C.c_int8(details), header_byteorder,
         alloc_data, diag_print, log_print)
 

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -701,7 +701,7 @@ LinkedIDList._fields_ = [
 clibmseed.readMSEEDBuffer.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.int8, ndim=1,
                            flags=native_str('C_CONTIGUOUS')),
-    C.c_int,
+    C.c_ulonglong,
     C.POINTER(Selections),
     C.c_int8,
     C.c_int,

--- a/obspy/io/mseed/src/libmseed/doc/ms_find_reclen.3
+++ b/obspy/io/mseed/src/libmseed/doc/ms_find_reclen.3
@@ -6,7 +6,8 @@ Determine SEED record data length
 .nf
 .B #include <libmseed.h>
 
-.BI "int  \fBms_find_reclen\fP ( const char *" recbuf ", int " recbuflen ",
+.BI "int  \fBms_find_reclen\fP ( const char *" recbuf ",
+.BI                              unsigned long long " recbuflen ",
 .BI "                            FILE " *fileptr " );
 .fi
 

--- a/obspy/io/mseed/src/libmseed/doc/msr_parse.3
+++ b/obspy/io/mseed/src/libmseed/doc/msr_parse.3
@@ -6,10 +6,12 @@ Detect and parse a SEED data record from a memory buffer
 .nf
 .B #include <libmseed.h>
 
-.BI "int  \fBmsr_parse\fP ( char *" record ", int " recbuflen ", MSRecord " **ppmsr "," 
+.BI "int  \fBmsr_parse\fP ( char *" record ",
+.BI                   unsigned long long " recbuflen ", MSRecord " **ppmsr ","
 .BI "                 int " reclen ", flag " dataflag ", flag " verbose " );"
 
-.BI "int  \fBmsr_parse_selection\fP ( char *" recbuf ", int " recbuflen ","
+.BI "int  \fBmsr_parse_selection\fP ( char *" recbuf ",
+.BI                             unsinged long long " recbuflen ","
 .BI "                           int64_t *" offset ", MSRecord " **ppmsr ","
 .BI "                           int " reclen ", Selections *" selections ","
 .BI "                           flag " dataflag ", flag " verbose " );"

--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -520,10 +520,12 @@ extern int unpackencodingfallback;
 #define MS_UNPACKENCODINGFALLBACK(X) (unpackencodingfallback = X);
 
 /* Mini-SEED record related functions */
-extern int           msr_parse (char *record, int recbuflen, MSRecord **ppmsr, int reclen,
+extern int           msr_parse (char *record, unsigned long long recbuflen,
+				MSRecord **ppmsr, int reclen,
 				flag dataflag, flag verbose);
 
-extern int           msr_parse_selection ( char *recbuf, int recbuflen, int64_t *offset,
+extern int           msr_parse_selection ( char *recbuf,
+					   unsigned long long recbuflen, int64_t *offset,
 					   MSRecord **ppmsr, int reclen,
 					   Selections *selections, flag dataflag, flag verbose );
 
@@ -553,7 +555,7 @@ extern char*         msr_srcname (MSRecord *msr, char *srcname, flag quality);
 extern void          msr_print (MSRecord *msr, flag details);
 extern double        msr_host_latency (MSRecord *msr);
 
-extern int           ms_detect (const char *record, int recbuflen);
+extern int           ms_detect (const char *record, unsigned long long recbuflen);
 extern int           ms_parse_raw (char *record, int maxreclen, flag details, flag swapflag);
 
 

--- a/obspy/io/mseed/src/libmseed/parseutils.c
+++ b/obspy/io/mseed/src/libmseed/parseutils.c
@@ -41,8 +41,8 @@
  *  <0 : libmseed error code (listed in libmseed.h) is returned.
  *********************************************************************/
 int
-msr_parse ( char *record, int recbuflen, MSRecord **ppmsr, int reclen,
-	    flag dataflag, flag verbose )
+msr_parse ( char *record, unsigned long long recbuflen, MSRecord **ppmsr,
+            int reclen, flag dataflag, flag verbose )
 {
   int detlen = 0;
   int retcode = 0;
@@ -144,8 +144,8 @@ msr_parse ( char *record, int recbuflen, MSRecord **ppmsr, int reclen,
  * returned when end-of-buffer is reached.
  *********************************************************************/
 int
-msr_parse_selection ( char *recbuf, int recbuflen, int64_t *offset,
-		      MSRecord **ppmsr, int reclen,
+msr_parse_selection ( char *recbuf, unsigned long long recbuflen,
+                      int64_t *offset, MSRecord **ppmsr, int reclen,
 		      Selections *selections, flag dataflag, flag verbose )
 {
   int retval = MS_GENERROR;
@@ -228,7 +228,7 @@ msr_parse_selection ( char *recbuf, int recbuflen, int64_t *offset,
  * >0 : size of the record in bytes
  *********************************************************************/
 int
-ms_detect ( const char *record, int recbuflen )
+ms_detect ( const char *record, unsigned long long recbuflen )
 {
   uint16_t blkt_offset;    /* Byte offset for next blockette */
   uint8_t swapflag  = 0;   /* Byte swapping flag */

--- a/obspy/io/mseed/src/libmseed/parseutils.c
+++ b/obspy/io/mseed/src/libmseed/parseutils.c
@@ -54,7 +54,7 @@ msr_parse ( char *record, unsigned long long recbuflen, MSRecord **ppmsr,
     return MS_GENERROR;
   
   /* Sanity check: record length cannot be larger than buffer */
-  if ( reclen > 0 && reclen > recbuflen )
+  if ( reclen > 0 && (unsigned int) reclen > recbuflen )
     {
       ms_log (2, "ms_parse() Record length (%d) cannot be larger than buffer (%d)\n",
 	      reclen, recbuflen);
@@ -96,7 +96,7 @@ msr_parse ( char *record, unsigned long long recbuflen, MSRecord **ppmsr,
     }
   
   /* Check if more data is required, return hint */
-  if ( reclen > recbuflen )
+  if ( (unsigned int) reclen > recbuflen )
     {
       if ( verbose > 2 )
 	ms_log (1, "Detected %d byte record, need %d more bytes\n",
@@ -162,7 +162,7 @@ msr_parse_selection ( char *recbuf, unsigned long long recbuflen,
   if ( ! offset )
     return MS_GENERROR;
   
-  while ( *offset < recbuflen )
+  while ( (unsigned long long)*offset < recbuflen )
     {
       retval = msr_parse (recbuf+*offset, (int)(recbuflen-*offset), ppmsr, reclen, 0, verbose);
       
@@ -276,7 +276,7 @@ ms_detect ( const char *record, unsigned long long recbuflen )
       
       /* Found a 1000 blockette, not truncated */
       if ( blkt_type == 1000  &&
-	   (int)(blkt_offset + 4 + sizeof(struct blkt_1000_s)) <= recbuflen )
+	   (unsigned long long)(blkt_offset + 4 + sizeof(struct blkt_1000_s)) <= recbuflen )
 	{
           blkt_1000 = (struct blkt_1000_s *) (record + blkt_offset + 4);
 	  
@@ -306,7 +306,7 @@ ms_detect ( const char *record, unsigned long long recbuflen )
       nextfsdh = record + MINRECLEN;
       
       /* Check for record header or blank/noise record at MINRECLEN byte offsets */
-      while ( ((nextfsdh - record) + 48) < recbuflen )
+      while ( (unsigned long long)((nextfsdh - record) + 48) < recbuflen )
 	{
 	  if ( MS_ISVALIDHEADER(nextfsdh) || MS_ISVALIDBLANK(nextfsdh) )
             {

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -183,9 +183,10 @@ void empty_print(char *string) {}
 // Function that reads from a MiniSEED binary file from a char buffer and
 // returns a LinkedIDList.
 LinkedIDList *
-readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
-                 unpack_data, int reclen, flag verbose, flag details,
-                 int header_byteorder, long long (*allocData) (int, char),
+readMSEEDBuffer (char *mseed, unsigned long long buflen,
+                 Selections *selections, flag unpack_data, int reclen,
+                 flag verbose, flag details, int header_byteorder,
+                 long long (*allocData) (int, char),
                  void (*diag_print) (char*), void (*log_print) (char*))
 {
     int retcode = 0;
@@ -193,7 +194,7 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
     flag swapflag = 0;
 
     // current offset of mseed char pointer
-    int offset = 0;
+    unsigned long long offset = 0;
 
     // Unpack without reading the data first
     flag dataflag = 0;

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -214,12 +214,12 @@ readMSEEDBuffer (char *mseed, unsigned long long buflen,
     hptime_t lastgap = 0;
     hptime_t hptimetol = 0;
     hptime_t nhptimetol = 0;
-    long long data_offset;
+    unsigned long long data_offset;
     LinkedRecordList *recordHead = NULL;
     LinkedRecordList *recordPrevious = NULL;
     LinkedRecordList *recordCurrent = NULL;
-    int datasize;
-    int record_count = 0;
+    unsigned int datasize;
+    unsigned long long record_count = 0;
 
     // A negative verbosity suppressed as much as possible.
     if (verbose < 0) {


### PR DESCRIPTION
When I'm trying to read large mseed file (3 to 8 GB)

`st = obspy.read('./mseed/TM_TMDB_2012.mseed')`

> <decorator-gen-155> in read(pathname_or_url, format, headonly, starttime, endtime, nearest_sample, dtype, apply_calib, **kwargs)
> 
> /home/user/anaconda/lib/python2.7/site-packages/obspy/core/util/decorator.pyc in _map_example_filename(func, _args, *_kwargs)
>     287                         except IOError:
>     288                             pass
> --> 289         return func(_args, *_kwargs)
>     290     return _map_example_filename
>     291 
> 
> /home/user/anaconda/lib/python2.7/site-packages/obspy/core/stream.pyc in read(pathname_or_url, format, headonly, starttime, endtime, nearest_sample, dtype, apply_calib, **kwargs)
>     241             # set start/end time. Not sure what to do in this case.
>     242             elif not starttime and not endtime:
> --> 243                 raise Exception("Cannot open file/files: %s" % pathname)
>     244     # Trim if times are given.
>     245     if headonly and (starttime or endtime or dtype):
> 
> Exception: Cannot open file/files: ./mseed/TM_TMDB_2012.mseed

If I specify the `starttime` and/or `endtime`, no exceptions raise but it returns an empty Stream without Traces.
