### PR TITLE
copy() method for UTCDateTime

### DIFF
--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -16,6 +16,7 @@ from future.utils import native_str
 import datetime
 import math
 import time
+from copy import copy
 
 
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
@@ -1117,6 +1118,15 @@ class UTCDateTime(object):
         """
         # explicitly flag it as unhashable
         return None
+
+    def copy(self):
+        """
+        Return a copy of the UTCDateTime object.
+
+        :return: Copy of the UTCDateTime object.
+
+        """
+        return copy(self)
 
     def strftime(self, format):
         """


### PR DESCRIPTION
Just found myself needing to copy a `UTCDateTime()` object.
I thought that it might be useful.
