### PR TITLE
SLIST/TSPAIR: fix writing files with floating point sampling rates + don't set 'stats.mseed.dataquality' with a blank

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,10 @@
  - obspy.db:
    * Fixed a bug in obspy-indexer command line script (see #1369,
      command line script was not working, probably since 0.10.0)
+ - obspy.io.ascii:
+   * Fixed a bug that lead to wrong header information in output files when
+     writing non-integer sampling rate data to SLIST or TSPAIR formats
+     (see #1447)
  - obspy.io.mseed:
    * Fixed a bug in obspy-mseed-recordanalyzer (see #1386)
  - obspy.io.nlloc:

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -44,7 +44,7 @@ from obspy.core import Stats
 from obspy.core.util import AttribDict, loadtxt
 
 
-HEADER = "TIMESERIES %s_%s_%s_%s_%s, %d samples, %d sps, %.26s, %s, %s, %s\n"
+HEADER = "TIMESERIES %s_%s_%s_%s_%s, %d samples, %s sps, %.26s, %s, %s, %s\n"
 
 
 def _is_slist(filename):

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -165,7 +165,10 @@ def _read_slist(filename, headonly=False, **kwargs):  # @UnusedVariable
         stats.channel = temp[3]
         stats.sampling_rate = parts[4]
         # quality only used in MSEED
-        stats.mseed = AttribDict({'dataquality': temp[4]})
+        # don't put blank quality code into 'mseed' dictionary
+        # (quality code is mentioned as optional by format specs anyway)
+        if temp[4]:
+            stats.mseed = AttribDict({'dataquality': temp[4]})
         stats.ascii = AttribDict({'unit': parts[-1]})
         stats.starttime = UTCDateTime(parts[6])
         stats.npts = parts[2]
@@ -230,7 +233,10 @@ def _read_tspair(filename, headonly=False, **kwargs):  # @UnusedVariable
         stats.channel = temp[3]
         stats.sampling_rate = parts[4]
         # quality only used in MSEED
-        stats.mseed = AttribDict({'dataquality': temp[4]})
+        # don't put blank quality code into 'mseed' dictionary
+        # (quality code is mentioned as optional by format specs anyway)
+        if temp[4]:
+            stats.mseed = AttribDict({'dataquality': temp[4]})
         stats.ascii = AttribDict({'unit': parts[-1]})
         stats.starttime = UTCDateTime(parts[6])
         stats.npts = parts[2]

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -44,7 +44,21 @@ from obspy.core import Stats
 from obspy.core.util import AttribDict, loadtxt
 
 
-HEADER = "TIMESERIES %s_%s_%s_%s_%s, %d samples, %s sps, %.26s, %s, %s, %s\n"
+HEADER = ("TIMESERIES {network}_{station}_{location}_{channel}_{dataquality}, "
+          "{npts:d} samples, {sampling_rate} sps, {starttime!s:.26s}, "
+          "{format}, {dtype}, {unit}\n")
+
+
+def _format_header(stats, format, dataquality, dtype, unit):
+    sampling_rate = str(stats.sampling_rate)
+    if "." in sampling_rate and "E" not in sampling_rate.upper():
+        sampling_rate = sampling_rate.rstrip('0').rstrip('.')
+    header = HEADER.format(
+        network=stats.network, station=stats.station, location=stats.location,
+        channel=stats.channel, dataquality=dataquality, npts=stats.npts,
+        sampling_rate=sampling_rate, starttime=stats.starttime,
+        format=format, dtype=dtype, unit=unit)
+    return header
 
 
 def _is_slist(filename):
@@ -314,10 +328,7 @@ def _write_slist(stream, filename, **kwargs):  # @UnusedVariable
             except:
                 unit = ''
             # write trace header
-            header = HEADER % (stats.network, stats.station, stats.location,
-                               stats.channel, dataquality, stats.npts,
-                               stats.sampling_rate, stats.starttime, 'SLIST',
-                               dtype, unit)
+            header = _format_header(stats, 'SLIST', dataquality, dtype, unit)
             fh.write(header.encode('ascii', 'strict'))
             # write data
             rest = stats.npts % 6
@@ -425,10 +436,7 @@ def _write_tspair(stream, filename, **kwargs):  # @UnusedVariable
             except:
                 unit = ''
             # write trace header
-            header = HEADER % (stats.network, stats.station, stats.location,
-                               stats.channel, dataquality, stats.npts,
-                               stats.sampling_rate, stats.starttime, 'TSPAIR',
-                               dtype, unit)
+            header = _format_header(stats, 'TSPAIR', dataquality, dtype, unit)
             fh.write(header.encode('ascii', 'strict'))
             # write data
             times = np.linspace(stats.starttime.timestamp,

--- a/obspy/io/ascii/tests/test_ascii.py
+++ b/obspy/io/ascii/tests/test_ascii.py
@@ -475,6 +475,25 @@ class ASCIITestCase(unittest.TestCase):
                 self.assertEqual(len(st), 1)
                 self.assertEqual(len(st[0]), num)
 
+    def test_float_sampling_rates_write_and_read(self):
+        """
+        Tests writing and reading Traces with floating point and with less than
+        1 Hz sampling rates.
+        """
+        tr = Trace(np.arange(10))
+        check_sampling_rates = (0.000000001, 1.000000001, 100.000000001,
+                                99.999999999, 1.5, 1.666666, 10000.0001)
+        for format in ['SLIST', 'TSPAIR']:
+            for sps in check_sampling_rates:
+                tr.stats.sampling_rate = sps
+                with NamedTemporaryFile() as tf:
+                    tempfile = tf.name
+                    tr.write(tempfile, format=format)
+                    # test results
+                    got = read(tempfile, format=format)[0]
+                self.assertEqual(tr.stats.sampling_rate,
+                                 got.stats.sampling_rate)
+
 
 def suite():
     return unittest.makeSuite(ASCIITestCase, 'test')


### PR DESCRIPTION
Writing to SLIST and TSPAIR so far wrote sampling rate formatted as an integer into file headers, leading to..
 * raised exceptions for <1 Hz sampling rates, and far worse..
 * plain wrong output files >1 Hz non-integer sampling rates

Although [format definition](http://ds.iris.edu/ds/nodes/dmc/data/formats/simple-ascii/) only shows examples with integer sampling rates and doesn't speak about floating point sampling rates, when [looking at served data](service.iris.edu/irisws/timeseries/1/query?net=IU&sta=ANMO&loc=00&cha=VHZ&starttime=2005-01-01T00:00:00&endtime=2005-01-01T00:01:00&output=ascii), the sampling rate is just written as a float with "`.`":
```
TIMESERIES IU_ANMO_00_VHZ_M, 6 samples, 0.1 sps, 2005-01-01T00:00:07.986000, SLIST, INTEGER, COUNTS
-3643
-3658
-3636
-3618
-3628
-3668
```

Safest thing it to just leave it to Python to format the sampling rate as a string. This might lead to scientific notation in output for very crazy sampling rates but that shouldn't be a problem (at least not for us.. ;-).

Although probably not a lot of people use these formats, this is a **very** bad bug  and I think warrants a 1.0.2 release.