### PR TITLE
Fixing issue when writing StationXML with manually set poles and zeroes.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -55,6 +55,8 @@
    * SACTrace.read now replaces non-ASCII and null-termination characters in
      string headers with whitespace unless the "debug_strings=True" flag is
      used. (see #1432)
+ - obspy.io.stationxml:
+   * Always set the number attribute for poles and zeros. (see #1481)
  - obspy.signal:
    * PPSD.plot(): fix plotting of percentiles, mode and mean and setting
      period limits when using "xaxis_frequency=True" (see #1406, #1416)


### PR DESCRIPTION
Another last minute fix for 1.0.2!! Very small fix but it solves a nasty problem. Includes a regression test.

This fixes an issue when manually settings poles and zeros in a response object and serializing to StationXML. StationXML requires `numbers` attributes which have to be written.

```python
# cut down to a single channel.
inv = obspy.read_inventory()
inv.networks = inv[:1]
inv[0].stations = inv[0][:1]
inv[0][0].channels = inv[0][0][:1]

# Manually set the poles and zeros - thus these are cast to our
# custom classes but number are not yet set.
inv[0][0][0].response.response_stages[0].poles = [0 + 1j, 2 + 3j]
inv[0][0][0].response.response_stages[0].zeros = [0 + 1j, 2 + 3j]

inv.write("test.xml", format="stationxml")
```

Output without this PR:

```xml
              <Zero>
                <Real>0.0</Real>
                <Imaginary>1.0</Imaginary>
              </Zero>
              <Zero>
                <Real>2.0</Real>
                <Imaginary>3.0</Imaginary>
              </Zero>
              <Pole>
                <Real>0.0</Real>
                <Imaginary>1.0</Imaginary>
              </Pole>
              <Pole>
                <Real>2.0</Real>
                <Imaginary>3.0</Imaginary>
              </Pole>
```


Output with this PR:

```xml
              <Zero number="0">
                <Real>0.0</Real>
                <Imaginary>1.0</Imaginary>
              </Zero>
              <Zero number="1">
                <Real>2.0</Real>
                <Imaginary>3.0</Imaginary>
              </Zero>
              <Pole number="0">
                <Real>0.0</Real>
                <Imaginary>1.0</Imaginary>
              </Pole>
              <Pole number="1">
                <Real>2.0</Real>
                <Imaginary>3.0</Imaginary>
              </Pole>
```