### PR TITLE
Bad error message when adding two UTCDateTime objects

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1003,6 +1003,16 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(UTCDateTime('2015-07-03-06-42-1.5123'),
                          UTCDateTime(2015, 7, 3, 6, 42, 1, 512300))
 
+    def test_add_error_message(self):
+        t = UTCDateTime()
+        t2 = UTCDateTime()
+        with self.assertRaises(TypeError) as context:
+            t + t2
+        self.assertEqual(
+            str(context.exception),
+            "unsupported operand type(s) for +: 'UTCDateTime' and "
+            "'UTCDateTime'")
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -855,6 +855,10 @@ class UTCDateTime(object):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
                      86400) * 1000000) / 1000000.0
+        elif isinstance(value, UTCDateTime):
+            msg = ("unsupported operand type(s) for +: 'UTCDateTime' and "
+                   "'UTCDateTime'")
+            raise TypeError(msg)
         return UTCDateTime(self.timestamp + value)
 
     def __sub__(self, value):


### PR DESCRIPTION
Adding two UTCDateTime objects makes little sense but the error message is confusing for users and we should change it:

```
In [1]: import obspy

In [2]: obspy.UTCDateTime() + obspy.UTCDateTime()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-6a746d0eba8e> in <module>()
----> 1 obspy.UTCDateTime() + obspy.UTCDateTime()

/Users/lion/workspace/code/obspy/obspy/core/utcdatetime.py in __add__(self, value)
    856             value = (value.microseconds + (value.seconds + value.days *
    857                      86400) * 1000000) / 1000000.0
--> 858         return UTCDateTime(self.timestamp + value)
    859
    860     def __sub__(self, value):

TypeError: unsupported operand type(s) for +: 'float' and 'UTCDateTime'
```
