### PR TITLE
Reference time not written to SAC file when made from scratch

### DIFF
--- a/obspy/io/sac/header.py
+++ b/obspy/io/sac/header.py
@@ -250,6 +250,10 @@ STRHDRS = ('kstnm', 'kevnm', 'kevnm2', 'khole', 'ko', 'ka', 'kt0', 'kt1',
            'kt2', 'kt3', 'kt4', 'kt5', 'kt6', 'kt7', 'kt8', 'kt9', 'kf',
            'kuser0', 'kuser1', 'kuser2', 'kcmpnm', 'knetwk', 'kdatrd', 'kinst')
 
+# Headers that are in seconds relative to the reference "nz" times
+RELHDRS = ('b', 'e', 'a', 'o', 'f', 't0', 't1', 't2', 't3', 't4', 't5', 't6',
+           't7', 't8', 't9')
+
 """
 NOTE:
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -369,6 +369,12 @@ from . import arrayio as _io
 # See:
 # https://stackoverflow.com/q/2123585
 #
+# TODO: Replace all these factories and properties with Python Descriptors.
+#   http://nbviewer.jupyter.org/urls/gist.github.com/ChrisBeaumont/
+#       5758381/raw/descriptor_writeup.ipynb
+#   Also, don't forget to worry about access to __doc__ on both the class and
+#   the instances.
+#
 # floats
 def _floatgetter(hdr):
     def get_float(self):


### PR DESCRIPTION
(See the lengthy-ish discussion halfway down #1519 by @claudiodsf )

On 0.10.3 you can do:

``` python
import numpy as np
from obspy import Trace, UTCDateTime

tr = Trace(np.zeros(1000))
tr.stats.delta = 0.01
tr.stats.station = 'XXX'
tr.stats.starttime = UTCDateTime()
tr.stats.sac = {}
tr.stats.sac['a'] = 12.34
tr.write('test.sac', format='SAC')
```

and get a sac file with the correct reference time and the "a" header field set.  If you do the same thing in 1.0.2, what you get is a sac file without reference time, unless you do not set the "a" field.
