### PR TITLE
fix current Travis problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,6 @@ branches:
     - "master"
     - "maintenance_1.0.x"
 
-env:
-  global:
-    - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-        export RUNTESTSOPTIONS="--ci-url https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}"
-      else
-        export RUNTESTSOPTIONS="--ci-url https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID} --pr-url https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}"
-      fi
-
 matrix:
   include:
     # do one build run with our minimum dependencies
@@ -154,8 +146,15 @@ script:
   - mkdir empty
   - cd empty
   - export MODULELIST=`python -c "from obspy.core.util import DEFAULT_MODULES as MODULES; print('obspy.' + ',obspy.'.join(MODULES))"`
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+      export RUNTESTSOPTIONS="--ci-url=\"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}\"";
+    else
+      export RUNTESTSOPTIONS="--ci-url=\"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID} --pr-url=\"https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}\"";
+    fi;
   - echo $MODULELIST
-  - coverage run --rcfile=.coveragerc --source=$MODULELIST -m obspy.scripts.runtests -n travis-ci -r $RUNTESTSOPTIONS
+  - echo $RUNTESTSOPTIONS
+  - echo "coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r ${RUNTESTSOPTIONS}"
+  - coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r ${RUNTESTSOPTIONS}
 
 after_success:
   - mv .coverage ../.coverage.empty


### PR DESCRIPTION
Travis is currently failing on all new commits. Compare [one of the last good runs](https://travis-ci.org/obspy/obspy/jobs/137457180#L673) and [one of the recent failing runs](https://travis-ci.org/obspy/obspy/jobs/137803540#L684).

It seems that the module list to test does not get provided correctly to the  `coverage` call (it [looks rather OK, though](https://travis-ci.org/obspy/obspy/jobs/137853500#L660)).