### PR TITLE
Possible memory leak in remove_response() (numpy FFT cache growing)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
 1.0.2: (doi: 10.5281/zenodo.49636)
+ - obspy.core:
+   * Added workaround for numpy issue where many FFTs of various lengths fill
+     a cache that never gets cleared, effectively creating a memory leak
+     (see #1424).
  - obspy.clients.fdsn:
    * Fixing issue with location codes potentially resulting in unwanted data
      to be requested. (see #1422)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -27,7 +27,8 @@ from obspy.core.util import AttribDict, create_empty_data_chunk
 from obspy.core.util.base import _get_function_from_entry_point
 from obspy.core.util.decorator import (
     deprecated, raise_if_masked, skip_if_no_data)
-from obspy.core.util.misc import flat_not_masked_contiguous, get_window_times
+from obspy.core.util.misc import (flat_not_masked_contiguous, get_window_times,
+                                  limit_numpy_fft_cache)
 
 
 class Stats(AttribDict):
@@ -2579,6 +2580,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             plot is saved to file (filename must have a valid image suffix
             recognizable by matplotlib e.g. '.png').
         """
+        limit_numpy_fft_cache()
+
         from obspy.core.inventory import PolynomialResponseStage
         from obspy.signal.invsim import (cosine_taper, cosine_sac_taper,
                                          invert_spectrum)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -520,7 +520,7 @@ def limit_numpy_fft_cache(max_size_in_mb_per_cache=100):
         try:
             total_size = sum([_j.nbytes for _i in cache.values() for _j in _i])
         except:
-            pass
+            continue
         if total_size > max_size_in_mb_per_cache * 1024 * 1024:
             cache.clear()
 


### PR DESCRIPTION
I'm trying to use ObsPy to remove the instrument response from a whole year of data of a station, so I wrote a python script that loops over the miniseed files and apply the relevant functions. What I found out is that after a while the script gets killed by the kernel's out of memory killer. Indeed the memory it uses grows indefinitely during the iterations.

I wrote a minimal example that is able to reproduce this issue, you'll be able to see the memory growing using `top` or similar tools. 

```python
#!/usr/bin/python

from __future__ import print_function
import sys

import obspy
import obspy.clients.fdsn

for i in range(1,365):

    t = obspy.UTCDateTime(year=2014, julday=i)

    client = obspy.clients.fdsn.Client('IPGP')
    st = client.get_waveforms(network="G", station="CCD", location="00", channel="BHZ", starttime=t, endtime=(t + 86400), attach_response=True)

    tr = st[0]

    tr.remove_response()

    print('.', end="")
    sys.stdout.flush()
```

I'm using python-obspy 1.0.1 from the `deb.obspy.org` Debian repository on an up-to-date Debian "sid" system:

```
~ $ uname -a
Linux mandragola 4.5.0-2-amd64 #1 SMP Debian 4.5.4-1 (2016-05-16) x86_64 GNU/Linux
~ $ python --version
Python 2.7.11+
```

Unfortunately I can't try the python3 module, as it doesn't work with Python 3.5 (lacks `libmseed_Linux_64bit_py35.cpython-34m.so`)

I'm willing to help in solving this issue, so if you need any other information just let me know.

Thank you!
