### PR TITLE
Remove unnecessary and broken distutils entrypoint.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,9 +135,6 @@ ENTRY_POINTS = {
         'obspy-xseed2dataless = obspy.io.xseed.scripts.xseed2dataless:main',
         'obspy-dataless2resp = obspy.io.xseed.scripts.dataless2resp:main',
         ],
-    'distutils.commands': [
-        'build_man = Help2Man'
-        ],
     'obspy.plugin.waveform': [
         'TSPAIR = obspy.io.ascii.core',
         'SLIST = obspy.io.ascii.core',


### PR DESCRIPTION
I ran into some issue with pbr, and then found [this report](https://bugs.launchpad.net/pbr/+bug/1624980) pointing to some invalid stuff in ObsPy. The entrypoint is not needed and in fact would not work since the class it names does not exist. The `build_man` and `install_man` commands are provided by `cmdclass` later in `setup.py`.