### PR TITLE
reftek: add channel_number to tr.stats.reftek130

### DIFF
--- a/obspy/io/reftek/core.py
+++ b/obspy/io/reftek/core.py
@@ -290,7 +290,10 @@ class Reftek130(object):
                         sample_data = _unpack_C0_data(packets_)
                         npts = len(sample_data)
 
-                    tr = Trace(data=sample_data, header=header.copy())
+                    tr = Trace(data=sample_data, header=copy.deepcopy(header))
+                    # channel number is not included in the EH/ET packet
+                    # payload, so add it to stats as well..
+                    tr.stats.reftek130['channel_number'] = channel_number
                     if headonly:
                         tr.stats.npts = npts
                     tr.stats.starttime = UTCDateTime(starttime)


### PR DESCRIPTION
Otherwise it's impossible to know which traces belong to which channel number in the original recording setup after reading. The channel number is in the extended header section of DT packets and was thus missing so far (stats.reftek130 is based on EH packet info which is the same for all channels)

Also make a deepcopy of the header dictionary to make sure we have separate instances o all sub-objects in the dictionaries.