### PR TITLE
Problem with printing inventory objects

### DIFF
--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -838,8 +838,15 @@ def _seed_id_keyfunction(x):
         # special comparison for component code, convert "ZNE" to integers
         # which compare less than any character
         comp = "ZNE".find(x[-1])
+        # last item is component code, either the original 1-char string, or an
+        # int from 0-2 if any of "ZNE". Python3 does not allow comparison of
+        # int and string anymore (Python 2 always compares ints smaller than
+        # any string), so we need to work around this by making this last item
+        # a tuple with first item False for ints and True for strings.
         if comp >= 0:
-            x[-1] = comp
+            x[-1] = (False, comp)
+        else:
+            x[-1] = (True, x[-1])
     # all other cases, just leave the upper case string, it will compare
     # greater than any of the split lists
     else:

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -27,6 +27,7 @@ from obspy.core.util.base import get_basemap_version, get_cartopy_version
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy.core.inventory import (Channel, Inventory, Network, Response,
                                   Station)
+from obspy.core.inventory.util import _unified_content_strings
 
 
 MATPLOTLIB_VERSION = get_matplotlib_version()
@@ -334,6 +335,54 @@ class InventoryTestCase(unittest.TestCase):
         # Should only be empty if trying to select something that does not
         # exist.
         self.assertEqual(len(inv.select(network="RR")), 0)
+
+    def test_util_unified_content_string(self):
+        """
+        Tests helper routine that compresses inventory content lists.
+        """
+        contents = (
+            [u'IU.ULN (Ulaanbaatar, Mongolia)',
+             u'IU.ULN (Ulaanbaatar, Mongolia)',
+             u'IU.ULN (Ulaanbaatar, Mongolia)'],
+            [u'IU.ULN.00.BH1', u'IU.ULN.00.BH2', u'IU.ULN.00.BHE',
+             u'IU.ULN.00.BHE', u'IU.ULN.00.BHE', u'IU.ULN.00.BHE',
+             u'IU.ULN.00.BHN', u'IU.ULN.00.BHN', u'IU.ULN.00.BHN',
+             u'IU.ULN.00.BHN', u'IU.ULN.00.BHZ', u'IU.ULN.00.BHZ',
+             u'IU.ULN.00.BHZ', u'IU.ULN.00.BHZ', u'IU.ULN.00.BHZ',
+             u'IU.ULN.00.LH1', u'IU.ULN.00.LH2', u'IU.ULN.00.LHE',
+             u'IU.ULN.00.LHE', u'IU.ULN.00.LHE', u'IU.ULN.00.LHE',
+             u'IU.ULN.00.LHN', u'IU.ULN.00.LHN', u'IU.ULN.00.LHN',
+             u'IU.ULN.00.LHN', u'IU.ULN.00.LHZ', u'IU.ULN.00.LHZ',
+             u'IU.ULN.00.LHZ', u'IU.ULN.00.LHZ', u'IU.ULN.00.LHZ',
+             u'IU.ULN.00.UHE', u'IU.ULN.00.UHE', u'IU.ULN.00.UHN',
+             u'IU.ULN.00.UHN', u'IU.ULN.00.UHZ', u'IU.ULN.00.UHZ',
+             u'IU.ULN.00.VE1', u'IU.ULN.00.VE1', u'IU.ULN.00.VH1',
+             u'IU.ULN.00.VH2', u'IU.ULN.00.VHE', u'IU.ULN.00.VHE',
+             u'IU.ULN.00.VHE', u'IU.ULN.00.VHE', u'IU.ULN.00.VHN',
+             u'IU.ULN.00.VHN', u'IU.ULN.00.VHN', u'IU.ULN.00.VHN',
+             u'IU.ULN.00.VHZ', u'IU.ULN.00.VHZ', u'IU.ULN.00.VHZ',
+             u'IU.ULN.00.VHZ', u'IU.ULN.00.VHZ', u'IU.ULN.00.VK1',
+             u'IU.ULN.00.VK1', u'IU.ULN.00.VM1', u'IU.ULN.00.VM2',
+             u'IU.ULN.00.VME', u'IU.ULN.00.VME', u'IU.ULN.00.VMN',
+             u'IU.ULN.00.VMN', u'IU.ULN.00.VMZ', u'IU.ULN.00.VMZ',
+             u'IU.ULN.00.VMZ'],
+            )
+        expected = (
+            [u'IU.ULN (Ulaanbaatar, Mongolia) (3x)'],
+            [u'IU.ULN.00.BHZ (5x)', u'IU.ULN.00.BHN (4x)',
+             u'IU.ULN.00.BHE (4x)', u'IU.ULN.00.BH1', u'IU.ULN.00.BH2',
+             u'IU.ULN.00.LHZ (5x)', u'IU.ULN.00.LHN (4x)',
+             u'IU.ULN.00.LHE (4x)', u'IU.ULN.00.LH1', u'IU.ULN.00.LH2',
+             u'IU.ULN.00.UHZ (2x)', u'IU.ULN.00.UHN (2x)',
+             u'IU.ULN.00.UHE (2x)', u'IU.ULN.00.VE1 (2x)',
+             u'IU.ULN.00.VHZ (5x)', u'IU.ULN.00.VHN (4x)',
+             u'IU.ULN.00.VHE (4x)', u'IU.ULN.00.VH1', u'IU.ULN.00.VH2',
+             u'IU.ULN.00.VK1 (2x)', u'IU.ULN.00.VMZ (3x)',
+             u'IU.ULN.00.VMN (2x)', u'IU.ULN.00.VME (2x)', u'IU.ULN.00.VM1',
+             u'IU.ULN.00.VM2'],
+            )
+        for contents_, expected_ in zip(contents, expected):
+            self.assertEqual(expected_, _unified_content_strings(contents_))
 
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')


### PR DESCRIPTION
```python
>>> from obspy import read_inventory
>>> inv = read_inventory("http://examples.obspy.org/IU_ULN.xml")
>>> print(inv)
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-c3ac4c4e8a67> in <module>()
      1 from obspy import read_inventory
      2 inv = read_inventory("http://examples.obspy.org/IU_ULN.xml")
----> 3 print(inv)
      4 inv.plot(projection="ortho")

/Users/lion/workspace/code/obspy/obspy/core/inventory/inventory.py in __str__(self)
    234         ret_str += "\t\tChannels (%i):\n" % len(contents["channels"])
    235         ret_str += "\n".join(_textwrap(
--> 236             ", ".join(_unified_content_strings(contents["channels"])),
    237             initial_indent="\t\t\t", subsequent_indent="\t\t\t",
    238             expand_tabs=False))

/Users/lion/workspace/code/obspy/obspy/core/inventory/util.py in _unified_content_strings(contents)
    774 
    775 def _unified_content_strings(contents):
--> 776     contents_unique = sorted(set(contents), key=_seed_id_keyfunction)
    777     contents_counts = [
    778         (item, contents.count(item)) for item in contents_unique]

TypeError: unorderable types: str() < int()


```
