### PR TITLE
Include libmseed test data in ObsPy packages

### DIFF
--- a/debian/patches/patch_libmseed_test_data_location.diff
+++ b/debian/patches/patch_libmseed_test_data_location.diff
@@ -1,0 +1,26 @@
+Description: patch locating libmseed test data
+ Libmseed test data originally in "../io/mseed/src/libmseed" are moved to
+ "../io/mseed/tests/data" in Debian packaging. Therefore we need to change the
+ directory lookup in the test routines.
+Author: Tobias Megies
+Bug: https://github.com/obspy/obspy/issues/1568
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
++++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+@@ -1441,13 +1441,12 @@ class MSEEDReadingAndWritingTestCase(uni
+             else:  # pragma: no cover
+                 raise NotImplemented
+ 
+-        folder = os.path.join(self.path, os.path.pardir, "src", "libmseed",
+-                              "test")
++        folder = os.path.join(self.path, "data", "libmseed")
+ 
+         # Get all the tests.
+         tests = sorted(glob.glob(os.path.join(folder, "*.test")))
+         # And all the test data.
+-        test_files = glob.glob(os.path.join(folder, "data", "*.mseed"))
++        test_files = glob.glob(os.path.join(folder, "*.mseed"))
+         # And their paths relative to the test folder.
+         rel_test_files = [os.path.normpath(os.path.relpath(_i, folder))
+                           for _i in test_files]

--- a/debian/patches/remove_basemap_warning.diff
+++ b/debian/patches/remove_basemap_warning.diff
@@ -18,5 +18,5 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 -                      "still work but the maps might be wrong. Please update "
 -                      "your basemap installation.")
  else:
-     warnings.warn("basemap not installed.")
      HAS_BASEMAP = False
+ 

--- a/debian/patches/rename_console_scripts_on_py3
+++ b/debian/patches/rename_console_scripts_on_py3
@@ -7,17 +7,17 @@ Author: megies@geophysik.uni-muenchen.de
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 --- a/setup.py
 +++ b/setup.py
-@@ -429,6 +429,13 @@ ENTRY_POINTS = {
-         'bandpass_preview = obspy.db.feature:BandpassPreviewFeature',
-         ],
+@@ -450,6 +450,13 @@ ENTRY_POINTS = {
      }
-+
-+
+ 
+ 
 +# PY3: rename entry points for executable scripts to "obspy3-..."
 +if sys.version_info[0] == 3:
 +    ENTRY_POINTS['console_scripts'] = [
 +        string.replace("obspy", "obspy3", 1)
 +        for string in ENTRY_POINTS['console_scripts']]
- 
- 
++
++
  def find_packages():
+     """
+     Simple function to find all modules under the current folder.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 remove_basemap_warning.diff
 rename_console_scripts_on_py3
+patch_libmseed_test_data_location.diff

--- a/debian/pybuild/rules
+++ b/debian/pybuild/rules
@@ -51,6 +51,15 @@ override_dh_auto_install:
 	ls -1 build/man/obspy3-* | sed 's#.*/#./debian/#' > debian/python3-obspy.manpages
 
 override_dh_install:
+	# hard link test files of libmseed to normal mseed test directories
+	mkdir debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/*.test debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/*.test.ref debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/data/*.mseed debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	cd debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/tests/data && mkdir libmseed
+	ln debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/src/libmseed/test/*.test debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/src/libmseed/test/*.test.ref debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/src/libmseed/test/data/*.mseed debian/tmp/usr/lib/python3*/dist-packages/obspy/io/mseed/tests/data/libmseed
 	# data files get separated into /usr/share for both python2/3 to use
 	sh -x debian/_dh_install_data_files.sh
 	# files for normal packages

--- a/debian/python_distutils/rules
+++ b/debian/python_distutils/rules
@@ -13,6 +13,11 @@ override_dh_auto_install:
 	dh_numpy
 
 override_dh_install:
+	# hard link test files of libmseed to normal mseed test directories
+	mkdir debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/*.test debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/*.test.ref debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
+	ln debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/src/libmseed/test/data/*.mseed debian/tmp/usr/lib/python2.7/dist-packages/obspy/io/mseed/tests/data/libmseed
 	# data files get separated into /usr/share for both python2/3 to use
 	sh -x debian/_dh_install_data_files.sh
 	# files for normal packages


### PR DESCRIPTION
e.g. Obspy Debian/Ubuntu packaging does not include libmseed test data that is in use in mseed test cases since merging #1540 (obspy/io/mseed/src/libmseed/test and test/data). This currently leads to some test fails in the docker deb build/testbot, e.g. http://tests.obspy.org/55986/#1
