### PR TITLE
GSE2: make sure network code is written/read

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,9 @@
    * Fixed a bug that lead to wrong header information in output files when
      writing non-integer sampling rate data to SLIST or TSPAIR formats
      (see #1447)
+ - obspy.io.gse2:
+   * Fixed a bug that could lead to network code not present in GSE2 output
+     (see #1448)
  - obspy.io.mseed:
    * Fixed a bug in obspy-mseed-recordanalyzer (see #1386)
  - obspy.io.nlloc:

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -149,9 +149,12 @@ class WaveformPluginsTestCase(unittest.TestCase):
                         self.assertEqual(st[0].stats.delta, 0.005)
                         self.assertEqual(st[0].stats.sampling_rate, 200.0)
                     # network/station/location/channel codes
-                    if format in ['Q', 'SH_ASC', 'GSE2']:
-                        # no network or location code in Q, SH_ASC, GSE2
+                    if format in ['Q', 'SH_ASC']:
+                        # no network or location code in Q, SH_ASC
                         self.assertEqual(st[0].id, ".MANZ1..EHE")
+                    elif format == "GSE2":
+                        # no location code in GSE2
+                        self.assertEqual(st[0].id, "BW.MANZ1..EHE")
                     elif format not in ['WAV']:
                         self.assertEqual(st[0].id, "BW.MANZ1.00.EHE")
 

--- a/obspy/io/gse2/tests/test_core.py
+++ b/obspy/io/gse2/tests/test_core.py
@@ -323,6 +323,20 @@ class CoreTestCase(unittest.TestCase):
         testdata = [n * tr.stats.calib for n in testdata]
         self.assertEqual(tr.data[0:13].tolist(), testdata)
 
+    def test_write_and_read_correct_network(self):
+        """
+        Tests that writing and reading the STA2 line works (otherwise the
+        network code of the data is missing), even if some details like e.g.
+        latitude are not present.
+        """
+        tr = Trace(np.arange(5, dtype=np.int32))
+        tr.stats.network = "BW"
+        with NamedTemporaryFile() as tf:
+            tmpfile = tf.name
+            tr.write(tmpfile, format='GSE2')
+            tr = read(tmpfile)[0]
+        self.assertEqual(tr.stats.network, "BW")
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')


### PR DESCRIPTION
..even if some other details like latitude can not be written/parsed to/from STA2 header line (e.g. because they are not found in trace.stats.gse)

a.k.a. "A missing `trace.stats.gse` must not prevent the network code being written to file correctly."