### PR TITLE
docker tests: mixed improvements

### DIFF
--- a/misc/docker_tests/README.md
+++ b/misc/docker_tests/README.md
@@ -30,7 +30,19 @@ with the `-e` argument. To for example only the MiniSEED test suite on CentOS
 $ ./run_obspy_tests.sh -eio.mseed centos_7
 ```
 
+A specific commit from a specific obspy fork (or main repo) can be tested using
+the `-t` (for "target") argument.
+
 Make sure to use the `-e` argument before the list of images to run on.
+
+```bash
+$ # test a commit that is in the obspy main repo
+$ ./run_obspy_tests.sh -tobspy:bdc6dd855c00c831bcc007b607d83f6070b5b1c0
+$ # test a commit that only exists in a fork (but might be the tip of a PR)
+$ ./run_obspy_tests.sh -tclaudiodsf:2fa3d3bdaded126a9ebdaf73cf60403c1acb3457
+```
+
+Make sure to use the `-t` argument before the list of images to run on.
 
 If the image is not yet available it will be created automatically. The
 `base_images` directory contains all available images receipts.

--- a/misc/docker_tests/README.md
+++ b/misc/docker_tests/README.md
@@ -24,10 +24,19 @@ $ ./run_obspy_tests.sh
 
 Additionally arguments can be passed to `obspy-runtests` in the Docker images
 with the `-e` argument. To for example only the MiniSEED test suite on CentOS
-7, do
+7, do:
 
 ```bash
 $ ./run_obspy_tests.sh -eio.mseed centos_7
+```
+Or to also provide a pull request url to `obspy-runtests` with the `-e`
+argument and using quotes (including bash variable replacement) to mark the
+start and end of the `-e` option, do (again with just a single distribution)
+the following:
+
+```bash
+$ export PR=1460
+$ ./run_obspy_tests.sh -e"io.ndk --pr-url=https://github.com/obspy/obspy/pull/${PR}" centos_7
 ```
 
 A specific commit from a specific obspy fork (or main repo) can be tested using
@@ -43,6 +52,13 @@ $ ./run_obspy_tests.sh -tclaudiodsf:2fa3d3bdaded126a9ebdaf73cf60403c1acb3457
 ```
 
 Make sure to use the `-t` argument before the list of images to run on.
+
+The `-t` and `-e` options can also be combined, e.g.:
+
+```bash
+$ # see http://tests.obspy.org/46691/ for the result of this command:
+$ ./run_obspy_tests.sh -ttrichter:e6da3ddb5 -e"io.ndk --pr-url=https://github.com/obspy/obspy/pull/${PR}" fedora_24
+```
 
 If the image is not yet available it will be created automatically. The
 `base_images` directory contains all available images receipts.

