### PR TITLE
Allow integers for SACTrace "iqual"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -65,6 +65,8 @@ master:
  - obspy.io.sac:
    * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
      true.  If "dist" header is found, distances aren't calculated.
+   * SACTrace.iqual is no longer accepts enumerated string values, but
+     arbitrary integer values.
  - obspy.signal:
    * PPSD.plot(): fix plotting of percentiles, mode and mean and setting
      period limits when using "xaxis_frequency=True" (see #1406, #1416)

--- a/obspy/io/sac/header.py
+++ b/obspy/io/sac/header.py
@@ -180,13 +180,13 @@ DOC = {'npts': 'N    Number of points per data component. [required]',
        'gcarc': 'F    Station to event great circle arc length (degrees).',
        'lcalda': 'L    TRUE if DIST AZ BAZ and GCARC are to be calculated '
                  'from st event coordinates.',
-       'iqual': '''I    Quality of data [not currently used]:
+       'iqual': '''N    Quality of data, as integers. Enum values listed:
 
-                  * IGOOD (Good data)
-                  * IGLCH (Glitches)
-                  * IDROP (Dropouts)
-                  * ILOWSN (Low signal to noise ratio)
-                  * IOTHER (Other)''',
+                  * IGOOD (45) (Good data)
+                  * IGLCH (46) (Glitches)
+                  * IDROP (47) (Dropouts)
+                  * ILOWSN (48) (Low signal to noise ratio)
+                  * IOTHER (44) (Other)''',
        'isynth': '''I    Synthetic data flag [not currently used]:
 
                   * IRLDTA (Real data)

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -929,7 +929,7 @@ class SACTrace(object):
                       doc=HD.DOC['ievreg'])
     ievtyp = property(_enumgetter('ievtyp'), _enumsetter('ievtyp'),
                       doc=HD.DOC['ievtyp'])
-    iqual = property(_enumgetter('iqual'), _enumsetter('iqual'),
+    iqual = property(_intgetter('iqual'), _intsetter('iqual'),
                      doc=HD.DOC['iqual'])
     isynth = property(_enumgetter('isythn'), _enumsetter('isynth'),
                       doc=HD.DOC['isynth'])


### PR DESCRIPTION
Common use of the SAC "iqual" header is to hold user-determined application-specific integer quality values.  Strict enumerated strings are too restrictive for this use.  Pre-1.0 ObsPy versions made this simple, but `SACTrace` is rather strict about it.  This issue is to request that this functionality be restored, or at least made more accessible, to recognize this common use.  This will involve (optionally?) switching the setter function for the `SACTrace.iqual` property from an enum-type to a regular integer-type setter.