### PR TITLE
sh: whitespace in header is not stripped anymore

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
       inheritance. (see #1507)
 - obspy.io.sh:
    * Fix writing of long headers for python3
+   * Whitespace in header fields is not ignored anymore (see #1552)
  - obspy.io.stationxml:
    * Datetime fields are written with microseconds to StationXML if
      microseconds are present. (see #1511)

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -387,24 +387,21 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
             raise IOError(msg % data_file)
         fh_data = open(data_file, 'rb')
     # loop through read header file
-    fh = open(filename, 'rt')
-    line = fh.readline()
-    cmtlines = int(line[5:7]) - 1
-    # comment lines
-    comments = []
-    for _i in range(0, cmtlines):
-        comments += [fh.readline()]
+    with open(filename, 'rt') as fh:
+        lines = fh.read().splitlines()
+    # number of comment lines
+    cmtlines = int(lines[0][5:7])
     # trace lines
     traces = {}
     i = -1
     id = ''
-    for line in fh:
+    for line in lines[cmtlines:]:
         cid = int(line[0:2])
         if cid != id:
             id = cid
             i += 1
         traces.setdefault(i, '')
-        traces[i] += line[3:].rstrip('\n')
+        traces[i] += line[3:]
     # create stream object
     stream = Stream()
     for id in sorted(traces.keys()):
@@ -476,7 +473,6 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
             stream.append(Trace(data=data, header=header))
     if not headonly:
         fh_data.close()
-    fh.close()
     return stream
 
 

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -404,7 +404,7 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
             id = cid
             i += 1
         traces.setdefault(i, '')
-        traces[i] += line[3:].strip()
+        traces[i] += line[3:].rstrip('\n')
     # create stream object
     stream = Stream()
     for id in sorted(traces.keys()):
@@ -417,8 +417,8 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
         channel = ['', '', '']
         npts = 0
         for item in traces[id].split('~'):
-            key = item.strip()[0:4]
-            value = item.strip()[5:].strip()
+            key = item.lstrip()[0:4]
+            value = item.lstrip()[5:]
             if key == 'L001':
                 npts = header['npts'] = int(value)
             elif key == 'L000':

--- a/obspy/io/sh/tests/test_core.py
+++ b/obspy/io/sh/tests/test_core.py
@@ -286,6 +286,21 @@ class CoreTestCase(unittest.TestCase):
             os.remove(os.path.splitext(tempfile)[0] + '.QBN')
         self.assertEqual(tr.stats.sh.COMMENT, tr2.stats.sh.COMMENT)
 
+    def test_header_whitespaces(self):
+        """
+        Test for issue #1552
+        """
+        tr = read()[0]
+        tr.stats.sh = {'COMMENT': 30 * '   *   '}
+        with NamedTemporaryFile(suffix='.QHD') as tf:
+            tempfile = tf.name
+            tr.write(tempfile, format="Q")
+            tr2 = read(tempfile)[0]
+            # remove binary file too (dynamically created)
+            os.remove(os.path.splitext(tempfile)[0] + '.QBN')
+        self.assertEqual(len(tr.stats.sh.COMMENT), len(tr2.stats.sh.COMMENT))
+        self.assertEqual(tr.stats.sh.COMMENT, tr2.stats.sh.COMMENT)
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')


### PR DESCRIPTION
The added test failed, because lines and values from the Q header files are stripped while reading. This not only affected empty strings as in the test, but every header value with a whitespace anywhere if it happens to be written on the first or last column of the line.