### PR TITLE
FDSN Mass Downloader supporting restricted data

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -18,6 +18,11 @@ component integrated into a bigger project.
     (https://www.gnu.org/copyleft/lesser.html)
 
 
+.. contents:: Contents
+    :local:
+    :depth: 2
+
+
 Why Would You Want to Use This?
 -------------------------------
 
@@ -467,7 +472,7 @@ and downloading whatever it offers. A bit more detail:
 
 
 Logging
-~~~~~~~
+-------
 
 The download helpers utilizes Python's `logging facilities
 <https://docs.python.org/2/library/logging.html>`__. By default it will log to
@@ -481,8 +486,23 @@ the corresponding logger after you import the download helpers module:
 >>> logger.setLevel(logging.DEBUG)  # doctest: +SKIP
 
 
+Authentication
+--------------
+
+To make the mass downloader work for restricted data, just initialize it
+with existing :class:`~obspy.clients.fdsn.client.Client` instances that have
+credentials. Note that you can mix already initialized clients with varying
+credientials and just passing the name of the FDSN services to query.
+
+>>> from obspy.clients.fdsn import Client
+>>> client_orfeus = Client("ORFEUS", user="random", password="some_pw")
+>>> client_eth = Client("ETH", user="from_me", password="to_you")
+>>> mdl = MassDownloader(providers=[client_orfeus, "IRIS", client_eth]) \
+    # doctest: +SKIP
+
+
 Further Documentation
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 Further functionality of this module is documented at a couple of other places:
 

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -64,7 +64,8 @@ class MassDownloader(object):
         more then one provider it will always be downloaded from the
         provider that comes first in the list.
     :param debug: Debug flag passed to the underlying FDSN web service clients.
-    :type providers: list of str
+    :type providers: list of str or :class:`~obspy.clients.fdsn.client.Client`
+        instances
     """
     def __init__(self, providers=None, debug=False):
         self.debug = debug

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -283,28 +283,36 @@ class MassDownloader(object):
         """
         Initialize all clients.
         """
-        logger.info("Initializing FDSN client(s) for %s."
-                    % ", ".join(self.providers))
+        logger.info("Initializing FDSN client(s) for %s." % ", ".join(
+            _i.base_url if hasattr(_i, "base_url") else _i
+            for _i in self.providers))
 
         def _get_client(client_name):
-            try:
-                this_client = Client(client_name, debug=self.debug)
-            except utils.ERRORS as e:
-                if "timeout" in str(e).lower():
-                    extra = " (timeout)"
-                else:
-                    extra = ""
-                logger.warn("Failed to initialize client '%s'.%s"
-                            % (client_name, extra))
-                return client_name, None
-            services = sorted([_i for _i in this_client.services.keys()
+            # It might already be an initialized client - in that case just
+            # use it.
+            if isinstance(client_name, Client):
+                name, client = client_name.base_url, client_name
+            else:
+                try:
+                    this_client = Client(client_name, debug=self.debug)
+                    name, client = client_name, this_client
+                except utils.ERRORS as e:
+                    if "timeout" in str(e).lower():
+                        extra = " (timeout)"
+                    else:
+                        extra = ""
+                    logger.warn("Failed to initialize client '%s'.%s"
+                                % (client_name, extra))
+                    return client_name, None
+
+            services = sorted([_i for _i in client.services.keys()
                                if not _i.startswith("available")])
             if "dataselect" not in services or "station" not in services:
                 logger.info("Cannot use client '%s' as it does not have "
                             "'dataselect' and/or 'station' services."
-                            % client_name)
-                return client_name, None
-            return client_name, this_client
+                            % name)
+                return name, None
+            return name, client
 
         # Catch warnings in the main thread. The catch_warnings() context
         # manager does not reliably work when used in multiple threads.
@@ -318,11 +326,15 @@ class MassDownloader(object):
                          "clients: " + str(warning.message))
 
         clients = {key: value for key, value in clients if value is not None}
-        # Write to initialized clients dictionary preserving order.
+
+        # Write to initialized clients dictionary preserving order. Remember
+        # that each passed provider might already be an initialized client
+        # instance.
         for client in self.providers:
-            if client not in clients:
+            if client not in clients and client not in clients.values():
                 continue
-            self._initialized_clients[client] = clients[client]
+            name = client.base_url if hasattr(client, "base_url") else client
+            self._initialized_clients[name] = clients[name]
 
         logger.info("Successfully initialized %i client(s): %s."
                     % (len(self._initialized_clients),


### PR DESCRIPTION
It could be useful if "FDSN Mass Downloader" would support downloading restricted data apart from public one.

Could be something like this:

`providers = [`
`[http://fdsn.service, username, password],`
`[http://fdsn.service2, username2, password2],`
`[http://fdsn.service3, username3, password3]`
`]`

