### PR TITLE
FDSN client ignores empty network, station, and channels codes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,9 @@ master: (doi: 10.5281/zenodo.165135)
    * Instrument responses can now also be calculated for a given list of
      frequencies (see #1598).
  - obspy.clients.fdsn:
+   * empty SEED codes (e.g. ``network=''``) will now be properly sent to the
+     server as options and not omitted, which led to wildcard matching (for
+     details see #1578)
    * The mass downloader now has `exclude_networks` and `exclude_stations`
      arguments to not download certain pieces of data. (see #1305)
    * The mass downloader can now download stations that are part of a given

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1151,9 +1151,6 @@ class Client(object):
                 raise TypeError(msg)
             # Now convert to a string that is accepted by the webservice.
             value = convert_to_string(value)
-            if isinstance(value, (str, native_str)):
-                if not value and key != "location":
-                    continue
             final_parameter_set[key] = value
 
         return self._build_url(service, "query",


### PR DESCRIPTION
ObsPy currently ignores empty network, station, and channel codes, e.g.

```python
In [1]: import obspy

In [2]: from obspy.clients.fdsn import Client

In [3]: c = Client("IRIS", debug=True)
...

In [4]: c.get_waveforms(network="", station="", location="", channel="", 
                        starttime=obspy.UTCDateTime(), endtime=obspy.UTCDateTime())
Downloading http://service.iris.edu/fdsnws/dataselect/1/query?starttime=2016-10-31T09%3A41%3A34.590162&endtime=2016-10-31T09%3A41%3A34.590166&location=-- without requesting gzip compression
```

will download this URL: http://service.iris.edu/fdsnws/dataselect/1/query?starttime=2016-10-31T09%3A41%3A34.590162&endtime=2016-10-31T09%3A41%3A34.590166&location=--

The empty location parameter is dealt with correctly as it is special, but network/station/channel identifiers are just ignored. On the server side this results in them being replaced with their default values which should be a full wildcard `*`.

I'm not sure if ObsPy should behave like this or not. Thoughts?
