### PR TITLE
SAC: writing to disk a new Trace object ignores custom header fields, if an arrival time is set

### DIFF
--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -342,7 +342,7 @@ from obspy import Trace, UTCDateTime
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from . import header as HD  # noqa
-from .util import SacError, SacHeaderError, SacHeaderTimeError
+from .util import SacError, SacHeaderError
 from . import util as _ut
 from . import arrayio as _io
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1286,13 +1286,15 @@ class SACTrace(object):
         :type keep_sac_header: bool
 
         """
-        try:
-            header = _ut.obspy_to_sac_header(trace.stats, keep_sac_header)
-        except SacError:
-            # not enough time info in old SAC header
-            # XXX: try to do something besides ignore the old header?
-            header = _ut.obspy_to_sac_header(trace.stats,
-                                             keep_sac_header=False)
+        header = _ut.obspy_to_sac_header(trace.stats)
+
+        if keep_sac_header and trace.stats.get('sac'):
+            try:
+                header = _ut.merge_sac_headers(trace.stats.sac, header)
+            except SacError:
+                # not enough time info in old SAC header
+                # XXX: do something besides ignore the old header
+                pass
 
         # handle the data headers
         data = trace.data

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -342,7 +342,7 @@ from obspy import Trace, UTCDateTime
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 from . import header as HD  # noqa
-from .util import SacError, SacHeaderError
+from .util import SacError, SacHeaderError, SacHeaderTimeError
 from . import util as _ut
 from . import arrayio as _io
 
@@ -764,13 +764,9 @@ class SACTrace(object):
                   'lcalda': lcalda, 'lpspol': lpspol, 'lovrok': lovrok,
                   'internal0': internal0}
 
-        # required = ['delta', 'b', 'npts', ...]
-        # provided = locals()
-        # for hdr in required:
-        #     header[hdr] = kwargs.pop(hdr, provided[hdr])
-
         # combine header with remaining non-required args.
-        # XXX: user can put non-SAC key:value pairs into the header.
+        # user can put non-SAC key:value pairs into the header, but they're
+        # ignored on write.
         header.update(kwargs)
 
         # -------------------------- DATA ARRAY -------------------------------
@@ -1286,15 +1282,7 @@ class SACTrace(object):
         :type keep_sac_header: bool
 
         """
-        header = _ut.obspy_to_sac_header(trace.stats)
-
-        if keep_sac_header and trace.stats.get('sac'):
-            try:
-                header = _ut.merge_sac_headers(trace.stats.sac, header)
-            except SacError:
-                # not enough time info in old SAC header
-                # XXX: do something besides ignore the old header
-                pass
+        header = _ut.obspy_to_sac_header(trace.stats, keep_sac_header)
 
         # handle the data headers
         data = trace.data

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -897,6 +897,7 @@ class CoreTestCase(unittest.TestCase):
         self.assertAlmostEqual(tr1.stats.sac.stlo, -5., places=4)
         self.assertAlmostEqual(tr1.stats.sac.a, 12.34, places=5)
 
+
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')
 

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -85,8 +85,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SACXY')
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 2)
+                self.assertIn('reference', str(w[-1].message))
             tr1 = read(tempfile)[0]
         self.assertEqual(tr, tr1)
 
@@ -625,8 +625,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, fh)
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 2)
+                self.assertIn('reference', str(w[-1].message))
             fh.seek(0, 0)
             st2 = _read_sac_xy(fh)
 
@@ -643,8 +643,8 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 _write_sac_xy(st, tf)
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+                self.assertEqual(len(w), 2)
+                self.assertIn('reference', str(w[-1].message))
             tf.seek(0, 0)
             st2 = _read_sac_xy(tf)
 
@@ -779,11 +779,7 @@ class CoreTestCase(unittest.TestCase):
 
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                tr.write(tempfile, format='SAC')
-                self.assertEqual(len(w), 1)
-                self.assertIn('reftime', str(w[-1].message))
+            tr.write(tempfile, format='SAC')
             tr1 = read(tempfile)[0]
 
         # starttime made its way to SAC file
@@ -821,7 +817,7 @@ class CoreTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always')
                 tr.write(tempfile, format='SAC')
