### PR TITLE
SAC header with numpy types instead of native types

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,8 @@
  - obspy.io.sac:
    * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
      true.  If "dist" header is found, distances aren't calculated.
+   * SACTrace class returns header values as native Python types instead of
+     NumPy types.
  - obspy.signal:
    * PPSD.plot(): fix plotting of percentiles, mode and mean and setting
      period limits when using "xaxis_frequency=True" (see #1406, #1416)

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -328,6 +328,7 @@ Convert to/from ObsPy Traces
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import native_str
 
 import sys
 import warnings
@@ -459,10 +460,10 @@ def _strgetter(hdr):
     def get_str(self):
         try:
             # value is a bytes
-            value = unicode(self._hs[HD.STRHDRS.index(hdr)].decode())
+            value = native_str(self._hs[HD.STRHDRS.index(hdr)].decode())
         except AttributeError:
             # value is a str
-            value = unicode(self._hs[HD.STRHDRS.index(hdr)])
+            value = native_str(self._hs[HD.STRHDRS.index(hdr)])
 
         if value == HD.SNULL:
             value = None

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -369,7 +369,7 @@ from . import arrayio as _io
 # floats
 def _floatgetter(hdr):
     def get_float(self):
-        value = self._hf[HD.FLOATHDRS.index(hdr)]
+        value = float(self._hf[HD.FLOATHDRS.index(hdr)])
         if value == HD.FNULL:
             value = None
         return value
@@ -387,7 +387,7 @@ def _floatsetter(hdr):
 # ints
 def _intgetter(hdr):
     def get_int(self):
-        value = self._hi[HD.INTHDRS.index(hdr)]
+        value = int(self._hi[HD.INTHDRS.index(hdr)])
         if value == HD.INULL:
             value = None
         return value
@@ -459,10 +459,10 @@ def _strgetter(hdr):
     def get_str(self):
         try:
             # value is a bytes
-            value = self._hs[HD.STRHDRS.index(hdr)].decode()
+            value = unicode(self._hs[HD.STRHDRS.index(hdr)].decode())
         except AttributeError:
             # value is a str
-            value = self._hs[HD.STRHDRS.index(hdr)]
+            value = unicode(self._hs[HD.STRHDRS.index(hdr)])
 
         if value == HD.SNULL:
             value = None
@@ -500,15 +500,17 @@ def _make_data_func(func, hdr):
     def do_data_func(self):
         try:
             value = func(self.data)
+            if not isinstance(value, int):
+                value = float(value)
         except TypeError:
-            # data=None (headonly=True)
+            # data is None, get the value from header
             try:
-                value = self._hf[HD.FLOATHDRS.index(hdr)]
-                null = HD.INULL
+                value = float(self._hf[HD.FLOATHDRS.index(hdr)])
+                null = HD.FNULL
             except ValueError:
                 # hdr is 'npts', the only integer
-                # Will this also trip if a data-centric header is misspelled?
-                value = self._hi[HD.INTHDRS.index(hdr)]
+                # XXX: this also trip if a data-centric header is misspelled?
+                value = int(self._hi[HD.INTHDRS.index(hdr)])
                 null = HD.INULL
             if value == null:
                 value = None

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import native_str
 
 import os
 import unittest
@@ -15,6 +16,7 @@ from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from ..sactrace import SACTrace
 from ..util import SacHeaderError
+from .. import header as HD
 
 
 class SACTraceTestCase(unittest.TestCase):
@@ -211,6 +213,20 @@ class SACTraceTestCase(unittest.TestCase):
         # values are set. NOTE: still have a problem when others are "None".
         sac = SACTrace(lcalda=True, stla=stla)
         self.assertRaises(SacHeaderError, sac._set_distances, force=True)
+
+    def test_native_types(self):
+        """
+        SACTrace headers should be returned as native Python types.
+        Addresses #1456.
+        """
+        # sac = SACTrace.read(self.fileseis)
+        sac = SACTrace()
+        native_types = (float, int, type(native_str()), type(None))
+        skip_headers = ('reftime', 'data')
+        for attr in dir(sac):
+            if (not attr.startswith('_') and 'method' not in \
+                    str(getattr(sac, attr)) and attr not in skip_headers):
+                self.assertIsInstance(getattr(sac, attr), native_types)
 
 
 def suite():

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -16,7 +16,6 @@ from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from ..sactrace import SACTrace
 from ..util import SacHeaderError
-from .. import header as HD
 
 
 class SACTraceTestCase(unittest.TestCase):
@@ -213,20 +212,6 @@ class SACTraceTestCase(unittest.TestCase):
         # values are set. NOTE: still have a problem when others are "None".
         sac = SACTrace(lcalda=True, stla=stla)
         self.assertRaises(SacHeaderError, sac._set_distances, force=True)
-
-    def test_native_types(self):
-        """
-        SACTrace headers should be returned as native Python types.
-        Addresses #1456.
-        """
-        # sac = SACTrace.read(self.fileseis)
-        sac = SACTrace()
-        native_types = (float, int, type(native_str()), type(None))
-        skip_headers = ('reftime', 'data')
-        for attr in dir(sac):
-            if (not attr.startswith('_') and 'method' not in \
-                    str(getattr(sac, attr)) and attr not in skip_headers):
-                self.assertIsInstance(getattr(sac, attr), native_types)
 
 
 def suite():

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import native_str
 
 import os
 import unittest


### PR DESCRIPTION
All numeric SAC headers seem to be numpy types (obspy 1.0.1). Probably it is better to cast them to native floats and ints. Also the isynth attribute is not accesible for a fresh SACTrace.

```
from obspy.io.sac.sactrace import SACTrace
sac = SACTrace()
for attr in dir(sac):
    if (not attr.startswith('_') and attr != 'isynth' and
            'method' not in str(getattr(sac, attr))):
        print attr, getattr(sac, attr), type(getattr(sac, attr))
print
sac.isynth
```

```
a None <type 'NoneType'>
az None <type 'NoneType'>
b 0.0 <type 'numpy.float32'>
baz None <type 'NoneType'>
byteorder little <type 'str'>
cmpaz None <type 'NoneType'>
cmpinc None <type 'NoneType'>
data None <type 'NoneType'>
delta 1.0 <type 'numpy.float32'>
depmax None <type 'NoneType'>
depmen None <type 'NoneType'>
depmin None <type 'NoneType'>
dist None <type 'NoneType'>
e 0.0 <type 'numpy.float32'>
evdp None <type 'NoneType'>
evla None <type 'NoneType'>
evlo None <type 'NoneType'>
f None <type 'NoneType'>
gcarc None <type 'NoneType'>
idep None <type 'NoneType'>
ievreg None <type 'NoneType'>
ievtyp None <type 'NoneType'>
iftype itime <type 'unicode'>
iinst None <type 'NoneType'>
imagsrc None <type 'NoneType'>
imagtyp None <type 'NoneType'>
internal0 2.0 <type 'numpy.float32'>
iqual None <type 'NoneType'>
istreg None <type 'NoneType'>
iztype ib <type 'unicode'>
ka None <type 'NoneType'>
kcmpnm None <type 'NoneType'>
kdatrd None <type 'NoneType'>
kevnm None <type 'NoneType'>
kf None <type 'NoneType'>
khole None <type 'NoneType'>
kinst None <type 'NoneType'>
knetwk None <type 'NoneType'>
ko None <type 'NoneType'>
kstnm None <type 'NoneType'>
kt0 None <type 'NoneType'>
kt1 None <type 'NoneType'>
kt2 None <type 'NoneType'>
kt3 None <type 'NoneType'>
kt4 None <type 'NoneType'>
kt5 None <type 'NoneType'>
kt6 None <type 'NoneType'>
kt7 None <type 'NoneType'>
kt8 None <type 'NoneType'>
kt9 None <type 'NoneType'>
kuser0 None <type 'NoneType'>
kuser1 None <type 'NoneType'>
kuser2 None <type 'NoneType'>
lcalda False <type 'bool'>
leven True <type 'bool'>
lovrok True <type 'bool'>
lpspol True <type 'bool'>
mag None <type 'NoneType'>
nevid None <type 'NoneType'>
norid None <type 'NoneType'>
npts 0 <type 'numpy.int32'>
nvhdr 6 <type 'numpy.int32'>
nwfid None <type 'NoneType'>
nzhour 0 <type 'numpy.int32'>
nzjday 1 <type 'numpy.int32'>
nzmin 0 <type 'numpy.int32'>
nzmsec 0 <type 'numpy.int32'>
nzsec 0 <type 'numpy.int32'>
nzyear 1970 <type 'numpy.int32'>
o None <type 'NoneType'>
odelta None <type 'NoneType'>
reftime 1970-01-01T00:00:00.000000Z <class 'obspy.core.utcdatetime.UTCDateTime'>
scale None <type 'NoneType'>
stdp None <type 'NoneType'>
stel None <type 'NoneType'>
stla None <type 'NoneType'>
stlo None <type 'NoneType'>
t0 None <type 'NoneType'>
t1 None <type 'NoneType'>
t2 None <type 'NoneType'>
t3 None <type 'NoneType'>
t4 None <type 'NoneType'>
t5 None <type 'NoneType'>
t6 None <type 'NoneType'>
t7 None <type 'NoneType'>
t8 None <type 'NoneType'>
t9 None <type 'NoneType'>
unused23 None <type 'NoneType'>
user0 None <type 'NoneType'>
user1 None <type 'NoneType'>
user2 None <type 'NoneType'>
user3 None <type 'NoneType'>
user4 None <type 'NoneType'>
user5 None <type 'NoneType'>
user6 None <type 'NoneType'>
user7 None <type 'NoneType'>
user8 None <type 'NoneType'>
user9 None <type 'NoneType'>

Traceback (most recent call last):
  File "bug_wrong_component.py", line 17, in <module>
    sac.isynth
  File "/usr/local/lib/python2.7/dist-packages/obspy/io/sac/sactrace.py", line 430, in get_enum
    value = self._hi[HD.INTHDRS.index(hdr)]
ValueError: tuple.index(x): x not in tuple
```

