### PR TITLE
Ubuntu xenial+yakkety: problematic requests version

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -21,17 +21,22 @@ import gzip
 import io
 import os
 import re
+import sys
 from socket import timeout as socket_timeout
 import textwrap
 import threading
 import warnings
 
 with standard_library.hooks():
-    import queue
     import urllib.error
     import urllib.parse
     import urllib.request
     from collections import OrderedDict
+
+if sys.version_info.major == 2:
+    import Queue as queue
+else:
+    import queue
 
 from lxml import etree
 


### PR DESCRIPTION
Ubuntu xenial and yakkety have a `python-requests` version that obspy currently does not work with, see #1608 and #1599. The problem seems to be monkey patching done by `future` which causes problems for `Queue` module when imported via `six.moves`.

 - http://tests.obspy.org/61797/
 - http://tests.obspy.org/61804/

Either we..
 - find a way around that problem inside obspy (not very likely, or at least will be extremely ugly, probably)
 - package and distribute a newer requests version via deb.obspy.org for those two Ubuntu releases
 - ....?