### PR TITLE
properly sort contributors by last name

### DIFF
--- a/misc/docs/make_credits.py
+++ b/misc/docs/make_credits.py
@@ -25,9 +25,23 @@ libraries and applications, our build tools and our web sites.
 
 """)
 
+
 # add contributors
+def name_key_function(name):
+    """
+    Key function for use with :py:func:`sorted` to sort full names given as
+    "last name, first names" (e.g. `u'van Driel, Martin\n'`).
+    """
+    last, first = name.split(",")
+    last = last.split()
+    # "pop" any last name prefixes that should be ignored during sorting
+    if last[0] in ["van"]:
+        last.pop(0)
+    return last, first
+
 filename = os.path.join(os.pardir, os.pardir, 'CONTRIBUTORS.txt')
-contributors = sorted(codecs.open(filename, 'r', 'utf-8').readlines())
+contributors = sorted(codecs.open(filename, 'r', 'utf-8').readlines(),
+                      key=name_key_function)
 
 for item in contributors:
     fh.write("    * %s" % (item))

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -1,71 +1,71 @@
-Charles J. Ammon
-Emanuel Antunes
-Ólafur St. Arnarsson
-Markus Bank
-Robert Barsch
-Yannik Behr
-Fabrizio Bernardi
-Felix Bernauer
-Moritz Beyreuther
-Sébastien Bonaimé
-Lloyd Carothers
-Peter Danecek
-Martin van Driel
-Fabian Engels
-Sven Egdorf
-Laura Ermert
-Tom Eulenfeld
-Clément Grellier
-Marc Grunberg
-Conny Hammer
-Sebastian Heimann
-Lukas Heiniger
-Gaute Hope
-Seyed Kasra Hosseini Zad
-Heiner Igel
-Adolfo Inza
-Marius Isken
-Paul Käufl
-David Ketchum
-Andreas Köhler
-Simon Kremers
-Victor Kress
-Lars Krieger
-Lion Krischer
-Mathijs Koymans
-Thomas Lecocq
-John Leeman
-Philippe Lesage
-Anthony Lomax
-Rui L. Lopes
-Jonathan MacCarthy
-Alessia Maggi
-Henri Martin
-Tobias Megies
-Matthias Meschede
-Alberto Michelini
-Bernhard Morgenstern
-Nathaniel C. Miller
-Ran Novitsky Nof
-Mark P. Panning
-Giovanni Rapagnani
-Celso Reyes
-Adam Ringler
-Nicolas Rothenhäusler
-Emiliano Russo
-Elliott Sales de Andrade
-Claudio Satriano
-Joachim Saul
-Chris Scheingraber
-Christian Sippl
-Arthur Snoke
-Stefan Stange
-Benjamin Sullivan
-Chad Trabant
-Tommaso Fabbri
-Leonardo Uieda
-Andrew Walker
-Marcus Walther
-Joachim Wassermann
-Mark C. Williams
-Andrew Winkelman
+Ammon, Charles J.
+Antunes, Emanuel
+Arnarsson, Ólafur St.
+Bank, Markus
+Barsch, Robert
+Behr, Yannik
+Bernardi, Fabrizio
+Bernauer, Felix
+Beyreuther, Moritz
+Bonaimé, Sébastien
+Carothers, Lloyd
+Danecek, Peter
+van Driel, Martin
+Egdorf, Sven
+Engels, Fabian
+Ermert, Laura
+Eulenfeld, Tom
+Fabbri, Tommaso
+Grellier, Clément
+Grunberg, Marc
+Hammer, Conny
+Heimann, Sebastian
+Heiniger, Lukas
+Hope, Gaute
+Igel, Heiner
+Inza, Adolfo
+Isken, Marius
+Ketchum, David
+Koymans, Mathijs
+Kremers, Simon
+Kress, Victor
+Krieger, Lars
+Krischer, Lion
+Käufl, Paul
+Köhler, Andreas
+Lecocq, Thomas
+Leeman, John
+Lesage, Philippe
+Lomax, Anthony
+Lopes, Rui L.
+MacCarthy, Jonathan
+Maggi, Alessia
+Martin, Henri
+Megies, Tobias
+Meschede, Matthias
+Michelini, Alberto
+Miller, Nathaniel C.
+Morgenstern, Bernhard
+Nof, Ran Novitsky
+Panning, Mark P.
+Rapagnani, Giovanni
+Reyes, Celso
+Ringler, Adam
+Rothenhäusler, Nicolas
+Russo, Emiliano
+Sales de Andrade, Elliott
+Satriano, Claudio
+Saul, Joachim
+Scheingraber, Chris
+Sippl, Christian
+Snoke, Arthur
+Stange, Stefan
+Sullivan, Benjamin
+Trabant, Chad
+Uieda, Leonardo
+Walker, Andrew
+Walther, Marcus
+Wassermann, Joachim
+Williams, Mark C.
+Winkelman, Andrew
+Zad, Seyed Kasra Hosseini


### PR DESCRIPTION
Fix glitch with two names on one line on current contributors list...

![screenshot from 2016-09-26 10 38 57](https://cloud.githubusercontent.com/assets/1842780/18827916/898b4118-83d5-11e6-843f-aa56a950706b.png)

 ..and proper sorting by last name (should be clear enough for new additions that last/first name should be comma separated now, I think..)


+DOCS