### PR TITLE
read event from nlloc: set preferred origin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -54,6 +54,8 @@ master:
      function is also much faster. (see #1141)
    * Update to libmseed v2.18 (see #1540).
    * Correctly read MiniSEED files with a data offset of 48 bytes (see #1540).
+ - obspy.io.nlloc:
+   * Set preferred origin of event (see #1570)
  - obspy.io.xseed:
    * Added azimuth and dip to the get_coordinates() function.  (see #1315)
  - obspy.scripts:

--- a/obspy/io/nlloc/__init__.py
+++ b/obspy/io/nlloc/__init__.py
@@ -29,12 +29,13 @@ Hypocenter-Phase file into an ObsPy :class:`~obspy.core.event.Catalog` object:
 >>> print(event)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
 Event:	2006-07-15T17:21:20.195670Z | +51.658,   +7.737
 <BLANKLINE>
-       resource_id: ResourceIdentifier(id="smi:local/...")
-     creation_info: CreationInfo(creation_time=UTCDateTime(2013, 6, 21, ...),
-                                 version='NLLoc:v6.02.07')
-    ---------
-             picks: 5 Elements
-           origins: 1 Elements
+         resource_id: ResourceIdentifier(id="smi:local/...")
+       creation_info: CreationInfo(creation_time=UTCDateTime(2013, 6, 21, ...),
+                                   version='NLLoc:v6.02.07')
+ preferred_origin_id: ResourceIdentifier(id="smi:local/...")
+                ---------
+               picks: 5 Elements
+             origins: 1 Elements
 
 >>> origin = event.origins[0]
 >>> print(origin)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -223,6 +223,7 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks):
     event = Event()
     o = Origin()
     event.origins = [o]
+    event.preferred_origin_id = o.resource_id
     o.origin_uncertainty = OriginUncertainty()
     o.quality = OriginQuality()
     ou = o.origin_uncertainty

--- a/obspy/io/nlloc/tests/data/nlloc.qml
+++ b/obspy/io/nlloc/tests/data/nlloc.qml
@@ -6,6 +6,7 @@
       <version>ObsPy 1.0.1.post0+20.gbeb9f46723.dirty</version>
     </creationInfo>
     <event publicID="smi:local/0eee2e6f-064b-458a-934f-c5d3105e9529">
+      <preferredOriginID>smi:local/a2260002-95c6-42f7-8c44-f46124355228</preferredOriginID>
       <creationInfo>
         <creationTime>2013-06-21T12:53:34.000000Z</creationTime>
         <version>NLLoc:v6.02.07</version>

--- a/obspy/io/nlloc/tests/data/nlloc_custom.qml
+++ b/obspy/io/nlloc/tests/data/nlloc_custom.qml
@@ -6,6 +6,7 @@
       <version>ObsPy 0.9.2-1209-g0e9965dae0-dirty</version>
     </creationInfo>
     <event publicID="smi:local/cd1f535c-e75e-4dc6-8170-82e47cb40501">
+      <preferredOriginID>smi:local/3cb10e44-6aeb-4279-8caa-235452e5c9b3</preferredOriginID>
       <creationInfo>
         <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
         <version>NLLoc:v6.00.0</version>


### PR DESCRIPTION
With this PR, the preferred origin (being the only origin) is set on the event. See #1569 were this surfaced and caused a bit of confusion.