### PR TITLE
NEIC client producing problematic data?

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@
    * properly pass through kwargs specified for Trace.plot() down to the
      low-level plotting routines (e.g. events were not shown properly in
      dayplot of a trace, see #1566)
+ - obspy.clients.neic:
+   * Better end of stream detection. (see #1563)
  - obspy.io.mseed:
    * ObsPy can now also read (Mini)SEED files with noise records. (see #1495)
    * ObsPy can now read records with a data-offset of zero. (see #1509, #1525)

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -203,7 +203,7 @@ class Client(object):
                             if self.debug:
                                 print(ascdate(), asctime(), "read len",
                                       str(len(data)), " total", str(totlen))
-                            if data.find(b"EOR") >= 0:
+                            if data.find(b"<EOR>") >= 0:
                                 if self.debug:
                                     print(ascdate(), asctime(), b"<EOR> seen")
                                 tf.write(data[0:data.find(b"<EOR>")])

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -12,12 +12,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import io
 import socket
 import traceback
 from time import sleep
 
 from obspy import Stream, UTCDateTime, read
-from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.decorator import deprecated
 from .util import ascdate, asctime
 
@@ -185,10 +185,7 @@ class Client(object):
         while not success:
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                with NamedTemporaryFile() as tf:
-                    if self.debug:
-                        print(ascdate(), asctime(), "connecting temp file",
-                              tf.name)
+                with io.BytesIO() as tf:
                     s.connect((self.host, self.port))
                     s.setblocking(0)
                     s.send(line.encode('ascii', 'strict'))
@@ -210,7 +207,7 @@ class Client(object):
                                 totlen += len(data[0:data.find(b"<EOR>")])
                                 tf.seek(0)
                                 try:
-                                    st = read(tf.name, 'MSEED')
+                                    st = read(tf, 'MSEED')
                                 except Exception as e:
                                     st = Stream()
                                 st.trim(starttime, starttime + duration)


### PR DESCRIPTION
One of my colleagues is getting some problematic data when we request from the neic client.  We weren't sure if this was something on our end or something in obspy.  The following code:

```
#!/usr/bin/env python

from obspy.clients.neic import Client
from obspy.core import UTCDateTime


client = Client()
day = UTCDateTime('2016255')
st = client.get_waveforms('NE' , 'BRYW' , '00' , 'HH2' , day , day + 24*60*60)
```
Results in an internal mseed warning:
```

python check.py 
/usr/lib/python2.7/site-packages/obspy-1.0.2-py2.7-linux-x86_64.egg/obspy/io/mseed/core.py:384: InternalMSEEDReadingWarning: readMSEEDBuffer(): Unknown error '121' in record starting at offset 9310720. The rest of the file will not be read.
  warnings.warn(*_i)
```

When we request it through a CWBQuery we don't get an error. In the following sense:
`
java -jar /APPS/bin/CWBQuery.jar -s "NEBRYW HH200" -b "2016/09/11 00:00:00" -d 86400 -t ms`

gives us a miniseed file and it reads correctly:

```
from obspy.core import read
>>> st = read('NEBRYW_HH200.ms')
>>> print(st)
1 Trace(s) in Stream:
NE.BRYW.00.HH2 | 2016-09-11T00:00:00.005000Z - 2016-09-11T23:59:59.995000Z | 100.0 Hz, 8640000 samples
>>> exit()

```

Can anyone confirm if this is an obspy issue (or an issue with something we are doing)?    

Thanks for your help,
Adam

