### PR TITLE
fix CI/PR urls reported in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,15 +146,12 @@ script:
   - mkdir empty
   - cd empty
   - export MODULELIST=`python -c "from obspy.core.util import DEFAULT_MODULES as MODULES; print('obspy.' + ',obspy.'.join(MODULES))"`
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      export RUNTESTSOPTIONS="--ci-url=\"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}\"";
-    else
-      export RUNTESTSOPTIONS="--ci-url=\"https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}\" --pr-url=\"https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}\"";
-    fi;
   - echo $MODULELIST
-  - echo $RUNTESTSOPTIONS
-  - echo "coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r ${RUNTESTSOPTIONS}"
-  - coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r ${RUNTESTSOPTIONS}
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}";
+    else
+      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --pr-ur="https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}";
+    fi;
 
 after_success:
   - mv .coverage ../.coverage.empty


### PR DESCRIPTION
Variable replacement in the travis.yml with quoted URLs is very fragile, so do it at the end in one step, although this means duplicating the whole testrun call..

see e.g. the following, where both CI and PR url are mixed together into one command line option, so that the links in the test report pages are not properly parsed for the overview table..
https://travis-ci.org/obspy/obspy/jobs/148268300#L681
http://tests.obspy.org/46115/xml/