### PR TITLE
Fix reading nlloc hypocenter files with unicode characters in them

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,8 @@
  - obspy.io.quakeml:
    * Fixed issue with improperly raised warnings when the same file is read
      twice. (#1376)
+   * Fix writing empty network/station/channel codes in WaveformStreamID
+     objects to QuakeML. (see #1483)
  - obspy.io.sac:
    * Try to set SAC distances (dist, az, baz, gcarc) on read, if "lcalda" is
      true.  If "dist" header is found, distances aren't calculated.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,8 @@
      no custom coordinate converter is provided. (see #1390)
    * Fix reading NonLinLoc Hypocenter-Phase files with more than one
      hypocenter in it. (see #1480)
+   * Fix reading NonLinLoc Hypocenter-Phase files with unicode characters in
+     them. (see #1483)
  - obspy.io.quakeml:
    * Fixed issue with improperly raised warnings when the same file is read
      twice. (#1376)

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -83,18 +83,19 @@ def read_nlloc_hyp(filename, coordinate_converter=None, picks=None, **kwargs):
     if not hasattr(filename, "read"):
         # Check if it exists, otherwise assume its a string.
         try:
-            with open(filename, "rt") as fh:
+            with open(filename, "rb") as fh:
                 data = fh.read()
+            data = data.decode("UTF-8")
         except:
             try:
-                data = filename.decode()
+                data = filename.decode("UTF-8")
             except:
                 data = str(filename)
             data = data.strip()
     else:
         data = filename.read()
         if hasattr(data, "decode"):
-            data = data.decode()
+            data = data.decode("UTF-8")
 
     # split lines and remove empty ones
     lines = [line for line in data.splitlines() if line.strip()]

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -307,7 +307,10 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks):
         arrival.time_residual = float(line[16])
         arrival.time_weight = float(line[17])
         pick = Pick()
-        wid = WaveformStreamID(station_code=station)
+        # network codes are not used by NonLinLoc, so they can not be known
+        # when reading the .hyp file.. to conform with QuakeML standard set an
+        # empty network code
+        wid = WaveformStreamID(network_code="", station_code=station)
         date, hourmin, sec = map(str, line[6:9])
         t = UTCDateTime().strptime(date + hourmin, "%Y%m%d%H%M") + float(sec)
         pick.waveform_id = wid

--- a/obspy/io/nlloc/tests/data/nlloc_custom.qml
+++ b/obspy/io/nlloc/tests/data/nlloc_custom.qml
@@ -151,7 +151,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:25.930000Z</value>
           <uncertainty>0.02</uncertainty>
         </time>
-        <waveformID stationCode="UH3"></waveformID>
+        <waveformID networkCode="" stationCode="UH3"></waveformID>
         <phaseHint>P</phaseHint>
       </pick>
       <pick publicID="smi:local/3a0bde89-d7e6-45ef-a08a-4b950720f7be">
@@ -159,7 +159,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:27.100000Z</value>
           <uncertainty>0.06</uncertainty>
         </time>
-        <waveformID stationCode="UH3"></waveformID>
+        <waveformID networkCode="" stationCode="UH3"></waveformID>
         <phaseHint>S</phaseHint>
       </pick>
       <pick publicID="smi:local/95492f79-0db4-4bba-a198-6c08db43dd83">
@@ -167,7 +167,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:26.040000Z</value>
           <uncertainty>0.03</uncertainty>
         </time>
-        <waveformID stationCode="UH2"></waveformID>
+        <waveformID networkCode="" stationCode="UH2"></waveformID>
         <phaseHint>P</phaseHint>
       </pick>
       <pick publicID="smi:local/75ca039c-bfca-41c3-8fd3-9d70341a23fe">
@@ -175,7 +175,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:27.270000Z</value>
           <uncertainty>0.06</uncertainty>
         </time>
-        <waveformID stationCode="UH2"></waveformID>
+        <waveformID networkCode="" stationCode="UH2"></waveformID>
         <phaseHint>S</phaseHint>
       </pick>
       <pick publicID="smi:local/550537fb-922c-4742-9bcc-504c1d330480">
@@ -183,7 +183,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:26.130000Z</value>
           <uncertainty>0.02</uncertainty>
         </time>
-        <waveformID stationCode="UH1"></waveformID>
+        <waveformID networkCode="" stationCode="UH1"></waveformID>
         <phaseHint>P</phaseHint>
       </pick>
       <pick publicID="smi:local/0783bf9f-6862-40a3-baeb-ed247b73ca6f">
@@ -191,7 +191,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:27.460000Z</value>
           <uncertainty>0.03</uncertainty>
         </time>
-        <waveformID stationCode="UH1"></waveformID>
+        <waveformID networkCode="" stationCode="UH1"></waveformID>
         <phaseHint>S</phaseHint>
       </pick>
       <pick publicID="smi:local/d6fa4a8a-6e4c-48a1-9ab9-e84b60038f4b">
@@ -199,7 +199,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:26.930000Z</value>
           <uncertainty>0.06</uncertainty>
         </time>
-        <waveformID stationCode="UH4"></waveformID>
+        <waveformID networkCode="" stationCode="UH4"></waveformID>
         <phaseHint>P</phaseHint>
       </pick>
       <pick publicID="smi:local/b0b74d7c-bd9e-4183-abcb-5c784a53f8b0">
@@ -207,7 +207,7 @@ STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ
           <value>2010-05-27T16:56:28.900000Z</value>
           <uncertainty>0.11</uncertainty>
         </time>
-        <waveformID stationCode="UH4"></waveformID>
+        <waveformID networkCode="" stationCode="UH4"></waveformID>
         <phaseHint>S</phaseHint>
       </pick>
     </event>

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1112,13 +1112,13 @@ class Pickler(object):
         if obj is None:
             return
         attrib = {}
-        if obj.network_code:
+        if obj.network_code is not None:
             attrib['networkCode'] = obj.network_code
-        if obj.station_code:
+        if obj.station_code is not None:
             attrib['stationCode'] = obj.station_code
         if obj.location_code is not None:
             attrib['locationCode'] = obj.location_code
-        if obj.channel_code:
+        if obj.channel_code is not None:
             attrib['channelCode'] = obj.channel_code
         subelement = etree.Element('waveformID', attrib=attrib)
         # WaveformStreamID has a non-mandatory resource_id


### PR DESCRIPTION
This fixes reading nlloc hypocenter files with unicode characters in them by properly decoding the input data with UTF-8. This problem only surfaced with #1480 because the new test data have non-ASCII characters in them.

The reading of multiple hypocenters from a single file is also sanitized, getting rid of several ugly while loops.