### PR TITLE
Events not plotting on dayplot

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
 1.0.3:
+ - obspy.core:
+   * properly pass through kwargs specified for Trace.plot() down to the
+     low-level plotting routines (e.g. events were not shown properly in
+     dayplot of a trace, see #1566)
  - obspy.io.mseed:
    * ObsPy can now also read (Mini)SEED files with noise records. (see #1495)
    * ObsPy can now read records with a data-offset of zero. (see #1509, #1525)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -843,7 +843,7 @@ class Trace(object):
         """
         from obspy.imaging.waveform import WaveformPlotting
         waveform = WaveformPlotting(stream=self, **kwargs)
-        return waveform.plot_waveform()
+        return waveform.plot_waveform(**kwargs)
 
     def spectrogram(self, **kwargs):
         """


### PR DESCRIPTION
On Windows, python 2.7, obspy 1.0.1.

To get events to print on a dayploy I had to edit these lines in imaging/waveform/plot_day:

```
486        events = kwargs.get("events", []) 
487         # Potentially download some events with the help of obspy.clients.fdsn. 
488         if "min_magnitude" in events: 
489             try: 
490                 from obspy.clients.fdsn import Client 
491                 c = Client("EMSC") 
492                 events = c.get_events(starttime=self.starttime, 
493                                       endtime=self.endtime, 
494                                       minmagnitude=events["min_magnitude"]) 
495             except Exception as e: 
496                 events = None 
497                 msg = "Could not download the events because of '%s: %s'." % \ 
498                     (e.__class__.__name__, str(e)) 
499                 warnings.warn(msg) 
500         if events: 
```

to 
```
486        events = self.kwargs.get("events", []) 
500         if not events: 
```
May be a bug, or may be the user here.

