### PR TITLE
Calculation of azimuth is missing in obspy.taup.taup_geo.calc_dist

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -58,6 +58,9 @@ master:
  - obspy.signal:
    * New obspy.signal.quality_control module to compute quality metrics from
      MiniSEED files. (see #1141)
+ - obspy.taup:
+   * Add obspy.taup.taup_geo.calc_dist_azi, a function to return the distance,
+     azimuth and backazimuth for a source - receiver pair. (see #1538)
 
 1.0.3:
  - obspy.io.mseed:

--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -32,7 +32,7 @@ def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
               receiver_latitude_in_deg, receiver_longitude_in_deg,
               radius_of_planet_in_km, flattening_of_planet):
     """
-    Given the source and receiver location, calculate the azimuth and distance.
+    Given the source and receiver location, calculate distance.
 
     :param source_latitude_in_deg: Source location latitude in degrees
     :type source_latitude_in_deg: float
@@ -50,6 +50,36 @@ def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
     :return: distance_in_deg
     :rtype: float
     """
+    return calc_dist_azi(source_latitude_in_deg, source_longitude_in_deg,
+                         receiver_latitude_in_deg, receiver_longitude_in_deg,
+                         radius_of_planet_in_km, flattening_of_planet)[0]
+
+
+def calc_dist_azi(source_latitude_in_deg, source_longitude_in_deg,
+                  receiver_latitude_in_deg, receiver_longitude_in_deg,
+                  radius_of_planet_in_km, flattening_of_planet):
+    """
+    Given the source and receiver location, calculate the azimuth from the
+    source to the receiver at the source, the backazimuth from the receiver
+    to the source at the receiver and distance between the source and receiver.
+
+    :param source_latitude_in_deg: Source location latitude in degrees
+    :type source_latitude_in_deg: float
+    :param source_longitude_in_deg: Source location longitude in degrees
+    :type source_longitude_in_deg: float
+    :param receiver_latitude_in_deg: Receiver location latitude in degrees
+    :type receiver_latitude_in_deg: float
+    :param receiver_longitude_in_deg: Receiver location longitude in degrees
+    :type receiver_longitude_in_deg: float
+    :param radius_of_planet_in_km: Radius of the planet in km
+    :type radius_of_planet_in_km: float
+    :param flattening_of_planet: Flattening of planet (0 for a sphere)
+    :type receiver_longitude_in_deg: float
+
+    :returns: distance_in_deg (in degrees), source_receiver_azimuth (in
+              degrees) and receiver_to_source_backazimuth (in degrees).
+    :rtype: tuple of three floats
+    """
     if geodetics.HAS_GEOGRAPHICLIB:
         ellipsoid = Geodesic(a=radius_of_planet_in_km * 1000.0,
                              f=flattening_of_planet)
@@ -58,6 +88,8 @@ def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
                               receiver_latitude_in_deg,
                               receiver_longitude_in_deg)
         distance_in_deg = g['a12']
+        source_receiver_azimuth = g['azi1']
+        receiver_to_source_backazimuth = (g['azi2'] + 180) % 360
 
     else:
         # geographiclib is not installed - use obspy/geodetics
@@ -68,6 +100,8 @@ def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
                                   a=radius_of_planet_in_km * 1000.0,
                                   f=flattening_of_planet)
         distance_in_km = values[0]/1000.0
+        source_receiver_azimuth = values[1]
+        receiver_to_source_backazimuth = values[2]
         # NB - km2deg assumes spherical planet... generate a warning
         if flattening_of_planet != 0.0:
             msg = "Assuming spherical planet when calculating epicentral " + \
@@ -76,7 +110,8 @@ def calc_dist(source_latitude_in_deg, source_longitude_in_deg,
             warnings.warn(msg)
         distance_in_deg = kilometer2degrees(distance_in_km,
                                             radius=radius_of_planet_in_km)
-    return distance_in_deg
+    return (distance_in_deg, source_receiver_azimuth,
+            receiver_to_source_backazimuth)
 
 
 def add_geo_to_arrivals(arrivals, source_latitude_in_deg,

--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -100,8 +100,8 @@ def calc_dist_azi(source_latitude_in_deg, source_longitude_in_deg,
                                   a=radius_of_planet_in_km * 1000.0,
                                   f=flattening_of_planet)
         distance_in_km = values[0]/1000.0
-        source_receiver_azimuth = values[1]
-        receiver_to_source_backazimuth = values[2]
+        source_receiver_azimuth = values[1] % 360
+        receiver_to_source_backazimuth = values[2] % 360
         # NB - km2deg assumes spherical planet... generate a warning
         if flattening_of_planet != 0.0:
             msg = "Assuming spherical planet when calculating epicentral " + \

--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -88,7 +88,7 @@ def calc_dist_azi(source_latitude_in_deg, source_longitude_in_deg,
                               receiver_latitude_in_deg,
                               receiver_longitude_in_deg)
         distance_in_deg = g['a12']
-        source_receiver_azimuth = g['azi1']
+        source_receiver_azimuth = g['azi1'] % 360
         receiver_to_source_backazimuth = (g['azi2'] + 180) % 360
 
     else:

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 
 from obspy.taup import TauPyModel
-from obspy.taup.taup_geo import calc_dist
+from obspy.taup.taup_geo import calc_dist, calc_dist_azi
 from obspy.taup.tau import Arrivals
 import obspy.geodetics.base as geodetics
 
@@ -137,6 +137,45 @@ class TauPyModelTestCase(unittest.TestCase):
                                          receiver_longitude_in_deg=33.0,
                                          radius_of_planet_in_km=6.371,
                                          flattening_of_planet=0.0), 35.0, 5)