--- a/misc/docker_tests/README.md
+++ b/misc/docker_tests/README.md
@@ -22,6 +22,16 @@ Running it without any commands will execute the test suite on all available ima
 $ ./run_obspy_tests.sh
 ```
 
+Additionally arguments can be passed to `obspy-runtests` in the Docker images
+with the `-e` argument. To for example only the MiniSEED test suite on CentOS
+7, do
+
+```bash
+$ ./run_obspy_tests.sh -eio.mseed centos_7
+```
+
+Make sure to use the `-e` argument before the list of images to run on.
+
 If the image is not yet available it will be created automatically. The
 `base_images` directory contains all available images receipts.
 

--- a/misc/docker_tests/base_images/centos_7/Dockerfile
+++ b/misc/docker_tests/base_images/centos_7/Dockerfile
@@ -7,7 +7,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum -y upgrade || true
 RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-pip python-requests python-decorator
 RUN easy_install -U setuptools pip
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # Force agg.
 RUN mkdir -p /root/.matplotlib && echo "backend: agg" > /root/.matplotlib/matplotlibrc

--- a/misc/docker_tests/base_images/centos_7/Dockerfile
+++ b/misc/docker_tests/base_images/centos_7/Dockerfile
@@ -8,5 +8,6 @@ RUN yum -y upgrade || true
 RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-pip python-requests python-decorator
 RUN easy_install -U setuptools pip
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # Force agg.
 RUN mkdir -p /root/.matplotlib && echo "backend: agg" > /root/.matplotlib/matplotlibrc

--- a/misc/docker_tests/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker_tests/base_images/debian_7_wheezy/Dockerfile
@@ -6,4 +6,5 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip ttf-bitstream-vera python-decorator python-requests
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker_tests/base_images/debian_7_wheezy/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip ttf-bitstream-vera python-decorator python-requests
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker_tests/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -6,4 +6,5 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip ttf-bitstream-vera python-decorator python-requests
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker_tests/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip ttf-bitstream-vera python-decorator python-requests
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker_tests/base_images/debian_8_jessie/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker_tests/base_images/debian_8_jessie/Dockerfile
@@ -6,3 +6,4 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_22/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_22/Dockerfile
@@ -6,3 +6,4 @@ MAINTAINER Lion Krischer
 RUN yum -y upgrade || true
 RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_22/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_22/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN yum -y upgrade || true
 RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_22/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_22/Dockerfile
@@ -1,9 +1,0 @@
-FROM fedora:22
-
-MAINTAINER Lion Krischer
-
-# Can fail on occasion.
-RUN yum -y upgrade || true
-RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_23/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_23/Dockerfile
@@ -4,5 +4,5 @@ MAINTAINER Lion Krischer
 
 # Can fail on occasion.
 RUN dnf -y upgrade || true
-RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-flake8 python-future
+RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_23/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_23/Dockerfile
@@ -5,3 +5,4 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN dnf -y upgrade || true
 RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-flake8 python-future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/fedora_24/Dockerfile
+++ b/misc/docker_tests/base_images/fedora_24/Dockerfile
@@ -1,0 +1,8 @@
+FROM fedora:24
+
+MAINTAINER Lion Krischer
+
+# Can fail on occasion.
+RUN dnf -y upgrade || true
+RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/opensuse_13_2/Dockerfile
+++ b/misc/docker_tests/base_images/opensuse_13_2/Dockerfile
@@ -7,3 +7,4 @@ RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
 RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-flake8 python-basemap python-basemap-data python-nose ca-certificates-mozilla
 RUN pip install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/opensuse_13_2/Dockerfile
+++ b/misc/docker_tests/base_images/opensuse_13_2/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Lion Krischer
 RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_13.2/Application:Geo.repo
 RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
-RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-flake8 python-basemap python-basemap-data python-nose ca-certificates-mozilla
+RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose ca-certificates-mozilla
 RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/opensuse_leap_42_1/Dockerfile
+++ b/misc/docker_tests/base_images/opensuse_leap_42_1/Dockerfile
@@ -7,4 +7,5 @@ RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
 RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-flake8 python-basemap python-basemap-data python-nose
 RUN pip install --index-url=http://pypi.python.org/simple/ --trusted-host pypi.python.org future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN zypper --non-interactive install ca-certificates-mozilla

--- a/misc/docker_tests/base_images/opensuse_leap_42_1/Dockerfile
+++ b/misc/docker_tests/base_images/opensuse_leap_42_1/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Lion Krischer
 RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_42.1/Application:Geo.repo
 RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
-RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-flake8 python-basemap python-basemap-data python-nose
+RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose
 RUN pip install --index-url=http://pypi.python.org/simple/ --trusted-host pypi.python.org future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN zypper --non-interactive install ca-certificates-mozilla

--- a/misc/docker_tests/base_images/ubuntu_12_04_precise/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_12_04_precise/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/ubuntu_12_04_precise/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_12_04_precise/Dockerfile
@@ -6,4 +6,5 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker_tests/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-requests python-decorator
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -6,3 +6,4 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-requests python-decorator
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
@@ -5,5 +5,5 @@ MAINTAINER Lion Krischer
 # Can fail on occasion.
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
-RUN pip install flake8 future
+RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
@@ -6,3 +6,4 @@ MAINTAINER Lion Krischer
 RUN apt-get update && apt-get upgrade || true
 RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
 RUN pip install flake8 future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_15_10_wily/Dockerfile
@@ -1,9 +1,0 @@
-FROM ubuntu:15.10
-
-MAINTAINER Lion Krischer
-
-# Can fail on occasion.
-RUN apt-get update && apt-get upgrade || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/base_images/ubuntu_16_04_xenial/Dockerfile
+++ b/misc/docker_tests/base_images/ubuntu_16_04_xenial/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+
+MAINTAINER Lion Krischer
+
+# Can fail on occasion.
+RUN apt-get update && apt-get upgrade || true
+RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
+RUN pip install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker_tests/cronjob_docker_tests.sh
+++ b/misc/docker_tests/cronjob_docker_tests.sh
@@ -1,0 +1,68 @@
+# this script is currently used in a Debian Linux virtual machine's crontab
+# (which gets started headless once per day):
+# 
+# OBSPY_COMMIT_STATUS_TOKEN=....
+# @reboot mv $HOME/docker_testbot.log $HOME/docker_testbot.log.old; bash /path/to/cronjob_docker_tests.sh > $HOME/docker_testbot.log 2>&1
+
+# sleep for some time, so that the cronjob can be killed if the VM is entered
+# for some manual tampering
+sleep 60
+# keep VM up to date
+sudo aptitude update && sudo aptitude upgrade -y
+
+# start with a clean slate, remove all cached docker containers and images
+docker rm $(docker ps -qa)
+docker rmi $(docker images -q)
+
+# path to a dedicated obspy clone for running docker tests,
+# we run a lot of radical `git clean -fdx` in that repo, so any local changes
+# will be regularly lost
+# obspy main repo is expected to be registered as remote "origin"
+OBSPY_DOCKER=$HOME/obspy_docker_tests
+# we don't want to operate in "cp" mode of the docker test script..
+export OBSPY_DOCKER_TEST_SOURCE_TREE="clone"
+
+# run docker tests on any commit that is the tip of a pull request and that
+# does not have a docker testbot commit status
+cd ${OBSPY_DOCKER} || exit 1
+git fetch origin
+git clean -fdx
+git checkout master
+git pull
+git reset --hard FETCH_HEAD
+git clean -fdx
+cd ${OBSPY_DOCKER}/misc/docker_tests/
+TARGETS=`bash github_get_all_pr_heads_without_docker-testbot_status.sh`
+for TARGET in $TARGETS
+do
+    # TARGET is e.g. '1002-krischer:966a4a93b3376866c9fade5ded73a7d6e3a20492'
+    PR_REPO_SHA=(${TARGET//-/ })
+    PR=${PR_REPO_SHA[0]}
+    REPO_SHA=${PR_REPO_SHA[1]}
+    bash run_obspy_tests.sh -t${REPO_SHA} -e"--pr-url=https://github.com/obspy/obspy/pull/${PR}"
+done
+
+# run docker tests on maintenance_1.0.x and master
+for BRANCH in maintenance_1.0.x master
+do
+    cd ${OBSPY_DOCKER} || exit 1
+    git fetch origin
+    git clean -fdx
+    git checkout $BRANCH
+    git pull
+    git reset --hard FETCH_HEAD
+    git clean -fdx
+    cd ${OBSPY_DOCKER}/misc/docker_tests/
+    bash run_obspy_tests.sh
+done
+
+# build and test debian packages
+cd $HOME
+## run tests in chroots
+#bash $HOME/schroot_testrun.sh -f obspy -t master
+# build and test all deb packages
+# bash ./deb_build_testrun.sh
+
+# sleep for some time, so a login user has a chance to kill the cronjob before
+# it halts the VM
+(sleep 600; sudo halt)

--- a/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
+++ b/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
@@ -14,6 +14,7 @@ echo "" >> $LOG
 # than extract all matches with grep, one per line
 #    ..assuming the following structure in the returned json:
 #      ...
+#      "comments_url": "https://api.github.com/repos/obspy/obspy/issues/1452/comments",
 #      "statuses_url": "https://api.github.com/repos/obspy/obspy/statuses/dd58fbbc33a8d8ce6f1a76013a5daa9e4a7db72a",
 #      "head": {
 #        "label": "obspy:docker_rm_old_logs",
@@ -23,25 +24,29 @@ echo "" >> $LOG
 #          "login": "obspy",
 #      ...
 # finally extract the interesting parts with sed and regex
-COMMITS=`echo $DATA | sed 's#\s##g' | grep -s --only-matching --extended-regexp '"head":{"label":"[^"]*","ref":"[^"]*","sha":"[a-z0-9]{40}"' | sed 's#.*"label":"\([^:]*\):.*"sha":"\([a-z0-9]\{40\}\)"#\1:\2#'`
-echo $COMMITS >> $LOG
+TARGETS=`echo $DATA | sed 's#\s##g' | grep -s --only-matching --extended-regexp '"comments_url":"[^"]*","statuses_url":"[^"]*","head":{"label":"[^"]*","ref":"[^"]*","sha":"[a-z0-9]{40}"' | sed 's#.*/issues/\([0-9]*\)/comments".*"head":{"label":"\([^:]*\):.*"sha":"\([a-z0-9]\{40\}\)"#\1-\2:\3#'`
+# output is PRNUMBER-FORK:SHA
+echo $TARGETS >> $LOG
 echo "" >> $LOG
 
 # helper function to determine if given commit hash has a status with "docker-testbot" context or not
 # returns 0 if no such status exists, i.e. build needed
 # returns 1 if such status exists, i.e. no build needed
-commit_needs_build() {
-    REPO_SHA=(${1//:/ })
+target_needs_build() {
+    # split target which is e.g. 1484-obspy:8fb11420de52392bdb61424f1cfc824a1987a02e
+    PR_REPO_SHA=(${1//-/ })
+    REPO_SHA=${PR_REPO_SHA[1]}
+    REPO_SHA=(${REPO_SHA//:/ })
     SHA=${REPO_SHA[1]}
     curl --silent --show-error --no-buffer -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET "https://api.github.com/repos/obspy/obspy/commits/${SHA}/status" 2>> $LOG | grep -q -s '"context":[ ]*"docker-testbot"' >> $LOG 2>&1
     if [ $? = 0 ]; then return 1; else return 0; fi
 }
 
-for COMMIT in $COMMITS
+for TARGET in $TARGETS
 do
-    if commit_needs_build $COMMIT
+    if target_needs_build $TARGET
     then
-        echo $COMMIT
-        echo $COMMIT >> $LOG
+        echo $TARGET
+        echo $TARGET >> $LOG
     fi
 done

--- a/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
+++ b/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+mkdir -p logs
+LOG=logs/github_get_all_pr_heads_without_docker-testbot_status.log
+
+rm $LOG
+
+# get a list of commit hashes for open pull requests
+DATA=`curl --silent -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET 'https://api.github.com/repos/obspy/obspy/pulls?state=open&sort=updated&direction=desc&per_page=100'`
+echo $DATA >> $LOG
+echo "" >> $LOG
+COMMITS=`echo $DATA | grep -s --only-matching --extended-regexp '"statuses_url": "https://api.github.com/repos/obspy/obspy/statuses/([0-9a-z]{40})",' | sed 's#.*/##' | sed 's#".*##'`
+echo $COMMITS >> $LOG
+echo "" >> $LOG
+
+# helper function to determine if given commit hash has a status with "docker-testbot" context or not
+# returns 0 if no such status exists, i.e. build needed
+# returns 1 if such status exists, i.e. no build needed
+commit_needs_build() {
+    curl --silent --show-error --no-buffer -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET "https://api.github.com/repos/obspy/obspy/commits/$1/status" 2>> $LOG | grep -q -s '"context":[ ]*"docker-testbot"' >> $LOG 2>&1
+    if [ $? = 0 ]; then return 1; else return 0; fi
+}
+
+for COMMIT in $COMMITS
+do
+    if commit_needs_build $COMMIT
+    then
+        echo $COMMIT
+        echo $COMMIT >> $LOG
+    fi
+done

--- a/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
+++ b/misc/docker_tests/github_get_all_pr_heads_without_docker-testbot_status.sh
@@ -9,7 +9,21 @@ rm $LOG
 DATA=`curl --silent -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET 'https://api.github.com/repos/obspy/obspy/pulls?state=open&sort=updated&direction=desc&per_page=100'`
 echo $DATA >> $LOG
 echo "" >> $LOG
-COMMITS=`echo $DATA | grep -s --only-matching --extended-regexp '"statuses_url": "https://api.github.com/repos/obspy/obspy/statuses/([0-9a-z]{40})",' | sed 's#.*/##' | sed 's#".*##'`
+# echo without quotes gets rid of line breaks, which makes regex simpler
+# than get rid of spaces and tabs with sed
+# than extract all matches with grep, one per line
+#    ..assuming the following structure in the returned json:
+#      ...
+#      "statuses_url": "https://api.github.com/repos/obspy/obspy/statuses/dd58fbbc33a8d8ce6f1a76013a5daa9e4a7db72a",
+#      "head": {
+#        "label": "obspy:docker_rm_old_logs",
+#        "ref": "docker_rm_old_logs",
+#        "sha": "dd58fbbc33a8d8ce6f1a76013a5daa9e4a7db72a",
+#        "user": {
+#          "login": "obspy",
+#      ...
+# finally extract the interesting parts with sed and regex
+COMMITS=`echo $DATA | sed 's#\s##g' | grep -s --only-matching --extended-regexp '"head":{"label":"[^"]*","ref":"[^"]*","sha":"[a-z0-9]{40}"' | sed 's#.*"label":"\([^:]*\):.*"sha":"\([a-z0-9]\{40\}\)"#\1:\2#'`
 echo $COMMITS >> $LOG
 echo "" >> $LOG
 
@@ -17,7 +31,9 @@ echo "" >> $LOG
 # returns 0 if no such status exists, i.e. build needed
 # returns 1 if such status exists, i.e. no build needed
 commit_needs_build() {
-    curl --silent --show-error --no-buffer -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET "https://api.github.com/repos/obspy/obspy/commits/$1/status" 2>> $LOG | grep -q -s '"context":[ ]*"docker-testbot"' >> $LOG 2>&1
+    REPO_SHA=(${1//:/ })
+    SHA=${REPO_SHA[1]}
+    curl --silent --show-error --no-buffer -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request GET "https://api.github.com/repos/obspy/obspy/commits/${SHA}/status" 2>> $LOG | grep -q -s '"context":[ ]*"docker-testbot"' >> $LOG 2>&1
     if [ $? = 0 ]; then return 1; else return 0; fi
 }
 

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -128,7 +128,7 @@ run_tests_on_image () {
     image_name=$1;
     printf "\n\e[101m\e[30m  >>> Running tests for image '"$image_name"'...\e[0m\n"
     # Copy dockerfile and render template.
-    sed "s/{{IMAGE_NAME}}/$image_name/g; s/{{EXTRA_ARGS}}/$extra_args/g" scripts/Dockerfile_run_tests.tmpl > $TEMP_PATH/Dockerfile
+    sed "s#{{IMAGE_NAME}}#$image_name#g; s#{{EXTRA_ARGS}}#$extra_args#g" scripts/Dockerfile_run_tests.tmpl > $TEMP_PATH/Dockerfile
 
     # Where to save the logs, and a random ID for the containers.
     LOG_DIR=${LOG_DIR_BASE}/$image_name

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -4,9 +4,9 @@ DATETIME=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
 LOG_DIR_BASE=logs/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-# all output to log file
-exec > $LOG_DIR_BASE/docker.log 2>&1
-
+# This bracket is closed at the very end and causes a redirection of everything
+# to the logfile as well as stdout.
+{
 # remove log directories older than 14 days (to avoid cluttering with GB of
 # data on buildbots that are run regularly)
 find logs/2[0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]T[012][0-9]-[0-5][0-9]-[0-5][0-9]Z -type d -not -newermt `date --date='14 days ago' --rfc-3339=date` -exec rm -rf {} \;
@@ -182,3 +182,5 @@ fi
 curl -H "Content-Type: application/json" -H "Authorization: token ${OBSPY_COMMIT_STATUS_TOKEN}" --request POST --data "{\"state\": \"${COMMIT_STATUS}\", \"context\": \"docker-testbot\", \"description\": \"${COMMIT_STATUS_DESCRIPTION}\", \"target_url\": \"${COMMIT_STATUS_TARGET_URL}\"}" https://api.github.com/repos/obspy/obspy/statuses/${COMMIT}
 
 rm -rf $TEMP_PATH
+
+} 2>&1 | tee -a $LOG_DIR_BASE/docker.log

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -7,9 +7,9 @@ mkdir -p $LOG_DIR_BASE
 # This bracket is closed at the very end and causes a redirection of everything
 # to the logfile as well as stdout.
 {
-# remove log directories older than 14 days (to avoid cluttering with GB of
-# data on buildbots that are run regularly)
-find logs/2[0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]T[012][0-9]-[0-5][0-9]-[0-5][0-9]Z -type d -not -newermt `date --date='14 days ago' --rfc-3339=date` -exec rm -rf {} \;
+# Delete all but the last 15 log directories. The `+16` is intentional. Fully
+# POSIX compliant version adapted from http://stackoverflow.com/a/34862475/1657047
+ls -tp logs | tail -n +16 | xargs -I % rm -rf -- logs/%
 
 OBSPY_PATH=$(dirname $(dirname $(pwd)))
 

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -84,7 +84,7 @@ create_image () {
     if [ "$has_image" ]; then
         printf "\e[101m\e[30m  >>> Image '$image_name' already exists.\e[0m\n"
     else
-        printf "\e[101m\e[30m  Image '$image_name'will be created.\e[0m\n"
+        printf "\e[101m\e[30m  Image '$image_name' will be created.\e[0m\n"
         $DOCKER build -t obspy:$image_name $image_path
     fi
 }

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -20,6 +20,7 @@ while getopts "t:e:" opt; do
         ;;
     esac
 done
+shift $(expr $OPTIND - 1 )
 
 # This bracket is closed at the very end and causes a redirection of everything
 # to the logfile as well as stdout.

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+DATETIME=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+LOG_DIR_BASE=logs/$DATETIME
+mkdir -p $LOG_DIR_BASE
+
+# all output to log file
+exec > $LOG_DIR_BASE/docker.log 2>&1
+
 # remove log directories older than 14 days (to avoid cluttering with GB of
 # data on buildbots that are run regularly)
 find logs/2[0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]T[012][0-9]-[0-5][0-9]-[0-5][0-9]Z -type d -not -newermt `date --date='14 days ago' --rfc-3339=date` -exec rm -rf {} \;
@@ -15,8 +22,6 @@ rm -rf $OBSPY_PATH/obspy/station/tests/images/testrun
 DOCKERFILE_FOLDER=base_images
 TEMP_PATH=temp
 NEW_OBSPY_PATH=$TEMP_PATH/obspy
-DATETIME=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
-LOG_DIR_BASE=logs/$DATETIME
 
 # Determine the docker binary name. The official debian packages use docker.io
 # for the binary's name due to some legacy docker package.

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -4,6 +4,16 @@ DATETIME=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
 LOG_DIR_BASE=logs/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
+# Parse the additional args later passed to `obspy-runtests` in
+# the docker images.
+extra_args=""
+while getopts "e:" opt; do
+    case "$opt" in
+    e)  extra_args=', "'$OPTARG'"'
+        ;;
+    esac
+done
+
 # This bracket is closed at the very end and causes a redirection of everything
 # to the logfile as well as stdout.
 {
@@ -95,7 +105,7 @@ run_tests_on_image () {
     image_name=$1;
     printf "\n\e[101m\e[30m  >>> Running tests for image '"$image_name"'...\e[0m\n"
     # Copy dockerfile and render template.
-    sed 's/{{IMAGE_NAME}}/'$image_name'/g' scripts/Dockerfile_run_tests.tmpl > $TEMP_PATH/Dockerfile
+    sed "s/{{IMAGE_NAME}}/$image_name/g; s/{{EXTRA_ARGS}}/$extra_args/g" scripts/Dockerfile_run_tests.tmpl > $TEMP_PATH/Dockerfile
 
     # Where to save the logs, and a random ID for the containers.
     LOG_DIR=${LOG_DIR_BASE}/$image_name

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# remove log directories older than 14 days (to avoid cluttering with GB of
+# data on buildbots that are run regularly)
+find logs/2[0-9][0-9][0-9]-[01][0-9]-[0-3][0-9]T[012][0-9]-[0-5][0-9]-[0-5][0-9]Z -type d -not -newermt `date --date='14 days ago' --rfc-3339=date` -exec rm -rf {} \;
+
 OBSPY_PATH=$(dirname $(dirname $(pwd)))
 
 # Remove all test images stored locally. Otherwise they'll end up on the

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -160,7 +160,12 @@ overall_status() {
     ls ${LOG_DIR_BASE}/*/success 2>&1 > /dev/null && return 0
     return 1
 }
-COMMIT_STATUS_TARGET_URL="http://tests.obspy.org/?version=${FULL_VERSION}"
+# encode parameter part of the URL, using requests as it is installed anyway..
+# (since we use python to import obspy to generate RELEASE-VERSION above)
+# it's just looking up the correct quoting function from urllib depending on
+# py2/3 and works with requests >= 1.0 (which is from 2012)
+FULL_VERSION_URLENCODED=`python -c "from requests.compat import quote; print(quote(\"${FULL_VERSION}\"))"`
+COMMIT_STATUS_TARGET_URL="http://tests.obspy.org/?version=${FULL_VERSION_URLENCODED}"
 if overall_status ;
 then
     COMMIT_STATUS=success

--- a/misc/docker_tests/run_obspy_tests.sh
+++ b/misc/docker_tests/run_obspy_tests.sh
@@ -76,12 +76,21 @@ then
     # we're cloning so we have a non-dirty version actually
     cat $OBSPY_PATH/obspy/RELEASE-VERSION | sed 's#\.dirty$##' > $NEW_OBSPY_PATH/obspy/RELEASE-VERSION
     if [ "$TARGET" = true ] ; then
-        cd $NEW_OBSPY_PATH
-        git remote add TEMP git://github.com/$REPO/obspy
-        git fetch TEMP
+        # get a fresh and clean obspy main repo clone (e.g. to avoid unofficial
+        # tags tampering with version number lookup)
+        rm -rf $NEW_OBSPY_PATH
+        git clone git://github.com/obspy/obspy $NEW_OBSPY_PATH || exit 1
+        # be nice, make sure to only run git commands when successfully changed
+        # to new temporary clone, exit otherwise
+        cd $NEW_OBSPY_PATH || exit 1
+        if [ "$REPO" != "obspy" ]
+        then
+            git remote add $REPO git://github.com/$REPO/obspy
+            git fetch $REPO
+        fi
+        # everything comes from a clean clone, so there should be no need to
+        # git-clean the repo
         git checkout $SHA
-        git remote remove TEMP || git remote rm TEMP
-        git clean -fdx
         git status
         cd $CURDIR
         # write RELEASE-VERSION file in temporary obspy clone without

--- a/misc/docker_tests/scripts/Dockerfile_run_tests.tmpl
+++ b/misc/docker_tests/scripts/Dockerfile_run_tests.tmpl
@@ -5,4 +5,4 @@ MAINTAINER Lion Krischer
 ADD install_and_run_tests_on_image.sh install_and_run_tests_on_image.sh
 ADD obspy /obspy
 RUN echo {{IMAGE_NAME}} > container_name.txt
-CMD ["/bin/bash", "install_and_run_tests_on_image.sh"]
+CMD ["/bin/bash", "install_and_run_tests_on_image.sh"{{EXTRA_ARGS}}]

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -3,8 +3,6 @@ red='\e[0;31m'
 green='\e[0;32m'
 no_color='\e[0m'
 
-pip install https://github.com/Damgaard/PyImgur/archive/master.zip
-
 # Install ObsPy and run the tests.
 cd /obspy
 

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -16,7 +16,7 @@ fi
 
 cd
 
-obspy-runtests -r --keep-images --node=docker-$(cat /container_name.txt) > /TEST_LOG.txt 2>&1
+obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) > /TEST_LOG.txt 2>&1
 
 
 if [ $? != 0 ]; then

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -23,8 +23,10 @@ obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.
 
 if [ $? != 0 ]; then
     echo -e "${red}Tests failed!${no_color}"
+    touch /failure
 else
     echo -e "${green}Tests successful!${no_color}"
+    touch /success
 fi
 
 echo "Done with everything!"

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -3,6 +3,8 @@ red='\e[0;31m'
 green='\e[0;32m'
 no_color='\e[0m'
 
+pip install https://github.com/Damgaard/PyImgur/archive/master.zip
+
 # Install ObsPy and run the tests.
 cd /obspy
 

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -16,7 +16,7 @@ fi
 
 cd
 
-obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) 2>&1 | tee /TEST_LOG.txt
+obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) $1 2>&1 | tee /TEST_LOG.txt
 
 
 if [ $? != 0 ]; then

--- a/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker_tests/scripts/install_and_run_tests_on_image.sh
@@ -6,7 +6,7 @@ no_color='\e[0m'
 # Install ObsPy and run the tests.
 cd /obspy
 
-pip install -v -e . > /INSTALL_LOG.txt 2>&1
+pip install -v -e . 2>&1 | tee /INSTALL_LOG.txt
 
 if [ $? != 0 ]; then
     echo -e "${red}Installation failed!${no_color}"
@@ -16,7 +16,7 @@ fi
 
 cd
 
-obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) > /TEST_LOG.txt 2>&1
+obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) 2>&1 | tee /TEST_LOG.txt
 
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
### Summary

 - remove old logs when running docker tests (to avoid huge space consumption of log directories), only keep the last 15 log dirs
 - don't run flake8 tests (flake8 is too version-dependent and it's tested in Travis anyway, which is sufficient)
 - docker test runner script can now be used to test an arbitrary fork/commit combination (to test PRs)
 - additional parameters can now be passed down into `obspy-runtests` (e.g. to only test a single module)
 - install pyimgur before testing (for image fail uploads)
 - set github commit status with overall result across all docker images
 - add script to fetch all commits that are the tip of an open PR that does not have a commit status with "docker-testbot" context
 - add an example cronjob to run docker tests on all open+updated PRs