### PR TITLE
Travis: test *all* modules when building pushes to main branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,16 +153,16 @@ script:
         # we're building a pull request, so check what modules should be tested
         then export MODULELIST=`python -c "from obspy_github_api import get_module_test_list; print('obspy.' + ',obspy.'.join(get_module_test_list($TRAVIS_PULL_REQUEST)))"`
              export MODULELISTSPACES=`python -c "from obspy_github_api import get_module_test_list; print(' '.join(get_module_test_list($TRAVIS_PULL_REQUEST)))"`
-        # we're building a branch on the main repo
-        else export MODULELIST=`python -c "from obspy.core.util import DEFAULT_MODULES as MODULES; print('obspy.' + ',obspy.'.join(MODULES))"`
-             export MODULELISTSPACES=`python -c "from obspy.core.util import DEFAULT_MODULES as MODULES; print(' '.join(MODULES))"`; fi \
-      || echo
+        # we're building a branch on the main repo, so test *all* modules
+        else export MODULELIST=`python -c "from obspy.core.util import ALL_MODULES as MODULES; print('obspy.' + ',obspy.'.join(MODULES))"`
+      fi
   - echo $MODULELIST
   - echo $MODULELISTSPACES
   # need to set IFS so that space-separated MODULELISTSPACES list is interpreted correctly by run_tests()
   - export IFS=" "
+  # if not on a PR, i.e. running on a push to master or maintenance_XXX: test *all* modules
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" $MODULELISTSPACES;
+      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --all -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}";
     else
       coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --pr-url="https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}" $MODULELISTSPACES;
     fi;


### PR DESCRIPTION
We use Travis in two ways:
 - **for PRs** we build the merge commit and report it in the PR's commit status. This should be reasonably fast to give timely feedback to authors of PRs and because relatively often PR branches will get pushed to and thus triggering Travis builds. Therefore we don't test network modules in this case (unless explicitly specified, see #1408).
 - **for pushes** to branches, we only trigger builds for our main branches (`master` and `maintenance_...`). This mostly happens when PRs eventually get merged, and sometimes for direct pushes of really small changes. So, not that many Travis builds are triggered in this way..

Therefore, I'm proposing to build *all* modules (i.e. also network modules) on *pushes* (to `master`/`maintenance_...`), so that we know when/if network modules break..

As a side effect, our build status might show up as "broken" many times, if we don't continuously monitor and fix network related issues.

There's no way to check the effects of this PR before merging it into `master`, so this issue is for documentation and discussion.


EDIT: As side notes..
 - we could remove `obspy.taup` from `DEFAULT_MODULES` and only trigger it manually on changes (in PRs), which would cut (PRs') test time on Travis in half, roughly
 - we could devise a helper routine in `obspy_github_api` that checks which modules are changed by a PR and automatically add tests for these..