+
+    def test_taup_geo_calc_dist_azi(self):
+        """Test for calc_dist"""
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assertAlmostEqual(azi, 0.0, 5)
+        self.assertAlmostEqual(backazi, 180.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=55.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=20.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assertAlmostEqual(azi, 180.0, 5)
+        self.assertAlmostEqual(backazi, 0.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=-55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assertAlmostEqual(azi, 180.0, 5)
+        self.assertAlmostEqual(backazi, 0.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=-55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6.371,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assertAlmostEqual(azi, 180.0, 5)
+        self.assertAlmostEqual(backazi, 0.0, 5)
 
     @unittest.skipIf(not geodetics.HAS_GEOGRAPHICLIB,
                      'Module geographiclib is not installed')

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -17,7 +17,6 @@ import warnings
 import numpy as np
 
 from obspy.taup import TauPyModel
-from obspy.taup.taup_geo import calc_dist, calc_dist_azi
 from obspy.taup.tau import Arrivals
 import obspy.geodetics.base as geodetics
 
@@ -110,72 +109,6 @@ class TauPyModelTestCase(unittest.TestCase):
         self.assertAlmostEqual(p_arrival.incident_angle, 26.70, 2)
         self.assertAlmostEqual(p_arrival.purist_distance, 35.00, 2)
         self.assertEqual(p_arrival.purist_name, "P")
-
-    def test_taup_geo_calc_dist(self):
-        """Test for calc_dist"""
-        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=20.0,
-                                         source_longitude_in_deg=33.0,
-                                         receiver_latitude_in_deg=55.0,
-                                         receiver_longitude_in_deg=33.0,
-                                         radius_of_planet_in_km=6371.0,
-                                         flattening_of_planet=0.0), 35.0, 5)
-        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=55.0,
-                                         source_longitude_in_deg=33.0,
-                                         receiver_latitude_in_deg=20.0,
-                                         receiver_longitude_in_deg=33.0,
-                                         radius_of_planet_in_km=6371.0,
-                                         flattening_of_planet=0.0), 35.0, 5)
-        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=-20.0,
-                                         source_longitude_in_deg=33.0,
-                                         receiver_latitude_in_deg=-55.0,
-                                         receiver_longitude_in_deg=33.0,
-                                         radius_of_planet_in_km=6371.0,
-                                         flattening_of_planet=0.0), 35.0, 5)
-        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=-20.0,
-                                         source_longitude_in_deg=33.0,
-                                         receiver_latitude_in_deg=-55.0,
-                                         receiver_longitude_in_deg=33.0,
-                                         radius_of_planet_in_km=6.371,
-                                         flattening_of_planet=0.0), 35.0, 5)
-
-    def test_taup_geo_calc_dist_azi(self):
-        """Test for calc_dist"""
-        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=20.0,
-                                           source_longitude_in_deg=33.0,
-                                           receiver_latitude_in_deg=55.0,
-                                           receiver_longitude_in_deg=33.0,
-                                           radius_of_planet_in_km=6371.0,
-                                           flattening_of_planet=0.0)
-        self.assertAlmostEqual(dist, 35.0, 5)
-        self.assertAlmostEqual(azi, 0.0, 5)
-        self.assertAlmostEqual(backazi, 180.0, 5)
-        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=55.0,
-                                           source_longitude_in_deg=33.0,
-                                           receiver_latitude_in_deg=20.0,
-                                           receiver_longitude_in_deg=33.0,
-                                           radius_of_planet_in_km=6371.0,
-                                           flattening_of_planet=0.0)
-        self.assertAlmostEqual(dist, 35.0, 5)
-        self.assertAlmostEqual(azi, 180.0, 5)
-        self.assertAlmostEqual(backazi, 0.0, 5)
-        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
-                                           source_longitude_in_deg=33.0,
-                                           receiver_latitude_in_deg=-55.0,
-                                           receiver_longitude_in_deg=33.0,
-                                           radius_of_planet_in_km=6371.0,
-                                           flattening_of_planet=0.0)
-        self.assertAlmostEqual(dist, 35.0, 5)
-        self.assertAlmostEqual(azi, 180.0, 5)
-        self.assertAlmostEqual(backazi, 0.0, 5)
-        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
-                                           source_longitude_in_deg=33.0,
-                                           receiver_latitude_in_deg=-55.0,
-                                           receiver_longitude_in_deg=33.0,
-                                           radius_of_planet_in_km=6.371,
-                                           flattening_of_planet=0.0)
-        self.assertAlmostEqual(dist, 35.0, 5)
-        self.assertAlmostEqual(azi, 180.0, 5)
-        self.assertAlmostEqual(backazi, 0.0, 5)
 
     @unittest.skipIf(not geodetics.HAS_GEOGRAPHICLIB,
                      'Module geographiclib is not installed')

