### PR TITLE
Response: cast to CustomComplex when setting poles/zeros lists

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -22,7 +22,7 @@ from math import pi
 import numpy as np
 
 from obspy.core.util.base import ComparingObject
-from obspy.core.util.obspy_types import (CustomComplex, CustomFloat,
+from obspy.core.util.obspy_types import (ComplexWithUncertainties, CustomFloat,
                                          FloatWithUncertainties,
                                          FloatWithUncertaintiesAndUnit,
                                          ObsPyException,
@@ -260,8 +260,8 @@ class PolesZerosResponseStage(ResponseStage):
     def zeros(self, value):
         value = list(value)
         for i, x in enumerate(value):
-            if not isinstance(x, CustomComplex):
-                value[i] = CustomComplex(x)
+            if not isinstance(x, ComplexWithUncertainties):
+                value[i] = ComplexWithUncertainties(x)
         self._zeros = value
 
     @property
@@ -272,8 +272,8 @@ class PolesZerosResponseStage(ResponseStage):
     def poles(self, value):
         value = list(value)
         for i, x in enumerate(value):
-            if not isinstance(x, CustomComplex):
-                value[i] = CustomComplex(x)
+            if not isinstance(x, ComplexWithUncertainties):
+                value[i] = ComplexWithUncertainties(x)
         self._poles = value
 
     @property

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -277,6 +277,14 @@ class PolesZerosResponseStage(ResponseStage):
         self._poles = value
 
     @property
+    def normalization_frequency(self):
+        return self._normalization_frequency
+
+    @normalization_frequency.setter
+    def normalization_frequency(self, value):
+        self._normalization_frequency = Frequency(value)
+
+    @property
     def pz_transfer_function_type(self):
         return self._pz_transfer_function_type
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -258,10 +258,10 @@ class PolesZerosResponseStage(ResponseStage):
 
     @zeros.setter
     def zeros(self, value):
-        for x in value:
+        value = list(value)
+        for i, x in enumerate(value):
             if not isinstance(x, CustomComplex):
-                msg = "Zeros must be of CustomComplex type."
-                raise TypeError(msg)
+                value[i] = CustomComplex(x)
         self._zeros = value
 
     @property
@@ -270,10 +270,10 @@ class PolesZerosResponseStage(ResponseStage):
 
     @poles.setter
     def poles(self, value):
-        for x in value:
+        value = list(value)
+        for i, x in enumerate(value):
             if not isinstance(x, CustomComplex):
-                msg = "Poles must be of CustomComplex type."
-                raise TypeError(msg)
+                value[i] = CustomComplex(x)
         self._poles = value
 
     @property

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -26,7 +26,7 @@ from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
     _pitick2latex, PolesZerosResponseStage)
 from obspy.core.util.misc import CatchOutput
-from obspy.core.util.obspy_types import CustomComplex
+from obspy.core.util.obspy_types import ComplexWithUncertainties
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy.signal.invsim import evalresp
 from obspy.io.xseed import Parser
@@ -165,15 +165,15 @@ class ResponseTestCase(unittest.TestCase):
     def test_custom_types_init(self):
         """
         Test initializations that involve custom decimal types like
-        `CustomComplex`.
+        `ComplexWithUncertainties`.
         """
         # initializing poles / zeros from native types should work
         poles = [1+1j, 1, 1j]
         zeros = [2+3j, 2, 3j]
         stage = PolesZerosResponseStage(
             1, 1, 1, "", "", "LAPLACE (HERTZ)", 1, zeros, poles)
-        self.assertEqual(type(stage.zeros[0]), CustomComplex)
-        self.assertEqual(type(stage.poles[0]), CustomComplex)
+        self.assertEqual(type(stage.zeros[0]), ComplexWithUncertainties)
+        self.assertEqual(type(stage.poles[0]), ComplexWithUncertainties)
         self.assertEqual(stage.poles, poles)
         self.assertEqual(stage.zeros, zeros)
 

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -23,10 +23,12 @@ import numpy as np
 from matplotlib import rcParams
 
 from obspy import UTCDateTime, read_inventory
+from obspy.core.inventory.response import (
+    _pitick2latex, PolesZerosResponseStage)
 from obspy.core.util.misc import CatchOutput
+from obspy.core.util.obspy_types import CustomComplex
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy.signal.invsim import evalresp
-from obspy.core.inventory.response import _pitick2latex
 from obspy.io.xseed import Parser
 
 
@@ -159,6 +161,21 @@ class ResponseTestCase(unittest.TestCase):
             self.assertRaises(ValueError,
                               inv[0][0][0].response.get_evalresp_response,
                               t_samp, nfft, output="DISP")
+
+    def test_custom_types_init(self):
+        """
+        Test initializations that involve custom decimal types like
+        `CustomComplex`.
+        """
+        # initializing poles / zeros from native types should work
+        poles = [1+1j, 1, 1j]
+        zeros = [2+3j, 2, 3j]
+        stage = PolesZerosResponseStage(
+            1, 1, 1, "", "", "LAPLACE (HERTZ)", 1, zeros, poles)
+        self.assertEqual(type(stage.zeros[0]), CustomComplex)
+        self.assertEqual(type(stage.poles[0]), CustomComplex)
+        self.assertEqual(stage.poles, poles)
+        self.assertEqual(stage.zeros, zeros)
 
 
 def suite():


### PR DESCRIPTION
Currently something like ..
```python
PolesZerosResponseStage(..., zeros=[[0j, 0j, 150.5]], ...)
```
..fails with:
```
    262             if not isinstance(x, CustomComplex):
    263                 msg = "Zeros must be of CustomComplex type."
--> 264                 raise TypeError(msg)
    265         self._zeros = value
    266 

TypeError: Zeros must be of CustomComplex type.
```

I think we should probably just cast to the correct type..