### PR TITLE
Inventory Query (get_all) function

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -676,6 +676,17 @@ class Inventory(ComparingObject):
                            the attribute is extracted from parameter `level`
         :param level: the level at which the attributes are extracted.
         :param default: default value if the attribute is doesn't exist
+        :returns: list of lists. Each sublist contains the attribute values for
+                  each network/station/channel.
+
+        .. rubric:: Basic Usage
+        >>> import obspy
+        >>> inv = obspy.read_inventory()
+        >>> query = inv.get_all(('net.code', 'code'), level='station')
+        >>> query[0]
+        [u'GR', u'GR', u'BW', u'BW', u'BW']
+        >>> query[1]
+        [u'FUR', u'WET', u'RJOB', u'RJOB', u'RJOB']
         """
         query = [[] for attrib in attributes]
         for iattrib, attrib in enumerate(attributes):


### PR DESCRIPTION
### What does this PR do?
This proposal adds a short and simple query function to the inventory object. It corresponds to the discussion in #1236 (as well for a catalog). Usage is like this:
```
In [1]: import obspy
In [2]: inv = obspy.read_inventory()
In [3]: inv.get_all(('net.code', 'code'), level='station')
Out[3]: [['GR', 'GR', 'BW', 'BW', 'BW'], ['FUR', 'WET', 'RJOB', 'RJOB', 'RJOB']]
```

Open for discussion.

### Related Discussion from #1236
> MMesch (Feb 18):
>I am just thinking how to continue. I structure the plotting routines of inventory and catalog better and to include the ray path plotting routine, I will add an 'get_all' function to inventory and catalog. This could be called as:

 >   long_list = catalog.get_all(['latitude', 'longitude', 'depth', 'focal_mechanism'])

>this would replace the current
>```
>for network in inventory:
>   for station in network:
>       lats.append(station.latitude)
>         [...]
>```
>loops in the plotting functions and is also useful for other functions that need bulk inventory/catalog
>data. Tell me if you have a better idea...
>
>Krischer (Feb 18):
> We could also do a slightly more generic variant:
> 
> ```python
> catalog.get_all(('preferred_origin.latitude', 'preferred_origin.longitude',
>                  'preferred_focal_mechanism.mt.tensor', ...))
> ```
> 
> Which would return lists of dictionaries with the requested keys. I'm not sure if we need the `preferred_` prefix or not but I think it might be useful. For inventories this is a bit more complex as they are nested. We could also think to add a more generic query interface that would replace the current `filter()` methods. I did something along these lines here which I think has quite a nice interface: http://seismicdata.github.io/pyasdf/querying_data.html
> 
> I also want to add a couple of more things. I'll do it after the release:
> 
> * The WebGL renderer for the raypaths.
> * Plots like in the middle of this page: http://www.isc.ac.uk/standards/phases/
> 

### PR Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .