### PR TITLE
trim/slice nearest_sample argument docstring wrong.

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1458,17 +1458,18 @@ class Stream(object):
             given ``fill_value``. Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
 
         :type fill_value: int, float or ``None``, optional
         :param fill_value: Fill value for gaps. Defaults to ``None``. Traces
@@ -1592,17 +1593,19 @@ class Stream(object):
             Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
+
         :return: :class:`~obspy.core.stream.Stream`
 
         .. note::
@@ -1684,17 +1687,18 @@ class Stream(object):
             shorter then 99.9 % of the desired length are returned.
         :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
         :type nearest_sample: bool, optional
         """
         starttime = min(tr.stats.starttime for tr in self)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1041,17 +1041,18 @@ class Trace(object):
             given ``fill_value``. Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
 
         :type fill_value: int, float or ``None``, optional
         :param fill_value: Fill value for gaps. Defaults to ``None``. Traces
@@ -1104,17 +1105,18 @@ class Trace(object):
         :param endtime: Specify the end time of slice.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
 
         :return: New :class:`~obspy.core.trace.Trace` object. Does not copy
             data but just passes a reference to it.
@@ -1170,17 +1172,18 @@ class Trace(object):
             shorter then 99.9 % of the desired length are returned.
         :type include_partial_windows: bool
         :param nearest_sample: If set to ``True``, the closest sample is
-            selected, if set to ``False``, the outer (previous sample for a
-            start time border, next sample for an end time border) sample
+            selected, if set to ``False``, the inner (next sample for a
+            start time border, previous sample for an end time border) sample
             containing the time is selected. Defaults to ``True``.
 
-            Given the following trace containing 4 samples, "|" are the
+            Given the following trace containing 6 samples, "|" are the
             sample points, "A" is the requested starttime::
 
-                |        A|         |         |
+                |         |A        |         |       B |         |
+                1         2         3         4         5         6
 
-            ``nearest_sample=True`` will select the second sample point,
-            ``nearest_sample=False`` will select the first sample point.
+            ``nearest_sample=True`` will select samples 2-5,
+            ``nearest_sample=False`` will select samples 3-4 only.
         :type nearest_sample: bool, optional
         """
         windows = get_window_times(


### PR DESCRIPTION
We document the `nearest_sample` argument like this:

<img width="812" alt="screen shot 2016-08-19 at 00 51 48" src="https://cloud.githubusercontent.com/assets/800487/17793387/362df386-65a7-11e6-8c20-2e2ebd0b3ad4.png">

Thus setting it to `False` should select the outer samples but we indeed appear to be selecting the inner sample, which we also test:

```python
    def test_slice_nearest_sample(self):
        """
        Tests slicing with the nearest sample flag set to on or off.
        """
        tr = Trace(data=np.arange(6))
        # Samples at:
        # 0       10       20       30       40       50
        tr.stats.sampling_rate = 0.1

        # Nearest sample flag defaults to true.
        tr2 = tr.slice(UTCDateTime(4), UTCDateTime(44))
        self.assertEqual(tr2.stats.starttime, UTCDateTime(0))
        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))

        tr2 = tr.slice(UTCDateTime(8), UTCDateTime(48))
        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
        self.assertEqual(tr2.stats.endtime, UTCDateTime(50))

        # Setting it to False changes the returned values.
        tr2 = tr.slice(UTCDateTime(4), UTCDateTime(44), nearest_sample=False)
        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))

        tr2 = tr.slice(UTCDateTime(8), UTCDateTime(48), nearest_sample=False)
        self.assertEqual(tr2.stats.starttime, UTCDateTime(10))
        self.assertEqual(tr2.stats.endtime, UTCDateTime(40))
```

We have to either change the documentation or the implementation. I suggest to change it to

`Trace.trim(..., select_sample="nearest", ...)` with `"nearest"`, `"inner"`, `"outer"` as possible choices. This of course requires some deprecation fallbacks. Thoughts?