### PR TITLE
Reading some QuakeML files multiple times issues warning about updated ResourceIdentifier links

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,9 @@
  - obspy.io.nlloc:
    * Use geographic coordinates from the NonLinLoc Hypocenter-Phase file if
      no custom coordinate converter is provided.
+ - obspy.io.quakeml:
+   * Fixed issue with improperly raised warnings when the same file is read
+     twice. (#1376)
  - obspy.io.sac:
    * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
      true.  If "dist" header is found, distances aren't calculated.

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -525,7 +525,7 @@ class Unpickler(object):
         self._extra(element, obj)
         return obj
 
-    def _origin(self, element):
+    def _origin(self, element, arrivals):
         """
         Converts an etree.Element into an Origin object.
 
@@ -541,7 +541,7 @@ class Unpickler(object):
         ... </origin>'''
         >>> xml_doc = etree.fromstring(XML)
         >>> unpickler = Unpickler(xml_doc)
-        >>> origin = unpickler._origin(xml_doc)
+        >>> origin = unpickler._origin(xml_doc, arrivals=[])
         >>> print(origin.latitude)
         34.23
         """
@@ -568,6 +568,7 @@ class Unpickler(object):
         obj.creation_info = self._creation_info(element)
         obj.comments = self._comments(element)
         obj.origin_uncertainty = self._origin_uncertainty(element)
+        obj.arrivals = arrivals
         obj.resource_id = element.get('publicID')
         self._extra(element, obj)
         return obj
@@ -935,12 +936,18 @@ class Unpickler(object):
             # origins
             event.origins = []
             for origin_el in self._xpath('origin', event_el):
-                origin = self._origin(origin_el)
-                # arrivals
-                origin.arrivals = []
+                # Have to be created before the origin is created to avoid a
+                # rare issue where a warning is read when the same event is
+                # read twice - the warnings does not occur if two referred
+                # to objects compare equal - for this the arrivals have to
+                # be bound to the event before the resource id is assigned.
+                arrivals = []
                 for arrival_el in self._xpath('arrival', origin_el):
                     arrival = self._arrival(arrival_el)
-                    origin.arrivals.append(arrival)
+                    arrivals.append(arrival)
+
+                origin = self._origin(origin_el, arrivals=arrivals)
+
                 # append origin with arrivals
                 event.origins.append(origin)
             # magnitudes

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -951,6 +951,47 @@ class QuakeMLTestCase(unittest.TestCase):
         self.assertTrue(hasattr(cat, "nsmap"))
         self.assertEqual(getattr(cat, "nsmap")['ns0'], nsmap['ns0'])
 
+    def test_read_same_file_twice_to_same_variable(self):
+        """
+        Reading the same file twice to the same variable should not raise a
+        warning.
+        """
+        sio = io.BytesIO(b"""<?xml version='1.0' encoding='utf-8'?>
+        <q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
+                   xmlns="http://quakeml.org/xmlns/bed/1.2">
+          <eventParameters publicID="smi:local/catalog">
+            <event publicID="smi:local/event">
+              <origin publicID="smi:local/origin">
+                <time>
+                  <value>1970-01-01T00:00:00.000000Z</value>
+                </time>
+                <latitude>
+                  <value>0.0</value>
+                </latitude>
+                <longitude>
+                  <value>0.0</value>
+                </longitude>
+                <depth>
+                  <value>0.0</value>
+                </depth>
+                <arrival publicID="smi:local/arrival">
+                  <pickID>smi:local/pick</pickID>
+                  <phase>P</phase>
+                </arrival>
+              </origin>
+            </event>
+          </eventParameters>
+        </q:quakeml>
+        """)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cat1 = read_events(sio)  # NOQA
+            cat2 = read_events(sio)  # NOQA
+
+        # No warning should have been raised.
+        self.assertEqual(len(w), 0)
+
 
 def suite():
     return unittest.makeSuite(QuakeMLTestCase, 'test')


### PR DESCRIPTION
Reading some QuakeML files multiple times results in a warning getting issued that is supposed to only show up when objects with same ResourceIdentifier string but different content get serialized:
```python
from StringIO import StringIO
from obspy import read_events
from obspy.core.event import ResourceIdentifier

sio = StringIO("""<?xml version='1.0' encoding='utf-8'?>
<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
           xmlns="http://quakeml.org/xmlns/bed/1.2">
  <eventParameters publicID="smi:local/catalog">
    <event publicID="smi:local/event">
      <origin publicID="smi:local/origin">
        <time>
          <value>1970-01-01T00:00:00.000000Z</value>
        </time>
        <latitude>
          <value>0.0</value>
        </latitude>
        <longitude>
          <value>0.0</value>
        </longitude>
        <depth>
          <value>0.0</value>
        </depth>
        <arrival publicID="smi:local/arrival">
          <pickID>smi:local/pick</pickID>
          <phase>P</phase>
        </arrival>
      </origin>
    </event>
  </eventParameters>
</q:quakeml>
""")

cat1 = read_events(sio)
cat2 = read_events(sio)
```
```
/home/megies/git/obspy/obspy/core/event/base.pyc:324: UserWarning: The resource identifier 'smi:local/origin' already exists and points to another object: 'Origin(resource_id=ResourceIdentifier(id="smi:local/origin"), time=UTCDateTime(1970, 1, 1, 0, 0), longitude=0.0, latitude=0.0, depth=0.0)'.It will now point to the object referred to by the new resource identifier.
  Will return None if no object could be found.
```
The warning does not show up when removing the `Arrival` tag from the example QuakeML string.