### PR TITLE
mseed-qc: first continuous segment start at window start

### DIFF
--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -489,11 +489,16 @@ class MSEEDMetadata(object):
         if not self.data:
             return
 
+        if self.meta['start_gap'] is None and self.window_start is not None:
+            first_segment_start = self.window_start
+        else:
+            first_segment_start = self.data[0].stats.starttime
+
         # Collect data in arrays of continuous segments
         # Manually set the first segment
         c_seg = {
-            'start': self.data[0].stats.starttime,
-            'data': self.data[0].data,
+            'start': first_segment_start,
+            'data': self.data[0].data
         }
 
         c_segs = []

--- a/obspy/signal/tests/test_quality_control.py
+++ b/obspy/signal/tests/test_quality_control.py
@@ -591,10 +591,10 @@ class QualityControlTestCase(unittest.TestCase):
         # Test single continuous segments
         # Gap in beginning, cseg starts at first sample
         cseg = md.meta['c_segments'][0]
-        self.assertTrue(cseg['start_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 625000))
-        self.assertTrue(cseg['end_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
+        self.assertEqual(cseg['start_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 625000))
+        self.assertEqual(cseg['end_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
 
         # Start beyond a sample, but it is padded to the left, no gap
         starttime = obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 630000)
@@ -607,10 +607,10 @@ class QualityControlTestCase(unittest.TestCase):
         # Test single continuous segments
         # first sample is padded, first cseg starttime is window starttime
         cseg = md.meta['c_segments'][0]
-        self.assertTrue(cseg['start_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 630000))
-        self.assertTrue(cseg['end_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
+        self.assertEqual(cseg['start_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 630000))
+        self.assertEqual(cseg['end_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
 
         md = MSEEDMetadata([file], add_c_segments=True)
         self.assertTrue(md.meta["num_gaps"] == 0)
@@ -619,10 +619,10 @@ class QualityControlTestCase(unittest.TestCase):
         # Test single continuous segments
         # No window, start time is first sample, end time is last sample + dt
         cseg = md.meta['c_segments'][0]
-        self.assertTrue(cseg['start_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 600000))
-        self.assertTrue(cseg['end_time'],
-                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
+        self.assertEqual(cseg['start_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 625000))
+        self.assertEqual(cseg['end_time'],
+                         obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 325000))
 
     def test_random_window(self):
         """

--- a/obspy/signal/tests/test_quality_control.py
+++ b/obspy/signal/tests/test_quality_control.py
@@ -581,22 +581,48 @@ class QualityControlTestCase(unittest.TestCase):
         # first sample is 625000, so we introduce a gap of 0.025
         starttime = obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 600000)
         endtime = obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000)
-        md = MSEEDMetadata([file], starttime=starttime, endtime=endtime)
+        md = MSEEDMetadata([file], starttime=starttime, endtime=endtime,
+                           add_c_segments=True)
 
         self.assertTrue(md.meta["num_gaps"] == 1)
         self.assertTrue(md.meta["sum_gaps"] == 0.025)
         self.assertTrue(md.meta["start_gap"] == 0.025)
 
+        # Test single continuous segments
+        # Gap in beginning, cseg starts at first sample
+        cseg = md.meta['c_segments'][0]
+        self.assertTrue(cseg['start_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 625000))
+        self.assertTrue(cseg['end_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
+
         # Start beyond a sample, but it is padded to the left, no gap
         starttime = obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 630000)
         endtime = obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000)
-        md = MSEEDMetadata([file], starttime=starttime, endtime=endtime)
+        md = MSEEDMetadata([file], starttime=starttime, endtime=endtime,
+                           add_c_segments=True)
         self.assertTrue(md.meta["num_gaps"] == 0)
         self.assertTrue(md.meta["start_gap"] is None)
 
-        md = MSEEDMetadata([file])
+        # Test single continuous segments
+        # first sample is padded, first cseg starttime is window starttime
+        cseg = md.meta['c_segments'][0]
+        self.assertTrue(cseg['start_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 630000))
+        self.assertTrue(cseg['end_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
+
+        md = MSEEDMetadata([file], add_c_segments=True)
         self.assertTrue(md.meta["num_gaps"] == 0)
         self.assertTrue(md.meta["start_gap"] is None)
+
+        # Test single continuous segments
+        # No window, start time is first sample, end time is last sample + dt
+        cseg = md.meta['c_segments'][0]
+        self.assertTrue(cseg['start_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 1, 600000))
+        self.assertTrue(cseg['end_time'],
+                        obspy.UTCDateTime(2015, 10, 16, 0, 0, 59, 300000))
 
     def test_random_window(self):
         """


### PR DESCRIPTION
Changed the code so that the first continuous segment uses the window start (if specified) instead of the first sample as its start time when there is no start gap.

Added expected continuous segments start & end to `test_start_gap`.
