### PR TITLE
SDS client: use "sourcename" option during "read()" (for MSEED format data)

### DIFF
--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -162,6 +162,8 @@ class Client(object):
             raise ValueError(msg)
         sds_type = sds_type or self.sds_type
 
+        seed_pattern = ".".join((network, station, location, channel))
+
         st = Stream()
         full_paths = self._get_filenames(
             network=network, station=station, location=location,
@@ -169,7 +171,7 @@ class Client(object):
             sds_type=sds_type)
         for full_path in full_paths:
             st += read(full_path, format=self.format, starttime=starttime,
-                       endtime=endtime, **kwargs)
+                       endtime=endtime, sourcename=seed_pattern, **kwargs)
 
         # make sure we only have the desired data, just in case the file
         # contents do not match the expected SEED id
@@ -363,6 +365,8 @@ class Client(object):
         """
         sds_type = sds_type or self.sds_type
 
+        seed_pattern = ".".join((network, station, location, channel))
+
         if not self.has_data(
                 network=network, station=station, location=location,
                 channel=channel, sds_type=sds_type):
@@ -379,7 +383,8 @@ class Client(object):
                 network=network, station=station, location=location,
                 channel=channel, time=time, sds_type=sds_type)
             if os.path.isfile(filename):
-                st = read(filename, format=self.format, headonly=True)
+                st = read(filename, format=self.format, headonly=True,
+                          sourcename=seed_pattern)
                 st = st.select(network=network, station=station,
                                location=location, channel=channel)
                 if st:


### PR DESCRIPTION
Just a minor improvement, in case of non-expected data stored in files. During reading data, only look at records with seed pattern of interest using "sourcename" option in _read_mseed().