### PR TITLE
Include sub seconds in stationxml write.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,9 @@
    * `SACTrace.lpspol` and `lcalda` are `True` and `False` by default, when
       created via `SACTrace.from_obspy_trace` with a `Trace` that has no SAC
       inheritance. (see #1507)
+ - obspy.io.stationxml:
+   * Datetime fields are written with microseconds to StationXML if
+     microseconds are present. (see #1511)
 
 1.0.2: (doi: 10.5281/zenodo.49636)
  - obspy.core:

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -1328,7 +1328,10 @@ def _obj2tag(parent, tag_name, tag_value):
 
 
 def _format_time(value):
-    return value.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+    if value.microsecond == 0:
+        return value.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    else:
+        return value.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
 
 # Remove once 0.11 has been released.

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -1328,7 +1328,7 @@ def _obj2tag(parent, tag_name, tag_value):
 
 
 def _format_time(value):
-    return value.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    return value.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
 
 # Remove once 0.11 has been released.

--- a/obspy/io/stationxml/tests/data/minimal_station_with_microseconds.xml
+++ b/obspy/io/stationxml/tests/data/minimal_station_with_microseconds.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML schemaVersion="1.0" xmlns="http://www.fdsn.org/xml/station/1">
+  <Source>OBS</Source>
+  <Module/>
+  <ModuleURI/>
+  <Created>2013-01-01T00:00:00.123456+00:00</Created>
+  <Network code="PY"/>
+</FDSNStationXML>

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -152,19 +152,9 @@ class StationXMLTestCase(unittest.TestCase):
         # writing of the ObsPy related tags to ease testing.
         file_buffer = io.BytesIO()
 
-        # XXX helper variable to debug writing the full random file, set True
-        # XXX for debug output
-        write_debug_output = False
-
         inv.write(file_buffer, format="StationXML",
-                  validate=(not write_debug_output),
                   _suppress_module_tags=True)
         file_buffer.seek(0, 0)
-
-        if write_debug_output:
-            with open("/tmp/debugout.xml", "wb") as open_file:
-                open_file.write(file_buffer.read())
-            file_buffer.seek(0, 0)
 
         with open(filename, "rb") as open_file:
             expected_xml_file_buffer = io.BytesIO(open_file.read())

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -129,19 +129,9 @@ class StationXMLTestCase(unittest.TestCase):
         # writing of the ObsPy related tags to ease testing.
         file_buffer = io.BytesIO()
 
-        # XXX helper variable to debug writing the full random file, set True
-        # XXX for debug output
-        write_debug_output = False
-
         inv.write(file_buffer, format="StationXML",
-                  validate=(not write_debug_output),
                   _suppress_module_tags=True)
         file_buffer.seek(0, 0)
-
-        if write_debug_output:
-            with open("/tmp/debugout.xml", "wb") as open_file:
-                open_file.write(file_buffer.read())
-            file_buffer.seek(0, 0)
 
         with open(filename, "rb") as open_file:
             expected_xml_file_buffer = io.BytesIO(open_file.read())

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -22,6 +22,7 @@ import unittest
 
 import obspy
 from obspy.core.inventory import Inventory, Network
+import obspy.io.stationxml.core
 
 
 class StationXMLTestCase(unittest.TestCase):
@@ -106,6 +107,41 @@ class StationXMLTestCase(unittest.TestCase):
         inv.write(file_buffer, format="StationXML", validate=True,
                   _suppress_module_tags=True)
         file_buffer.seek(0, 0)
+
+        with open(filename, "rb") as open_file:
+            expected_xml_file_buffer = io.BytesIO(open_file.read())
+        expected_xml_file_buffer.seek(0, 0)
+
+        self._assert_station_xml_equality(file_buffer,
+                                          expected_xml_file_buffer)
+
+    def test_subsecond_read_and_write_minimal_file(self):
+        """
+        Test reading and writing of sub-second time in datetime field,
+        using creation time
+
+        """
+        filename = os.path.join(self.data_dir,
+                                "minimal_station_with_microseconds.xml")
+        inv = obspy.read_inventory(filename)
+
+        # Write it again. Also validate it to get more confidence. Suppress the
+        # writing of the ObsPy related tags to ease testing.
+        file_buffer = io.BytesIO()
+
+        # XXX helper variable to debug writing the full random file, set True
+        # XXX for debug output
+        write_debug_output = False
+
+        inv.write(file_buffer, format="StationXML",
+                  validate=(not write_debug_output),
+                  _suppress_module_tags=True)
+        file_buffer.seek(0, 0)
+
+        if write_debug_output:
+            with open("/tmp/debugout.xml", "wb") as open_file:
+                open_file.write(file_buffer.read())
+            file_buffer.seek(0, 0)
 
         with open(filename, "rb") as open_file:
             expected_xml_file_buffer = io.BytesIO(open_file.read())


### PR DESCRIPTION
Currently stationxml.write() truncates to the second like so:
<Created>2013-12-11T16:29:13+00:00</Created>
This is ok for creation time, but for station and channel startdate and enddate sub seconds may be needed when metadata changes, while recording is continuous. 
startDate="2013-12-11T16:29:13.500000+00:00"
Dataless has subseconds.