### PR TITLE
Fix references in obspy.core.event docstrings

### DIFF
--- a/misc/docs/source/packages/obspy.core.event.header.rst
+++ b/misc/docs/source/packages/obspy.core.event.header.rst
@@ -1,0 +1,30 @@
+.. currentmodule:: obspy.core.event.header
+.. automodule:: obspy.core.event.header
+    :members:
+
+    .. comment to end block
+
+    Variables
+    ---------
+    .. autosummary::
+       :toctree: autogen
+       :nosignatures:
+
+       AmplitudeCategory
+       AmplitudeUnit
+       DataUsedWaveType
+       EvaluationMode
+       EvaluationStatus
+       EventDescriptionType
+       EventType
+       EventTypeCertainty
+       MTInversionType
+       MomentTensorCategory
+       OriginDepthType
+       OriginType
+       OriginUncertaintyDescription
+       PickOnset
+       PickPolarity
+       SourceTimeFunctionType
+
+    .. comment to end block

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -844,12 +844,14 @@ class CreationInfo(__CreationInfo):
 
     :type agency_id: str, optional
     :param agency_id: Designation of agency that published a resource.
-    :type agency_uri: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type agency_uri: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param agency_uri: Resource Identifier of the agency that published a
         resource.
     :type author: str, optional
     :param author: Name describing the author of a resource.
-    :type author_uri: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type author_uri: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param author_uri: Resource Identifier of the author of a resource.
     :type creation_time: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
     :param creation_time: Time of creation of a resource.
@@ -973,12 +975,13 @@ class Comment(__Comment):
 
     :type text: str
     :param text: Text of comment.
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param resource_id: Resource identifier of comment.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation info for the comment.
 
     >>> comment = Comment(text="Some comment")
@@ -1033,7 +1036,8 @@ class WaveformStreamID(__WaveformStreamID):
     :param location_code: Location code.
     :type channel_code: str, optional
     :param channel_code: Channel code.
-    :type resource_uri: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type resource_uri: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param resource_uri: Resource identifier for the waveform stream.
     :type seed_string: str, optional
     :param seed_string: Provides an alternative initialization way by passing a

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -1166,16 +1166,9 @@ class DataUsed(__DataUsed):
     moment-tensor inversion.
 
     :type wave_type: str
-    :param wave_type: Type of waveform data. This can be one of the following
-        values:
-
-        * ``"P waves"``,
-        * ``"body waves"``,
-        * ``"surface waves"``,
-        * ``"mantle waves"``,
-        * ``"combined"``,
-        * ``"unknown"``
-
+    :param wave_type: Type of waveform data.
+        See :class:`~obspy.core.event.header.DataUsedWaveType` for allowed
+        values.
     :type station_count: int, optional
     :param station_count: Number of stations that have contributed data of the
         type given in wave_type.

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -50,16 +50,16 @@ class Catalog(object):
     """
     This class serves as a container for Event objects.
 
-    :type events: list of :class:`~obspy.core.event.Event`, optional
+    :type events: list of :class:`~obspy.core.event.event.Event`, optional
     :param events: List of events
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of the catalog.
     :type description: str, optional
     :param description: Description string that can be assigned to the
         earthquake catalog, or collection of events.
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 
@@ -179,7 +179,7 @@ class Catalog(object):
         events will be appended.
 
         :type other: :class:`~obspy.core.event.Catalog` or
-            :class:`~obspy.core.event.Event`
+            :class:`~obspy.core.event.event.Event`
         :param other: Catalog or Event object to add.
         """
         if isinstance(other, Event):
@@ -222,7 +222,8 @@ class Catalog(object):
         Returns short summary string of the current catalog.
 
         It will contain the number of Events in the Catalog and the return
-        value of each Event's :meth:`~obspy.core.event.Event.__str__` method.
+        value of each Event's :meth:`~obspy.core.event.event.Event.__str__`
+        method.
 
         :type print_all: bool, optional
         :param print_all: If True, all events will be printed, otherwise a

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -51,7 +51,7 @@ class Event(__Event):
     event is usually associated with one or more magnitudes, and with one or
     more focal mechanism determinations.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Event.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
@@ -112,27 +112,28 @@ class Event(__Event):
         * ``"suspected"``
         * ``"known"``
 
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
     :type event_descriptions: list of
-        :class:`~obspy.core.event.EventDescription`
+        :class:`~obspy.core.event.event.EventDescription`
     :param event_descriptions: Additional event description, like earthquake
         name, Flinn-Engdahl region, etc.
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type picks: list of :class:`~obspy.core.event.Pick`
+    :type picks: list of :class:`~obspy.core.event.origin.Pick`
     :param picks: Picks associated with the event.
-    :type amplitudes: list of :class:`~obspy.core.event.Amplitude`
+    :type amplitudes: list of :class:`~obspy.core.event.magnitude.Amplitude`
     :param amplitudes: Amplitudes associated with the event.
-    :type focal_mechanisms: list of :class:`~obspy.core.event.FocalMechanism`
+    :type focal_mechanisms: list of
+        :class:`~obspy.core.event.source.FocalMechanism`
     :param focal_mechanisms: Focal mechanisms associated with the event
-    :type origins: list of :class:`~obspy.core.event.Origin`
+    :type origins: list of :class:`~obspy.core.event.origin.Origin`
     :param origins: Origins associated with the event.
-    :type magnitudes: list of :class:`~obspy.core.event.Magnitude`
+    :type magnitudes: list of :class:`~obspy.core.event.magnitude.Magnitude`
     :param magnitudes: Magnitudes associated with the event.
     :type station_magnitudes: list of
-        :class:`~obspy.core.event.StationMagnitude`
+        :class:`~obspy.core.event.magnitude.StationMagnitude`
     :param station_magnitudes: Station magnitudes associated with the event.
 
     .. note::

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -57,61 +57,13 @@ class Event(__Event):
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
     :type event_type: str, optional
