### PR TITLE
fix writing of long Q headers for python3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@
    * `SACTrace.lpspol` and `lcalda` are `True` and `False` by default, when
       created via `SACTrace.from_obspy_trace` with a `Trace` that has no SAC
       inheritance. (see #1507)
+- obspy.io.sh:
+   * Fix writing of long headers for python3
  - obspy.io.stationxml:
    * Datetime fields are written with microseconds to StationXML if
      microseconds are present. (see #1511)

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -561,7 +561,7 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
             temp += "%s:%s~ " % (SH_IDX[key], value)
         headers.append(temp)
         # get maximal number of trclines
-        nol = len(temp) / 74 + 1
+        nol = len(temp) // 74 + 1
         if nol > minnol:
             minnol = nol
     # first line: magic number, cmtlines, trclines

--- a/obspy/io/sh/tests/test_core.py
+++ b/obspy/io/sh/tests/test_core.py
@@ -16,8 +16,10 @@ from obspy.io.sh.core import (STANDARD_ASC_HEADERS, _is_asc, _is_q, _read_asc,
 
 
 class CoreTestCase(unittest.TestCase):
+
     """
     """
+
     def setUp(self):
         # Directory where the test files are located
         self.path = os.path.dirname(__file__)
@@ -268,6 +270,21 @@ class CoreTestCase(unittest.TestCase):
                     if format == 'Q':
                         os.remove(tempfile[:-4] + '.QBN')
                         os.remove(tempfile[:-4] + '.QHD')
+
+    def test_write_long_header(self):
+        """
+        Test for issue #1526
+        """
+        tr = read()[0]
+        comment = 'This is a long comment for testing purposes.'
+        tr.stats.sh = {'COMMENT': ' '.join(4 * [comment])}
+        with NamedTemporaryFile(suffix='.QHD') as tf:
+            tempfile = tf.name
+            tr.write(tempfile, format="Q")
+            tr2 = read(tempfile)[0]
+            # remove binary file too (dynamically created)
+            os.remove(os.path.splitext(tempfile)[0] + '.QBN')
+        self.assertEqual(tr.stats.sh.COMMENT, tr2.stats.sh.COMMENT)
 
 
 def suite():


### PR DESCRIPTION
Fixes the following issue

```
  File "/home/richter/dev/rf/rf/rfstream.py", line 183, in write
    super(RFStream, self).write(filename, format, **kwargs)
  File "/home/richter/dev/obspy/obspy/core/stream.py", line 1439, in write
    write_format(self, filename, **kwargs)
  File "/home/richter/dev/obspy/obspy/io/sh/core.py", line 573, in _write_q
    for j in range(0, minnol):
TypeError: 'float' object cannot be interpreted as an integer
```