### PR TITLE
mass_downloader throws error with SCEDC station and waveform web services

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1663,6 +1663,11 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
     if debug is True:
         print("Downloading %s %s requesting gzip compression" % (
             url, "with" if use_gzip else "without"))
+        if data:
+            print("Sending along the following payload:")
+            print("-" * 70)
+            print(data.decode())
+            print("-" * 70)
 
     try:
         request = urllib.request.Request(url=url, headers=headers)


### PR DESCRIPTION
Hi,

I am using obspy version 1.0.1 and python2.7, installed via Anaconda, on a RHEL 6 machine. I am reproducing an error that one of our users reported. When using obspy.clients.fdsn.mass_downloader (with debug=True), I do not see any data returned back. This is specifically for the station and waveform queries. Running the same queries individually using obspy.fdsn.Client (with debug=True) returns data successfully. 

I am unable to detect where the issue might be. Could you please help me with debugging further or making the debugging more verbose? I have attached the following with this  bug:

1. script with mass_downloader (try-RTTracker-3258.py)
2. output of running 1. (try-RTTracker-3258.out)
3. script with obspy.fdsn.Client (try-obspy.py)
4. output of running 3. (try-obspy.out)

regards,
Aparna









[try-RTTracker-3258.py.txt](https://github.com/obspy/obspy/files/268858/try-RTTracker-3258.py.txt)
[try-RTTracker-3258.out.txt](https://github.com/obspy/obspy/files/268855/try-RTTracker-3258.out.txt)
[try-obspy.py.txt](https://github.com/obspy/obspy/files/268856/try-obspy.py.txt)
[try-obspy.out.txt](https://github.com/obspy/obspy/files/268857/try-obspy.out.txt)
