### PR TITLE
Shorten GitHub template and make it more readable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,19 +13,27 @@ community process works in practice.
  * [Download](https://git-scm.com/downloads) and install git
  * Read the [git documentation](https://git-scm.com/book/en/Git-Basics)
 
-## Git workflow
+## Submitting a Pull Request
 
 We love pull requests! Here's a quick guide:
 
+First, if the PR is directly related to an already existing issue (which is no PR yet), drop us a note in that issue before opening this PR. We can make existing issues into a PR, which avoids duplicated tickets. Otherwise, please follow the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model).
+
  1. Fork the repo.
- 2. Make a new branch. For feature additions/changes base your new branch at "master", for pure bugfixes base your new branch at e.g. "maintenance_1.0.x" (see [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)).
+ 2. Make a new branch. For feature additions/changes base your new branch at "master", for pure bugfixes base your new branch at e.g. "maintenance_1.0.x" .
  3. Run the tests. We only take pull requests with passing tests.
  4. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test!
  5. Make the test pass.
  6. Push to your fork and submit a pull request.
     - for feature branches set base branch to "obspy:master"
     - for bugfix branches set base branch to the latests maintenance branch, e.g. "obspy:maintenance_1.0.x"
- 7. Wait for our review. We may suggest some changes or improvements or alternatives.
+ 7. Wait for our review. We may suggest some changes or improvements or alternatives. Keep in mind that PR checklist items can be met after the pull request has been opened by adding more commits to the branch.
+
+The base branch of the PR cannot be changed after the pull request has been opened so please make sure to get the base branch (`master` vs. `maintenance_x.x.x`) correct the first time.
+
+All the submitted pieces including potential data must be compatible with the LGPLv3 license and will be LGPLv3 licensed as soon as they are part of ObsPy. Sending a pull request implies that you agree with this.
+
+Additionally take care to not add big files. Even for tests we generally only accept files that are very small and at max on the order of a few kilobytes. When in doubt.. ask us in the PR.
 
 ## Submitting an Issue
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,17 +17,16 @@ community process works in practice.
 
 We love pull requests! Here's a quick guide:
 
-First, if the PR is directly related to an already existing issue (which is no PR yet), drop us a note in that issue before opening this PR. We can make existing issues into a PR, which avoids duplicated tickets. Otherwise, please follow the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model).
+First, if the PR is directly related to an already existing issue (which is no PR yet), drop us a note in that issue before opening the PR. We can make existing issues into a PR, which avoids duplicated tickets. Otherwise, please follow the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model).
 
  1. Fork the repo.
  2. Make a new branch. For feature additions/changes base your new branch at "master", for pure bugfixes base your new branch at e.g. "maintenance_1.0.x" .
- 3. Run the tests. We only take pull requests with passing tests.
- 4. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test!
- 5. Make the test pass.
- 6. Push to your fork and submit a pull request.
+ 3. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test!
+ 4. Make the test pass.
+ 5. Push to your fork and submit a pull request.
     - for feature branches set base branch to "obspy:master"
     - for bugfix branches set base branch to the latests maintenance branch, e.g. "obspy:maintenance_1.0.x"
- 7. Wait for our review. We may suggest some changes or improvements or alternatives. Keep in mind that PR checklist items can be met after the pull request has been opened by adding more commits to the branch.
+ 6. Wait for our review. We may suggest some changes or improvements or alternatives. Keep in mind that PR checklist items can be met after the pull request has been opened by adding more commits to the branch.
 
 The base branch of the PR cannot be changed after the pull request has been opened so please make sure to get the base branch (`master` vs. `maintenance_x.x.x`) correct the first time.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,6 +27,47 @@ We love pull requests! Here's a quick guide:
     - for bugfix branches set base branch to the latests maintenance branch, e.g. "obspy:maintenance_1.0.x"
  7. Wait for our review. We may suggest some changes or improvements or alternatives.
 
