### PR TITLE
Future's filter() method acts as imposter for obspy.signal.filter

### DIFF
--- a/obspy/signal/__init__.py
+++ b/obspy/signal/__init__.py
@@ -195,6 +195,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+if "filter" in locals():
+    del filter
+
 import sys
 
 from obspy.core.util.deprecation_helpers import \


### PR DESCRIPTION
Small bug and **only on Python 2.7**:

In `obspy/signal/__init__.py`, the line

```python
from future.builtins import *
```

imports a `filter()` method (just an alias to `itertools.ifilter`) - people just importing `obspy.signal` will thus find `obspy.signal.filter` which is not the expected filter method.

```python
import obspy.signal
obspy.signal.filter.lowpass(...)
```

thus results in 

```
type object 'itertools.ifilter' has no attribute ‘lowpass’. 
```

There are of course ways around this but it is still annoying and might confuse users so we should fix it.