### PR TITLE
ZMAP output: origins/magnitudes not set as preferred are not used

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,9 @@
  - obspy.io.stationxml:
    * Datetime fields are written with microseconds to StationXML if
      microseconds are present. (see #1511)
+ - obspy.io.zmap:
+   * Use first origin/magnitude when writing to zmap if no origin/magnitude is
+     set as preferred. (see #1569)
  - obspy.signal:
    * PPSD: fix warning message on Python 3 that gets shown when waveforms and
      metadata mismatch (see #1506)

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -138,6 +138,8 @@ class Pickler(object):
             strings = dict.fromkeys(self.zmap_columns, 'NaN')
             # origin
             origin = ev.preferred_origin()
+            if origin is None and ev.origins:
+                origin = ev.origins[0]
             if origin:
                 dec_year = self._decimal_year(origin.time)
                 dec_second = origin.time.second + \
@@ -157,6 +159,8 @@ class Pickler(object):
                 })
             # magnitude
             magnitude = ev.preferred_magnitude()
+            if magnitude is None and ev.magnitudes:
+                magnitude = ev.magnitudes[0]
             if magnitude:
                 strings.update({
                     'mag':     self._num2str(magnitude.mag),

--- a/obspy/io/zmap/tests/test_zmap.py
+++ b/obspy/io/zmap/tests/test_zmap.py
@@ -55,18 +55,18 @@ class ZMAPTestCase(unittest.TestCase):
         dump = pickler.dumps(self.catalog)
         self.assertIn(self._expected_string(self.test_data), dump)
         self.assertEqual(dump.count('\n'), 3)
-        # no preferred origin
+        # no preferred origin -- still dump first origin
         oid = self.test_event.preferred_origin_id
         self.test_event.preferred_origin_id = None
         dump = pickler.dumps(self.catalog)
-        self.assertIn(self._expected_string({'mag': '4.400000'}), dump)
+        self.assertIn(self._expected_string(self.test_data), dump)
         self.test_event.preferred_origin_id = oid
-        # no preferred magnitude
+        # no preferred magnitude -- still dump first magnitude
+        mid = self.test_event.preferred_origin_id
         self.test_event.preferred_magnitude_id = None
         dump = pickler.dumps(self.catalog)
-        test_data = self.test_data.copy()
-        del test_data['mag']
-        self.assertIn(self._expected_string(test_data), dump)
+        self.assertIn(self._expected_string(self.test_data), dump)
+        self.test_event.preferred_magnitude_id = mid
 
     def test_plugin_interface(self):
         """


### PR DESCRIPTION
Dear all.

I have a problem saving catalog in a ZMAP format with built-in write function.

If I want to save my catalog as, lets say QUAKEML or KML, everything works fine, but with

cat.write("my_cat", format="ZMAP")

all the values i get in my_cat are NaN.

Thanks
(when i grab values manually, i can write outfile with true values without problem)
