### PR TITLE
Event-type objects: warn when setting non-default attribute

### DIFF
--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -200,6 +200,9 @@ def _event_type_class_factory(class_name, class_attributes=[],
         for key, value in _properties:
             _property_dict[key] = value
         _containers = class_contains
+        warn_on_non_default_key = True
+        defaults = dict.fromkeys(class_contains, [])
+        defaults.update(dict.fromkeys(_property_keys, None))
 
         def __init__(self, *args, **kwargs):
             # Make sure the args work as expected. Therefore any specified

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -298,7 +298,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
             if containers:
                 # Print delimiter only if there are attributes.
                 if attributes:
-                    ret_str += '\n\t---------'
+                    ret_str += '\n\t' + '---------'.rjust(max_length + 5)
                 element_str = "%" + str(max_length) + "s: %i Elements"
                 ret_str += "\n\t" + \
                     "\n\t".join(

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -203,6 +203,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
         warn_on_non_default_key = True
         defaults = dict.fromkeys(class_contains, [])
         defaults.update(dict.fromkeys(_property_keys, None))
+        do_not_warn_on = ["extra"]
 
         def __init__(self, *args, **kwargs):
             # Make sure the args work as expected. Therefore any specified

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -561,6 +561,9 @@ class ResourceIdentifier(object):
             self.fixed = False
             self._prefix = prefix
             self._uuid = str(uuid4())
+        elif isinstance(id, ResourceIdentifier):
+            self.__dict__.update(id.__dict__)
+            return
         else:
             self.fixed = True
             self.id = id

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -144,6 +144,8 @@ class Event(__Event):
         standard and how to output it to QuakeML see the
         :ref:`ObsPy Tutorial <quakeml-extra>`.
     """
+    do_not_warn_on = ["_format", "extra"]
+
     def short_str(self):
         """
         Returns a short string representation of the current Event.

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -34,7 +34,10 @@ __Event = _event_type_class_factory(
     class_attributes=[("resource_id", ResourceIdentifier),
                       ("event_type", EventType),
                       ("event_type_certainty", EventTypeCertainty),
-                      ("creation_info", CreationInfo)],
+                      ("creation_info", CreationInfo),
+                      ("preferred_origin_id", str),
+                      ("preferred_magnitude_id", str),
+                      ("preferred_focal_mechanism_id", str)],
     class_contains=['event_descriptions', 'comments', 'picks', 'amplitudes',
                     'focal_mechanisms', 'origins', 'magnitudes',
                     'station_magnitudes'])
@@ -182,31 +185,28 @@ class Event(__Event):
         """
         Returns the preferred origin
         """
-        try:
-            return ResourceIdentifier(self.preferred_origin_id).\
-                get_referred_object()
-        except AttributeError:
+        if self.preferred_origin_id is None:
             return None
+        return ResourceIdentifier(self.preferred_origin_id).\
+            get_referred_object()
 
     def preferred_magnitude(self):
         """
         Returns the preferred magnitude
         """
-        try:
-            return ResourceIdentifier(self.preferred_magnitude_id).\
-                get_referred_object()
-        except AttributeError:
+        if self.preferred_magnitude_id is None:
             return None
+        return ResourceIdentifier(self.preferred_magnitude_id).\
+            get_referred_object()
 
     def preferred_focal_mechanism(self):
         """
         Returns the preferred focal mechanism
         """
-        try:
-            return ResourceIdentifier(self.preferred_focal_mechanism_id).\
-                get_referred_object()
-        except AttributeError:
+        if self.preferred_focal_mechanism_id is None:
             return None
+        return ResourceIdentifier(self.preferred_focal_mechanism_id).\
+            get_referred_object()
 
     def plot(self, kind=[['ortho', 'beachball'], ['p_sphere', 's_sphere']],
              subplot_size=4.0, show=True, outfile=None, **kwargs):

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -35,9 +35,9 @@ __Event = _event_type_class_factory(
                       ("event_type", EventType),
                       ("event_type_certainty", EventTypeCertainty),
                       ("creation_info", CreationInfo),
-                      ("preferred_origin_id", str),
-                      ("preferred_magnitude_id", str),
-                      ("preferred_focal_mechanism_id", str)],
+                      ("preferred_origin_id", ResourceIdentifier),
+                      ("preferred_magnitude_id", ResourceIdentifier),
+                      ("preferred_focal_mechanism_id", ResourceIdentifier)],
     class_contains=['event_descriptions', 'comments', 'picks', 'amplitudes',
                     'focal_mechanisms', 'origins', 'magnitudes',
                     'station_magnitudes'])
@@ -189,8 +189,7 @@ class Event(__Event):
         """
         if self.preferred_origin_id is None:
             return None
-        return ResourceIdentifier(self.preferred_origin_id).\
-            get_referred_object()
+        return self.preferred_origin_id.get_referred_object()
 
     def preferred_magnitude(self):
         """
