### PR TITLE
Mock out http requests in unit tests (module core), skip http requests in doctests (modules core/signal)

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -153,8 +153,9 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     (3) Reading a remote file via HTTP protocol.
 
         >>> from obspy import read
-        >>> st = read("https://examples.obspy.org/loc_RJOB20050831023349.z")
-        >>> print(st)  # doctest: +ELLIPSIS
+        >>> st = read(  # doctest: +SKIP
+        ...     "https://examples.obspy.org/loc_RJOB20050831023349.z")
+        >>> print(st)  # doctest: +SKIP
         1 Trace(s) in Stream:
         .RJOB..Z | 2005-08-31T02:33:49.850000Z - ... | 200.0 Hz, 12000 samples
 
@@ -166,8 +167,9 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         1 Trace(s) in Stream:
         XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - ... | 40.0 Hz, 635 samples
 
-        >>> st = read("https://examples.obspy.org/slist.ascii.bz2")
-        >>> print(st)  # doctest: +ELLIPSIS
+        >>> st = read(  # doctest: +SKIP
+        ...     "https://examples.obspy.org/slist.ascii.bz2")
+        >>> print(st)  # doctest: +SKIP
         1 Trace(s) in Stream:
         XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - ... | 40.0 Hz, 635 samples
 
@@ -176,9 +178,10 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         >>> import requests
         >>> import io
         >>> example_url = "https://examples.obspy.org/loc_RJOB20050831023349.z"
-        >>> stringio_obj = io.BytesIO(requests.get(example_url).content)
-        >>> st = read(stringio_obj)
-        >>> print(st)  # doctest: +ELLIPSIS
+        >>> stringio_obj = io.BytesIO(
+        ...     requests.get(example_url).content)  # doctest: +SKIP
+        >>> st = read(stringio_obj)  # doctest: +SKIP
+        >>> print(st)  # doctest: +SKIP
         1 Trace(s) in Stream:
         .RJOB..Z | 2005-08-31T02:33:49.850000Z - ... | 200.0 Hz, 12000 samples
 
