### PR TITLE
Enable 32bit linux on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
     - master
     - /^maintenance_[0-9]+\.[0-9]+\.x$/
 
+sudo: true
+
 matrix:
   include:
     # do one build run with our minimum dependencies
@@ -20,13 +22,12 @@ matrix:
       env: PYTHON_VERSION=3.4
     - os: linux
       env: PYTHON_VERSION=3.5
-
+    - os: linux
+      env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
     - os: osx
       env: PYTHON_VERSION=2.7
     - os: osx
       env: PYTHON_VERSION=3.5
-
-sudo: false
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -34,10 +35,19 @@ install:
     else
       export OS="Linux";
     fi
-  - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-${OS}-x86_64.sh -O miniconda.sh;
+  # OPT used by setuptools patches contained in newer numpy versions
+  - |
+      if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
+      export ARCH="";
+      export OPT="-m32";
+      sudo dpkg --add-architecture i386;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh;
+      export ARCH="_64";
+    fi
+  - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,9 @@ install:
         export OPT="-m32"
         ls /etc/dpkg/dpkg.cfg.d/
         sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
-        sudo apt-get install ia32-libs
-        sudo apt-get install libc6-dev:i386
         sudo apt-get install libstdc++6:i386
         sudo apt-get install gcc-multilib
+        gcc --version
       else
         export ARCH="_64"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
       sudo: true
+      addons:
+        apt:
+          packages:
+            # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+            - libstdc++6:i386
+            - gcc-multilib
     #- os: osx
     #  env: PYTHON_VERSION=2.7
     #- os: osx
@@ -36,15 +42,13 @@ install:
     else
       export OS="Linux";
     fi
-  # OPT used by setuptools patches contained in newer numpy versions
   - |
       if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
         export ARCH=""
+        # OPT used by setuptools patches contained in newer numpy versions
         export OPT="-m32"
         ls /etc/dpkg/dpkg.cfg.d/
         sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
-        sudo apt-get install libstdc++6:i386
-        sudo apt-get install gcc-multilib
         gcc --version
       else
         export ARCH="_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,12 @@ install:
   # OPT used by setuptools patches contained in newer numpy versions
   - |
       if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
-      export ARCH="";
-      export OPT="-m32";
-      sudo dpkg --add-architecture i386;
-    else
-      export ARCH="_64";
-    fi
+        export ARCH=""
+        export OPT="-m32"
+        sudo dpkg --add-architecture i386
+      else
+        export ARCH="_64"
+      fi
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ matrix:
     # do one build run with our minimum dependencies
     # (or, well, at least the lowest version number that is available through
     #  anaconda..)
-    #- os: linux
-    #  env: PYTHON_VERSION=2.7 MINIMUM_DEPENDENCIES="True"
-    #- os: linux
-    #  env: PYTHON_VERSION=2.7
-    #- os: linux
-    #  env: PYTHON_VERSION=3.3
-    #- os: linux
-    #  env: PYTHON_VERSION=3.4
-    #- os: linux
-    #  env: PYTHON_VERSION=3.5
+    - os: linux
+      env: PYTHON_VERSION=2.7 MINIMUM_DEPENDENCIES="True"
+    - os: linux
+      env: PYTHON_VERSION=2.7
+    - os: linux
+      env: PYTHON_VERSION=3.3
+    - os: linux
+      env: PYTHON_VERSION=3.4
+    - os: linux
+      env: PYTHON_VERSION=3.5
     - os: linux
       env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
       addons:
@@ -30,10 +30,10 @@ matrix:
             # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
             - libstdc++6:i386
             - gcc-multilib
-    #- os: osx
-    #  env: PYTHON_VERSION=2.7
-    #- os: osx
-    #  env: PYTHON_VERSION=3.5
+    - os: osx
+      env: PYTHON_VERSION=2.7
+    - os: osx
+      env: PYTHON_VERSION=3.5
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -44,13 +44,14 @@ install:
   - |
       if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
         export ARCH=""
-        # OPT used by setuptools patches contained in newer numpy versions
+        # OPT is used by setuptools patches contained in newer numpy versions
+        # used by obspy when running pip install --no-deps .
         export OPT="-m32"
         # workaround for sudo dpkg --add-architecture i386
         # be sure multiarch is the only file in this directory
         ls /etc/dpkg/dpkg.cfg.d/
         # multiarch must contain foreign-architecture i386. If not it will
-        # error later and you need to do 
+        # error later and you need to do the following and add sudo: true
         #sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
         cat /etc/dpkg/dpkg.cfg.d/multiarch
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
     #  env: PYTHON_VERSION=3.5
     - os: linux
       env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
-      sudo: true
       addons:
         apt:
           packages:
@@ -47,9 +46,13 @@ install:
         export ARCH=""
         # OPT used by setuptools patches contained in newer numpy versions
         export OPT="-m32"
+        # workaround for sudo dpkg --add-architecture i386
+        # be sure multiarch is the only file in this directory
         ls /etc/dpkg/dpkg.cfg.d/
-        sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
-        gcc --version
+        # multiarch must contain foreign-architecture i386. If not it will
+        # error later and you need to do 
+        #sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
+        cat /etc/dpkg/dpkg.cfg.d/multiarch
       else
         export ARCH="_64"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,30 @@ branches:
     - master
     - /^maintenance_[0-9]+\.[0-9]+\.x$/
 
-sudo: true
+sudo: false
 
 matrix:
   include:
     # do one build run with our minimum dependencies
     # (or, well, at least the lowest version number that is available through
     #  anaconda..)
-    - os: linux
-      env: PYTHON_VERSION=2.7 MINIMUM_DEPENDENCIES="True"
-    - os: linux
-      env: PYTHON_VERSION=2.7
-    - os: linux
-      env: PYTHON_VERSION=3.3
-    - os: linux
-      env: PYTHON_VERSION=3.4
-    - os: linux
-      env: PYTHON_VERSION=3.5
+    #- os: linux
+    #  env: PYTHON_VERSION=2.7 MINIMUM_DEPENDENCIES="True"
+    #- os: linux
+    #  env: PYTHON_VERSION=2.7
+    #- os: linux
+    #  env: PYTHON_VERSION=3.3
+    #- os: linux
+    #  env: PYTHON_VERSION=3.4
+    #- os: linux
+    #  env: PYTHON_VERSION=3.5
     - os: linux
       env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
-    - os: osx
-      env: PYTHON_VERSION=2.7
-    - os: osx
-      env: PYTHON_VERSION=3.5
+      sudo: true
+    #- os: osx
+    #  env: PYTHON_VERSION=2.7
+    #- os: osx
+    #  env: PYTHON_VERSION=3.5
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -40,7 +41,12 @@ install:
       if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
         export ARCH=""
         export OPT="-m32"
-        sudo dpkg --add-architecture i386
+        ls /etc/dpkg/dpkg.cfg.d/
+        sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
+        sudo apt-get install ia32-libs
+        sudo apt-get install libc6-dev:i386
+        sudo apt-get install libstdc++6:i386
+        sudo apt-get install gcc-multilib
       else
         export ARCH="_64"
       fi


### PR DESCRIPTION
Motivated by gitter conversation:

> byt: megies is it worth a try, getting travis run 32bit? We had
> quite _some_ issues with 32bit and mseed... There are three
> possibilities I could think of: (i) cross compile and run
> directly on travis (ii) use a chroot as numpy does, (iii)
> use a docker test.  I would go for (i).


> megies: sure, would not hurt to have a 32bit test in our main CI..
> no idea how how much work it is..
