### PR TITLE
Proxy support for NEIC CWB QueryServer client (and others?)

### DIFF
--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -10,6 +10,9 @@ License:
 J. MacCarthy, modified from https://gist.github.com/frxstrem/4487802
 
 """
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
 
 import socket
 from base64 import b64encode

--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+Establish a socket connection through an HTTP proxy.
+Author: Fredrik Østrem <frx.apps@gmail.com>
+License:
+  This code can be used, modified and distributed freely, as long as it is this
+  note containing the original author, the source and this license, is put
+  along with the source code.
+
+J. MacCarthy, modified from https://gist.github.com/frxstrem/4487802
+
+"""
+
+import socket
+from base64 import b64encode
+import urllib
+import urlparse
+
+
+def get_proxy_tuple():
+    """
+    Return system http proxy as a urlparse.urlparse tuple or () if unset.
+    """
+    proxydict = urllib.getproxies()
+    proxystr = proxydict.get('http') or proxydict.get('https') or ''
+    if proxystr:
+        proxy = urlparse.urlparse(proxystr)
+    else:
+        proxy = ()
+
+    return proxy
+
+
+def valid_address(addr):
+    """ Verify that an IP/port tuple is valid """
+    TF = (isinstance(addr, (list, tuple)) and
+          len(addr) == 2 and
+          isinstance(addr[0], str) and
+          isinstance(addr[1], (int, long)))
+    return TF
+
+
+def http_proxy_connect(address, proxy, auth=None, headers={}):
+    """
+    Establish a socket connection through an HTTP proxy.
+
+    Arguments:
+      address (required)     = The address of the target
+      proxy (def: None)      = The address of the proxy server
+      auth (def: None)       = A tuple of the username and password used for
+                               authentication
+      headers (def: {})      = A set of headers that will be sent to the proxy
+
+    Returns:
+      A 3-tuple of the format:
+        (socket, status_code, headers)
+      Where `socket' is the socket object, `status_code` is the HTTP status
+      code that the server returned and `headers` is a dict of headers that the
+      server returned.
+
+    """
+    if not valid_address(address):
+        raise ValueError('Invalid target address')
+
+    if not valid_address(proxy):
+        raise ValueError('Invalid proxy address')
+
+    headers = {'host': address[0]}
+
+    if auth is not None:
+        if isinstance(auth, str):
+            headers['proxy-authorization'] = auth
+        elif auth and isinstance(auth, (tuple, list)) and len(auth) == 2:
+            proxy_authorization = 'Basic ' + b64encode('%s:%s' % auth)
+            headers['proxy-authorization'] = proxy_authorization
+        else:
+            raise ValueError('Invalid authentication specification')
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect(proxy)
+    fp = s.makefile('r+')
+
+    fp.write('CONNECT %s:%d HTTP/1.0\r\n' % address)
+    fp.write('\r\n'.join('%s: %s' % (k, v) for (k, v) in headers.items()) +
+             '\r\n\r\n')
+    fp.flush()
+
+    statusline = fp.readline().rstrip('\r\n')
+
+    if statusline.count(' ') < 2:
+        fp.close()
+        s.close()
+        raise IOError('Bad response')
+    version, status, statusmsg = statusline.split(' ', 2)
+    if version not in ('HTTP/1.0', 'HTTP/1.1'):
+        fp.close()
+        s.close()
+        raise IOError('Unsupported HTTP version')
+    try:
+        status = int(status)
+    except ValueError:
+        fp.close()
+        s.close()
+        raise IOError('Bad response')
+
+    response_headers = {}
+
+    while True:
+        l = fp.readline().rstrip('\r\n')
+        if l == '':
+            break
+        if ':' not in l:
+            continue
+        k, v = l.split(':', 1)
+        response_headers[k.strip().lower()] = v.strip()
+
+    fp.close()
+    return (s, status, response_headers)

--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -52,8 +52,8 @@ def http_proxy_connect(address, proxy, auth=None):
 
     Arguments:
       address (required)     = The address of the target
-      proxy (def: None)      = The address of the proxy server
-      auth                   = A tuple of the username and password used for
+      proxy   (required)     = The address of the proxy server
+      auth  (def: None)      = A tuple of the username and password used for
                                authentication
 
     Returns:
@@ -77,14 +77,14 @@ def http_proxy_connect(address, proxy, auth=None):
             headers['proxy-authorization'] = auth
         elif auth and isinstance(auth, (tuple, list)) and len(auth) == 2:
             auth_b64 = b64encode(bytes(('%s:%s' % auth).encode()))
