### PR TITLE
docker tests: interactive debugging on exception

### DIFF
--- a/misc/docker/run_obspy_tests.sh
+++ b/misc/docker/run_obspy_tests.sh
@@ -151,7 +151,7 @@ run_tests_on_image () {
 
     $DOCKER build -t temp:temp $TEMP_PATH
 
-    $DOCKER run --name=$ID temp:temp
+    $DOCKER run -i --tty --name=$ID temp:temp
 
     $DOCKER cp $ID:/INSTALL_LOG.txt $LOG_DIR
     $DOCKER cp $ID:/TEST_LOG.txt $LOG_DIR

--- a/misc/docker/scripts/install_and_run_tests_on_image.sh
+++ b/misc/docker/scripts/install_and_run_tests_on_image.sh
@@ -20,7 +20,9 @@ fi
 
 cd
 
-obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) $1 2>&1 | tee /TEST_LOG.txt
+# obspy-runtests -r --keep-images --no-flake8 --node=docker-$(cat /container_name.txt) $1 2>&1 | tee /TEST_LOG.txt
+pip install pytest
+py.test /obspy/obspy --pdb
 if [ $? != 0 ]; then
     echo -e "${red}Tests failed!${no_color}"
     touch /failure


### PR DESCRIPTION
Right now this is just a reminder how to jump into interactive debugging when running obspy docker tests via `misc/docker/run_obspy_tests.sh` script, but we should add some switch to enable this feature directly..