@@ -198,8 +197,7 @@ class Event(__Event):
         """
         if self.preferred_magnitude_id is None:
             return None
-        return ResourceIdentifier(self.preferred_magnitude_id).\
-            get_referred_object()
+        return self.preferred_magnitude_id.get_referred_object()
 
     def preferred_focal_mechanism(self):
         """
@@ -207,8 +205,7 @@ class Event(__Event):
         """
         if self.preferred_focal_mechanism_id is None:
             return None
-        return ResourceIdentifier(self.preferred_focal_mechanism_id).\
-            get_referred_object()
+        return self.preferred_focal_mechanism_id.get_referred_object()
 
     def plot(self, kind=[['ortho', 'beachball'], ['p_sphere', 's_sphere']],
              subplot_size=4.0, show=True, outfile=None, **kwargs):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -846,6 +846,16 @@ class ResourceIdentifierTestCase(unittest.TestCase):
                 ResourceIdentifier._ResourceIdentifier__resource_id_weak_dict),
             {})
 
+    def test_initialize_with_resource_identifier(self):
+        """
+        Test initializing an ResourceIdentifier with an ResourceIdentifier.
+        """
+        rid = ResourceIdentifier()
+        rid2 = ResourceIdentifier(str(rid))
+        rid3 = ResourceIdentifier(rid)
+        self.assertEqual(rid, rid2)
+        self.assertEqual(rid, rid3)
+
 
 class BaseTestCase(unittest.TestCase):
     """

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -45,6 +45,7 @@ class AttribDict(collections.MutableMapping):
     defaults = {}
     readonly = []
     warn_on_non_default_key = False
