### PR TITLE
Filtering at Nyquist (or above Nyquist) has no effect

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,9 @@
  - obspy.signal:
    * PPSD.plot(): fix plotting of percentiles, mode and mean and setting
      period limits when using "xaxis_frequency=True" (see #1406, #1416)
+   * Work around a bug in SciPy that results in wrong results for bandpass
+     filter when using Nyquist frequency (or higher) as high corner of the
+     passband (see #1451)
  - obspy.taup:
    * Fixing path for Pn. (see #1392)
 

--- a/obspy/signal/filter.py
+++ b/obspy/signal/filter.py
@@ -60,10 +60,11 @@ def bandpass(data, freqmin, freqmax, df, corners=4, zerophase=False):
     low = freqmin / fe
     high = freqmax / fe
     # raise for some bad scenarios
-    if high > 1:
-        high = 1.0
-        msg = "Selected high corner frequency is above Nyquist. " + \
-              "Setting Nyquist as high corner."
+    if high >= 1.0:
+        high = 0.999999999
+        msg = ("Selected high corner frequency ({}) is at or above Nyquist "
+               "({}). Setting ({} * Nyquist = {} Hz) as high corner.").format(
+                   freqmax, fe, high, high * fe)
         warnings.warn(msg)
     if low > 1:
         msg = "Selected low corner frequency is above Nyquist."

--- a/obspy/signal/filter.py
+++ b/obspy/signal/filter.py
@@ -60,12 +60,13 @@ def bandpass(data, freqmin, freqmax, df, corners=4, zerophase=False):
     low = freqmin / fe
     high = freqmax / fe
     # raise for some bad scenarios
-    if high >= 1.0:
-        high = 0.999999999
-        msg = ("Selected high corner frequency ({}) is at or above Nyquist "
-               "({}). Setting ({} * Nyquist = {} Hz) as high corner.").format(
-                   freqmax, fe, high, high * fe)
+    if high - 1.0 > -1e-6:
+        msg = ("Selected high corner frequency ({}) of bandpass is at or "
+               "above Nyquist ({}). Applying a high-pass instead.").format(
+                    freqmax, fe)
         warnings.warn(msg)
+        return highpass(data, freq=freqmin, df=df, corners=corners,
+                        zerophase=zerophase)
     if low > 1:
         msg = "Selected low corner frequency is above Nyquist."
         raise ValueError(msg)

--- a/obspy/signal/tests/test_filter.py
+++ b/obspy/signal/tests/test_filter.py
@@ -10,10 +10,12 @@ from future.builtins import *  # NOQA
 import gzip
 import os
 import unittest
+import warnings
 
 import numpy as np
 import scipy.signal as sg
 
+from obspy import read
 from obspy.signal.filter import (bandpass, highpass, lowpass, envelope,
                                  lowpass_cheby_2)
 
@@ -238,6 +240,30 @@ class FilterTestCase(unittest.TestCase):
         self.assertGreater(-96, h_db[freq > 50].max())
         # be 0 (1dB ripple) before filter ramp
         self.assertGreater(h_db[freq < 25].min(), -1)
+
+    def test_bandpass_high_corner_at_nyquist(self):
+        """
+        Check that using exactly Nyquist for high corner gives correct results.
+        See #1451.
+        """
+        tr = read()[0]
+        data = tr.data[:1000]
+
+        df = tr.stats.sampling_rate
+        nyquist = df / 2.0
+
+        for low_corner in (6.0, 8.55, 8.59):
+            for corners in (3, 4, 5, 6):
+                expected = bandpass(data, low_corner, nyquist - 1e-5,
+                                    df=df, corners=corners)
+                got1 = bandpass(data, low_corner, nyquist,
+                                df=df, corners=corners)
+                with warnings.catch_warnings(record=True):
+                    got2 = bandpass(data, low_corner, nyquist + 1.78,
+                                    df=df, corners=corners)
+                for got in (got1, got2):
+                    np.testing.assert_allclose(got, expected, rtol=1e-3,
+                                               atol=1e-3)
 
 
 def suite():


### PR DESCRIPTION
This code fails silently, without modifying (significantly) the traces:
```python
from obspy import read
st = read()
print st[0].data[100]
st.plot()
# 50 Hz is the Nyquist frequency
st.filter(type='bandpass', freqmin=2., freqmax=50.)
print st[0].data[100]  # data is unmodified or this value changes very little (10**-13)
st.plot() # plot looks exactly the same
```
This variant produces a warning, but then defaults to Nyquist and behaves like above.
```python
from obspy import read
st = read()
st.filter(type='bandpass', freqmin=2., freqmax=51.)
```
