### PR TITLE
fix seishub POST requests without data

### DIFF
--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -202,7 +202,7 @@ class Client(object):
         doc = response.read()
         return doc
 
-    def _http_request(self, url, method, xml_string="", headers={}):
+    def _http_request(self, url, method, xml_string=None, headers={}):
         """
         Send a HTTP request via urllib2.
 


### PR DESCRIPTION
`requests` was complaining about the empty string as default kwarg:

```
  File "/home/megies/anaconda/envs/obspyck/lib/python2.7/site-packages/obspy/clients/seishub/client.py", line 306, in delete_resource
    url, method="DELETE", headers=headers)
  File "/home/megies/anaconda/envs/obspyck/lib/python2.7/site-packages/obspy/clients/seishub/client.py", line 221, in _http_request
    response = urllib.request.urlopen(req, timeout=self.timeout)
  File "/home/megies/anaconda/envs/obspyck/lib/python2.7/site-packages/future/backports/urllib/request.py", line 171, in urlopen
    return opener.open(url, data, timeout)
  File "/home/megies/anaconda/envs/obspyck/lib/python2.7/site-packages/future/backports/urllib/request.py", line 492, in open
    req = meth(req)
  File "/home/megies/anaconda/envs/obspyck/lib/python2.7/site-packages/future/backports/urllib/request.py", line 1204, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```