### PR TITLE
Nested custom tags in QuakeML

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ master:
      vertical, see #1445).
  - obspy.io.css
     * Read support for NNSA KB Core format waveform data. (see #1332)
+ - obspy.io.quakeml
+    * Read and write support for nested custom tags (see #1463)
  - obspy.io.segy:
     * Iterative reading of large SEG-Y and SU files with
 	  `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.

--- a/misc/docs/source/tutorial/code_snippets/quakeml_custom_tags.rst
+++ b/misc/docs/source/tutorial/code_snippets/quakeml_custom_tags.rst
@@ -4,12 +4,12 @@
 Handling custom defined tags in QuakeML and the ObsPy Catalog/Event framework
 =============================================================================
 
-QuakeML allows use of custom elements in addition to the "usual" information
+QuakeML allows use of custom elements in addition to the 'usual' information
 defined by the QuakeML standard. It allows *a)* custom namespace attributes to
 QuakeML namespace tags and *b)* custom namespace subtags to QuakeML namespace
 elements.
-ObsPy can handle both basic (non-nested) custom tags in event type objects
-(*a)*) and custom attributes (*b)*) during input/output to/from QuakeML.
+ObsPy can handle both basic custom tags in event type objects (*a*) and custom
+attributes (*b*) during input/output to/from QuakeML.
 The following basic example illustrates how to output a valid QuakeML file
 with custom xml tags/attributes:
 
@@ -18,23 +18,23 @@ with custom xml tags/attributes:
     from obspy import Catalog, UTCDateTime
 
     extra = {'my_tag': {'value': True,
-                        'namespace': r"http://some-page.de/xmlns/1.0",
-                        'attrib': {r"{http://some-page.de/xmlns/1.0}my_attrib1": "123.4",
-                                   r"{http://some-page.de/xmlns/1.0}my_attrib2": "567"}},
-             'my_tag_2': {'value': u"True",
-                          'namespace': r"http://some-page.de/xmlns/1.0"},
+                        'namespace': 'http://some-page.de/xmlns/1.0',
+                        'attrib': {'{http://some-page.de/xmlns/1.0}my_attrib1': '123.4',
+                                   '{http://some-page.de/xmlns/1.0}my_attrib2': '567'}},
+             'my_tag_2': {'value': u'True',
+                          'namespace': 'http://some-page.de/xmlns/1.0'},
              'my_tag_3': {'value': 1,
-                          'namespace': r"http://some-page.de/xmlns/1.0"},
+                          'namespace': 'http://some-page.de/xmlns/1.0'},
              'my_tag_4': {'value': UTCDateTime('2013-01-02T13:12:14.600000Z'),
-                          'namespace': r"http://test.org/xmlns/0.1"},
+                          'namespace': 'http://test.org/xmlns/0.1'},
              'my_attribute': {'value': 'my_attribute_value',
                               'type': 'attribute',
-                              'namespace': r"http://test.org/xmlns/0.1"}}
+                              'namespace': 'http://test.org/xmlns/0.1'}}
 
     cat = Catalog()
     cat.extra = extra
-    cat.write("my_catalog.xml", "QUAKEML",
-              nsmap={"my_ns": r"http://test.org/xmlns/0.1"})
+    cat.write('my_catalog.xml', format='QUAKEML',
+              nsmap={'my_ns': 'http://test.org/xmlns/0.1'})
 
 All custom information to be stored in the customized QuakeML has to
 be stored in form of a :class:`dict` or
@@ -58,25 +58,30 @@ The xml output of the above example looks like:
 .. code-block:: xml
 
     <?xml version='1.0' encoding='utf-8'?>
-    <q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns:ns0="http://some-page.de/xmlns/1.0"
-               xmlns:my_ns="http://test.org/xmlns/0.1" xmlns="http://quakeml.org/xmlns/bed/1.2">
-      <eventParameters publicID="smi:local/b425518c-9445-40c7-8284-d1f299ed2eac" my_ns:my_attribute="my_attribute_value">
-        <ns0:my_tag ns0:my_attrib1="123.4" ns0:my_attrib2="567">true</ns0:my_tag>
+    <q:quakeml xmlns:q='http://quakeml.org/xmlns/quakeml/1.2'
+               xmlns:ns0='http://some-page.de/xmlns/1.0'
+               xmlns:my_ns='http://test.org/xmlns/0.1'
+               xmlns='http://quakeml.org/xmlns/bed/1.2'>
+      <eventParameters publicID='smi:local/b425518c-9445-40c7-8284-d1f299ed2eac'
+                       my_ns:my_attribute='my_attribute_value'>
+        <ns0:my_tag ns0:my_attrib1='123.4' ns0:my_attrib2='567'>true</ns0:my_tag>
         <my_ns:my_tag_4>2013-01-02T13:12:14.600000Z</my_ns:my_tag_4>
         <ns0:my_tag_2>True</ns0:my_tag_2>
         <ns0:my_tag_3>1</ns0:my_tag_3>
       </eventParameters>
     </q:quakeml>
 
-When reading the above xml again, the custom tags get parsed and attached to
-the respective Event type objects (in this example to the Catalog object) as
-``.extra``:
+When reading the above xml again, using
+:meth:`read_events() <obspy.core.event.read_events>`, the custom tags get
+parsed and attached to the respective Event type objects (in this example to
+the Catalog object) as ``.extra``.
+Note that all values are read as text strings:
 
 .. code-block:: python
 
     from obspy import read_events
 
-    cat = read("my_catalog.xml")
+    cat = read_events('my_catalog.xml')
     print(cat.extra)
 
 .. code-block:: python
@@ -94,3 +99,62 @@ the respective Event type objects (in this example to the Catalog object) as
                               u'value': 'True'},
                 u'my_tag_3': {u'namespace': u'http://some-page.de/xmlns/1.0',
                               u'value': '1'}})
+
+Custom tags can be nested:
+
+.. code-block:: python
+
+    from obspy import Catalog
+    from obspy.core import AttribDict
+
+    ns = 'http://some-page.de/xmlns/1.0'
+
+    my_tag = AttribDict()
+    my_tag.namespace = ns
+    my_tag.value = AttribDict()
+
+    my_tag.value.my_nested_tag1 = AttribDict()
+    my_tag.value.my_nested_tag1.namespace = ns
+    my_tag.value.my_nested_tag1.value = 1.23E+10
+
+    my_tag.value.my_nested_tag2 = AttribDict()
+    my_tag.value.my_nested_tag2.namespace = ns
+    my_tag.value.my_nested_tag2.value = True
+
+    cat = Catalog()
+    cat.extra = AttribDict()
+    cat.extra.my_tag = my_tag
+    cat.write('my_catalog.xml', 'QUAKEML')
+
+This will produce an xml output similar to the following:
+
+.. code-block:: xml
+
+    <?xml version='1.0' encoding='utf-8'?>
+    <q:quakeml xmlns:q='http://quakeml.org/xmlns/quakeml/1.2'
+               xmlns:ns0='http://some-page.de/xmlns/1.0'
+               xmlns='http://quakeml.org/xmlns/bed/1.2'>
+      <eventParameters publicID='smi:local/97d2b338-0701-41a4-9b6b-5903048bc341'>
+        <ns0:my_tag>
+          <ns0:my_nested_tag1>12300000000.0</ns0:my_nested_tag1>
+          <ns0:my_nested_tag2>true</ns0:my_nested_tag2>
+        </ns0:my_tag>
+      </eventParameters>
+    </q:quakeml>
+
+The output xml can be read again using
+:meth:`read_events() <obspy.core.event.read_events>` and the nested tags can be
+retrieved in the following way:
+
+.. code-block:: python
+
+    from obspy import read_events
+
+    cat = read_events('my_catalog.xml')
+    print(cat.extra.my_tag.value.my_nested_tag1.value)
+    print(cat.extra.my_tag.value.my_nested_tag2.value)
+
+.. code-block:: python
+
+    12300000000.0
+    true

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -29,6 +29,7 @@ import io
 import os
 import warnings
 
+from collections import Mapping
 from lxml import etree
 
 from obspy.core.event import (Amplitude, Arrival, Axis, Catalog, Comment,
@@ -987,7 +988,13 @@ class Unpickler(object):
             for el in element.iterfind("{%s}*" % ns):
                 # remove namespace from tag name
                 _, name = el.tag.split("}")
-                value = el.text
+                # check if element has children (nested tags)
+                if len(el):
+                    sub_obj = AttribDict()
+                    self._extra(el, sub_obj)
+                    value = sub_obj.extra
+                else:
+                    value = el.text
                 try:
                     extra = obj.setdefault("extra", AttribDict())
                 # Catalog object is not based on AttribDict..
@@ -1171,7 +1178,10 @@ class Pickler(object):
         """
         if not hasattr(obj, "extra"):
             return
-        for key, item in obj.extra.items():
+        self._custom(obj.extra, element)
+
+    def _custom(self, obj, element):
+        for key, item in obj.items():
             value = item["value"]
             ns = item["namespace"]
             attrib = item.get("attrib", {})
@@ -1182,7 +1192,11 @@ class Pickler(object):
             if type_.lower() in ("attribute", "attrib"):
                 element.attrib[tag] = str(value)
             elif type_.lower() == "element":
-                if isinstance(value, bool):
+                # check if value is dictionary-like
+                if isinstance(value, Mapping):
+                    subelement = etree.SubElement(element, tag, attrib=attrib)
+                    self._custom(value, subelement)
+                elif isinstance(value, bool):
                     self._bool(value, element, tag, attrib=attrib)
                 else:
                     self._str(value, element, tag, attrib=attrib)


### PR DESCRIPTION
This PR adds support for nested custom tags in QuakeML.

The page on ObsPy tutorial describing custom tags is updated accordingly.

Todo:
   - [x] test
   - [x] changelog