### PR TITLE
Some minor improvements to runtests

### DIFF
--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -617,6 +617,9 @@ def run(argv=None, interactive=True):
                         help='verbose mode')
     parser.add_argument('-q', '--quiet', action='store_true',
                         help='quiet mode')
+    parser.add_argument('--raise-all-warnings', action='store_true',
+                        help='All warnings are raised as exceptions when this '
+                             'flag is set. Only for debugging purposes.')
 
     # filter options
     filter = parser.add_argument_group('Module Filter',
@@ -678,9 +681,7 @@ def run(argv=None, interactive=True):
     if args.verbose:
         verbosity = 2
         # raise all NumPy warnings
-        np.seterr(all='raise')
-        # raise user and deprecation warnings
-        warnings.simplefilter("error", UserWarning)
+        np.seterr(all='warn')
     elif args.quiet:
         verbosity = 0
         # ignore user and deprecation warnings
@@ -694,6 +695,12 @@ def run(argv=None, interactive=True):
         np.seterr(all='print')
         # ignore user warnings
         warnings.simplefilter("ignore", UserWarning)
+    # whether to raise any warning that's appearing
+    if args.raise_all_warnings:
+        # raise all NumPy warnings
+        np.seterr(all='raise')
+        # raise user and deprecation warnings
+        warnings.simplefilter("error", UserWarning)
     # check for send report option or environmental settings
     if args.report or 'OBSPY_REPORT' in os.environ.keys():
         report = True

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -326,6 +326,22 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     result['errors'] = errors
     result['failures'] = failures
     result['skipped'] = skipped
+    # try to append info on skipped tests:
+    result['skipped_tests_details'] = []
+    try:
+        for module, testresult_ in ttrs.items():
+            if testresult_.skipped:
+                for skipped_test, skip_message in testresult_.skipped:
+                    result['skipped_tests_details'].append(
+                        (module, skipped_test.__module__,
+                         skipped_test.__class__.__name__,
+                         skipped_test._testMethodName, skip_message))
+    except:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        print("\n".join(traceback.format_exception(exc_type, exc_value,
+                                                   exc_tb)))
+        result['skipped_tests_details'] = []
+
     if ci_url is not None:
         result['ciurl'] = ci_url
     if pr_url is not None:


### PR DESCRIPTION
 *  separate "raise all warnings" aspect from "verbose" mode

Setting "-v" does not raise on just any warning that might be shown anymore,
for this a new flag "--raise-all-warnings" is introduced. (fixes #1503)

 *  add detailed info on skipped tests to xml report

e.g.:
```xml
...
  <errors>0</errors>
  <timestamp>1470667146</timestamp>
  <skipped_tests_details>[('io.ndk', 'obspy.io.ndk.tests.test_ndk',
  'NDKTestCase', 'test_read_single_ndk', u'skipped for some reason
  or other'), ('io.nied', 'obspy.io.nied.tests.test_knet_reading',
  'KnetReadingTestCase', 'test_read_knet_ascii_from_open_files',
  u'skipped for another silly reason')]</skipped_tests_details>
  <timetaken>1.49724602699</timetaken>
  <platform>
    <node>wintermute</node>
...
```