--- a/obspy/taup/tests/test_taup_geo.py
+++ b/obspy/taup/tests/test_taup_geo.py
@@ -10,6 +10,7 @@ from future.builtins import *  # NOQA
 import unittest
 
 from obspy.taup.tau import TauPyModel
+from obspy.taup.taup_geo import calc_dist, calc_dist_azi
 import obspy.geodetics.base as geodetics
 
 
@@ -35,8 +36,97 @@ class TaupGeoTestCase(unittest.TestCase):
             self.assertAlmostEqual(stlon, stlon_path, delta=0.1)
 
 
+class TaupGeoDistTestCase(unittest.TestCase):
+    """
+    Test suite for calc_dist and calc_dist_azi in taup_geo.
+    """
+    def assert_angle_almost_equal(self, first, second, places=7, msg=None,
+                                  delta=None):
+        """
+        Compare two angles (in degrees) for equality
+
+        This method considers numbers close to 359.9999999 to be similar
+        to 0.00000001 and supports the same arguments as assertAlmostEqual
+        """
+        if first > second:
+            difference = (second - first) % 360.0
+        else:
+            difference = (first - second) % 360.0
+        self.assertAlmostEqual(difference, 0.0, places=places, msg=msg,
+                               delta=delta)
+
+    def test_taup_geo_calc_dist(self):
+        """Test for calc_dist"""
+        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=20.0,
+                                         source_longitude_in_deg=33.0,
+                                         receiver_latitude_in_deg=55.0,
+                                         receiver_longitude_in_deg=33.0,
+                                         radius_of_planet_in_km=6371.0,
+                                         flattening_of_planet=0.0), 35.0, 5)
+        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=55.0,
+                                         source_longitude_in_deg=33.0,
+                                         receiver_latitude_in_deg=20.0,
+                                         receiver_longitude_in_deg=33.0,
+                                         radius_of_planet_in_km=6371.0,
+                                         flattening_of_planet=0.0), 35.0, 5)
+        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=-20.0,
+                                         source_longitude_in_deg=33.0,
+                                         receiver_latitude_in_deg=-55.0,
+                                         receiver_longitude_in_deg=33.0,
+                                         radius_of_planet_in_km=6371.0,
+                                         flattening_of_planet=0.0), 35.0, 5)
+        self.assertAlmostEqual(calc_dist(source_latitude_in_deg=-20.0,
+                                         source_longitude_in_deg=33.0,
+                                         receiver_latitude_in_deg=-55.0,
+                                         receiver_longitude_in_deg=33.0,
+                                         radius_of_planet_in_km=6.371,
+                                         flattening_of_planet=0.0), 35.0, 5)
+
+    def test_taup_geo_calc_dist_azi(self):
+        """Test for calc_dist"""
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assert_angle_almost_equal(azi, 0.0, 5)
+        self.assert_angle_almost_equal(backazi, 180.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=55.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=20.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assert_angle_almost_equal(azi, 180.0, 5)
+        self.assert_angle_almost_equal(backazi, 0.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=-55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6371.0,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assert_angle_almost_equal(azi, 180.0, 5)
+        self.assert_angle_almost_equal(backazi, 0.0, 5)
+        dist, azi, backazi = calc_dist_azi(source_latitude_in_deg=-20.0,
+                                           source_longitude_in_deg=33.0,
+                                           receiver_latitude_in_deg=-55.0,
+                                           receiver_longitude_in_deg=33.0,
+                                           radius_of_planet_in_km=6.371,
+                                           flattening_of_planet=0.0)
+        self.assertAlmostEqual(dist, 35.0, 5)
+        self.assert_angle_almost_equal(azi, 180.0, 5)
+        self.assert_angle_almost_equal(backazi, 0.0, 5)
+
+
 def suite():
-    return unittest.makeSuite(TaupGeoTestCase, 'test')
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TaupGeoTestCase, 'test'))
+    suite.addTest(unittest.makeSuite(TaupGeoDistTestCase, 'test'))
+    return suite
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the documentation of obspy.taup.taup_geo.calc_dist it says that both distance and azimuth are calculated and returned. However, this is not the case, only distance_in_deg is calculated. It would be very simple to add the output of azimuth, as only one more line of code is needed (to be added just after https://github.com/obspy/obspy/blob/master/obspy/taup/taup_geo.py#L53-L60):

azimuth = g[azi1]

Alternatively, one could generate a new method calc_azimuth to not alter the existing calc_dist behaviour.



