### PR TITLE
Write blockette 100 if accuracy might otherwise be lost

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@
    * ObsPy can now read MiniSEED files with micro-second wrap arounds.
      (see #1531)
    * ObsPy can now read MiniSEED files with no blockette 1000. (see #1544)
+   * ObsPy now always writes Blockette 100 if sampling rate accuracy is
+     otherwise lost. (see #1550)
  - obspy.io.sac:
    * `SACTrace.lpspol` and `lcalda` are `True` and `False` by default, when
       created via `SACTrace.from_obspy_trace` with a `Trace` that has no SAC

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -870,12 +870,37 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
                 clibmseed.msr_free(C.pointer(msr))
                 del msr
                 raise Exception('Error in msr_addblockette')
+
         # Only use Blockette 100 if necessary.
         # Determine if a blockette 100 will be needed to represent the input
         # sample rate or if the sample rate in the fixed section of the data
         # header will suffice (see ms_genfactmult in libmseed/genutils.c)
+        #
+        # It is definitely necessary for very large or small sampling rates (
+        # using libmseed for the test would result in an overflow).
         if trace.stats.sampling_rate >= 32727.0 or \
                 trace.stats.sampling_rate <= (1.0 / 32727.0):
+            use_blkt_100 = True
+        else:
+            use_blkt_100 = False
+
+            _factor = C.c_int16()
+            _multiplier = C.c_int16()
+            clibmseed.ms_genfactmult(
+                trace.stats.sampling_rate, C.pointer(_factor),
+                C.pointer(_multiplier))
+            ms_sr = clibmseed.ms_nomsamprate(_factor.value, _multiplier.value)
+
+            # It is also necessary if the libmseed calculated sampling rate
+            # would result in a loss of accuracy - the floating point
+            # comparision is on purpose here as it will always try to
+            # preserve all accuracy.
+            # Cast to float32 and back to not add blockette 100 for values
+            # that cannot be represented with 32bits.
+            if ms_sr != float(np.float32(trace.stats.sampling_rate)):
+                use_blkt_100 = True
+
+        if use_blkt_100:
             size = C.sizeof(Blkt100S)
             blkt100 = C.c_char(b' ')
             C.memset(C.pointer(blkt100), 0, size)

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -895,9 +895,9 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
             # would result in a loss of accuracy - the floating point
             # comparision is on purpose here as it will always try to
             # preserve all accuracy.
-            # Cast to float32 and back to not add blockette 100 for values
+            # Cast to float32 to not add blockette 100 for values
             # that cannot be represented with 32bits.
-            if ms_sr != float(np.float32(trace.stats.sampling_rate)):
+            if np.float32(ms_sr) != np.float32(trace.stats.sampling_rate):
                 use_blkt_100 = True
 
         if use_blkt_100:

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -734,6 +734,21 @@ clibmseed.allocate_bytes.argtypes = (C.c_int,)
 clibmseed.allocate_bytes.restype = C.c_void_p
 
 
+clibmseed.ms_genfactmult.argtypes = [
+    C.c_double,
+    C.POINTER(C.c_int16),
+    C.POINTER(C.c_int16)
+]
+clibmseed.ms_genfactmult.restype = C.c_int
+
+
+clibmseed.ms_nomsamprate.argtypes = [
+    C.c_int,
+    C.c_int
+]
+clibmseed.ms_nomsamprate.restype = C.c_double
+
+
 # Python callback functions for C
 def _py_file_callback(_f):
     return 1

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -999,47 +999,61 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             sr = 200.0
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertFalse(has_blkt_100(tempfile))
 
             # A more detailed one does.
             sr = 199.9997
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertTrue(has_blkt_100(tempfile))
 
             # As does a very large one.
             sr = 1E6
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertTrue(has_blkt_100(tempfile))
 
             # And a very small one.
             sr = 1E-6
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertTrue(has_blkt_100(tempfile))
 
-            # Two more "clean" ones.
+            # Three more "clean" ones.
             sr = 1.0
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertFalse(has_blkt_100(tempfile))
 
             sr = 0.5
             tr.stats.sampling_rate = sr
             tr.write(tempfile, format="mseed")
-            self.assertEqual(read(tempfile)[0].stats.sampling_rate,
-                             np.float32(sr))
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
+            self.assertFalse(has_blkt_100(tempfile))
+
+            sr = 0.1
+            tr.stats.sampling_rate = sr
+            tr.write(tempfile, format="mseed")
+            self.assertEqual(
+                np.float32(read(tempfile)[0].stats.sampling_rate),
+                np.float32(sr))
             self.assertFalse(has_blkt_100(tempfile))
 
 


### PR DESCRIPTION
This PR causes `obspy.io.mseed` to always write Blockette 100 if sampling rate accuracy might be lost otherwise.

Blockette 100 can store a single precision floating point sampling rate. With this PR ObsPy will always write Blockette 100 if the sampling rate cannot exactly be represented with the sampling rate factor and multiplier in the fixed header.

The test might be a bit strict but it is the correct thing to do and the only price to pay are potentially slightly bigger MiniSEED files. "Clean" sampling rates still will not have Blockette 100.