### PR TITLE
User-Agent: separate product from version with a slash instead of space

### DIFF
--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -69,10 +69,10 @@ else:
     encoding = sys.getdefaultencoding() or "UTF-8"
     platform_ = platform.platform().encode(encoding).decode("ascii", "ignore")
 # The default User Agent that will be sent with every request.
-DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (
+DEFAULT_USER_AGENT = "ObsPy/%s (%s, Python %s)" % (
     obspy.__version__, platform_, platform.python_version())
 # The user agent tests should use by default.
-DEFAULT_TESTING_USER_AGENT = "ObsPy %s (test suite) (%s, Python %s)" % (
+DEFAULT_TESTING_USER_AGENT = "ObsPy/%s (test suite) (%s, Python %s)" % (
     obspy.__version__, platform_, platform.python_version())
 
 

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -65,7 +65,7 @@ else:
     encoding = sys.getdefaultencoding() or "UTF-8"
     platform_ = platform.platform().encode(encoding).decode("ascii", "ignore")
 # The default User Agent that will be sent with every request.
-DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (
+DEFAULT_USER_AGENT = "ObsPy/%s (%s, Python %s)" % (
     __version__, platform_, platform.python_version())
 
 

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -26,7 +26,7 @@ from obspy import Stream, UTCDateTime, __version__, read
 from obspy.core.util import NamedTemporaryFile, loadtxt
 
 
-DEFAULT_USER_AGENT = "ObsPy %s (%s, Python %s)" % (__version__,
+DEFAULT_USER_AGENT = "ObsPy/%s (%s, Python %s)" % (__version__,
                                                    platform.platform(),
                                                    platform.python_version())
 DEFAULT_PHASES = ['p', 's', 'P', 'S', 'Pn', 'Sn', 'PcP', 'ScS', 'Pdiff',


### PR DESCRIPTION
This small change to the default User-Agent HTTP header for clients separates the product from the version using a slash instead of a space.  In short, User-Agent headers starting with "ObsPy/1.0.2" instead of "ObsPy 1.0.2".

This follows the pattern in RFC 7231, specifically section 5.5.3:
https://tools.ietf.org/html/rfc7231#section-5.5.3