+## Submitting an Issue
+
+If you want to ask a question about a specific ObsPy aspect, please first of all..
+
+ * search through [Github issues tagged as "question"](https://github.com/obspy/obspy/issues?q=label%3Aquestion)
+   (you can add more search terms in the search box, e.g.
+   [search for Mini SEED related questions with additional search term "mseed"](
+    https://github.com/obspy/obspy/issues?utf8=%E2%9C%93&q=label%3Aquestion+mseed))
+ * search the [obspy-users] mailing list archives, e.g.
+   [searching for term "mseed" via Google with search string "mseed site:http://lists.swapbytes.de/archives/obspy-users/"](
+    https://www.google.de/#q=mseed+site:http:%2F%2Flists.swapbytes.de%2Farchives%2Fobspy-users%2F)
+
+If you want to post a problem/bug, to help us understand and resolve your issue
+please check that you have provided the information below:
+
+*  ObsPy version, Python version and Platform (Windows, OSX, Linux ...)
+*  How did you install ObsPy and Python (pip, anaconda, from source ...)
+*  If possible please supply a [Short, Self Contained, Correct, Example](http://sscce.org/)
+      that demonstrates the issue i.e a small piece of code which reproduces
+      the issue and can be run with out any other (or as few as possible)
+      external dependencies.
+*  If this is a regression (Used to work in an earlier version of ObsPy),
+      please note when it used to work.
+
+You can also do a quick check whether..
+
+ * the bug was already fixed in the current maintenance branch for the next bug
+   fix release, e.g. for the `1.0.x` maintenance line check the..
+
+   * [corresponding changelog section "1.0.x:" right at the top](
+      https://github.com/obspy/obspy/blob/maintenance_1.0.x/CHANGELOG.txt)
+      which contains bug fixes that will be in the next release) or..
+
+ * if it was already reported and/or is maybe even being worked on already by
+   checking open issues of the corresponding milestone, e.g. see
+
+   * [all open issues in milestone "1.0.x"](
+      https://github.com/obspy/obspy/milestones/1.0.x) or optionally see..
+   * [open and closed issues with "bug" label in that milestone](
+      https://github.com/obspy/obspy/issues?utf8=%E2%9C%93&q=milestone%3A1.0.x+label%3Abug+)).
+
 ## Additional Resources
 
  * [Style Guide](https://docs.obspy.org/coding_style.html)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,38 +1,12 @@
-If you want to ask a question about a specific ObsPy aspect, please first of all..
+Before submitting an Issue, please review the [Issue Guidelines](https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md).
 
- * search through [Github issues tagged as "question"](https://github.com/obspy/obspy/issues?q=label%3Aquestion)
-   (you can add more search terms in the search box, e.g.
-   [search for Mini SEED related questions with additional search term "mseed"](
-    https://github.com/obspy/obspy/issues?utf8=%E2%9C%93&q=label%3Aquestion+mseed))
- * search the [obspy-users] mailing list archives, e.g.
-   [searching for term "mseed" via Google with search string "mseed site:http://lists.swapbytes.de/archives/obspy-users/"](
-    https://www.google.de/#q=mseed+site:http:%2F%2Flists.swapbytes.de%2Farchives%2Fobspy-users%2F)
+* Please check whether the bug was already reported or fixed.
+* Please provide the following information:
+  -  ObsPy version, Python version and Platform (Windows, OSX, Linux ...)
+  -  How did you install ObsPy and Python (pip, anaconda, from source ...)
+  -  If possible please supply a short, self contained, correct example that
+     demonstrates the issue.
+  -  If this is a regression (used to work in an earlier version of ObsPy),
+     please note when it used to work.
 
-If you want to post a problem/bug, to help us understand and resolve your issue
-please check that you have provided the information below:
 
-- [ ] ObsPy version, Python version and Platform (Windows, OSX, Linux ...)
-- [ ] How did you install ObsPy and Python (pip, anaconda, from source ...)
-- [ ] If possible please supply a [Short, Self Contained, Correct, Example](http://sscce.org/)
-      that demonstrates the issue i.e a small piece of code which reproduces
-      the issue and can be run with out any other (or as few as possible)
-      external dependencies.
-- [ ] If this is a regression (Used to work in an earlier version of ObsPy),
-      please note where it used to work.
-
-You can also do a quick check whether..
-
- * the bug was already fixed in the current maintenance branch for the next bug
-   fix release, e.g. for the `1.0.x` maintenance line check the..
-
-   * [corresponding changelog section "1.0.x:" right at the top](
-      https://github.com/obspy/obspy/blob/maintenance_1.0.x/CHANGELOG.txt)
-      which contains bug fixes that will be in the next release) or..
-
- * if it was already reported and/or is maybe even being worked on already by
-   checking open issues of the corresponding milestone, e.g. see
-
-   * [all open issues in milestone "1.0.x"](
-      https://github.com/obspy/obspy/milestones/1.0.x) or optionally see..
-   * [open and closed issues with "bug" label in that milestone](
-      https://github.com/obspy/obspy/issues?utf8=%E2%9C%93&q=milestone%3A1.0.x+label%3Abug+)).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Before submitting an Issue, please review the [Issue Guidelines](https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md).
+Before submitting an Issue, please review the [Issue Guidelines](https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md#submitting-an-issue).
 
 * Please check whether the bug was already reported or fixed.
 * Please provide the following information:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,13 @@
-Thank your for submitting a pull request (PR) to ObsPy to help develop and improve it!
+Thank your for contributing to ObsPy!  Before submitting a PR, please review the [pull request guidelines](https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md#submitting-a-pull-request). Also, please make sure you are following the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model).
 
-First of all: If this PR is directly related to an already existing issue (which is no PR yet), drop us a note in that issue before opening this PR. We can make existing issues into a PR, which avoids duplicated tickets.
+### What does this PR do?
 
-Otherwise, if this is a ..
+### Why was it initiated?  Any relevant Issues?
 
- - **new feature**: make sure that..
-   - you choose the `master` branch as the "base" branch of this PR, and...
-   - you started your local new branch from the `master` branch (if not rebase your local branch)
- - **bug fix**: make sure that..
-   - you choose the latest `maintenance_x.x.x` branch (e.g. `maintenance_1.0.x` if current stable version is `1.0.0` or `1.0.1` etc.) as the "base" branch of this PR, and...
-   - you started your local new branch from the latest `maintenance_x.x.x` branch (if not rebase your local branch)
-
-The base branch of the PR cannot be changed after the pull request has been opened so please make sure to get the base branch (`master` vs. `maintenance_x.x.x`) correct the first time. See our [git branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model) and our [general contribution guide](https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md) for more details.
-
-All the submitted pieces including potential data must be compatible with the LGPLv3 license and will be LGPLv3 licensed as soon as they are part of ObsPy. Sending a pull request implies that you agree with this.
-
-Additionally take care to not add big files. Even for tests we generally only accept files that are very small and at max on the order of a few kilobytes. When in doubt.. ask us in the PR.
-
-Before this can be merged, the following requirements must also be fulfilled. Note that these can also be met after the pull request has been opened, adding more commits to the branch:
-
+### PR Checklist
+- [ ] This PR is not directly related to an existing issue (which has no PR yet).
 - [ ] All tests still pass.
-- [ ] Any new features or fixed regressions must be covered via new tests.
-- [ ] Any new or changed features have to be fully documented.
-- [ ] If the change is significant enough to warrant it, add it to the [Changelog](https://github.com/obspy/obspy/blob/master/CHANGELOG.txt).
-- [ ] If this is your first time contributing, please add your name to the [Contributors List](https://github.com/obspy/obspy/blob/master/obspy/CONTRIBUTORS.txt).
+- [ ] Any new features or fixed regressions are be covered via new tests.
+- [ ] Any new or changed features have are fully documented.
+- [ ] Significant changes have been added to `CHANGELOG.txt` .
+- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
-Thank your for contributing to ObsPy!  Before submitting a PR, please review the [pull request guidelines](https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md#submitting-a-pull-request). Also, please make sure you are following the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model).
+Thank your for contributing to ObsPy!
+
+Before submitting a PR, please review the pull request guidelines:
+https://github.com/obspy/obspy/blob/master/.github/CONTRIBUTING.md#submitting-a-pull-request
+
+Also, please make sure you are following the ObsPy branching model:
+https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model
 
 ### What does this PR do?
 


### PR DESCRIPTION
This PR moves most of the `ISSUE_TEMPLATE.md` markdown into a new section in `CONTRIBUTING.md`, points the user there, and leaves a shorter, more text-readable version in the template.