### PR TITLE
read_inventory, sensor not parsed from xml

### DIFF
--- a/obspy/core/inventory/channel.py
+++ b/obspy/core/inventory/channel.py
@@ -188,7 +188,8 @@ class Channel(BaseNode):
                                if self.types else ""),
                 sampling_rate=("\tSampling Rate: %.2f Hz\n" %
                                self.sample_rate if self.sample_rate else ""),
-                sensor=("\tSensor: %s\n" % self.sensor.type
+                sensor=("\tSensor (Description): %s (%s)\n" % (
+                        self.sensor.type, self.sensor.description)
                         if self.sensor else ""),
                 response=("\tResponse information available"
                           if self.response else ""))

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -124,7 +124,7 @@ class ChannelTestCase(unittest.TestCase):
             "\tDip: 6.00 degrees down from horizontal\n"
             "\tChannel types: A, B\n"
             "\tSampling Rate: 10.00 Hz\n"
-            "\tSensor: None\n"
+            "\tSensor (Description): None (None)\n"
             "\tResponse information available"
         )
 
@@ -139,7 +139,7 @@ class ChannelTestCase(unittest.TestCase):
             "\tDip: 6.00 degrees down from horizontal\n"
             "\tChannel types: A, B\n"
             "\tSampling Rate: 10.00 Hz\n"
-            "\tSensor: random\n"
+            "\tSensor (Description): random (None)\n"
             "\tResponse information available"
         )
 
@@ -154,7 +154,7 @@ class ChannelTestCase(unittest.TestCase):
             "\tDip: 6.00 degrees down from horizontal\n"
             "\tChannel types: A, B\n"
             "\tSampling Rate: 10.00 Hz\n"
-            "\tSensor: None\n"
+            "\tSensor (Description): None (some description)\n"
             "\tResponse information available"
         )
 
@@ -169,7 +169,7 @@ class ChannelTestCase(unittest.TestCase):
             "\tDip: 6.00 degrees down from horizontal\n"
             "\tChannel types: A, B\n"
             "\tSampling Rate: 10.00 Hz\n"
-            "\tSensor: random\n"
+            "\tSensor (Description): random (some description)\n"
             "\tResponse information available"
         )
 

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -23,6 +23,7 @@ from matplotlib import rcParams
 
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy import read_inventory
+from obspy.core.inventory import Channel, Equipment
 
 
 MATPLOTLIB_VERSION = get_matplotlib_version()
@@ -60,6 +61,117 @@ class ChannelTestCase(unittest.TestCase):
                                  reltol=reltol) as ic:
                 rcParams['savefig.dpi'] = 72
                 cha.plot(0.005, outfile=ic.name)
+
+    def test_channel_str(self):
+        """
+        Tests the __str__ method of the channel object.
+        """
+        c = Channel(code="BHE", location_code="10", latitude=1, longitude=2,
+                    elevation=3, depth=4, azimuth=5, dip=6)
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n")
+
+        # Adding channel types.
+        c.types = ["A", "B"]
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n")
+
+        # Adding channel types.
+        c.sample_rate = 10.0
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n")
+
+        # "Adding" response
+        c.response = True
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n"
+            "\tResponse information available"
+        )
+
+        # Adding an empty sensor.
+        c.sensor = Equipment(type=None)
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n"
+            "\tSensor: None\n"
+            "\tResponse information available"
+        )
+
+        # Adding a sensor with only a type.
+        c.sensor = Equipment(type="random")
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n"
+            "\tSensor: random\n"
+            "\tResponse information available"
+        )
+
+        # Adding a sensor with only a description
+        c.sensor = Equipment(description="some description")
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n"
+            "\tSensor: None\n"
+            "\tResponse information available"
+        )
+
+        # Adding a sensor with type and description
+        c.sensor = Equipment(type="random", description="some description")
+        assert str(c) == (
+            "Channel 'BHE', Location '10' \n"
+            "\tTime range: -- - --\n"
+            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "Local Depth: 4.0 m\n"
+            "\tAzimuth: 5.00 degrees from north, clockwise\n"
+            "\tDip: 6.00 degrees down from horizontal\n"
+            "\tChannel types: A, B\n"
+            "\tSampling Rate: 10.00 Hz\n"
+            "\tSensor: random\n"
+            "\tResponse information available"
+        )
 
 
 def suite():


### PR DESCRIPTION
Python3.5, Obspy 1.0.1

read_inventory does not parse the sensor information from a station xml file, example;
```python
import obspy
from obspy.clients.fdsn import Client
from obspy import read_inventory


network="BK"
station="KCC"
channel="BHZ"
client = Client("IRIS")
client.get_stations(network=network, station=station,channel=channel,level="response",format="xml",filename="tmp.xml")
inventory=read_inventory("tmp.xml",format="STATIONXML")
print(inventory[0][0][1])
```
output;
```
Channel 'BHZ', Location '' 
	Time range: 1996-01-10T23:42:00.000000Z - 2003-07-17T23:00:00.000000Z
	Latitude: 37.32, Longitude: -119.32, Elevation: 888.1 m, Local Depth: 87.3 m
	Azimuth: 0.00 degrees from north, clockwise
	Dip: -90.00 degrees down from horizontal
	Channel types: CONTINUOUS, GEOPHYSICAL
	Sampling Rate: 20.00 Hz
	Sensor: None
	Response information available
```
but, you can see in the saved xml file, the sensor type is there.