@@ -187,8 +190,8 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         >>> from obspy import read
         >>> dt = UTCDateTime("2005-08-31T02:34:00")
         >>> st = read("https://examples.obspy.org/loc_RJOB20050831023349.z",
-        ...           starttime=dt, endtime=dt+10)
-        >>> print(st)  # doctest: +ELLIPSIS
+        ...           starttime=dt, endtime=dt+10)  # doctest: +SKIP
+        >>> print(st)  # doctest: +SKIP
         1 Trace(s) in Stream:
         .RJOB..Z | 2005-08-31T02:34:00.000000Z - ... | 200.0 Hz, 2001 samples
     """

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -15,7 +15,9 @@ from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core.compatibility import mock
 from obspy.core.stream import _is_pickle, _read_pickle, _write_pickle
 from obspy.core.util.attribdict import AttribDict
-from obspy.core.util.base import NamedTemporaryFile, get_scipy_version
+from obspy.core.util.base import (
+    NamedTemporaryFile, get_scipy_version, get_example_file)
+from obspy.core.util.testing import MockResponse
 from obspy.io.xseed import Parser
 
 
@@ -1716,17 +1718,26 @@ class StreamTestCase(unittest.TestCase):
         self.assertFalse(tr.data)
 
         # 2 - via http
+        test_sac_url = 'https://examples.obspy.org/test.sac'
+        test_sac_data = open(get_example_file('test.sac'), 'rb').read()
+        mock_response = MockResponse(test_sac_data)
         # dtype
-        tr = read('https://examples.obspy.org/test.sac', dtype=np.int32)[0]
+        with mock.patch('requests.get', return_value=mock_response) as mock_:
+            tr = read(test_sac_url, dtype=np.int32)[0]
+            mock_.assert_called_once_with(test_sac_url, stream=True)
         self.assertEqual(tr.data.dtype, np.int32)
         # start/end time
-        tr2 = read('https://examples.obspy.org/test.sac',
-                   starttime=tr.stats.starttime + 1,
-                   endtime=tr.stats.endtime - 2)[0]
+        with mock.patch('requests.get', return_value=mock_response) as mock_:
+            tr2 = read(test_sac_url,
+                       starttime=tr.stats.starttime + 1,
+                       endtime=tr.stats.endtime - 2)[0]
+            mock_.assert_called_once_with(test_sac_url, stream=True)
         self.assertEqual(tr2.stats.starttime, tr.stats.starttime + 1)
         self.assertEqual(tr2.stats.endtime, tr.stats.endtime - 2)
         # headonly
-        tr = read('https://examples.obspy.org/test.sac', headonly=True)[0]
+        with mock.patch('requests.get', return_value=mock_response) as mock_:
+            tr = read(test_sac_url, headonly=True)[0]
+            mock_.assert_called_once_with(test_sac_url, stream=True)
         self.assertFalse(tr.data)
 
         # 3 - some example within obspy

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1720,14 +1720,15 @@ class StreamTestCase(unittest.TestCase):
         # 2 - via http
         test_sac_url = 'https://examples.obspy.org/test.sac'
         test_sac_data = open(get_example_file('test.sac'), 'rb').read()
-        mock_response = MockResponse(test_sac_data)
         # dtype
-        with mock.patch('requests.get', return_value=mock_response) as mock_:
+        with mock.patch('requests.get',
+                        new=MockResponse(test_sac_data)) as mock_:
             tr = read(test_sac_url, dtype=np.int32)[0]
             mock_.assert_called_once_with(test_sac_url, stream=True)
         self.assertEqual(tr.data.dtype, np.int32)
         # start/end time
-        with mock.patch('requests.get', return_value=mock_response) as mock_:
+        with mock.patch('requests.get',
+                        new=MockResponse(test_sac_data)) as mock_:
             tr2 = read(test_sac_url,
                        starttime=tr.stats.starttime + 1,
                        endtime=tr.stats.endtime - 2)[0]
@@ -1735,7 +1736,8 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(tr2.stats.starttime, tr.stats.starttime + 1)
         self.assertEqual(tr2.stats.endtime, tr.stats.endtime - 2)
         # headonly
-        with mock.patch('requests.get', return_value=mock_response) as mock_:
+        with mock.patch('requests.get',
+                        new=MockResponse(test_sac_data)) as mock_:
             tr = read(test_sac_url, headonly=True)[0]
             mock_.assert_called_once_with(test_sac_url, stream=True)
         self.assertFalse(tr.data)

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -29,6 +29,7 @@ from distutils.version import LooseVersion
 from lxml import etree
 import numpy as np
 
+from obspy.core.compatibility import mock
 from obspy.core.util.base import NamedTemporaryFile, get_matplotlib_version
 from obspy.core.util.misc import CatchOutput, get_untracked_files_from_git, \
     MatplotlibBackend
@@ -716,12 +717,13 @@ def get_all_py_files():
     return sorted(py_files)
 
 
-class MockResponse(object):
+class MockResponse(mock.MagicMock):
     """
     Mimicks a `requests.Response` object resulting from a successful http
     request, serving the specified data (usually bytes).
     """
     def __init__(self, data, stream=False):
+        super(MockResponse, self).__init__(return_value=self)
         self.data = data
         self.stream = stream
 

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -716,5 +716,24 @@ def get_all_py_files():
     return sorted(py_files)
 
 
+class MockResponse(object):
+    """
+    Mimicks a `requests.Response` object resulting from a successful http
+    request, serving the specified data (usually bytes).
+    """
+    def __init__(self, data, stream=False):
+        self.data = data
+        self.stream = stream
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=1, decode_unicode=False):
+        pos = 0
+        while pos < len(self.data):
+            yield self.data[pos:pos + chunk_size]
+            pos += chunk_size
+
+
 if __name__ == '__main__':
     doctest.testmod(exclude_empty=True)

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -1435,7 +1435,8 @@ def plot_tfr(st, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6, left=0.1,
     .. rubric:: Example
 
     >>> from obspy import read
-    >>> tr = read("https://examples.obspy.org/a02i.2008.240.mseed")[0]
+    >>> tr = read(  # doctest: +SKIP
+    ...     "https://examples.obspy.org/a02i.2008.240.mseed")[0]
     >>> plot_tfr(tr.data, dt=tr.stats.delta, fmin=.01, # doctest: +SKIP
     ...         fmax=50., w0=8., nf=64, fft_zero_pad_fac=4)
 


### PR DESCRIPTION
This PR makes the complete test suites of `DEFAULT_MODULES` network-independent by..

 - mocking some requests to `https://examples.obspy.org` in unit tests of `core` (returning the expected data and otherwise leaving the tests unchanged)
 - skipping some http-based doctests in core (these routines are extensively tested in unit tests, see above bullet point)
 - skipping one http request in `signal.tf_misfits` doctests (the downloaded data is not used anyway, as the plot is skipped)

This is a workaround for currently failing http requests to `https://examples.obspy.org` as described in #1599, which make all CI fail right now, which makes it extremely cumbersome to review currently open PRs.