### PR TITLE
Write support for stationtxt format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,6 +56,8 @@ master: (doi: 10.5281/zenodo.165135)
     * Read and write support for nested custom tags (see #1463)
  - obspy.io.seiscomp
     * Write support for SC3ML event (see #1638)
+ - obspy.io.stationtxt
+    * Write support for stationtxt format (see #1466)
  - obspy.io.stationxml
     * Read and write support for custom tags (see #1024)
     * No longer add the (unused) time zone field to StationXML datetimes to

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -347,12 +347,12 @@ def inventory_to_station_text(inventory_or_network, level):
                 sensitivity = resp and resp.instrument_sensitivity
                 line = "|".join(_to_str(x) for x in (
                     net.code, sta.code, cha.location_code, cha.code,
-                    cha.latitude is not None
-                    and cha.latitude or sta.latitude,
-                    cha.longitude is not None
-                    and cha.longitude or sta.longitude,
-                    cha.elevation is not None
-                    and cha.elevation or sta.elevation,
+                    cha.latitude is not None and
+                    cha.latitude or sta.latitude,
+                    cha.longitude is not None and
+                    cha.longitude or sta.longitude,
+                    cha.elevation is not None and
+                    cha.elevation or sta.elevation,
                     cha.depth, cha.azimuth, cha.dip,
                     cha.sensor.type
                     if (cha.sensor and cha.sensor.type) else None,

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -393,13 +393,15 @@ def _write_stationtxt(inventory, path_or_file_object, level='channel',
         ``'station'`` or ``'channel'``.
     """
     stationtxt = inventory_to_station_text(inventory, level)
-    if isinstance(path_or_file_object, str):
-        path_or_file_object = open(path_or_file_object, 'w')
-    if hasattr(path_or_file_object, 'write'):
-        path_or_file_object.write(stationtxt)
+    if not hasattr(path_or_file_object, 'write'):
+        f = open(path_or_file_object, 'w')
     else:
-        msg = ("path_or_file_object must be a string or a file-like object")
-        raise TypeError(msg)
+        f = path_or_file_object
+    try:
+        f.write(stationtxt)
+    finally:
+        if not hasattr(path_or_file_object, 'write'):
+            f.close()
 
 
 if __name__ == '__main__':

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -287,6 +287,7 @@ def inventory_to_station_text(inventory_or_network, level):
 
     # Write items at to the requested level of detail. Raises a ValueError if
     # insufficient information is present for the requested level of detail.
+    level = level.upper()
     if level == "NETWORK":
         # get network level items
         for net in networks:
@@ -307,7 +308,7 @@ def inventory_to_station_text(inventory_or_network, level):
             else:
                 raise ValueError("Unable to write stationtxt "
                                  "at STATION level. One or more "
-                                 "networks contain no stations.")
+                                 "networks contains no stations.")
         if all(sta is not None for net, sta, cha in items):
             header = ("#Network|Station|Latitude|Longitude|Elevation|SiteName|"
                       "StartTime|EndTime")

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -372,7 +372,7 @@ def inventory_to_station_text(inventory_or_network, level):
     return "\n".join(lines)
 
 
-def _write_stationtxt(inventory, path_or_file_object, level, **kwargs):
+def _write_stationtxt(inventory, path_or_file_object, level='channel', **kwargs):
     """
     Writes an inventory object to a file or file-like object in stationtxt
     format.

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -263,6 +263,7 @@ def inventory_to_station_text(inventory_or_network, level):
     :type inventory_or_network:
         :class:`~obspy.core.inventory.inventory.Inventory` or
         :class:`~obspy.core.inventory.network.Network`
+    :param inventory_or_network: The object to convert.
     :type level: str
     :param level: Specify level of detail using ``'network'``, ``'station'`` or
         ``'channel'``

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -885,8 +885,8 @@ class StationTextTestCase(unittest.TestCase):
                                   level="CHANNEL")
                 written_text_file = tf.read()
             # ignores whitespace
-            expected_content = "".join(expected_content.split(" "))
-            written_content = "".join(written_text_file.split(" "))
+            expected_content = b"".join(expected_content.split(b" "))
+            written_content = b"".join(written_text_file.split(b" "))
             for line in written_content:
                 self.assertIn(line, expected_content)
 

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -782,19 +782,19 @@ class StationTextTestCase(unittest.TestCase):
         test_inv.write(stio, format="STATIONTXT", level="CHANNEL")
         # check contents
         content = stio.getvalue()
-        expected = [(b"Network|Station|Location|Channel|Latitude|Longitude|"
-                     b"Elevation|Depth|Azimuth|Dip|SensorDescription|Scale|"
-                     b"ScaleFreq|ScaleUnits|SampleRate|StartTime|EndTime"),
-                    (b"IU|ANMO||BCI|34.9459|-106.4572|1850.0|100.0|0.0|"
-                     b"0.0|Geotech KS-36000-I Borehole Seismometer|"
-                     b"848507000.0|0.02|M/S|0.0|1989-08-29T00:00:00|"
-                     b"1995-02-01T00:00:00"),
-                    (b"IU|ANMO|20|LNZ|34.9459|-106.4572|1820.7|0.0|0.0|"
-                     b"-90.0|Titan Accelerometer|53435.4|1.0|M/S**2|0.0|"
-                     b"2013-06-20T16:30:00|"),
-                    (b"6E|SH01||LOG|37.7457|-88.1368|126.0|0.0|0.0|0.0|"
-                     b"Reftek 130 Datalogger|627252000.0|0.03|M/S|0.0|"
-                     b"2013-11-23T00:00:00|2016-12-31T23:59:59"),
+        expected = [("Network|Station|Location|Channel|Latitude|Longitude|"
+                     "Elevation|Depth|Azimuth|Dip|SensorDescription|Scale|"
+                     "ScaleFreq|ScaleUnits|SampleRate|StartTime|EndTime"),
+                    ("IU|ANMO||BCI|34.9459|-106.4572|1850.0|100.0|0.0|"
+                     "0.0|Geotech KS-36000-I Borehole Seismometer|"
+                     "848507000.0|0.02|M/S|0.0|1989-08-29T00:00:00|"
+                     "1995-02-01T00:00:00"),
+                    ("IU|ANMO|20|LNZ|34.9459|-106.4572|1820.7|0.0|0.0|"
+                     "-90.0|Titan Accelerometer|53435.4|1.0|M/S**2|0.0|"
+                     "2013-06-20T16:30:00|"),
+                    ("6E|SH01||LOG|37.7457|-88.1368|126.0|0.0|0.0|0.0|"
+                     "Reftek 130 Datalogger|627252000.0|0.03|M/S|0.0|"
+                     "2013-11-23T00:00:00|2016-12-31T23:59:59"),
                     ]
         num_lines_written = 0
         for line in expected:
@@ -809,10 +809,10 @@ class StationTextTestCase(unittest.TestCase):
         test_inv.write(stio, format="STATIONTXT", level="STATION")
         # check contents
         content = stio.getvalue()
-        expected = [(b"Network|Station|Latitude|Longitude|"
-                     b"Elevation|SiteName|StartTime|EndTime"),
-                    (b"IU|ANMO|34.9459|-106.4572|1850.0||"),
-                    (b"6E|SH01|37.7457|-88.1368|126.0||"),
+        expected = [("Network|Station|Latitude|Longitude|"
+                     "Elevation|SiteName|StartTime|EndTime"),
+                    ("IU|ANMO|34.9459|-106.4572|1850.0||"),
+                    ("6E|SH01|37.7457|-88.1368|126.0||"),
                     ]
         num_lines_written = 0
         for line in expected:
@@ -827,11 +827,11 @@ class StationTextTestCase(unittest.TestCase):
         test_inv.write(stio, format="STATIONTXT", level="NETWORK")
         # check contents
         content = stio.getvalue()
-        expected = [(b"Network|Description|StartTime|EndTime|TotalStations"),
-                    (b"IU|Global Seismograph Network (GSN - IRIS/USGS)|"
-                     b"1988-01-01T00:00:00|2500-12-31T23:59:59|1"),
-                    (b"6E|Wabash Valley Seismic Zone|"
-                     b"2013-01-01T00:00:00|2016-12-31T23:59:59|1"),
+        expected = [("Network|Description|StartTime|EndTime|TotalStations"),
+                    ("IU|Global Seismograph Network (GSN - IRIS/USGS)|"
+                     "1988-01-01T00:00:00|2500-12-31T23:59:59|1"),
+                    ("6E|Wabash Valley Seismic Zone|"
+                     "2013-01-01T00:00:00|2016-12-31T23:59:59|1"),
                     ]
         num_lines_written = 0
         for line in expected:

--- a/setup.py
+++ b/setup.py
@@ -382,6 +382,7 @@ ENTRY_POINTS = {
         'isFormat = obspy.io.stationtxt.core:is_fdsn_station_text_file',
         'readFormat = '
         'obspy.io.stationtxt.core:read_fdsn_station_text_file',
+        'writeFormat = obspy.io.stationtxt.core:_write_stationtxt',
         ],
     'obspy.plugin.inventory.KML': [
         'writeFormat = obspy.io.kml.core:_write_kml',


### PR DESCRIPTION
We should add write support for stationtxt format to `Inventory`.

TODO:
- [x] write wrapper that writes station text representation to file
- [x] register as plugin
- [x] tests