+    do_not_warn_on = []
 
     def __init__(self, *args, **kwargs):
         """
@@ -82,10 +83,18 @@ class AttribDict(collections.MutableMapping):
         if key in self.readonly:
             msg = 'Attribute "%s" in %s object is read only!'
             raise AttributeError(msg % (key, self.__class__.__name__))
-        if self.warn_on_non_default_key and key not in self.defaults:
-            msg = ('Setting attribute "{}" which is not a default attribute '
-                   '("{}").').format(key, '", "'.join(self.defaults.keys()))
-            warnings.warn(msg)
+        if self.warn_on_non_default_key:
+            # issue warning if not a default key
+            # (and not in the list of exceptions)
+            if key in self.defaults:
+                pass
+            elif key in self.do_not_warn_on:
+                pass
+            else:
+                msg = ('Setting attribute "{}" which is not a default '
+                       'attribute ("{}").').format(
+                            key, '", "'.join(self.defaults.keys()))
+                warnings.warn(msg)
 
         if isinstance(value, collections.Mapping) and \
            not isinstance(value, AttribDict):

--- a/obspy/io/kml/tests/data/catalog.kml
+++ b/obspy/io/kml/tests/data/catalog.kml
@@ -45,13 +45,15 @@
         </Point>
         <description>Event:	2012-04-04T14:21:42.300000Z | +41.818,  +79.689 | 4.4 mb | manual
 
-	        resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000041")
-	         event_type: 'not reported'
-	      creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	---------
-	 event_descriptions: 1 Elements
-	            origins: 1 Elements
-	         magnitudes: 1 Elements</description>
+	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000041")
+	             event_type: 'not reported'
+	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
+	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261020/782484'
+	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261020/782484/796646'
+	                  ---------
+	     event_descriptions: 1 Elements
+	                origins: 1 Elements
+	             magnitudes: 1 Elements</description>
         <TimeStamp>2012-04-04T14:21:42.300000Z</TimeStamp>
       </Placemark>
       <Placemark>
@@ -70,13 +72,15 @@
         </Point>
         <description>Event:	2012-04-04T14:18:37.000000Z | +39.342,  +41.044 | 4.3 ML | manual
 
-	        resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000038")
-	         event_type: 'not reported'
-	      creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	---------
-	 event_descriptions: 1 Elements
-	            origins: 1 Elements
-	         magnitudes: 1 Elements</description>
+	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000038")
+	             event_type: 'not reported'
+	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
+	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261017/782476'
+	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261017/782476/796628'
+	                  ---------
+	     event_descriptions: 1 Elements
+	                origins: 1 Elements
+	             magnitudes: 1 Elements</description>
         <TimeStamp>2012-04-04T14:18:37.000000Z</TimeStamp>
       </Placemark>
       <Placemark>
@@ -95,13 +99,15 @@
         </Point>
         <description>Event:	2012-04-04T14:08:46.000000Z | +38.017,  +37.736 | 3.0 ML | manual
 
-	        resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000039")
-	         event_type: 'not reported'
-	      creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	---------
-	 event_descriptions: 1 Elements
-	            origins: 1 Elements
-	         magnitudes: 1 Elements</description>
+	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000039")
+	             event_type: 'not reported'
+	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
+	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261018/782478'
+	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261018/782478/796631'
+	                  ---------
+	     event_descriptions: 1 Elements
+	                origins: 1 Elements
+	             magnitudes: 1 Elements</description>
         <TimeStamp>2012-04-04T14:08:46.000000Z</TimeStamp>
       </Placemark>
     </Folder>

--- a/obspy/io/kml/tests/data/catalog.kml
+++ b/obspy/io/kml/tests/data/catalog.kml
@@ -48,8 +48,8 @@
 	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000041")
 	             event_type: 'not reported'
 	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261020/782484'
-	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261020/782484/796646'
+	    preferred_origin_id: ResourceIdentifier(id="quakeml:eu.emsc/origin/rts/261020/782484")
+	 preferred_magnitude_id: ResourceIdentifier(id="quakeml:eu.emsc/NetworkMagnitude/rts/261020/782484/796646")
 	                  ---------
 	     event_descriptions: 1 Elements
 	                origins: 1 Elements
@@ -75,8 +75,8 @@
 	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000038")
 	             event_type: 'not reported'
 	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261017/782476'
-	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261017/782476/796628'
+	    preferred_origin_id: ResourceIdentifier(id="quakeml:eu.emsc/origin/rts/261017/782476")
+	 preferred_magnitude_id: ResourceIdentifier(id="quakeml:eu.emsc/NetworkMagnitude/rts/261017/782476/796628")
 	                  ---------
 	     event_descriptions: 1 Elements
 	                origins: 1 Elements
@@ -102,8 +102,8 @@
 	            resource_id: ResourceIdentifier(id="quakeml:eu.emsc/event/20120404_0000039")
 	             event_type: 'not reported'
 	          creation_info: CreationInfo(agency_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), author_uri=ResourceIdentifier(id="smi:smi-registry/organization/EMSC"), creation_time=UTCDateTime(2012, 4, 4, 16, 40, 50), version='1.0.1')
-	    preferred_origin_id: 'quakeml:eu.emsc/origin/rts/261018/782478'
-	 preferred_magnitude_id: 'quakeml:eu.emsc/NetworkMagnitude/rts/261018/782478/796631'
+	    preferred_origin_id: ResourceIdentifier(id="quakeml:eu.emsc/origin/rts/261018/782478")
+	 preferred_magnitude_id: ResourceIdentifier(id="quakeml:eu.emsc/NetworkMagnitude/rts/261018/782478/796631")
 	                  ---------
 	     event_descriptions: 1 Elements
 	                origins: 1 Elements

--- a/obspy/io/nied/__init__.py
+++ b/obspy/io/nied/__init__.py
@@ -29,12 +29,16 @@ The event will contain a couple of origins and magnitudes.
 >>> print(cat[0])  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
 Event:  2011-03-11T05:46:18.120000Z | +38.103, +142.861 | 8.7 Mw
 <BLANKLINE>
-              resource_id: ResourceIdentifier(id="...")
-               event_type: 'earthquake'
-        ---------
-         focal_mechanisms: 1 Elements
-                  origins: 2 Elements
-               magnitudes: 2 Elements
+                   resource_id: ResourceIdentifier(id="smi:local/fnetmt/2011excpds/event")
+                    event_type: 'earthquake'
+           preferred_origin_id: 'smi:local/fnetmt/2011excpds/origin#MT'
+        preferred_magnitude_id: 'smi:local/fnetmt/2011excpds/magnitude#MT'
+  preferred_focal_mechanism_id: 'smi:local/fnetmt/2011excpds/focal_mechanism'
+                          ---------
+              focal_mechanisms: 1 Elements
+                       origins: 2 Elements
+                    magnitudes: 2 Elements
+
 
 obspy.io.nied.knet - K-NET and KiK-net ASCII format support for ObsPy
 =====================================================================

--- a/obspy/io/nied/__init__.py
+++ b/obspy/io/nied/__init__.py
@@ -31,9 +31,9 @@ Event:  2011-03-11T05:46:18.120000Z | +38.103, +142.861 | 8.7 Mw
 <BLANKLINE>
                    resource_id: ResourceIdentifier(id="smi:local/fnetmt/2011excpds/event")
                     event_type: 'earthquake'
-           preferred_origin_id: 'smi:local/fnetmt/2011excpds/origin#MT'
-        preferred_magnitude_id: 'smi:local/fnetmt/2011excpds/magnitude#MT'
-  preferred_focal_mechanism_id: 'smi:local/fnetmt/2011excpds/focal_mechanism'
+           preferred_origin_id: ResourceIdentifier(id="smi:local/fnetmt/2011excpds/origin#MT")
+        preferred_magnitude_id: ResourceIdentifier(id="smi:local/fnetmt/2011excpds/magnitude#MT")
+  preferred_focal_mechanism_id: ResourceIdentifier(id="smi:local/fnetmt/2011excpds/focal_mechanism")
                           ---------
               focal_mechanisms: 1 Elements
                        origins: 2 Elements


### PR DESCRIPTION
Follow-up to #1418. Make event-type objects issue a warning when a non-default attribute is set. The main purpose for this PR is that it has happened several times before that users had a typo when setting a field (or just using a wrong field name) and then surprised that the information was lost on output to QuakeML.