### PR TITLE
add setter for Trace.id property

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@ master:
      "timestamp": array of float POSIX timestamps, compare
      `UTCDateTime.timestamp`; "matplotlib": array of float matplotlib dates,
      useful for plotting on matplotlib time axes; see #1307)
+   * A trace's stats.network/station/location/channel can now also be set in
+     one line using a SEED ID string (e.g. `trace.id = "GR.FUR..HHZ"`,
+     see #1439).
  - obspy.clients.fdsn:
    * The mass downloader now has `exclude_networks` and `exclude_stations`
      arguments to not download certain pieces of data. (see #1305)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2591,6 +2591,30 @@ class TraceTestCase(unittest.TestCase):
             tr_float64.copy().interpolate(
                 1.0, method="lanczos", a=2).data.dtype, np.float64)
 
+    def test_set_trace_id(self):
+        """
+        Test setter of `id` property.
+        """
+        tr = Trace()
+        tr.stats.location = "00"
+        # check setting net/sta/loc/cha with an ID
+        tr.id = "GR.FUR..HHZ"
+        self.assertEqual(tr.stats.network, "GR")
+        self.assertEqual(tr.stats.station, "FUR")
+        self.assertEqual(tr.stats.location, "")
+        self.assertEqual(tr.stats.channel, "HHZ")
+        # check that invalid types will raise
+        invalid = (True, False, -10, 0, 1.0, [1, 4, 3, 2], np.ones(4))
+        for id_ in invalid:
+            with self.assertRaises(TypeError):
+                tr.id = id_
+        # check that invalid ID strings will raise
+        invalid = ("ABCD", "AB.CD", "AB.CD.00", "..EE", "....",
+                   "GR.FUR..HHZ.", "GR.FUR..HHZ...")
+        for id_ in invalid:
+            with self.assertRaises(ValueError):
+                tr.id = id_
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -807,6 +807,41 @@ class Trace(object):
 
     id = property(get_id)
 
+    @id.setter
+    def id(self, value):
+        """
+        Set network, station, location and channel codes from a SEED ID.
+
+        Raises an Exception if the provided ID does not contain exactly three
+        dots (or is not of type `str`).
+
+        >>> from obspy import read
+        >>> tr = read()[0]
+        >>> print(tr)  # doctest: +ELLIPSIS
+        BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z ... | 100.0 Hz, 3000 samples
+        >>> tr.id = "GR.FUR..HHZ"
+        >>> print(tr)  # doctest: +ELLIPSIS
+        GR.FUR..HHZ | 2009-08-24T00:20:03.000000Z ... | 100.0 Hz, 3000 samples
+
+        :type value: str
+        :param value: SEED ID to use for setting `self.stats.network`,
+            `self.stats.station`, `self.stats.location` and
+            `self.stats.channel`.
+        """
+        try:
+            net, sta, loc, cha = value.split(".")
+        except AttributeError:
+            msg = ("Can only set a Trace's SEED ID from a string "
+                   "(and not from {})").format(type(value))
+            raise TypeError(msg)
+        except ValueError:
+            msg = ("Not a valid SEED ID: '{}'").format(value)
+            raise ValueError(msg)
+        self.stats.network = net
+        self.stats.station = sta
+        self.stats.location = loc
+        self.stats.channel = cha
+
     def plot(self, **kwargs):
         """
         Create a simple graph of the current trace.


### PR DESCRIPTION
So much more convenient to do..

```python
 >>> tr.id = "GR.FUR..HHZ"
```

than..

```python
 >>> tr.stats.network = "GR"
 >>> tr.stats.station = "FUR"
 >>> tr.stats.location = ""
 >>> tr.stats.channel = "HHZ"
```

Includes tests..