### PR TITLE
Make sure newer CMTSOLUTION files can also be read.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,8 @@
    * Fixed a bug that lead to wrong header information in output files when
      writing non-integer sampling rate data to SLIST or TSPAIR formats
      (see #1447)
+- obspy.io.cmtsolution:
+   * Make sure newer CMTSOLUTION files can also be read (see #1479).
  - obspy.io.gse2:
    * Fixed a bug that could lead to network code not present in GSE2 output
      (see #1448)

--- a/obspy/io/cmtsolution/core.py
+++ b/obspy/io/cmtsolution/core.py
@@ -156,9 +156,9 @@ def _internal_read_single_cmtsolution(buf):
     # The first line encodes the preliminary epicenter.
     line = buf.readline()
 
-    hypocenter_catalog = line[:4].strip().decode()
+    hypocenter_catalog = line[:5].strip().decode()
 
-    origin_time = line[4:].strip().split()[:6]
+    origin_time = line[5:].strip().split()[:6]
     values = list(map(int, origin_time[:-1])) + \
         [float(origin_time[-1])]
     try:
@@ -167,7 +167,7 @@ def _internal_read_single_cmtsolution(buf):
         warnings.warn("Could not determine origin time from line: %s. Will "
                       "be set to zero." % line)
         origin_time = UTCDateTime(0)
-    line = line.split()[7:]
+    line = line[28:].split()
     latitude, longitude, depth, body_wave_mag, surface_wave_mag = \
         map(float, line[:5])
 

--- a/obspy/io/cmtsolution/tests/data/CMTSOLUTION_NEW
+++ b/obspy/io/cmtsolution/tests/data/CMTSOLUTION_NEW
@@ -1,0 +1,41 @@
+ PDEW2015  1  1  9 42  0.70  55.2900  163.0600  10.0 0.0 4.8 OFF EAST COAST OF KAMCHA
+event name:     201501010942A
+time shift:      5.3400
+half duration:   0.6000
+latitude:       55.0700
+longitude:     163.9400
+depth:          29.4000
+Mrr:       2.030000e+23
+Mtt:      -4.180000e+22
+Mpp:      -1.610000e+23
+Mrt:       8.890000e+22
+Mrp:       8.990000e+22
+Mtp:      -9.020000e+22
+
+ SWEQ2015  1  1  9 47 44.00 -13.7500 -111.7500  10.0 0.0 5.0 CENTRAL EAST PACIFIC RIS
+event name:     201501010947A
+time shift:     -0.3400
+half duration:   0.6000
+latitude:      -13.4500
+longitude:    -111.9900
+depth:          17.4200
+Mrr:      -5.980000e+22
+Mtt:       8.270000e+22
+Mpp:      -2.280000e+22
+Mrt:      -3.510000e+22
+Mrp:      -5.020000e+22
+Mtp:       2.160000e+23
+
+ PDEW2015  1  1 10  8 27.70 -13.6800 -111.9300  10.0 0.0 4.8 CENTRAL EAST PACIFIC RIS
+event name:     201501011007A
+time shift:      0.6600
+half duration:   0.7000
+latitude:      -13.4000
+longitude:    -111.9200
+depth:          24.5400
+Mrr:      -2.630000e+22
+Mtt:       3.960000e+22
+Mpp:      -1.330000e+22
+Mrt:      -7.310000e+22
+Mrp:      -7.630000e+22
+Mtp:       2.230000e+23

--- a/obspy/io/cmtsolution/tests/test_core.py
+++ b/obspy/io/cmtsolution/tests/test_core.py
@@ -224,6 +224,26 @@ class CmtsolutionTestCase(unittest.TestCase):
         self.assertEqual(data.decode().splitlines(),
                          new_data.decode().splitlines())
 
+    def test_reading_newer_cmtsolution_files(self):
+        """
+        The format changed a bit. Make sure these files can also be read.
+        """
+        filename = os.path.join(self.datapath, "CMTSOLUTION_NEW")
+        cat = obspy.read_events(filename)
+
+        self.assertEqual(len(cat), 3)
+
+        # Test the hypocentral origins as the "change" to the format only
+        # affected the first line.
+        self.assertEqual(cat[0].origins[1].latitude, 55.29)
+        self.assertEqual(cat[0].origins[1].longitude, 163.06)
+
+        self.assertEqual(cat[1].origins[1].latitude, -13.75)
+        self.assertEqual(cat[1].origins[1].longitude, -111.75)
+
+        self.assertEqual(cat[2].origins[1].latitude, -13.68)
+        self.assertEqual(cat[2].origins[1].longitude, -111.93)
+
 
 def suite():
     return unittest.makeSuite(CmtsolutionTestCase, "test")


### PR DESCRIPTION
This is a small fix that makes sure `obspy.io.cmtsolution` can also read newer CMTSOLUTION files which was not possible before due to some assumptions in the code.

I hope this can still make it into 1.0.2 but the fix is simple so it should work out.