-                self.assertEqual(len(w), 1)
+                self.assertEqual(len(w), 2)
             tr1 = read(tempfile)[0]
 
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -893,10 +893,10 @@ class CoreTestCase(unittest.TestCase):
         tr.stats.delta = 0.01
         tr.stats.station = 'XXX'
         tr.stats.sac = {'stla': 10., 'stlo': -5., 'a': 12.34}
-        with NamedTemporaryFile() as tf:
-            tempfile = tf.name
-            tr.write(tempfile, format='SAC')
-            tr1 = read(tempfile)[0]
+        with io.BytesIO() as tf:
+            tr.write(tf, format='SAC')
+            tf.seek(0)
+            tr1 = read(tf)[0]
         self.assertAlmostEqual(tr1.stats.sac.stla, 10., places=4)
         self.assertAlmostEqual(tr1.stats.sac.stlo, -5., places=4)
         self.assertAlmostEqual(tr1.stats.sac.a, 12.34, places=5)

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -82,11 +82,7 @@ class CoreTestCase(unittest.TestCase):
         tr = read(self.filexy, format='SACXY')[0]
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                tr.write(tempfile, format='SACXY')
-                self.assertEqual(len(w), 2)
-                self.assertIn('reference', str(w[-1].message))
+            tr.write(tempfile, format='SACXY')
             tr1 = read(tempfile)[0]
         self.assertEqual(tr, tr1)
 
@@ -622,11 +618,7 @@ class CoreTestCase(unittest.TestCase):
         st = _read_sac_xy(self.filexy)
 
         with io.BytesIO() as fh:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                _write_sac_xy(st, fh)
-                self.assertEqual(len(w), 2)
-                self.assertIn('reference', str(w[-1].message))
+            _write_sac_xy(st, fh)
             fh.seek(0, 0)
             st2 = _read_sac_xy(fh)
 
@@ -640,11 +632,7 @@ class CoreTestCase(unittest.TestCase):
         st = _read_sac_xy(self.filexy)
 
         with NamedTemporaryFile() as tf:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                _write_sac_xy(st, tf)
-                self.assertEqual(len(w), 2)
-                self.assertIn('reference', str(w[-1].message))
+            _write_sac_xy(st, tf)
             tf.seek(0, 0)
             st2 = _read_sac_xy(tf)
 
@@ -814,10 +802,7 @@ class CoreTestCase(unittest.TestCase):
 
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
-                tr.write(tempfile, format='SAC')
-                self.assertEqual(len(w), 2)
+            tr.write(tempfile, format='SAC')
             tr1 = read(tempfile)[0]
 
         self.assertEqual(tr1.stats.starttime, tr.stats.starttime)

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -884,6 +884,24 @@ class CoreTestCase(unittest.TestCase):
         self.assertFalse(sac.lcalda)
         self.assertTrue(sac.lpspol)
 
+    def test_sac_file_from_new_header(self):
+        """
+        Writing to disk a new Trace object shouldn't ignore custom header
+        fields, if an arrival time is set. See ObsPy issue #1519
+        """
+        tr = Trace(np.zeros(1000))
+        tr.stats.delta = 0.01
+        tr.stats.station = 'XXX'
+        tr.stats.sac = {'stla': 10., 'stlo': -5., 'a': 12.34}
+        with NamedTemporaryFile() as tf:
+            tempfile = tf.name
+            tr.write(tempfile, format='SAC')
+            tr1 = read(tempfile)[0]
+        self.assertAlmostEqual(tr1.stats.sac.stla, 10., places=4)
+        self.assertAlmostEqual(tr1.stats.sac.stlo, -5., places=4)
+        self.assertAlmostEqual(tr1.stats.sac.a, 12.34, places=5)
+
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -897,8 +897,6 @@ class CoreTestCase(unittest.TestCase):
         self.assertAlmostEqual(tr1.stats.sac.stlo, -5., places=4)
         self.assertAlmostEqual(tr1.stats.sac.a, 12.34, places=5)
 
-
-
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')
 

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -342,11 +342,9 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
             header['b'] = b
             header['e'] = b + (stats['endtime'] - stats['starttime'])
         else:
-            msg = "Invalid reference time detected."
-            warnings.warn(msg)
+            # Invalid reference time.
             if relhdrs:
