### PR TITLE
travis: install packages for testing through conda-forge rather than pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,12 +106,12 @@ install:
   - conda config --add channels conda-forge
   # "--no-update-dependencies" to not change versions of already installed packages
   # github3.py is dependency of obspy_github_api
-  - conda install --no-update-dependencies
-        pep8-naming
-        github3.py
+  - ADDITIONAL_PACKAGES="pep8-naming github3.py codecov geographiclib"
+  - PIP_PACKAGES=""
+  - for PACKAGE in $ADDITIONAL_PACKAGES; do conda install --no-update-dependencies $PACKAGE || PIP_PACKAGES="$PACKAGE $PIP_PACKAGES"; done
   # install packages not available via conda
-  - pip install codecov
-  - pip install geographiclib
+  - if [[ $PIP_PACKAGES ]]; then pip install $PIP_PACKAGES; fi
+  # install packages from urls
   # current pyimgur stable release has a py3 incompatibility
   - pip install https://github.com/megies/PyImgur/archive/py3.zip
   - pip install https://github.com/obspy/obspy_github_api/archive/0.5.0.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,9 @@ install:
   # "--no-update-dependencies" to not change versions of already installed packages
   # github3.py is dependency of obspy_github_api
   - ADDITIONAL_PACKAGES="pep8-naming github3.py codecov geographiclib"
-  - PIP_PACKAGES=""
-  - for PACKAGE in $ADDITIONAL_PACKAGES; do conda install --no-update-dependencies $PACKAGE || PIP_PACKAGES="$PACKAGE $PIP_PACKAGES"; done
+  - for PACKAGE in $ADDITIONAL_PACKAGES; do conda install --no-update-dependencies $PACKAGE; done
   # install packages not available via conda
-  - if [[ $PIP_PACKAGES ]]; then pip install $PIP_PACKAGES; fi
+  - pip install ${ADDITIONAL_PACKAGES}
   # install packages from urls
   # current pyimgur stable release has a py3 incompatibility
   - pip install https://github.com/megies/PyImgur/archive/py3.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,14 +100,22 @@ install:
         requests
         jsonschema
   - source activate test-environment
+  # install additional packages through conda-forge, wherever possible, since
+  # it seems a bit more stable than pip which sometimes fails with what looks
+  # like network errors
+  - conda config --add channels conda-forge
+  # "--no-update-dependencies" to not change versions of already installed packages
+  # github3.py is dependency of obspy_github_api
+  - conda install --no-update-dependencies
+        pep8-naming
+        github3.py
   # install packages not available via conda
   - pip install codecov
   - pip install geographiclib
   # current pyimgur stable release has a py3 incompatibility
   - pip install https://github.com/megies/PyImgur/archive/py3.zip
+  - pip install https://github.com/obspy/obspy_github_api/archive/0.5.0.zip
   - pip freeze
-  - pip install pep8-naming
-  - pip install https://github.com/obspy/obspy_github_api/archive/0.3.0.zip
   - conda list
   # done installing dependencies
   - git version


### PR DESCRIPTION
Install additional packages in Travis through conda-forge, wherever possible, since it seems a bit more stable than pip which sometimes fails with what looks like network errors (see https://github.com/obspy/obspy/pull/1540#issuecomment-254552889). Also see related #1548 where we can install cartopy on some architectures via conda-forge.

The option `--no-update-dependencies` seems to properly leave alone package versions of already installed packages, so that our version matrix in Travis is untouched (safest would be to handle our dependency version matrix via pinning in conda, but that feature is unfortunately not accessible via `conda` CLI, so we would have to set it in a local file which path we need to figure out at runtime, so that's too messy and error prone)