-    :param event_type: Describes the type of an event. Allowed values are the
-        following:
-
-        * ``"not existing"``
-        * ``"not reported"``
-        * ``"earthquake"``
-        * ``"anthropogenic event"``
-        * ``"collapse"``
-        * ``"cavity collapse"``
-        * ``"mine collapse"``
-        * ``"building collapse"``
-        * ``"explosion"``
-        * ``"accidental explosion"``
-        * ``"chemical explosion"``
-        * ``"controlled explosion"``
-        * ``"experimental explosion"``
-        * ``"industrial explosion"``
-        * ``"mining explosion"``
-        * ``"quarry blast"``
-        * ``"road cut"``
-        * ``"blasting levee"``
-        * ``"nuclear explosion"``
-        * ``"induced or triggered event"``
-        * ``"rock burst"``
-        * ``"reservoir loading"``
-        * ``"fluid injection"``
-        * ``"fluid extraction"``
-        * ``"crash"``
-        * ``"plane crash"``
-        * ``"train crash"``
-        * ``"boat crash"``
-        * ``"other event"``
-        * ``"atmospheric event"``
-        * ``"sonic boom"``
-        * ``"sonic blast"``
-        * ``"acoustic noise"``
-        * ``"thunder"``
-        * ``"avalanche"``
-        * ``"snow avalanche"``
-        * ``"debris avalanche"``
-        * ``"hydroacoustic event"``
-        * ``"ice quake"``
-        * ``"slide"``
-        * ``"landslide"``
-        * ``"rockslide"``
-        * ``"meteorite"``
-        * ``"volcanic eruption"``
-
+    :param event_type: Describes the type of an event.
+        See :class:`~obspy.core.event.header.EventType` for allowed values.
     :type event_type_certainty: str, optional
     :param event_type_certainty: Denotes how certain the information on event
-        type is. Allowed values are the following:
-
-        * ``"suspected"``
-        * ``"known"``
-
+        type is.
+        See :class:`~obspy.core.event.header.EventTypeCertainty` for allowed
+        values.
     :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
@@ -354,16 +306,9 @@ class EventDescription(__EventDescription):
     :type text: str, optional
     :param text: Free-form text with earthquake description.
     :type type: str, optional
-    :param type: Category of earthquake description. Values
-        can be taken from the following:
-
-        * ``"felt report"``
-        * ``"Flinn-Engdahl region"``
-        * ``"local time"``
-        * ``"tectonic summary"``
-        * ``"nearest cities"``
-        * ``"earthquake name"``
-        * ``"region name"``
+    :param type: Category of earthquake description.
+        See :class:`~obspy.core.event.header.EventDescriptionType` for allowed
+        values.
 
     .. note::
 

