### PR TITLE
Response: cast to CustomComplex when setting poles/zeros lists

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -258,10 +258,10 @@ class PolesZerosResponseStage(ResponseStage):
 
     @zeros.setter
     def zeros(self, value):
-        for x in value:
+        value = list(value)
+        for i, x in enumerate(value):
             if not isinstance(x, CustomComplex):
-                msg = "Zeros must be of CustomComplex type."
-                raise TypeError(msg)
+                value[i] = CustomComplex(x)
         self._zeros = value
 
     @property
@@ -270,10 +270,10 @@ class PolesZerosResponseStage(ResponseStage):
 
     @poles.setter
     def poles(self, value):
-        for x in value:
+        value = list(value)
+        for i, x in enumerate(value):
             if not isinstance(x, CustomComplex):
-                msg = "Poles must be of CustomComplex type."
-                raise TypeError(msg)
+                value[i] = CustomComplex(x)
         self._poles = value
 
     @property


### PR DESCRIPTION
Currently something like ..
```python
PolesZerosResponseStage(..., zeros=[[0j, 0j, 150.5]], ...)
```
..fails with:
```
    262             if not isinstance(x, CustomComplex):
    263                 msg = "Zeros must be of CustomComplex type."
--> 264                 raise TypeError(msg)
    265         self._zeros = value
    266 

TypeError: Zeros must be of CustomComplex type.
```

I think we should probably just cast to the correct type..