-                msg = ("Relative times cannot be absolutely referenced.")
-                warnings.warn(msg)
+                # Relative times cannot be absolutely referenced.
                 if 'b' in relhdrs:
                     # Use the 'b' and add an 'e', but don't add a reftime.
                     header['e'] = header['b'] + (stats['endtime'] -

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -22,6 +22,7 @@ TWO_DIGIT_YEAR_MSG = ("SAC file with 2-digit year header field encountered. "
                       "This is not supported by the SAC file format standard. "
                       "Prepending '19'.")
 
+
 # ------------- SAC-SPECIFIC EXCEPTIONS ---------------------------------------
 class SacError(Exception):
     """
@@ -360,7 +361,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                 header['b'] = microsecond * 1e-6
                 header['e'] = header['b'] +\
                     (stats['npts'] - 1) * stats['delta']
-    
+
         # merge some values from stats if they're missing in the SAC header
         # ObsPy issues 1204, 1457
         # XXX: If Stats values are empty/"" and SAC header values are real,

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -22,8 +22,6 @@ TWO_DIGIT_YEAR_MSG = ("SAC file with 2-digit year header field encountered. "
                       "This is not supported by the SAC file format standard. "
                       "Prepending '19'.")
 
-DEFAULT_REFTIME = UTCDateTime(0)
-
 # ------------- SAC-SPECIFIC EXCEPTIONS ---------------------------------------
 class SacError(Exception):
     """
@@ -334,7 +332,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                        't9', 'b', 'e', 'a', 'o', 'f']
         relhdrs = [hdr for hdr in relhdrnames
                    if header.get(hdr) not in (None, HD.SNULL)]
-    
+
         if reftime:
             # oldsac probably came from an actual SAC file
             # Set "b" and "e" relative to the old SAC 'b' and reftime.
@@ -353,7 +351,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                     header['e'] = header['b'] + (stats['endtime'] -
                                                  stats['starttime'])
             else:
-                # Assume it's an "ib" type file. 
+                # Assume it's an "ib" type file.
                 # Set the stats.starttime as the reftime, set 'b' and 'e'.
                 # ObsPy issue 1204
                 reftime = stats['starttime']
@@ -362,7 +360,6 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
                 header['b'] = microsecond * 1e-6
                 header['e'] = header['b'] +\
                     (stats['npts'] - 1) * stats['delta']
-    
     
         # merge some values from stats if they're missing in the SAC header
         # ObsPy issues 1204, 1457
@@ -457,17 +454,3 @@ def get_sac_reftime(header):
         raise SacHeaderTimeError(msg)
 
     return reftime
-
-
-def pop_nztimes(header):
-    """Pop the nz time headers into a new dict.
-
-    Raises KeyError if an nztime is missing.
-    """
-    nztimes = ['nzyear', 'nzjday', 'nzhour', 'nzmin', 'nzsec', 'nzmsec']
-    return {hdr: header.pop(hdr) for hdr in nztimes}
-
-def pop_relative_time_headers(header):
-    """Pop any relative time headers into a new dict."""
-    rel_headers = ['b', 'e', 'a', 'f'] + ['t' + str(i) for i in range(10)]
-    return {hdr: header.pop(hdr) for hdr in rel_headers if header.get(hdr)}


### PR DESCRIPTION
Example:
```python
import numpy as np
from obspy import Trace, read

tr = Trace(np.zeros(1000))
tr.stats.delta = 0.01
tr.stats.station = 'XXX'
tr.stats.sac = {}
tr.stats.sac['stla'] = 10.
tr.stats.sac['stlo'] = -5.
tr.stats.sac['a'] = 12.34
tr.write('test.sac', format='SAC')

tr2 = read('test.sac')[0]
for k, v in sorted(tr2.stats.sac.items()):
    print('{}: {}'.format(k, v))
```
gives the following output:
```
b: 0.0
delta: 0.00999999977648
depmax: 0.0
depmen: 0.0
depmin: 0.0
e: 9.98999977112
iftype: 1
iztype: 9
kstnm: XXX
lcalda: 0
leven: 1
lovrok: 1
lpspol: 1
npts: 1000
nvhdr: 6
nzhour: 0
nzjday: 1
nzmin: 0
nzmsec: 0
nzsec: 0
nzyear: 1970
scale: 1.0
```
i.e., the custom header fields `stla`, `stlo` and `a` are not written to disk.
When removing the line:
```python
tr.stats.sac['a'] = 12.34
```
the two remaining custom fields are correctly written to disk, so I assume that this line is failing silently.

This bug (regression?) appears on both the current master and the maintenance branch.