-            proxy_authorization = 'Basic '.decode() + auth_b64
+            proxy_authorization = 'Basic '+ auth_b64.decode()
             headers['proxy-authorization'] = proxy_authorization
         else:
             raise ValueError('Invalid authentication specification')
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect(proxy)
-    fp = s.makefile('r')
+    fp = s.makefile('rw')
 
     fp.write('CONNECT %s:%d HTTP/1.0\r\n' % address)
     fp.write('\r\n'.join('%s: %s' % (k, v) for (k, v) in headers.items()) +
@@ -96,7 +96,7 @@ def http_proxy_connect(address, proxy, auth=None):
     if statusline.count(' ') < 2:
         fp.close()
         s.close()
-        raise IOError('Bad response. statusline:'.format(statusline))
+        raise IOError('Bad response. statusline: {}'.format(statusline))
     version, status, statusmsg = statusline.split(' ', 2)
     if version not in ('HTTP/1.0', 'HTTP/1.1'):
         fp.close()

--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -77,7 +77,7 @@ def http_proxy_connect(address, proxy, auth=None):
             headers['proxy-authorization'] = auth
         elif auth and isinstance(auth, (tuple, list)) and len(auth) == 2:
             auth_b64 = b64encode(bytes(('%s:%s' % auth).encode()))
-            proxy_authorization = 'Basic '+ auth_b64.decode()
+            proxy_authorization = 'Basic ' + auth_b64.decode()
             headers['proxy-authorization'] = proxy_authorization
         else:
             raise ValueError('Invalid authentication specification')

--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -96,7 +96,7 @@ def http_proxy_connect(address, proxy, auth=None):
     if statusline.count(' ') < 2:
         fp.close()
         s.close()
-        raise IOError('Bad response')
+        raise IOError('Bad response. statusline:'.format(statusline))
     version, status, statusmsg = statusline.split(' ', 2)
     if version not in ('HTTP/1.0', 'HTTP/1.1'):
         fp.close()

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -177,8 +177,8 @@ class Client(object):
         address = (self.host, self.port)
         if self.proxy:
             proxy = (self.proxy.hostname, self.proxy.port)
-            auth = (self.proxy.username, self.proxy.password)\
-                    if self.proxy.username else None
+            auth = ((self.proxy.username, self.proxy.password) if
+                    self.proxy.username else None)
 
         success = False
         while not success:

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -188,14 +188,12 @@ class Client(object):
                     # This socket is already connected to the proxy
                 else:
                     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    s.connect((self.host, self.port))
 
                 with NamedTemporaryFile() as tf:
                     if self.debug:
                         print(ascdate(), asctime(), "connecting temp file",
                               tf.name)
-                    if not self.proxy:
-                        # The proxy-ed socket is already connected
-                        s.connect((self.host, self.port))
                     s.setblocking(0)
                     s.send(line.encode('ascii', 'strict'))
                     if self.debug:


### PR DESCRIPTION
**Problem:**
The NEIC CWB client times-out when requesting a waveform (code example at end).

**Possible solution:**
I believe this is because it can't use my proxy server.  I've successfully tested a manual connection and waveform retrieval using a proxy-enabled socket, following the code example at [this Gist](https://gist.github.com/frxstrem/4487802).  I think that adding something like  `proxy_user=None, proxy_server=None, proxy_password=None` keyword arguments into the `Client.__init__`, or using `os.environ['HTTP_PROXY']`, and routing the socket creation through the code in the above Gist, would enable use client through a proxy.  Other clients (arclink?) may also benefit from a similar change.


**Details:** 
OSX, ObsPy 1.0.2 maintenance, installed with `pip install .`

**Code example:**
```python
In [14]: from obspy.clients.neic import Client

In [15]: from obspy import UTCDateTime

In [16]: client.get_waveforms('IU', 'ANMO', '00', 'BH?', UTCDateTime()-(72*3600), UTCDateTime()-(72*3600)+120)
Traceback (most recent call last):
  File "/Users/jkmacc/repos/obspy/obspy/clients/neic/client.py", line 192, in get_waveforms_nscl
    s.connect((self.host, self.port))
  File "/Users/jkmacc/anaconda/envs/obspy/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 60] Operation timed out

CWB QueryServer at 137.227.224.97/2061
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-16-b2e323e1ec90> in <module>()
----> 1 client.get_waveforms('IU', 'ANMO', '00', 'BH?', UTCDateTime()-(72*3600), UTCDateTime()-(72*3600)+120)

/Users/jkmacc/repos/obspy/obspy/clients/neic/client.pyc in get_waveforms(self, network, station, location, channel, starttime, endtime)
    130         seedname = seedname.replace("?", ".")
    131         return self.get_waveforms_nscl(seedname, starttime,
--> 132                                        endtime - starttime)
    133
    134     @deprecated("'getWaveformNSCL' has been renamed to 'get_waveforms_nscl'. "

/Users/jkmacc/repos/obspy/obspy/clients/neic/client.pyc in get_waveforms_nscl(self, seedname, starttime, duration)
    190                         print(ascdate(), asctime(), "connecting temp file",
    191                               tf.name)
--> 192                     s.connect((self.host, self.port))
    193                     s.setblocking(0)
    194                     s.send(line.encode('ascii', 'strict'))

/Users/jkmacc/anaconda/envs/obspy/lib/python2.7/socket.pyc in meth(name, self, *args)
    226
    227 def meth(name,self,*args):
--> 228     return getattr(self._sock,name)(*args)
    229
    230 for _m in _socketmethods:

error: [Errno 60] Operation timed out
```