### PR TITLE
evalresp: add routine to get response for specific frequencies

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -979,8 +979,8 @@ class Response(ComparingObject):
                     dtype=np.float64)
 
                 # Sanity check.
-                min_f = freqs[freqs > 0].min()
-                max_f = freqs.max()
+                min_f = frequencies[frequencies > 0].min()
+                max_f = frequencies.max()
 
                 min_f_avail = min(f)
                 max_f_avail = max(f)
@@ -1001,23 +1001,23 @@ class Response(ComparingObject):
                                             max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, amp, k=3)(freqs)
+                    f, amp, k=3)(frequencies)
                 phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, phase, k=3)(freqs)
+                    f, phase, k=3)(frequencies)
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0
                 phase[phase == 0] = 0
 
                 rl = blkt.blkt_info.list
-                rl.nresp = len(freqs)
+                rl.nresp = len(frequencies)
 
                 _freq_c = (C.c_double * rl.nresp)()
                 _amp_c = (C.c_double * rl.nresp)()
                 _phase_c = (C.c_double * rl.nresp)()
 
-                for i in range(len(freqs)):
-                    _freq_c[i] = freqs[i]
+                for i in range(len(frequencies)):
+                    _freq_c[i] = frequencies[i]
                     _amp_c[i] = amp[i]
                     _phase_c[i] = phase[i]
 
@@ -1145,7 +1145,7 @@ class Response(ComparingObject):
         chan.sensit = 0.0
         chan.sensfreq = 0.0
 
-        output = np.empty(len(freqs), dtype=np.complex128)
+        output = np.empty(len(frequencies), dtype=np.complex128)
         out_units = C.c_char_p(out_units.encode('ascii', 'strict'))
 
         # Set global variables
@@ -1165,7 +1165,8 @@ class Response(ComparingObject):
                 e, m = ew.ENUM_ERROR_CODES[rc]
                 raise e('norm_resp: ' + m)
 
-            rc = clibevresp._obspy_calc_resp(C.byref(chan), freqs, len(freqs),
+            rc = clibevresp._obspy_calc_resp(C.byref(chan), frequencies,
+                                             len(frequencies),
                                              output, out_units, -1, 0, 0)
             if rc:
                 e, m = ew.ENUM_ERROR_CODES[rc]

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -776,7 +776,7 @@ class Response(ComparingObject):
                    "or 'ACC'") % output
             raise ValueError(msg)
 
-        frequencies = np.array(frequencies)
+        frequencies = np.asarray(frequencies)
 
         # Whacky. Evalresp uses a global variable and uses that to scale the
         # response if it encounters any unit that is not SI.
@@ -1010,10 +1010,9 @@ class Response(ComparingObject):
                 _amp_c = (C.c_double * rl.nresp)()
                 _phase_c = (C.c_double * rl.nresp)()
 
-                for i in range(len(frequencies)):
-                    _freq_c[i] = frequencies[i]
-                    _amp_c[i] = amp[i]
-                    _phase_c[i] = phase[i]
+                _freq_c[:] = frequencies[:]
+                _amp_c[:] = amp[:]
+                _phase_c[:] = phase[:]
 
                 rl.freq = C.cast(C.pointer(_freq_c),
                                  C.POINTER(C.c_double))

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -106,6 +106,15 @@ class ResponseTestCase(unittest.TestCase):
                 self.assertTrue(np.allclose(seed_response, xml_response,
                                             rtol=1E-5))
 