--- a/obspy/core/event/header.py
+++ b/obspy/core/event/header.py
@@ -1,3 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+obspy.core.event.header - Enumeration types for event-type classes
+==================================================================
+This module provides enumerations defined in the
+`QuakeML <https://quake.ethz.ch/quakeml/>`_ standard.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (http://www.gnu.org/copyleft/lesser.html)
+"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
@@ -8,12 +21,6 @@ from obspy.core.util import Enum
 ATTRIBUTE_HAS_ERRORS = True
 
 
-OriginUncertaintyDescription = Enum([
-    "horizontal uncertainty",
-    "uncertainty ellipse",
-    "confidence ellipsoid",
-])
-
 AmplitudeCategory = Enum([
     "point",
     "mean",
@@ -22,60 +29,22 @@ AmplitudeCategory = Enum([
     "integral",
     "other",
 ])
+"""
+Amplitude category.  This attribute describes the way the
+waveform trace is evaluated to derive an amplitude value. This can be
+just reading a single value for a given point in time (point), taking a
+mean value over a time interval (mean), integrating the trace over a
+time interval (integral), specifying just a time interval (duration),
+or evaluating a period (period).
+Allowed values are:
 
-OriginDepthType = Enum([
-    "from location",
-    "from moment tensor inversion",
-    "from modeling of broad-band P waveforms",
-    "constrained by depth phases",
-    "constrained by direct phases",
-    "constrained by depth and direct phases",
-    "operator assigned",
-    "other",
-])
-
-OriginType = Enum([
-    "hypocenter",
-    "centroid",
-    "amplitude",
-    "macroseismic",
-    "rupture start",
-    "rupture end",
-])
-
-MTInversionType = Enum([
-    "general",
-    "zero trace",
-    "double couple",
-])
-
-EvaluationMode = Enum([
-    "manual",
-    "automatic",
-])
-
-EvaluationStatus = Enum([
-    "preliminary",
-    "confirmed",
-    "reviewed",
-    "final",
-    "rejected",
-])
-
-PickOnset = Enum([
-    "emergent",
-    "impulsive",
-    "questionable",
-])
-
-DataUsedWaveType = Enum([
-    "P waves",
-    "body waves",
-    "surface waves",
-    "mantle waves",
-    "combined",
-    "unknown",
-])
+* ``"point"``
+* ``"mean"``
+* ``"duration"``
+* ``"period"``
+* ``"integral"``
+* ``"other"``
+"""
 
 AmplitudeUnit = Enum([
     "m",
@@ -86,6 +55,66 @@ AmplitudeUnit = Enum([
     "dimensionless",
     "other",
 ])
+"""
+Amplitude unit. Values are specified as combinations of SI base units.
+Allowed values are:
+
+* ``"m"``
+* ``"s"``
+* ``"m/s"``
+* ``"m/(s*s)"``
+* ``"m*s"``
+* ``"dimensionless"``
+* ``"other"``
+"""
+
+DataUsedWaveType = Enum([
+    "P waves",
+    "body waves",
+    "surface waves",
+    "mantle waves",
+    "combined",
+    "unknown",
+])
+"""
+Type of waveform data. Allowed values are:
+
+* ``"P waves"``
+* ``"body waves"``
+* ``"surface waves"``
+* ``"mantle waves"``
+* ``"combined"``
+* ``"unknown"``
+"""
+
+EvaluationMode = Enum([
+    "manual",
+    "automatic",
+])
+"""
+Evaluation mode. Allowed values are:
+
+* ``"manual"``
+* ``"automatic"``
+"""
+
+EvaluationStatus = Enum([
+    "preliminary",
+    "confirmed",
+    "reviewed",
+    "final",
+    "rejected",
+])
+"""
+Evaluation status. Allowed values are:
+
+* ``"preliminary"``
+* ``"confirmed"``
+* ``"reviewed"``
+* ``"final"``
+* ``"rejected"``
+* ``"reported"``
+"""
 
 EventDescriptionType = Enum([
     "felt report",
@@ -96,11 +125,17 @@ EventDescriptionType = Enum([
     "earthquake name",
     "region name",
 ])
+"""
+Category of earthquake description. Allowed values are:
 
-MomentTensorCategory = Enum([
-    "teleseismic",
-    "regional",
-])
+* ``"felt report"``
+* ``"Flinn-Engdahl region"``
+* ``"local time"``
+* ``"tectonic summary"``
+* ``"nearest cities"``
+* ``"earthquake name"``
+* ``"region name"``
+"""
 
 EventType = Enum([
     "not existing",
@@ -148,11 +183,172 @@ EventType = Enum([
     "meteorite",
     "volcanic eruption",
 ], replace={'other': 'other event'})
+"""
+Describes the type of an event. Allowed values are:
+
+* ``"not existing"``
+* ``"not reported"``
+* ``"earthquake"``
+* ``"anthropogenic event"``
+* ``"collapse"``
+* ``"cavity collapse"``
+* ``"mine collapse"``
+* ``"building collapse"``
+* ``"explosion"``
+* ``"accidental explosion"``
+* ``"chemical explosion"``
+* ``"controlled explosion"``
+* ``"experimental explosion"``
+* ``"industrial explosion"``
+* ``"mining explosion"``
+* ``"quarry blast"``
+* ``"road cut"``
+* ``"blasting levee"``
+* ``"nuclear explosion"``
+* ``"induced or triggered event"``
+* ``"rock burst"``
+* ``"reservoir loading"``
+* ``"fluid injection"``
+* ``"fluid extraction"``
+* ``"crash"``
+* ``"plane crash"``
+* ``"train crash"``
+* ``"boat crash"``
+* ``"other event"``
+* ``"atmospheric event"``
+* ``"sonic boom"``
+* ``"sonic blast"``
+* ``"acoustic noise"``
+* ``"thunder"``
+* ``"avalanche"``
+* ``"snow avalanche"``
+* ``"debris avalanche"``
+* ``"hydroacoustic event"``
+* ``"ice quake"``
+* ``"slide"``
+* ``"landslide"``
+* ``"rockslide"``
+* ``"meteorite"``
+* ``"volcanic eruption"``
+"""
 
 EventTypeCertainty = Enum([
     "known",
     "suspected",
 ])
+"""
+Denotes how certain the information on event type is. Allowed values are:
+
+* ``"suspected"``
+* ``"known"``
+"""
+
+MTInversionType = Enum([
+    "general",
+    "zero trace",
+    "double couple",
+])
+"""
+Moment tensor inversion type. Allowed values are:
+
+* ``"general"``
+* ``"zero trace"``
+* ``"double couple"``
+"""
+
+MomentTensorCategory = Enum([
+    "teleseismic",
+    "regional",
+])
+"""
+Moment tensor category. Allowed values are:
+
+* ``"teleseismic"``
+* ``"regional"``
+"""
+
+OriginDepthType = Enum([
+    "from location",
+    "from moment tensor inversion",
+    "from modeling of broad-band P waveforms",
+    "constrained by depth phases",
+    "constrained by direct phases",
+    "constrained by depth and direct phases",
+    "operator assigned",
+    "other",
+])
+"""
+Type of origin depth determination. Allowed values are:
+
+* ``"from location"``
+* ``"from moment tensor inversion"``
+* ``"from modeling of broad-band P waveforms"``
+* ``"constrained by depth phases"``
+* ``"constrained by direct phases"``
+* ``"constrained by depth and direct phases"``
+* ``"operator assigned"``
+* ``"other"``
+"""
+
+OriginType = Enum([
+    "hypocenter",
+    "centroid",
+    "amplitude",
+    "macroseismic",
+    "rupture start",
+    "rupture end",
+])
+"""
+Origin type. Allowed values are:
+
+* ``"hypocenter"``
+* ``"centroid"``
+* ``"amplitude"``
+* ``"macroseismic"``
+* ``"rupture start"``
+* ``"rupture end"``
+"""
+
+OriginUncertaintyDescription = Enum([
+    "horizontal uncertainty",
+    "uncertainty ellipse",
+    "confidence ellipsoid",
+])
+"""
+Preferred origin uncertainty description. Allowed values are:
+
+* ``"horizontal uncertainty"``
+* ``"uncertainty ellipse"``
+* ``"confidence ellipsoid"``
+"""
+
+PickOnset = Enum([
+    "emergent",
+    "impulsive",
+    "questionable",
+])
+"""
+Flag that roughly categorizes the sharpness of the pick onset.
+Allowed values are:
+
+* ``"emergent"``
+* ``"impulsive"``
+* ``"questionable"``
+"""
+
+PickPolarity = Enum([
+    "positive",
+    "negative",
+    "undecidable",
+])
+"""
+Indicates the polarity of first motion, usually from impulsive onsets.
+Allowed values are:
+
+* ``"positive"``
+* ``"negative"``
+* ``"undecidable"``
+"""
 
 SourceTimeFunctionType = Enum([
     "box car",
@@ -160,9 +356,11 @@ SourceTimeFunctionType = Enum([
     "trapezoid",
     "unknown",
 ])
+"""
+Type of source time function. Allowed values are:
 
-PickPolarity = Enum([
-    "positive",
-    "negative",
-    "undecidable",
-])
+* ``"box car"``
+* ``"triangle"``
+* ``"trapezoid"``
+* ``"unknown"``
+"""

--- a/obspy/core/event/magnitude.py
+++ b/obspy/core/event/magnitude.py
@@ -54,15 +54,16 @@ class Magnitude(__Magnitude):
     originID. It is either a combination of different magnitude estimations, or
     it represents the reported magnitude for the given event.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Magnitude.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
     :type mag: float
     :param mag: Resulting magnitude value from combining values of type
-        :class:`~obspy.core.event.StationMagnitude`. If no estimations are
-        available, this value can represent the reported magnitude.
+        :class:`~obspy.core.event.magnitude.StationMagnitude`.
+        If no estimations are available, this value can represent the
+        reported magnitude.
     :type mag_errors: :class:`~obspy.core.event.base.QuantityError`
     :param mag_errors: AttribDict containing error quantities.
     :type magnitude_type: str, optional
@@ -79,10 +80,12 @@ class Magnitude(__Magnitude):
         * coda magnitude (``'Mc'``)
         * ``'MH'``, ``'Mwp'``, ``'M50'``, ``'M100'``, etc.
 
-    :type origin_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type origin_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param origin_id: Reference to an origin’s resource_id if the magnitude has
         an associated Origin.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Identifies the method of magnitude estimation. Users
         should avoid to give contradictory information in method_id and
         magnitude_type.
@@ -100,7 +103,7 @@ class Magnitude(__Magnitude):
         * ``"automatic"``
 
     :type evaluation_status:
-        :class:`~obspy.core.event_header.EvaluationStatus`, optional
+        :class:`~obspy.core.event.header.EvaluationStatus`, optional
     :param evaluation_status: Evaluation status of Magnitude. Allowed values
         are the following:
 
@@ -111,13 +114,13 @@ class Magnitude(__Magnitude):
         * ``"rejected"``
         * ``"reported"``
 
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type station_magnitude_contributions: list of
-        :class:`~obspy.core.event.StationMagnitudeContribution`.
+        :class:`~obspy.core.event.magnitude.StationMagnitudeContribution`.
     :param station_magnitude_contributions: StationMagnitudeContribution
         instances associated with the Magnitude.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 
@@ -146,12 +149,14 @@ class StationMagnitude(__StationMagnitude):
     """
     This class describes the magnitude derived from a single waveform stream.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param resource_id: Resource identifier of StationMagnitude.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
-    :type origin_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type origin_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param origin_id: Reference to an origin’s ``resource_id`` if the
         StationMagnitude has an associated :class:`~obspy.core.event.Origin`.
     :type mag: float
@@ -159,21 +164,25 @@ class StationMagnitude(__StationMagnitude):
     :type mag_errors: :class:`~obspy.core.event.base.QuantityError`
     :param mag_errors: AttribDict containing error quantities.
     :type station_magnitude_type: str, optional
-    :param station_magnitude_type: See :class:`~obspy.core.event.Magnitude`
-    :type amplitude_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :param station_magnitude_type: See
+        :class:`~obspy.core.event.magnitude.Magnitude`
+    :type amplitude_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param amplitude_id: Identifies the data source of the StationMagnitude.
         For magnitudes derived from amplitudes in waveforms (e.g., local
         magnitude ML), amplitudeID points to publicID in class Amplitude.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
-    :param method_id: See :class:`~obspy.core.event.Magnitude`
-    :type waveform_id: :class:`~obspy.core.event.WaveformStreamID`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
+    :param method_id: See :class:`~obspy.core.event.magnitude.Magnitude`
+    :type waveform_id: :class:`~obspy.core.event.base.WaveformStreamID`,
+        optional
     :param waveform_id: Identifies the waveform stream. This element can be
         helpful if no amplitude is referenced, or the amplitude is not
         available in the context. Otherwise, it would duplicate the waveform_id
         provided there and can be omitted.
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 
@@ -197,8 +206,8 @@ class StationMagnitudeContribution(__StationMagnitudeContribution):
     This class describes the weighting of magnitude values from several
     StationMagnitude objects for computing a network magnitude estimation.
 
-    :type station_magnitude_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type station_magnitude_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param station_magnitude_id: Refers to the resource_id of a
         StationMagnitude object.
     :type residual: float, optional
@@ -246,7 +255,7 @@ class Amplitude(__Amplitude):
     single amplitude measurement or a measurement of the visible signal
     duration for duration magnitudes.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Amplitude.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
@@ -309,7 +318,8 @@ class Amplitude(__Amplitude):
         * ``"dimensionless"``,
         * ``"other"``
 
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Describes the method of amplitude determination.
     :type period: float, optional
     :param period: Dominant period in the timeWindow in case of amplitude
@@ -317,16 +327,18 @@ class Amplitude(__Amplitude):
     :type snr: float, optional
     :param snr: Signal-to-noise ratio of the spectrogram at the location the
         amplitude was measured.
-    :type time_window: :class:`~obspy.core.event.TimeWindow`, optional
+    :type time_window: :class:`~obspy.core.event.base.TimeWindow`, optional
     :param time_window: Description of the time window used for amplitude
         measurement. Recommended for duration magnitudes.
-    :type pick_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type pick_id: :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param pick_id: Refers to the ``resource_id`` of an associated
-        :class:`~obspy.core.event.Pick` object.
-    :type waveform_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+        :class:`~obspy.core.event.origin.Pick` object.
+    :type waveform_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param waveform_id: Identifies the waveform stream on which the amplitude
         was measured.
-    :type filter_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type filter_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param filter_id: Identifies the filter or filter setup used for filtering
         the waveform stream referenced by ``waveform_id``.
     :type scaling_time: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
@@ -366,9 +378,9 @@ class Amplitude(__Amplitude):
         * ``"rejected"``
         * ``"reported"``
 
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: CreationInfo for the Amplitude object.
 
     .. note::

--- a/obspy/core/event/magnitude.py
+++ b/obspy/core/event/magnitude.py
@@ -96,24 +96,13 @@ class Magnitude(__Magnitude):
     :param azimuthal_gap: Azimuthal gap for this magnitude computation.
         Unit: deg
     :type evaluation_mode: str, optional
-    :param evaluation_mode: Evaluation mode of Magnitude. Allowed values are
-        the following:
-
-        * ``"manual"``
-        * ``"automatic"``
-
-    :type evaluation_status:
-        :class:`~obspy.core.event.header.EvaluationStatus`, optional
-    :param evaluation_status: Evaluation status of Magnitude. Allowed values
-        are the following:
-
-        * ``"preliminary"``
-        * ``"confirmed"``
-        * ``"reviewed"``
-        * ``"final"``
-        * ``"rejected"``
-        * ``"reported"``
-
+    :param evaluation_mode: Evaluation mode of Magnitude.
+        See :class:`~obspy.core.event.header.EvaluationMode` for allowed
+        values.
+    :type evaluation_status: str, optional
+    :param evaluation_status: Evaluation status of Magnitude.
+        See :class:`~obspy.core.event.header.EvaluationStatus` for allowed
+        values.
     :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type station_magnitude_contributions: list of
@@ -294,30 +283,15 @@ class Amplitude(__Amplitude):
         mean value over a time interval (mean), integrating the trace over a
         time interval (integral), specifying just a time interval (duration),
         or evaluating a period (period).
-        Possible values are:
-
-        * ``"point"``,
-        * ``"mean"``,
-        * ``"duration"``,
-        * ``"period"``,
-        * ``"integral"``,
-        * ``"other"``
-
+        See :class:`~obspy.core.event.header.AmplitudeCategory` for allowed
+        values.
     :type unit: str, optional
     :param unit: Amplitude unit. This attribute provides the most likely
         measurement units for the physical quantity described in the
         genericAmplitude attribute. Possible values are specified as
         combinations of SI base units.
-        Possible values are:
-
-        * ``"m"``,
-        * ``"s"``,
-        * ``"m/s"``,
-        * ``"m/(s*s)"``,
-        * ``"m*s"``,
-        * ``"dimensionless"``,
-        * ``"other"``
-
+        See :class:`~obspy.core.event.header.AmplitudeUnit` for allowed
+        values.
     :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
         optional
     :param method_id: Describes the method of amplitude determination.
@@ -361,23 +335,13 @@ class Amplitude(__Amplitude):
         * ``'MH'``, ``'Mwp'``, ``'M50'``, ``'M100'``, etc.
 
     :type evaluation_mode: str, optional
-    :param evaluation_mode: Evaluation mode of Amplitude. Allowed values are
-        the following:
-
-        * ``"manual"``
-        * ``"automatic"``
-
+    :param evaluation_mode: Evaluation mode of Amplitude.
+        See :class:`~obspy.core.event.header.EvaluationMode` for allowed
+        values.
     :type evaluation_status: str, optional
-    :param evaluation_status: Evaluation status of Amplitude. Allowed values
-        are the following:
-
-        * ``"preliminary"``
-        * ``"confirmed"``
-        * ``"reviewed"``
-        * ``"final"``
-        * ``"rejected"``
-        * ``"reported"``
-
+    :param evaluation_status: Evaluation status of Amplitude.
+        See :class:`~obspy.core.event.header.EvaluationStatus` for allowed
+        values.
     :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional

--- a/obspy/core/event/origin.py
+++ b/obspy/core/event/origin.py
@@ -64,8 +64,8 @@ class OriginUncertainty(__OriginUncertainty):
     :param azimuth_max_horizontal_uncertainty: Azimuth of major axis of
         confidence ellipse. Measured clockwise from South-North direction at
         epicenter. Unit: deg
-    :type confidence_ellipsoid: :class:`~obspy.core.event.ConfidenceEllipsoid`,
-        optional
+    :type confidence_ellipsoid:
+        :class:`~obspy.core.event.base.ConfidenceEllipsoid`, optional
     :param confidence_ellipsoid: Confidence ellipsoid
     :type preferred_description: str, optional
     :param preferred_description: Preferred uncertainty description. Allowed
@@ -187,7 +187,7 @@ class Origin(__Origin):
     earthquake hypocenter, as well as additional meta-information. Origin can
     have objects of type OriginUncertainty and Arrival as child elements.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Origin.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
@@ -235,28 +235,29 @@ class Origin(__Origin):
     :type epicenter_fixed: bool, optional
     :param epicenter_fixed: True if epicenter was kept fixed for computation of
         Origin.
-    :type reference_system_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type reference_system_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param reference_system_id: Identifies the reference system used for
         hypocenter determination. This is only necessary if a modified version
         of the standard (with local extensions) is used that provides a
         non-standard coordinate system.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Identifies the method used for locating the event.
-    :type earth_model_id: :class:`~obspy.core.event.ResourceIdentifier`,
+    :type earth_model_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
         optional
     :param earth_model_id: Identifies the earth model used in method_id.
-    :type arrivals: list of :class:`~obspy.core.event.Arrival`, optional
+    :type arrivals: list of :class:`~obspy.core.event.origin.Arrival`, optional
     :param arrivals: List of arrivals associated with the origin.
-    :type composite_times: list of :class:`~obspy.core.event.CompositeTime`,
-        optional
+    :type composite_times: list of
+        :class:`~obspy.core.event.base.CompositeTime`, optional
     :param composite_times: Supplementary information on time of rupture start.
         Complex descriptions of focal times of historic events are possible,
         see description of the CompositeTime type. Note that even if
         compositeTime is used, the mandatory time attribute has to be set, too.
         It has to be set to the single point in time (with uncertainties
         allowed) that is most characteristic for the event.
-    :type quality: :class:`~obspy.core.event.OriginQuality`, optional
+    :type quality: :class:`~obspy.core.event.origin.OriginQuality`, optional
     :param quality: Additional parameters describing the quality of an Origin
         determination.
     :type origin_type: str, optional
@@ -270,8 +271,8 @@ class Origin(__Origin):
         * ``"rupture start"``
         * ``"rupture end"``
 
-    :type origin_uncertainty: :class:`~obspy.core.event.OriginUncertainty`,
-        optional
+    :type origin_uncertainty:
+        :class:`~obspy.core.event.origin.OriginUncertainty`, optional
     :param origin_uncertainty: Describes the location uncertainties of an
         origin.
     :type region: str, optional
@@ -299,9 +300,9 @@ class Origin(__Origin):
         * ``"rejected"``
         * ``"reported"``
 
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 
@@ -356,7 +357,7 @@ class Pick(__Pick):
     A pick is the observation of an amplitude anomaly in a seismogram at a
     specific point in time. It is not necessarily related to a seismic event.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Pick.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
@@ -365,12 +366,14 @@ class Pick(__Pick):
     :param time: Observed onset time of signal (“pick time”).
     :type time_errors: :class:`~obspy.core.event.base.QuantityError`
     :param time_errors: AttribDict containing error quantities.
-    :type waveform_id: :class:`~obspy.core.event.WaveformStreamID`
+    :type waveform_id: :class:`~obspy.core.event.base.WaveformStreamID`
     :param waveform_id: Identifies the waveform stream.
-    :type filter_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type filter_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param filter_id: Identifies the filter or filter setup used for filtering
         the waveform stream referenced by waveform_id.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Identifies the picker that produced the pick. This can be
         either a detection software program or a person.
     :type horizontal_slowness: float, optional
@@ -384,8 +387,8 @@ class Pick(__Pick):
         array measurements. Unit: deg
     :type backazimuth_errors: :class:`~obspy.core.event.base.QuantityError`
     :param backazimuth_errors: AttribDict containing error quantities.
-    :type slowness_method_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type slowness_method_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param slowness_method_id: Identifies the method that was used to determine
         the slowness.
     :type onset: str, optional
@@ -425,9 +428,9 @@ class Pick(__Pick):
         * ``"rejected"``
         * ``"reported"``
 
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: CreationInfo for the Pick object.
 
     .. note::
@@ -470,12 +473,12 @@ class Arrival(__Arrival):
     slowness and backazimuth of the observed wave—especially if derived from
     array data—may further constrain the nature of the arrival.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of Arrival.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
-    :type pick_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type pick_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param pick_id: Refers to the resource_id of a Pick.
     :type phase: str
     :param phase: Phase identification. For possible values, please refer to
@@ -518,13 +521,13 @@ class Arrival(__Arrival):
     :param backazimuth_weight: Weight of the backazimuth for computation of the
         associated Origin. Note that the sum of all weights is not required to
         be unity.
-    :type earth_model_id: :class:`~obspy.core.event.ResourceIdentifier`,
+    :type earth_model_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
         optional
     :param earth_model_id: Earth model which is used for the association of
         Arrival to Pick and computation of the residuals.
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: CreationInfo for the Arrival object.
 
     .. note::

--- a/obspy/core/event/origin.py
+++ b/obspy/core/event/origin.py
@@ -68,13 +68,9 @@ class OriginUncertainty(__OriginUncertainty):
         :class:`~obspy.core.event.base.ConfidenceEllipsoid`, optional
     :param confidence_ellipsoid: Confidence ellipsoid
     :type preferred_description: str, optional
-    :param preferred_description: Preferred uncertainty description. Allowed
-        values are the following:
-
-        * horizontal uncertainty
-        * uncertainty ellipse
-        * confidence ellipsoid
-
+    :param preferred_description: Preferred uncertainty description.
+        See :class:`~obspy.core.event.header.OriginUncertaintyDescription` for
+        allowed values.
     :type confidence_level: float, optional
     :param confidence_level: Confidence level of the uncertainty, given in
         percent.
@@ -217,18 +213,9 @@ class Origin(__Origin):
     :type depth_errors: :class:`~obspy.core.event.base.QuantityError`
     :param depth_errors: AttribDict containing error quantities.
     :type depth_type: str, optional
-    :param depth_type: Type of depth determination. Allowed values are the
-        following:
-
-        * ``"from location"``
-        * ``"from moment tensor inversion"``
-        * ``"from modeling of broad-band P waveforms"``
-        * ``"constrained by depth phases"``
-        * ``"constrained by direct phases"``
-        * ``"constrained by depth and direct phases"``
-        * ``"operator assigned"``
-        * ``"other"``
-
+    :param depth_type: Type of depth determination.
+        See :class:`~obspy.core.event.header.OriginDepthType` for allowed
+        values.
     :type time_fixed: bool, optional
     :param time_fixed: True if focal time was kept fixed for computation of the
         Origin.
@@ -261,16 +248,8 @@ class Origin(__Origin):
     :param quality: Additional parameters describing the quality of an Origin
         determination.
     :type origin_type: str, optional
-    :param origin_type: Describes the origin type. Allowed values are the
-        following:
-
-        * ``"hypocenter"``
-        * ``"centroid"``
-        * ``"amplitude"``
-        * ``"macroseismic"``
-        * ``"rupture start"``
-        * ``"rupture end"``
-
+    :param origin_type: Describes the origin type.
+        See :class:`~obspy.core.event.header.OriginType` for allowed values.
     :type origin_uncertainty:
         :class:`~obspy.core.event.origin.OriginUncertainty`, optional
     :param origin_uncertainty: Describes the location uncertainties of an
@@ -283,23 +262,13 @@ class Origin(__Origin):
         of an Event object. The user has to take care that this information
         corresponds to the region attribute of the preferred Origin.
     :type evaluation_mode: str, optional
-    :param evaluation_mode: Evaluation mode of Origin. Allowed values are the
-        following:
-
-        * ``"manual"``
-        * ``"automatic"``
-
+    :param evaluation_mode: Evaluation mode of Origin.
+        See :class:`~obspy.core.event.header.EvaluationMode` for allowed
+        values.
     :type evaluation_status: str, optional
-    :param evaluation_status: Evaluation status of Origin. Allowed values are
-        the following:
-
-        * ``"preliminary"``
-        * ``"confirmed"``
-        * ``"reviewed"``
-        * ``"final"``
-        * ``"rejected"``
-        * ``"reported"``
-
+    :param evaluation_status: Evaluation status of Origin.
+        See :class:`~obspy.core.event.header.EvaluationStatus` for allowed
+        values.
     :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
@@ -393,41 +362,22 @@ class Pick(__Pick):
         the slowness.
     :type onset: str, optional
     :param onset: Flag that roughly categorizes the sharpness of the onset.
-        Allowed values are:
-
-        * ``"emergent"``
-        * ``"impulsive"``
-        * ``"questionable"``
-
+        See :class:`~obspy.core.event.header.PickOnset` for allowed values.
     :type phase_hint: str, optional
     :param phase_hint: Tentative phase identification as specified by the
         picker.
     :type polarity: str, optional
     :param polarity: Indicates the polarity of first motion, usually from
-        impulsive onsets. Allowed values are:
-
-        * ``"positive"``
-        * ``"negative"``
-        * ``"undecidable"``
-
+        impulsive onsets.
+        See :class:`~obspy.core.event.header.PickPolarity` for allowed values.
     :type evaluation_mode: str, optional
-    :param evaluation_mode: Evaluation mode of Pick. Allowed values are the
-        following:
-
-        * ``"manual"``
-        * ``"automatic"``
-
+    :param evaluation_mode: Evaluation mode of Pick.
+        See :class:`~obspy.core.event.header.EvaluationMode` for allowed
+        values.
     :type evaluation_status: str, optional
-    :param evaluation_status: Evaluation status of Pick. Allowed values are
-        the following:
-
-        * ``"preliminary"``
-        * ``"confirmed"``
-        * ``"reviewed"``
-        * ``"final"``
-        * ``"rejected"``
-        * ``"reported"``
-
+    :param evaluation_status: Evaluation status of Pick.
+        See :class:`~obspy.core.event.header.EvaluationStatus` for allowed
+        values.
     :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional

--- a/obspy/core/event/source.py
+++ b/obspy/core/event/source.py
@@ -224,14 +224,9 @@ class SourceTimeFunction(__SourceTimeFunction):
     Source time function used in moment-tensor inversion.
 
     :type type: str
-    :param type: Type of source time function. Values can be taken from the
-        following:
-
-        * ``"box car"``,
-        * ``"triangle"``,
-        * ``"trapezoid"``,
-        * ``"unknown"``
-
+    :param type: Type of source time function.
+        See :class:`~obspy.core.event.header.SourceTimeFunctionType` for
+        allowed values.
     :type duration: float
     :param duration: Source time function duration. Unit: s
     :type rise_time: float, optional
@@ -326,21 +321,14 @@ class MomentTensor(__MomentTensor):
     :param method_id: Resource identifier of the method used for moment-tensor
         inversion.
     :type category: str, optional
-    :param category: Moment tensor category. Values can be taken from the
-        following:
-
-        * ``"teleseismic"``,
-        * ``"regional"``
-
+    :param category: Moment tensor category.
+        See :class:`~obspy.core.event.header.MomentTensorCategory` for allowed
+        values.
     :type inversion_type: str, optional
     :param inversion_type: Moment tensor inversion type. Users should avoid to
-        give contradictory information in inversion_type and method_id. Values
-        can be taken from the following:
-
-        * ``"general"``,
-        * ``"zero trace"``,
-        * ``"double couple"``
-
+        give contradictory information in inversion_type and method_id.
+        See :class:`~obspy.core.event.header.MTInversionType` for allowed
+        values.
     :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
     :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
@@ -416,23 +404,13 @@ class FocalMechanism(__FocalMechanism):
     :param waveform_id: Refers to a set of waveform streams from which the
         focal mechanism was derived.
     :type evaluation_mode: str, optional
-    :param evaluation_mode: Evaluation mode of FocalMechanism. Allowed values
-        are the following:
-
-        * ``"manual"``
-        * ``"automatic"``
-
+    :param evaluation_mode: Evaluation mode of FocalMechanism.
+        See :class:`~obspy.core.event.header.EvaluationMode` for allowed
+        values.
     :type evaluation_status: str, optional
-    :param evaluation_status: Evaluation status of FocalMechanism. Allowed
-        values are the following:
-
-        * ``"preliminary"``
-        * ``"confirmed"``
-        * ``"reviewed"``
-        * ``"final"``
-        * ``"rejected"``
-        * ``"reported"``
-
+    :param evaluation_status: Evaluation status of FocalMechanism.
+        See :class:`~obspy.core.event.header.EvaluationStatus` for allowed
+        values.
     :type moment_tensor: :class:`~obspy.core.event.source.MomentTensor`,
         optional
     :param moment_tensor: Moment tensor description for this focal mechanism.

--- a/obspy/core/event/source.py
+++ b/obspy/core/event/source.py
@@ -117,10 +117,10 @@ class NodalPlanes(__NodalPlanes):
     solution. The attribute ``preferred_plane`` can be used to define which
     plane is the preferred one.
 
-    :type nodal_plane_1: :class:`~obspy.core.event.NodalPlane`, optional
+    :type nodal_plane_1: :class:`~obspy.core.event.source.NodalPlane`, optional
     :param nodal_plane_1: First nodal plane of double-couple moment tensor
         solution.
-    :type nodal_plane_2: :class:`~obspy.core.event.NodalPlane`, optional
+    :type nodal_plane_2: :class:`~obspy.core.event.source.NodalPlane`, optional
     :param nodal_plane_2: Second nodal plane of double-couple moment tensor
         solution.
     :type preferred_plane: int, optional
@@ -147,11 +147,11 @@ class PrincipalAxes(__PrincipalAxes):
     This class describes the principal axes of a double-couple moment tensor
     solution. t_axis and p_axis are required, while n_axis is optional.
 
-    :type t_axis: :class:`~obspy.core.event.Axis`
+    :type t_axis: :class:`~obspy.core.event.source.Axis`
     :param t_axis: T (tension) axis of a double-couple moment tensor solution.
-    :type p_axis: :class:`~obspy.core.event.Axis`
+    :type p_axis: :class:`~obspy.core.event.source.Axis`
     :param p_axis: P (pressure) axis of a double-couple moment tensor solution.
-    :type n_axis: :class:`~obspy.core.event.Axis`, optional
+    :type n_axis: :class:`~obspy.core.event.source.Axis`, optional
     :param n_axis: N (neutral) axis of a double-couple moment tensor solution.
 
     .. note::
@@ -274,16 +274,16 @@ class MomentTensor(__MomentTensor):
     This class represents a moment tensor solution for an event. It is an
     optional part of a FocalMechanism description.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of MomentTensor.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
-    :type derived_origin_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type derived_origin_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param derived_origin_id: Refers to the resource_id of the Origin derived
         in the moment tensor inversion.
-    :type moment_magnitude_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type moment_magnitude_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param moment_magnitude_id: Refers to the publicID of the Magnitude object
         which represents the derived moment magnitude.
     :type scalar_moment: float, optional
@@ -291,7 +291,7 @@ class MomentTensor(__MomentTensor):
         Unit: Nm
     :type scalar_moment_errors: :class:`~obspy.core.event.base.QuantityError`
     :param scalar_moment_errors: AttribDict containing error quantities.
-    :type tensor: :class:`~obspy.core.event.Tensor`, optional
+    :type tensor: :class:`~obspy.core.event.source.Tensor`, optional
     :param tensor: Tensor object holding the moment tensor elements.
     :type variance: float, optional
     :param variance: Variance of moment tensor inversion.
@@ -307,20 +307,22 @@ class MomentTensor(__MomentTensor):
     :type iso: float, optional
     :param iso: Isotropic part obtained from moment tensor inversion (decimal
         fraction between 0 and 1).
-    :type greens_function_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type greens_function_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param greens_function_id: Resource identifier of the Green’s function used
         in moment tensor inversion.
-    :type filter_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type filter_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param filter_id: Resource identifier of the filter setup used in moment
         tensor inversion.
-    :type source_time_function: :class:`~obspy.core.event.SourceTimeFunction`,
-        optional
+    :type source_time_function:
+        :class:`~obspy.core.event.source.SourceTimeFunction`, optional
     :param source_time_function: Source time function used in moment-tensor
         inversion.
-    :type data_used: list of :class:`~obspy.core.event.DataUsed`, optional
+    :type data_used: list of :class:`~obspy.core.event.base.DataUsed`, optional
     :param data_used: Describes waveform data used for moment-tensor inversion.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Resource identifier of the method used for moment-tensor
         inversion.
     :type category: str, optional
@@ -339,9 +341,9 @@ class MomentTensor(__MomentTensor):
         * ``"zero trace"``,
         * ``"double couple"``
 
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 
@@ -378,18 +380,19 @@ class FocalMechanism(__FocalMechanism):
     moment tensor description is provided by objects of the class MomentTensor
     which can be specified as child elements of FocalMechanism.
 
-    :type resource_id: :class:`~obspy.core.event.ResourceIdentifier`
+    :type resource_id: :class:`~obspy.core.event.base.ResourceIdentifier`
     :param resource_id: Resource identifier of FocalMechanism.
     :type force_resource_id: bool, optional
     :param force_resource_id: If set to False, the automatic initialization of
         `resource_id` attribute in case it is not specified will be skipped.
-    :type triggering_origin_id: :class:`~obspy.core.event.ResourceIdentifier`,
-        optional
+    :type triggering_origin_id:
+        :class:`~obspy.core.event.base.ResourceIdentifier`, optional
     :param triggering_origin_id: Refers to the resource_id of the triggering
         origin.
-    :type nodal_planes: :class:`~obspy.core.event.NodalPlanes`, optional
+    :type nodal_planes: :class:`~obspy.core.event.source.NodalPlanes`, optional
     :param nodal_planes: Nodal planes of the focal mechanism.
-    :type principal_axes: :class:`~obspy.core.event.PrincipalAxes`, optional
+    :type principal_axes: :class:`~obspy.core.event.source.PrincipalAxes`,
+        optional
     :param principal_axes: Principal axes of the focal mechanism.
     :type azimuthal_gap: float, optional
     :param azimuthal_gap: Largest azimuthal gap in distribution of stations
@@ -404,11 +407,12 @@ class FocalMechanism(__FocalMechanism):
         parameter. Indicates how the stations are distributed about the focal
         sphere (Reasenberg and Oppenheimer 1985). Decimal fraction between 0
         and 1.
-    :type method_id: :class:`~obspy.core.event.ResourceIdentifier`, optional
+    :type method_id: :class:`~obspy.core.event.base.ResourceIdentifier`,
+        optional
     :param method_id: Resource identifier of the method used for determination
         of the focal mechanism.
-    :type waveform_id: list of :class:`~obspy.core.event.WaveformStreamID`,
-        optional
+    :type waveform_id: list of
+        :class:`~obspy.core.event.base.WaveformStreamID`, optional
     :param waveform_id: Refers to a set of waveform streams from which the
         focal mechanism was derived.
     :type evaluation_mode: str, optional
@@ -429,11 +433,12 @@ class FocalMechanism(__FocalMechanism):
         * ``"rejected"``
         * ``"reported"``
 
-    :type moment_tensor: :class:`~obspy.core.event.MomentTensor`, optional
+    :type moment_tensor: :class:`~obspy.core.event.source.MomentTensor`,
+        optional
     :param moment_tensor: Moment tensor description for this focal mechanism.
-    :type comments: list of :class:`~obspy.core.event.Comment`, optional
+    :type comments: list of :class:`~obspy.core.event.base.Comment`, optional
     :param comments: Additional comments.
-    :type creation_info: :class:`~obspy.core.event.CreationInfo`, optional
+    :type creation_info: :class:`~obspy.core.event.base.CreationInfo`, optional
     :param creation_info: Creation information used to describe author,
         version, and creation time.
 

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -137,9 +137,47 @@ class Enum(object):
         >>> enum = Enum(["c", "a", "b"])
         >>> print(enum)
         Enum(["c", "a", "b"])
+        >>> enum = Enum(["not existing",
+        ...              "not reported",
+        ...              "earthquake",
+        ...              "controlled explosion",
+        ...              "experimental explosion",
+        ...              "industrial explosion"])
+        >>> print(enum)  # doctest: +NORMALIZE_WHITESPACE
+        Enum(["not existing", "not reported", ..., "experimental explosion",
+              "industrial explosion"])
         """
+        return self.__repr__()
+
+    def __repr__(self):
+        """
+        >>> enum = Enum(["c", "a", "b"])
+        >>> print(repr(enum))
+        Enum(["c", "a", "b"])
+        >>> enum = Enum(["not existing",
+        ...              "not reported",
+        ...              "earthquake",
+        ...              "controlled explosion",
+        ...              "experimental explosion",
+        ...              "industrial explosion"])
+        >>> print(repr(enum))  # doctest: +NORMALIZE_WHITESPACE
+        Enum(["not existing", "not reported", ..., "experimental explosion",
+              "industrial explosion"])
+        """
+        def _repr_list_of_keys(keys):
+            return ", ".join('"{}"'.format(_i) for _i in keys)
+
         keys = list(self.__enums.keys())
-        return "Enum([%s])" % ", ".join(['"%s"' % _i for _i in keys])
+        key_repr = _repr_list_of_keys(keys)
+        index = int(len(keys))
+        while len(key_repr) > 100:
+            if index == 0:
+                key_repr = "..."
+                break
+            index -= 1
+            key_repr = (_repr_list_of_keys(keys[:index]) + ", ..., " +
+                        _repr_list_of_keys(keys[-index:]))
+        return "Enum([{}])".format(key_repr)
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))


### PR DESCRIPTION
Those references where not correct anymore, after the `core.event` refactoring (see 80292c9).

I'm pretty sure I forgot something. I'll go through the new doc build and fix remaining issues.