### PR TITLE
Fix pep8 builds against newer flake8.

### DIFF
--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import unittest
 import warnings
+from distutils.version import LooseVersion
 
 from lxml import etree
 import numpy as np
@@ -615,8 +616,10 @@ def check_flake8():
                     break
             else:
                 files.append(py_file)
-    flake8_style = get_style_guide(parse_argv=False,
-                                   config_file=flake8.main.DEFAULT_CONFIG)
+    flake8_kwargs = {'parse_argv': False}
+    if LooseVersion(flake8.__version__) < LooseVersion('2.5.5'):
+        flake8_kwargs['config_file'] = flake8.main.DEFAULT_CONFIG
+    flake8_style = get_style_guide(**flake8_kwargs)
     flake8_style.options.ignore = tuple(set(
         flake8_style.options.ignore).union(set(FLAKE8_IGNORE_CODES)))
 

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -571,8 +571,9 @@ try:
 except ImportError:
     HAS_FLAKE8 = False
 else:
+    flake8_version = LooseVersion(flake8.__version__)
     # Only accept flake8 version >= 2.0
-    HAS_FLAKE8 = flake8.__version__ >= '2'
+    HAS_FLAKE8 = flake8_version >= LooseVersion('2')
 
 
 def check_flake8():
@@ -584,8 +585,6 @@ def check_flake8():
     if PY2:
         import pyflakes.checker  # @UnusedImport
         pyflakes.checker.PY2 = True
-    import flake8.main
-    from flake8.engine import get_style_guide
 
     test_dir = os.path.abspath(inspect.getfile(inspect.currentframe()))
     obspy_dir = os.path.dirname(os.path.dirname(os.path.dirname(test_dir)))
@@ -616,9 +615,16 @@ def check_flake8():
                     break
             else:
                 files.append(py_file)
+
+    if flake8_version >= LooseVersion('3.0.0'):
+        from flake8.api.legacy import get_style_guide
+    else:
+        from flake8.engine import get_style_guide
     flake8_kwargs = {'parse_argv': False}
-    if LooseVersion(flake8.__version__) < LooseVersion('2.5.5'):
+    if flake8_version < LooseVersion('2.5.5'):
+        import flake8.main
         flake8_kwargs['config_file'] = flake8.main.DEFAULT_CONFIG
+
     flake8_style = get_style_guide(**flake8_kwargs)
     flake8_style.options.ignore = tuple(set(
         flake8_style.options.ignore).union(set(FLAKE8_IGNORE_CODES)))


### PR DESCRIPTION
This should fix the `AttributeError: 'module' object has no attribute 'DEFAULT_CONFIG'` error that is raised with latest `flake8`.

`flake8` 2.5.5 sets `pep8.USER_CONFIG` itself without passing `config_file` instead.