+                # also test getting response for a set of discrete frequencies
+                indices = (-2, 0, -1, 1, 2, 20, -30, -100)
+                freqs = [seed_freq[i_] for i_ in indices]
+                response = inv[0][0][0].response
+                got = response.get_evalresp_response_for_frequencies(
+                    freqs, output=unit)
+                expected = [seed_response[i_] for i_ in indices]
+                np.testing.assert_allclose(got, expected, rtol=1E-5)
+
     def test_pitick2latex(self):
         self.assertEqual(_pitick2latex(3 * pi / 2), r'$\frac{3\pi}{2}$')
         self.assertEqual(_pitick2latex(2 * pi / 2), r'$\pi$')

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -272,7 +272,7 @@ def evalresp_for_frequencies(t_samp, frequencies, filename, date, station='*',
         datime = C.create_string_buffer(
             date.format_seed().encode('ascii', 'strict'))
         fn = C.create_string_buffer(tempfile.encode('ascii', 'strict'))
-        frequencies = np.array(frequencies)
+        frequencies = np.asarray(frequencies)
         nfreqs = C.c_int(frequencies.shape[0])
         res = clibevresp.evresp(sta, cha, net, locid, datime, unts, fn,
                                 frequencies, nfreqs, rtyp, vbs, start_stage,
@@ -689,7 +689,10 @@ def estimate_magnitude(paz, amplitude, timespan, h_dist):
             wood_anderson_amplitude_functions.append(
                 estimate_wood_anderson_amplitude_using_response)
         else:
-            raise TypeError()
+            msg = ("Unknown response specification (type '{}'). Use a "
+                   "dictionary structure with poles and zeros information or "
+                   "an obspy Response object.").format(type(i))
+            raise TypeError(msg)
     if not isinstance(amplitude, list) and not isinstance(amplitude, tuple):
         amplitude = [amplitude]
     if not isinstance(timespan, list) and not isinstance(timespan, tuple):

--- a/obspy/signal/tests/data/BW_RTSH.xml
+++ b/obspy/signal/tests/data/BW_RTSH.xml
@@ -1,0 +1,1467 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.0.xsd">
+  <Source>Jane</Source>
+  <Sender>Jane</Sender>
+  <Module>JANE WEB SERVICE: fdsnws-station | Jane version: 0.0.0+archive</Module>
+  <ModuleURI>http://jane/fdsnws/station/1/query?station=RTSH&amp;level=response&amp;starttime=2009-07-19&amp;endtime=2009-07-21</ModuleURI>
+  <Created>2016-11-23T12:04:00+00:00</Created>
+  <Network startDate="1999-01-01T00:00:00.000000Z" code="BW">
+    <Description>BayernNetz</Description>
+    <TotalNumberStations>80</TotalNumberStations>
+    <SelectedNumberStations>1</SelectedNumberStations>
+    <Station startDate="2004-01-01T00:00:00.000000Z" code="RTSH">
+      <Latitude plusError="0.0" minusError="0.0">47.754452</Latitude>
+      <Longitude plusError="0.0" minusError="0.0">12.849878</Longitude>
+      <Elevation plusError="0.0" minusError="0.0">1638.0</Elevation>
+      <Site>
+        <Name>Staufenhaus, Bavaria, BW-Net</Name>
+      </Site>
+      <CreationDate>2010-05-12T00:00:00.000</CreationDate>
+      <TotalNumberChannels>9</TotalNumberChannels>
+      <SelectedNumberChannels>3</SelectedNumberChannels>
+      <Channel locationCode="" code="EHZ" startDate="2007-07-18T00:00:00.000" endDate="2010-05-12T00:00:00.000">
+        <Latitude plusError="0.0" minusError="0.0">47.754452</Latitude>
+        <Longitude plusError="0.0" minusError="0.0">12.849878</Longitude>
+        <Elevation plusError="0.0" minusError="0.0">1638.0</Elevation>
+        <Depth plusError="0.0" minusError="0.0">0.0</Depth>
+        <Azimuth plusError="0.0" minusError="0.0">0.0</Azimuth>
+        <Dip plusError="0.0" minusError="0.0">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate plusError="0.0" minusError="0.0">200.0</SampleRate>
+        <ClockDrift plusError="0.0" minusError="0.0">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>6.7114E8</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency plusError="0.0" minusError="0.0">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">4.444</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">-4.444</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real plusError="0.0" minusError="0.0">-1.083</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.260141E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.5390089E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0501859E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.712792E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.494469E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.491013E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.6315771E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.8977249E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.999956E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.6246769E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>2.078273E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7297283E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.149</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel locationCode="" code="EHN" startDate="2007-07-18T00:00:00.000" endDate="2010-05-12T00:00:00.000">
+        <Latitude plusError="0.0" minusError="0.0">47.754452</Latitude>
+        <Longitude plusError="0.0" minusError="0.0">12.849878</Longitude>
+        <Elevation plusError="0.0" minusError="0.0">1638.0</Elevation>
+        <Depth plusError="0.0" minusError="0.0">0.0</Depth>
+        <Azimuth plusError="0.0" minusError="0.0">0.0</Azimuth>
+        <Dip plusError="0.0" minusError="0.0">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate plusError="0.0" minusError="0.0">200.0</SampleRate>
+        <ClockDrift plusError="0.0" minusError="0.0">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>6.7114E8</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency plusError="0.0" minusError="0.0">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">4.444</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">-4.444</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real plusError="0.0" minusError="0.0">-1.083</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.260141E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.5390089E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0501859E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.712792E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.494469E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.491013E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.6315771E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.8977249E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.999956E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.6246769E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>2.078273E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7297283E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.149</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel locationCode="" code="EHE" startDate="2007-07-18T00:00:00.000" endDate="2010-05-12T00:00:00.000">
+        <Latitude plusError="0.0" minusError="0.0">47.754452</Latitude>
+        <Longitude plusError="0.0" minusError="0.0">12.849878</Longitude>
+        <Elevation plusError="0.0" minusError="0.0">1638.0</Elevation>
+        <Depth plusError="0.0" minusError="0.0">0.0</Depth>
+        <Azimuth plusError="0.0" minusError="0.0">90.0</Azimuth>
+        <Dip plusError="0.0" minusError="0.0">0.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate plusError="0.0" minusError="0.0">200.0</SampleRate>
+        <ClockDrift plusError="0.0" minusError="0.0">0.02</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Lennartz LE-3D/1 seismometer</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>6.7114E8</Value>
+            <Frequency>2.0</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>Velocity in Meters per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>Velocity in Meters per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency plusError="0.0" minusError="0.0">3.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="2">
+                <Real plusError="0.0" minusError="0.0">0.0</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">4.444</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real plusError="0.0" minusError="0.0">-4.444</Real>
+                <Imaginary plusError="0.0" minusError="0.0">-4.444</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real plusError="0.0" minusError="0.0">-1.083</Real>
+                <Imaginary plusError="0.0" minusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>400.0</Value>
+              <Frequency>2.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1677850.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <FIR name="SCPXDECI2X1">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>EVEN</Symmetry>
+              <NumeratorCoefficient>-4.6243649E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.2582977E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.260141E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.5390089E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.665667E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0501859E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.712792E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.494469E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.491013E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.6315771E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.8977249E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.8573009E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0010917831</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.999956E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001206435</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0013971539</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.6246769E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002313273</NumeratorCoefficient>
+              <NumeratorCoefficient>2.078273E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0031300739</NumeratorCoefficient>
+              <NumeratorCoefficient>0.001137016</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0035433481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0030242419</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0032076361</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0052380068</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.001803839</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.007375909</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7297283E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0088709099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0048318468</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0090423049</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0098139048</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0071791359</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015253</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.002628732</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.020267591</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0051429141</NumeratorCoefficient>
+              <NumeratorCoefficient>0.02366362</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01657857</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.023875481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.032279529</NumeratorCoefficient>
+              <NumeratorCoefficient>0.01860678</NumeratorCoefficient>
+              <NumeratorCoefficient>0.053942081</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.003140518</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.088496208</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.04014856</NumeratorCoefficient>
+              <NumeratorCoefficient>0.1847636</NumeratorCoefficient>
+              <NumeratorCoefficient>0.4066011</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">2000.0</InputSampleRate>
+              <Factor>2</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.0</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="4">
+            <FIR name="LE24XDECI5">
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <Symmetry>NONE</Symmetry>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.171822</NumeratorCoefficient>
+              <NumeratorCoefficient>0.163569</NumeratorCoefficient>
+              <NumeratorCoefficient>0.14023601</NumeratorCoefficient>
+              <NumeratorCoefficient>0.105808</NumeratorCoefficient>
+              <NumeratorCoefficient>0.066007502</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0271481</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00510957</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0268043</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.036318101</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0344905</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.024210099</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0096030198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0049745901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.015899099</NumeratorCoefficient>
+              <NumeratorCoefficient>0.020984501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.019790299</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0134948</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044033802</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00475745</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0115716</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0145092</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0132197</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0084972102</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00195677</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0044690799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0090677198</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0107765</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0094031403</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0055976398</NumeratorCoefficient>
+              <NumeratorCoefficient>6.0405099E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0041235401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0073280199</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0082695298</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0068809399</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037303199</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8387201E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00373693</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0059917499</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0064373799</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0050937901</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0024651</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3457899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00332582</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0049074702</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0050333398</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0037791999</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00159018</NumeratorCoefficient>
+              <NumeratorCoefficient>8.6809002E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.002907</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0040037301</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0039307899</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00279555</NumeratorCoefficient>
+              <NumeratorCoefficient>9.8580797E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.5671299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00249505</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00324243</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00305578</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0020560501</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.75279E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.49518E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0021027999</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0026013399</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0023606501</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00150241</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0551199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.8152097E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0017401</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00206512</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00181116</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00109203</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.37322E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.78594E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>0.0014139001</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00162149</NumeratorCoefficient>
+              <NumeratorCoefficient>0.00138063</NumeratorCoefficient>
+              <NumeratorCoefficient>7.9203898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.0848299E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5987301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.0011283</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00125965</NumeratorCoefficient>
+              <NumeratorCoefficient>-0.00104741</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.7668798E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>6.3348898E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>5.3842302E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>8.8394701E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>9.6824899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.91898E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2381301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.29937E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.2503001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.8158598E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-7.3892699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-5.9995899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.1821601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.07424E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.24455E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.1804801E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>5.6182401E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.5808699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.4655199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.33714E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40772E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.9145499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.3054199E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.57899E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.0118E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.3234002E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>1.7545601E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.0062901E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4309301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.9872599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.8425001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.13618E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.21944E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.40478E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.9926599E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.87795E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1059001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.4517E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>6.6122302E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>2.15308E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4048001E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.2618299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6569499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.6067499E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>4.19285E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>3.5347699E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>2.7616299E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.98849E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>1.301E-4</NumeratorCoefficient>
+              <NumeratorCoefficient>7.4924603E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>3.4964702E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>9.2357604E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.8812999E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.06662E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-1.12882E-5</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.3231602E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-6.5589302E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-4.0230798E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-2.1460801E-6</NumeratorCoefficient>
+              <NumeratorCoefficient>-9.7192503E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-3.5193099E-7</NumeratorCoefficient>
+              <NumeratorCoefficient>-8.7308003E-8</NumeratorCoefficient>
+            </FIR>
+            <Decimation>
+              <InputSampleRate plusError="0.0" minusError="0.0">1000.0</InputSampleRate>
+              <Factor>5</Factor>
+              <Offset>0</Offset>
+              <Delay plusError="0.0" minusError="0.0">0.149</Delay>
+              <Correction plusError="0.0" minusError="0.0">0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>


### PR DESCRIPTION
This adds a routine to request response for a set of discrete frequencies using evalresp. I'll also add a routine for magnitude estimation based on a response object now.