### PR TITLE
Socket recv handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,8 +5,12 @@
      dayplot of a trace, see #1566)
  - obspy.core.event.source:
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
+ - obspy.clients.earthworm:
+   * Better end of stream detection. (see #1605)
  - obspy.clients.neic:
    * Better end of stream detection. (see #1563)
+ - obspy.clients.seedlink:
+   * Better end of stream detection. (see #1605)
  - obspy.io.mseed:
    * ObsPy can now also read (Mini)SEED files with noise records. (see #1495)
    * ObsPy can now read records with a data-offset of zero. (see #1509, #1525)

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -15,6 +15,7 @@ Fabian Engels
 Sven Egdorf
 Laura Ermert
 Tom Eulenfeld
+Jeremy Fee
 Marc Grunberg
 Conny Hammer
 Sebastian Heimann

--- a/obspy/clients/earthworm/waveserver.py
+++ b/obspy/clients/earthworm/waveserver.py
@@ -199,6 +199,8 @@ def get_sock_char_line(sock, timeout=10.):
             # see https://github.com/obspy/obspy/issues/383
             # indat = sock.recv(8192)
             indat = sock.recv(1)
+            if not indat:
+                break
             chunks.append(indat)
     except socket.timeout:
         print('socket timeout in get_sock_char_line()', file=sys.stderr)
@@ -221,6 +223,8 @@ def get_sock_bytes(sock, nbytes, timeout=None):
     try:
         while btoread:
             indat = sock.recv(min(btoread, 8192))
+            if not indat:
+                break
             btoread -= len(indat)
             chunks.append(indat)
     except socket.timeout:

--- a/obspy/clients/seedlink/easyseedlink.py
+++ b/obspy/clients/seedlink/easyseedlink.py
@@ -320,6 +320,8 @@ class EasySeedLinkClient(object):
         while True:
             bytes_read = self.conn.socket.recv(
                 SeedLinkConnection.DFT_READBUF_SIZE)
+            if not bytes_read:
+                break
             response += bytes_read
             for stopword in stop_on:
                 if response.endswith(stopword):


### PR DESCRIPTION
### What does this PR do?
Check the return value from socket.recv before buffering the (empty) response and looping forever.

### Why was it initiated?  Any relevant Issues?
I couldn't find any existing issues for this specific problem.

On a heavily loaded Scientific Linux 7 (RHEL flavor) system, we run many concurrent processes using the earthworm client to access data.  Intermittently (<1%, but every few hours) the process would spike CPU and leak memory until the kernel killed the process because the system ran out of memory.  Logs indicated this was while fetching data using the earthworm obspy client.  Using a copy of the earthworm client with these modifications has thus far eliminated this leak.

From https://docs.python.org/2/howto/sockets.html#using-a-socket
> When a recv returns 0 bytes, it means the other side has closed (or is in the process of closing) the connection. You will not receive any more data on this connection. Ever.


### PR Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
This is not reproducible under normal conditions.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .

