### PR TITLE
Add author to GSE2.0 bulletin module (#1528)

### DIFF
--- a/obspy/io/gse2/bulletin.py
+++ b/obspy/io/gse2/bulletin.py
@@ -2,6 +2,8 @@
 """
 GSE2.0 bulletin read support.
 
+:author:
+    EOST (École et Observatoire des Sciences de la Terre)
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
 :license:

--- a/obspy/io/gse2/tests/test_bulletin.py
+++ b/obspy/io/gse2/tests/test_bulletin.py
@@ -2,6 +2,14 @@
 # -*- coding: utf-8 -*-
 """
 The gse2.bulletin test suite.
+
+:author:
+    EOST (École et Observatoire des Sciences de la Terre)
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)


### PR DESCRIPTION
I did a module to read GSE2.0 bulletin (#1528) 1 month ago but I didn't specify that it was developed by the EOST. Is it possible to add it?

Thanks!

