### PR TITLE
Fix Stream.detrend kwargs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@
    * properly pass through kwargs specified for Trace.plot() down to the
      low-level plotting routines (e.g. events were not shown properly in
      dayplot of a trace, see #1566)
+   * properly pass through kwargs from Stream.detrend() to Trace.detrend()
+     (see #1607)
  - obspy.core.event.source:
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
  - obspy.clients.neic:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2400,7 +2400,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         return self
 
     @raise_if_masked
-    def detrend(self, type='simple'):
+    def detrend(self, type='simple', **options):
         """
         Remove a trend from all traces.
 
@@ -2409,7 +2409,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :class:`~obspy.core.trace.Trace`.
         """
         for tr in self:
-            tr.detrend(type=type)
+            tr.detrend(type=type, **options)
         return self
 
     def taper(self, *args, **kwargs):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2409,6 +2409,23 @@ class StreamTestCase(unittest.TestCase):
         for arg in patch.call_args_list:
             self.assertFalse(arg[1]["nearest_sample"])
 
+    def test_passing_kwargs_to_trace_detrend(self):
+        """
+        Simple regression test making sure kwargs are passed to the Trace's
+        detrend method.
+        """
+        st = read()
+
+        with mock.patch("obspy.core.trace.Trace.detrend") as patch:
+            st.detrend("polynomial", order=2, plot=True)
+
+        # 3 Traces.
+        self.assertEqual(patch.call_count, 3)
+
+        for arg in patch.call_args_list:
+            self.assertEqual(arg[1]["order"], 2)
+            self.assertEqual(arg[1]["plot"], True)
+
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')


### PR DESCRIPTION
Properly pass through kwargs from `Stream.detrend` to `Trace.detrend`.