### PR TITLE
Fix for the inventory pretty printing

### DIFF
--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -823,7 +823,11 @@ def _seed_id_keyfunction(x):
     #  - three dots: full SEED ID (e.g. "IU.ANMO.10.BHZ")
     #  - more dots: sort after any of the previous, plain lexical sort
     # if no "." in the string: assume it's a network code
-    number_of_dots = x.count(".")
+
+    # split to get rid of the description that that is added to networks and
+    # stations which might also contain dots.
+    number_of_dots = x.strip().split()[0].count(".")
+
     x = x.upper()
     if number_of_dots == 0:
         x = [x] + [""] * 4
@@ -847,10 +851,10 @@ def _seed_id_keyfunction(x):
             x[-1] = (False, comp)
         else:
             x[-1] = (True, x[-1])
-    # all other cases, just leave the upper case string, it will compare
-    # greater than any of the split lists
+    # all other cases, just convert the upper case string to a single item
+    # list - it will compare greater than any of the split lists.
     else:
-        pass
+        x = [x, ]
 
     return x
 

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -384,6 +384,27 @@ class InventoryTestCase(unittest.TestCase):
         for contents_, expected_ in zip(contents, expected):
             self.assertEqual(expected_, _unified_content_strings(contents_))
 
+    def test_util_unified_content_string_with_dots_in_description(self):
+        """
+        The unified content string might have dots in the station description.
+
+        Make sure it still works.
+        """
+        contents = (
+            ['II.ABKT (Alibek, Turkmenistan)',
+             'II.ALE (Alert, N.W.T., Canada)'],
+            [u'IU.ULN (Ulaanbaatar, A.B.C., Mongolia)',
+             u'IU.ULN (Ulaanbaatar, A.B.C., Mongolia)',
+             u'IU.ULN (Ulaanbaatar, A.B.C., Mongolia)'],
+        )
+        expected = (
+            ['II.ABKT (Alibek, Turkmenistan)',
+             'II.ALE (Alert, N.W.T., Canada)'],
+            [u'IU.ULN (Ulaanbaatar, A.B.C., Mongolia) (3x)'],
+        )
+        for contents_, expected_ in zip(contents, expected):
+            self.assertEqual(expected_, _unified_content_strings(contents_))
+
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')
 class InventoryBasemapTestCase(unittest.TestCase):


### PR DESCRIPTION
Some description strings might well have dots which breaks the old logic.

Should be safer now. Includes a test.

Target branch is `master` as the new compressed printing is only available in the master.