### PR TITLE
Raising upon setting non-finite floats.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -91,6 +91,8 @@ master: (doi: 10.5281/zenodo.165135)
      dayplot of a trace, see #1566)
    * properly pass through kwargs from Stream.detrend() to Trace.detrend()
      (see #1607)
+   * Non finite floats (NaN, inf, -inf) can now no longer be set for all
+     event objects (see #1597).
  - obspy.core.event.source:
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
  - obspy.clients.earthworm:

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -27,6 +27,7 @@ from future.utils import native_str
 import collections
 import copy
 import inspect
+import math
 import re
 import warnings
 import weakref
@@ -370,6 +371,15 @@ def _event_type_class_factory(class_name, class_attributes=[],
                         (str(value), str(attrib_type))
                     raise ValueError(msg)
                 value = new_value
+
+            # Make sure all floats are finite - otherwise this is most
+            # likely a user error.
+            if attrib_type is float and value is not None:
+                if not math.isfinite(value):
+                    msg = "Value '%s' for '%s' is not a finite floating " \
+                          "point value." % (str(value), name)
+                    raise ValueError(msg)
+
             AttribDict.__setattr__(self, name, value)
             # If "name" is resource_id and value is not None, set the referred
             # object of the ResourceIdentifier to self.

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -27,12 +27,13 @@ from future.utils import native_str
 import collections
 import copy
 import inspect
-import math
 import re
 import warnings
 import weakref
 from copy import deepcopy
 from uuid import uuid4
+
+import numpy as np
 
 from obspy.core.event.header import DataUsedWaveType, ATTRIBUTE_HAS_ERRORS
 from obspy.core.utcdatetime import UTCDateTime
@@ -375,7 +376,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
             # Make sure all floats are finite - otherwise this is most
             # likely a user error.
             if attrib_type is float and value is not None:
-                if not math.isfinite(value):
+                if not np.isfinite(value):
                     msg = "Value '%s' for '%s' is not a finite floating " \
                           "point value." % (str(value), name)
                     raise ValueError(msg)

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -377,8 +377,10 @@ def _event_type_class_factory(class_name, class_attributes=[],
             # likely a user error.
             if attrib_type is float and value is not None:
                 if not np.isfinite(value):
-                    msg = "Value '%s' for '%s' is not a finite floating " \
-                          "point value." % (str(value), name)
+                    msg = "On %s object: Value '%s' for '%s' is " \
+                          "not a finite floating point value." % (
+                            type(self).__name__, str(value), name)
+
                     raise ValueError(msg)
 
             AttribDict.__setattr__(self, name, value)

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -940,6 +940,31 @@ class BaseTestCase(unittest.TestCase):
                 obj.some_custom_non_default_crazy_key = "my_text_here"
                 self.assertEqual(len(w), 1)
 
+    def test_setting_nans_or_inf_fails(self):
+        """
+        Tests that settings NaNs or infs as floating point values fails.
+        """
+        o = Origin()
+
+        with self.assertRaises(ValueError) as e:
+            o.latitude = float('nan')
+        self.assertEqual(
+            e.exception.args[0],
+            "Value 'nan' for 'latitude' is not a finite floating point value.")
+
+        with self.assertRaises(ValueError) as e:
+            o.latitude = float('inf')
+        self.assertEqual(
+            e.exception.args[0],
+            "Value 'inf' for 'latitude' is not a finite floating point value.")
+
+        with self.assertRaises(ValueError) as e:
+            o.latitude = float('-inf')
+        self.assertEqual(
+            e.exception.args[0],
+            "Value '-inf' for 'latitude' is "
+            "not a finite floating point value.")
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -950,19 +950,21 @@ class BaseTestCase(unittest.TestCase):
             o.latitude = float('nan')
         self.assertEqual(
             e.exception.args[0],
-            "Value 'nan' for 'latitude' is not a finite floating point value.")
+            "On Origin object: Value 'nan' for 'latitude' is not a finite "
+            "floating point value.")
 
         with self.assertRaises(ValueError) as e:
             o.latitude = float('inf')
         self.assertEqual(
             e.exception.args[0],
-            "Value 'inf' for 'latitude' is not a finite floating point value.")
+            "On Origin object: Value 'inf' for 'latitude' is not a finite "
+            "floating point value.")
 
         with self.assertRaises(ValueError) as e:
             o.latitude = float('-inf')
         self.assertEqual(
             e.exception.args[0],
-            "Value '-inf' for 'latitude' is "
+            "On Origin object: Value '-inf' for 'latitude' is "
             "not a finite floating point value.")
 
 


### PR DESCRIPTION
This is a follow up to #1376. It makes sure non finite floats (NaN, inf, -inf) cannot be set as floating point values in all event objects. This should prevent a certain class of error.

Note that this also means ObsPy can no longer read files with infs and NaNs but I think this acceptable. What do people think?
