### PR TITLE
Don't upload staged test fail image in core tests to imgur

### DIFF
--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import unittest
 
+from obspy.core.compatibility import mock
 from obspy.core.util.base import NamedTemporaryFile, get_matplotlib_version
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
@@ -109,9 +110,12 @@ class UtilBaseTestCase(unittest.TestCase):
         self.assertFalse(os.path.exists(ic.name))
 
         # image comparison that should raise
-        self.assertRaises(ImageComparisonException,
-                          image_comparison_in_function, path, img_basename,
-                          img_fail)
+        # avoid uploading the staged test fail image
+        # (after an estimate of 10000 uploads of it.. ;-))
+        with mock.patch.object(ImageComparison, '_upload_images'):
+            self.assertRaises(ImageComparisonException,
+                              image_comparison_in_function, path, img_basename,
+                              img_fail)
         # check that temp file is deleted
         self.assertFalse(os.path.exists(ic.name))
 


### PR DESCRIPTION
The image we use for testing that ImageComparison actually raises on a bad image probably got uploaded lots of times to Imgur.. was wondering for quite some time why I'm seeing imgur errors in our docker testbot. Pinned it down now.. ;-)