### PR TITLE
WIP: Back to the past

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,6 @@ install:
         matplotlib=$MPL_VERSION
         $BASEMAP
         $PYPROJ
-        future
         lxml
         decorator
         sqlalchemy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,6 @@ install:
   - "conda install -q --yes pip numpy scipy \"matplotlib<1.9\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema"
   # additional dependencies
   - "pip install pyimgur"
-  - "pip install -U future"
   # list package versions
   - "conda list"
 

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -27,10 +27,7 @@ for seismology.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
+from __future__ import absolute_import, division, print_function
 
 import warnings
 import requests
@@ -39,6 +36,7 @@ import requests
 from obspy.core.utcdatetime import UTCDateTime  # NOQA
 from obspy.core.util import _get_version_string
 __version__ = _get_version_string(abbrev=10)
+from obspy.core.compatibility import PY2
 from obspy.core.trace import Trace  # NOQA
 from obspy.core.stream import Stream, read
 from obspy.core.event import read_events, Catalog
@@ -50,7 +48,6 @@ from obspy.core.util.obspy_types import (
 __all__ = ["UTCDateTime", "Trace", "__version__", "Stream", "read",
            "read_events", "Catalog", "read_inventory", "ObsPyException",
            "ObsPyReadingError"]
-__all__ = [native_str(i) for i in __all__]
 
 
 # insert supported read/write format plugin lists dynamically in docstrings

--- a/obspy/clients/__init__.py
+++ b/obspy/clients/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/clients/arclink/__init__.py
+++ b/obspy/clients/arclink/__init__.py
@@ -157,9 +157,7 @@ protocol.txt
 .. _`GNU Lesser General Public License, Version 3`:
         https://www.gnu.org/copyleft/lesser.html
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -8,10 +8,7 @@ ArcLink/WebDC client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -161,13 +161,12 @@ class Client(object):
     def _reconnect(self):
         self._client.close()
         try:
-            self._client.open(native_str(self._client.host),
+            self._client.open(self._client.host,
                               self._client.port,
                               self._client.timeout)
         except Exception:
             # old Python 2.7: port needs to be native int or string -> not long
-            self._client.open(native_str(self._client.host),
-                              native_str(self._client.port),
+            self._client.open(self._client.host, self._client.port,
                               self._client.timeout)
 
     def _write_ln(self, buffer):
@@ -541,7 +540,7 @@ class Client(object):
                    "'FSEED'")
             raise ArcLinkException(msg)
         # check parameters
-        is_name = isinstance(filename, (str, native_str))
+        is_name = isinstance(filename, str):
         if not is_name and not hasattr(filename, "write"):
             msg = "Parameter filename must be either string or file handler."
             raise TypeError(msg)

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -540,7 +540,7 @@ class Client(object):
                    "'FSEED'")
             raise ArcLinkException(msg)
         # check parameters
-        is_name = isinstance(filename, str):
+        is_name = isinstance(filename, str)
         if not is_name and not hasattr(filename, "write"):
             msg = "Parameter filename must be either string or file handler."
             raise TypeError(msg)

--- a/obspy/clients/arclink/decrypt.py
+++ b/obspy/clients/arclink/decrypt.py
@@ -10,9 +10,7 @@ Decryption class of ArcLink/WebDC client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import hashlib
 

--- a/obspy/clients/arclink/tests/__init__.py
+++ b/obspy/clients/arclink/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.arclink.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import io
 import operator

--- a/obspy/clients/arclink/tests/test_decrypt.py
+++ b/obspy/clients/arclink/tests/test_decrypt.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.arclink.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -47,10 +47,7 @@ class MyNewClient(WaveformClient, StationClient):
                                          starttime, endtime)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import PY2, with_metaclass
+from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractmethod
 import io

--- a/obspy/clients/earthworm/__init__.py
+++ b/obspy/clients/earthworm/__init__.py
@@ -40,9 +40,7 @@ Basic Usage
         st = client.get_waveforms('AV', 'ACH', '', 'EH*', t + 100, t + 130)
         st.plot()
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 

--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -10,9 +10,7 @@ Earthworm Wave Server client for ObsPy.
 
 .. seealso:: http://www.isti2.com/ew/PROGRAMMER/wsv_protocol.html
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 from fnmatch import fnmatch
 

--- a/obspy/clients/earthworm/tests/__init__.py
+++ b/obspy/clients/earthworm/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/earthworm/tests/test_client.py
+++ b/obspy/clients/earthworm/tests/test_client.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.earthworm.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/earthworm/waveserver.py
+++ b/obspy/clients/earthworm/waveserver.py
@@ -8,10 +8,7 @@ Low-level Earthworm Wave Server tools.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import socket
 import struct

--- a/obspy/clients/earthworm/waveserver.py
+++ b/obspy/clients/earthworm/waveserver.py
@@ -32,10 +32,10 @@ RETURNFLAG_KEY = {
 }
 
 DATATYPE_KEY = {
-    b't4': '>f4', b't8': '>f8',
-    b's4': '>i4', b's2': '>i2',
-    b'f4': '<f4', b'f8': '<f8',
-    b'i4': '<i4', b'i2': '<i2'
+    't4': '>f4', 't8': '>f8',
+    's4': '>i4', 's2': '>i2',
+    'f4': '<f4', 'f8': '<f8',
+    'i4': '<i4', 'i2': '<i2'
 }
 
 
@@ -45,7 +45,7 @@ def get_numpy_type(tpstr):
     return appropriate numpy.dtype object
     """
     dtypestr = DATATYPE_KEY[tpstr]
-    tp = np.dtype(native_str(dtypestr))
+    tp = np.dtype(dtypestr)
     return tp
 
 

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -153,7 +153,7 @@ if r"%s" in Client.__init__.__doc__:
             Client.__init__.__doc__ % \
             str(sorted(URL_MAPPINGS.keys())).strip("[]")
 
-__all__ = [native_str("Client")]
+__all__ = ["Client"]
 
 
 if __name__ == '__main__':

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -135,10 +135,7 @@ USP     http://sismo.iag.usp.br
 Please see the documentation for each method for further information and
 examples.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 from .header import URL_MAPPINGS  # NOQA

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -9,10 +9,7 @@ FDSN Web service client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy
@@ -39,7 +36,7 @@ else:
 from lxml import etree
 
 import obspy
-from obspy import UTCDateTime, read_inventory
+from obspy import UTCDateTime, read_inventory, compatibility
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES, URL_MAPPINGS,
                      WADL_PARAMETERS_NOT_TO_BE_PARSED, FDSNException,
@@ -1049,7 +1046,7 @@ class Client(object):
         # StringIO objects also have __iter__ so check for 'read' as well
         if isinstance(bulk, collections.Iterable) \
                 and not hasattr(bulk, "read") \
-                and not isinstance(bulk, (str, native_str)):
+                and not isinstance(bulk, str):
             tmp = ["%s=%s" % (key, convert_to_string(value))
                    for key, value in arguments.items() if value is not None]
             # empty location codes have to be represented by two dashes
@@ -1065,7 +1062,7 @@ class Client(object):
             # if it has a read method, read data from there
             if hasattr(bulk, "read"):
                 bulk = bulk.read()
-            elif isinstance(bulk, (str, native_str)):
+            elif isinstance(bulk, str):
                 # check if bulk is a local file
                 if "\n" not in bulk and os.path.isfile(bulk):
                     with open(bulk, 'r') as fh:
@@ -1129,7 +1126,7 @@ class Client(object):
             this_type = service_params[key]["type"]
 
             # Try to decode to be able to work with bytes.
-            if this_type is native_str:
+            if this_type is str:
                 try:
                     value = value.decode()
                 except AttributeError:
@@ -1539,7 +1536,7 @@ def convert_to_string(value):
     >>> print(convert_to_string(False))
     false
     """
-    if isinstance(value, (str, native_str)):
+    if isinstance(value, str):
         return value
     # Boolean test must come before integer check!
     elif isinstance(value, bool):
@@ -1550,7 +1547,7 @@ def convert_to_string(value):
         return str(value)
     elif isinstance(value, UTCDateTime):
         return str(value).replace("Z", "")
-    elif PY2 and isinstance(value, bytes):
+    elif compatibility.PY2 and isinstance(value, bytes):
         return value
     else:
         raise TypeError("Unexpected type %s" % repr(value))

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -17,26 +17,20 @@ import gzip
 import io
 import os
 import re
-import sys
 from socket import timeout as socket_timeout
 import textwrap
 import threading
 import warnings
-from collections import OrderedDict
 
-if sys.version_info.major == 2:
-    from urllib import urlencode
-    import urllib2 as urllib_request
-    import Queue as queue
-else:
-    from urllib.parse import urlencode
-    import urllib.request as urllib_request
-    import queue
 
 from lxml import etree
 
 import obspy
 from obspy import UTCDateTime, read_inventory, compatibility
+from obspy import UTCDateTime, read_inventory
+from obspy.core.compatibility import (
+    queue, urlencode, HTTPRedirectHandler, HTTPDigestAuthHandler,
+    HTTPPasswordMgrWithDefaultRealm, Request, build_opener)
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES, URL_MAPPINGS,
                      WADL_PARAMETERS_NOT_TO_BE_PARSED, FDSNException,
@@ -47,7 +41,7 @@ from .wadl_parser import WADLParser
 DEFAULT_SERVICE_VERSIONS = {'dataselect': 1, 'station': 1, 'event': 1}
 
 
-class CustomRedirectHandler(urllib_request.HTTPRedirectHandler):
+class CustomRedirectHandler(HTTPRedirectHandler):
     """
     Custom redirection handler to also do it for POST requests which the
     standard library does not do by default.
@@ -71,14 +65,14 @@ class CustomRedirectHandler(urllib_request.HTTPRedirectHandler):
 
         # Also redirect the data of the request which the standard library
         # interestingly enough does not do.
-        return urllib_request.Request(
+        return Request(
             newurl, headers=newheaders,
             data=req.data,
             origin_req_host=req.origin_req_host,
             unverifiable=True)
 
 
-class NoRedirectionHandler(urllib_request.HTTPRedirectHandler):
+class NoRedirectionHandler(HTTPRedirectHandler):
     """
     Handler that does not direct!
     """
@@ -221,9 +215,10 @@ class Client(object):
         handlers = []
         if user is not None and password is not None:
             # Create an OpenerDirector for HTTP Digest Authentication
-            password_mgr = urllib_request.HTTPPasswordMgrWithDefaultRealm()
+
+            password_mgr = HTTPPasswordMgrWithDefaultRealm()
             password_mgr.add_password(None, base_url, user, password)
-            handlers.append(urllib_request.HTTPDigestAuthHandler(password_mgr))
+            handlers.append(HTTPDigestAuthHandler(password_mgr))
 
         if (user is None and password is None) or force_redirect is True:
             # Redirect if no credentials are given or the force_redirect
@@ -233,7 +228,7 @@ class Client(object):
             handlers.append(NoRedirectionHandler())
 
         # Don't install globally to not mess with other codes.
-        self._url_opener = urllib_request.build_opener(*handlers)
+        self._url_opener = build_opener(*handlers)
 
         self.request_headers = {"User-Agent": user_agent}
         # Avoid mutable kwarg.
@@ -875,7 +870,7 @@ class Client(object):
             msg = "The current client does not have a dataselect service."
             raise ValueError(msg)
 
-        arguments = OrderedDict(
+        arguments = collections.OrderedDict(
             quality=quality,
             minimumlength=minimumlength,
             longestonly=longestonly
@@ -1020,7 +1015,7 @@ class Client(object):
             msg = "The current client does not have a station service."
             raise ValueError(msg)
 
-        arguments = OrderedDict(
+        arguments = collections.OrderedDict(
             level=level,
             includerestriced=includerestricted,
             includeavailability=includeavailability
@@ -1638,7 +1633,7 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
             print("-" * 70)
 
     try:
-        request = urllib_request.Request(url=url, headers=headers)
+        request = Request(url=url, headers=headers)
         # Request gzip encoding if desired.
         if use_gzip:
             request.add_header("Accept-encoding", "gzip")

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -8,10 +8,7 @@ Header files for the FDSN webservice.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2
+from __future__ import absolute_import, division, print_function
 
 import platform
 import sys

--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -510,10 +510,7 @@ Further functionality of this module is documented at a couple of other places:
 * :class:`~.restrictions.Restrictions` class
 * :class:`~.mass_downloader.MassDownloader` class
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import warnings
 
@@ -525,9 +522,8 @@ from .domain import (Domain, RectangularDomain,  # NOQA
                      CircularDomain, GlobalDomain)  # NOQA
 
 
-__all__ = [native_str(i) for i in (
-    'MassDownloader', 'Restrictions', 'Domain', 'RectangularDomain',
-    'CircularDomain', 'GlobalDomain')]
+__all__ = ['MassDownloader', 'Restrictions', 'Domain', 'RectangularDomain',
+           'CircularDomain', 'GlobalDomain']
 
 if SCIPY_VERSION < [0, 12]:
     msg = ('At least some parts of FDSN Mass downloader might not '

--- a/obspy/clients/fdsn/mass_downloader/domain.py
+++ b/obspy/clients/fdsn/mass_downloader/domain.py
@@ -13,10 +13,7 @@ for an example.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import with_metaclass
+from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractmethod
 

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -12,9 +12,7 @@ it understandable in the first place.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -10,9 +10,7 @@ services in an automated fashion.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import collections
 import logging

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -9,10 +9,7 @@ Non-geographical restrictions and constraints for the mass downloader.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -223,13 +223,13 @@ class Restrictions(object):
 
         # These must be iterables, but not strings.
         if not isinstance(channel_priorities, collections.Iterable) \
-                or isinstance(channel_priorities, (str, native_str)):
+                or isinstance(channel_priorities, str):
             msg = "'channel_priorities' must be a list or other iterable " \
                   "container."
             raise TypeError(msg)
 
         if not isinstance(location_priorities, collections.Iterable) \
-                or isinstance(location_priorities, (str, native_str)):
+                or isinstance(location_priorities, str):
             msg = "'location_priorities' must be a list or other iterable " \
                   "container."
             raise TypeError(msg)

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -9,9 +9,7 @@ Utility functions required for the download helpers.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import collections
 import fnmatch

--- a/obspy/clients/fdsn/tests/__init__.py
+++ b/obspy/clients/fdsn/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -9,9 +9,7 @@ The obspy.clients.fdsn.client test suite.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -134,14 +134,14 @@ class RestrictionsTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError) as e:
             Restrictions(starttime=start, endtime=end,
-                         channel_priorities=native_str("HHE"))
+                         channel_priorities="HHE")
         self.assertEqual(e.exception.args[0],
                          "'channel_priorities' must be a list or other "
                          "iterable container.")
 
         with self.assertRaises(TypeError) as e:
             Restrictions(starttime=start, endtime=end,
-                         channel_priorities=(native_str("HHE")))
+                         channel_priorities=("HHE"))
         self.assertEqual(e.exception.args[0],
                          "'channel_priorities' must be a list or other "
                          "iterable container.")
@@ -163,14 +163,14 @@ class RestrictionsTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError) as e:
             Restrictions(starttime=start, endtime=end,
-                         location_priorities=native_str("00"))
+                         location_priorities="00")
         self.assertEqual(e.exception.args[0],
                          "'location_priorities' must be a list or other "
                          "iterable container.")
 
         with self.assertRaises(TypeError) as e:
             Restrictions(starttime=start, endtime=end,
-                         location_priorities=(native_str("00")))
+                         location_priorities=("00"))
         self.assertEqual(e.exception.args[0],
                          "'location_priorities' must be a list or other "
                          "iterable container.")
@@ -185,15 +185,13 @@ class RestrictionsTestCase(unittest.TestCase):
         Restrictions(starttime=start, endtime=end,
                      channel_priorities=["HHE", "BHE"])
         Restrictions(starttime=start, endtime=end,
-                     channel_priorities=(native_str("HHE"),))
+                     channel_priorities=("HHE",))
         Restrictions(starttime=start, endtime=end,
-                     channel_priorities=[native_str("HHE")])
+                     channel_priorities=["HHE"])
         Restrictions(starttime=start, endtime=end,
-                     channel_priorities=(native_str("HHE"),
-                                         native_str("BHE")))
+                     channel_priorities=("HHE", "BHE"))
         Restrictions(starttime=start, endtime=end,
-                     channel_priorities=[native_str("HHE"),
-                                         native_str("BHE")])
+                     channel_priorities=["HHE", "BHE"])
         Restrictions(starttime=start, endtime=end,
                      location_priorities=("00",))
         Restrictions(starttime=start, endtime=end,
@@ -203,15 +201,13 @@ class RestrictionsTestCase(unittest.TestCase):
         Restrictions(starttime=start, endtime=end,
                      location_priorities=["00", "10"])
         Restrictions(starttime=start, endtime=end,
-                     location_priorities=(native_str("00"),))
+                     location_priorities=("00",))
         Restrictions(starttime=start, endtime=end,
-                     location_priorities=[native_str("00")])
+                     location_priorities=["00"])
         Restrictions(starttime=start, endtime=end,
-                     location_priorities=(native_str("00"),
-                                          native_str("10")))
+                     location_priorities=("00", "10"))
         Restrictions(starttime=start, endtime=end,
-                     location_priorities=[native_str("00"),
-                                          native_str("10")])
+                     location_priorities=["00", "10"])
 
     def test_restrictions_object(self):
         """

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -9,10 +9,7 @@ The obspy.clients.fdsn.download_helpers test suite.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy

--- a/obspy/clients/fdsn/tests/test_wadl_parser.py
+++ b/obspy/clients/fdsn/tests/test_wadl_parser.py
@@ -9,9 +9,7 @@ The obspy.clients.fdsn.wadl_parser test suite.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -12,9 +12,7 @@ and should be removed once the datacenters are fully standard compliant.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import warnings

--- a/obspy/clients/filesystem/__init__.py
+++ b/obspy/clients/filesystem/__init__.py
@@ -12,9 +12,7 @@ of ObsPy's I/O plugins (e.g. MiniSEED).
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -35,9 +35,7 @@ See https://www.seiscomp3.org/wiki/doc/applications/slarchive/SDS.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import glob
 import os

--- a/obspy/clients/filesystem/tests/__init__.py
+++ b/obspy/clients/filesystem/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import imghdr
 import inspect

--- a/obspy/clients/iris/__init__.py
+++ b/obspy/clients/iris/__init__.py
@@ -66,7 +66,7 @@ from __future__ import absolute_import, division, print_function
 from .client import Client  # NOQA
 
 
-__all__ = [native_str("Client")]
+__all__ = ["Client"]
 
 
 if __name__ == '__main__':

--- a/obspy/clients/iris/__init__.py
+++ b/obspy/clients/iris/__init__.py
@@ -61,10 +61,7 @@ IRIS (https://service.iris.edu/irisws/):
 Please see the documentation for each method for further information and
 examples to retrieve various data from the IRIS DMC.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -8,10 +8,7 @@ IRIS Web service client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import platform
@@ -158,7 +155,7 @@ class Client(object):
         # file name is given, create fh, write to file and return nothing
         if hasattr(filename, "write") and callable(filename.write):
             fh = filename
-        elif isinstance(filename, (str, native_str)):
+        elif isinstance(filename, str):
             fh = open(filename, method)
             file_opened = True
         else:
@@ -1001,7 +998,7 @@ class Client(object):
                     tf.write(data)
                     # force matplotlib to use internal PNG reader. image.imread
                     # will use PIL if available
-                    img = image._png.read_png(native_str(tf.name))
+                    img = image._png.read_png(tf.name)
                 # add image to axis
                 ax.imshow(img)
                 # hide axes

--- a/obspy/clients/iris/tests/__init__.py
+++ b/obspy/clients/iris/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.iris.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/clients/neic/__init__.py
+++ b/obspy/clients/neic/__init__.py
@@ -11,9 +11,7 @@ A public server is at 137.227.224.97 (cwbpub.cr.usgs.gov) on port 2061.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -8,9 +8,7 @@ NEIC CWB Query service client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import socket

--- a/obspy/clients/neic/tests/__init__.py
+++ b/obspy/clients/neic/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/neic/tests/test_client.py
+++ b/obspy/clients/neic/tests/test_client.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.neic.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/neic/util.py
+++ b/obspy/clients/neic/util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
 

--- a/obspy/clients/seedlink/__init__.py
+++ b/obspy/clients/seedlink/__init__.py
@@ -26,9 +26,7 @@ and Mitigation" under the European Community's Seventh Framework Programme
 activities of the JRA2/WP12 "Tools for real-time seismology, acquisition and
 mining".
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .basic_client import Client  # NOQA
 from .slclient import SLClient  # NOQA

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -8,9 +8,7 @@ SeedLink request client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import warnings
 

--- a/obspy/clients/seedlink/client/__init__.py
+++ b/obspy/clients/seedlink/client/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -11,9 +11,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import logging

--- a/obspy/clients/seedlink/client/slnetstation.py
+++ b/obspy/clients/seedlink/client/slnetstation.py
@@ -11,9 +11,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy.core.utcdatetime import UTCDateTime
 

--- a/obspy/clients/seedlink/client/slstate.py
+++ b/obspy/clients/seedlink/client/slstate.py
@@ -11,9 +11,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from ..seedlinkexception import SeedLinkException
 from ..slpacket import SLPacket

--- a/obspy/clients/seedlink/easyseedlink.py
+++ b/obspy/clients/seedlink/easyseedlink.py
@@ -52,10 +52,7 @@ connection object and cannot be easily influenced. Also, a ``HELLO`` is always
 sent to the server when connecting in order to determine the SeedLink protocol
 version.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/obspy/clients/seedlink/easyseedlink.py
+++ b/obspy/clients/seedlink/easyseedlink.py
@@ -132,7 +132,7 @@ class EasySeedLinkClient(object):
 
     def __init__(self, server_url, autoconnect=True):
         # Catch invalid server_url parameters
-        if not isinstance(server_url, (str, native_str)):
+        if not isinstance(server_url, str):
             raise ValueError('Expected string for SeedLink server URL')
         # Allow for sloppy server URLs (e.g. 'geofon.gfz-potsdam.de:18000).
         # (According to RFC 1808 the net_path segment needs to start with '//'

--- a/obspy/clients/seedlink/seedlinkexception.py
+++ b/obspy/clients/seedlink/seedlinkexception.py
@@ -11,9 +11,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 class SeedLinkException(Exception):

--- a/obspy/clients/seedlink/slclient.py
+++ b/obspy/clients/seedlink/slclient.py
@@ -16,9 +16,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import logging
 import sys

--- a/obspy/clients/seedlink/slpacket.py
+++ b/obspy/clients/seedlink/slpacket.py
@@ -11,9 +11,7 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 

--- a/obspy/clients/seedlink/tests/__init__.py
+++ b/obspy/clients/seedlink/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seedlink/tests/example_SL_Hello.py
+++ b/obspy/clients/seedlink/tests/example_SL_Hello.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import socket
 

--- a/obspy/clients/seedlink/tests/example_SL_RTTrace.py
+++ b/obspy/clients/seedlink/tests/example_SL_RTTrace.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import logging
 import sys

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.basic_client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seedlink/tests/test_seedlinkconnection.py
+++ b/obspy/clients/seedlink/tests/test_seedlinkconnection.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.client.seedlinkconnection test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seedlink/tests/test_slclient.py
+++ b/obspy/clients/seedlink/tests/test_slclient.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.slclient test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seedlink/tests/test_slnetstation.py
+++ b/obspy/clients/seedlink/tests/test_slnetstation.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.client.slnetstation test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seedlink/tests/test_slpacket.py
+++ b/obspy/clients/seedlink/tests/test_slpacket.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.slpacket test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os.path
 import unittest

--- a/obspy/clients/seedlink/tests/test_slstate.py
+++ b/obspy/clients/seedlink/tests/test_slstate.py
@@ -2,9 +2,7 @@
 """
 The obspy.clients.seedlink.client.slstate test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seishub/__init__.py
+++ b/obspy/clients/seishub/__init__.py
@@ -52,9 +52,7 @@ Advanced Examples
  ('sensitivity', 2516800000.0),
  ('zeros', [0j, 0j])]
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .client import Client
 

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -8,10 +8,7 @@ SeisHub database client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
+from __future__ import absolute_import, division, print_function
 
 import os
 import pickle
@@ -31,7 +28,7 @@ else:
 from lxml import objectify
 from lxml.etree import Element, SubElement, tostring
 
-from obspy import Catalog, UTCDateTime, read_events
+from obspy import Catalog, UTCDateTime, read_events, compatibility
 from obspy.core.util import guess_delta
 from obspy.core.util.decorator import deprecated_keywords
 from obspy.io.xseed import Parser
@@ -49,7 +46,7 @@ KEYWORDS = {'network': 'network_id', 'station': 'station_id',
 
 
 def _unpickle(data):
-    if PY2:
+    if compatibility.PY2:
         obj = pickle.loads(data)
     else:
         # https://api.mongodb.org/python/current/\
@@ -487,7 +484,7 @@ master/seishub/plugins/seismology/waveform.py
 
         # allow time strings in arguments
         for time_ in ["starttime", "endtime"]:
-            if isinstance(kwargs[time_], (str, native_str)):
+            if isinstance(kwargs[time_], native_str):
                 kwargs[time_] = UTCDateTime(kwargs[time_])
 
         trim_start = kwargs['starttime']

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -484,7 +484,7 @@ master/seishub/plugins/seismology/waveform.py
 
         # allow time strings in arguments
         for time_ in ["starttime", "endtime"]:
-            if isinstance(kwargs[time_], native_str):
+            if isinstance(kwargs[time_], str):
                 kwargs[time_] = UTCDateTime(kwargs[time_])
 
         trim_start = kwargs['starttime']

--- a/obspy/clients/seishub/tests/__init__.py
+++ b/obspy/clients/seishub/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/seishub/tests/test_client.py
+++ b/obspy/clients/seishub/tests/test_client.py
@@ -3,9 +3,7 @@
 """
 The obspy.clients.seishub.client test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import sys
 import unittest

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -122,7 +122,7 @@ from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 
-__all__ = [native_str("Client")]
+__all__ = ["Client"]
 
 
 if __name__ == '__main__':

--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -118,10 +118,7 @@ method should be used to retrieve information about a specific model.
 >>> print(db_info.period)
 5.125
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from .client import Client  # NOQA
 

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -9,10 +9,7 @@ ObsPy client for the IRIS Syngine service.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import io

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -141,7 +141,7 @@ class Client(WaveformClient, HTTPClient):
         int_arguments = ["kernelwidth"]
         time_arguments = ["origintime"]
 
-        for keys, t in ((str_arguments, native_str),
+        for keys, t in ((str_arguments, str),
                         (float_arguments, float),
                         (int_arguments, int),
                         (time_arguments, obspy.UTCDateTime)):
@@ -155,7 +155,7 @@ class Client(WaveformClient, HTTPClient):
                 value = t(value)
                 # String arguments are stripped and empty strings are not
                 # allowed.
-                if t is native_str:
+                if t is str:
                     value = value.strip()
                     if not value:
                         raise ValueError("String argument '%s' must not be "
@@ -177,7 +177,7 @@ class Client(WaveformClient, HTTPClient):
             # If a string like object, attempt to parse it to a datetime
             # object, otherwise assume it`s a phase-relative time and let the
             # Syngine service deal with the error handling.
-            elif isinstance(value, (str, native_str)):
+            elif isinstance(value, str):
                 try:
                     value = obspy.UTCDateTime(value)
                 except Exception:
@@ -186,7 +186,7 @@ class Client(WaveformClient, HTTPClient):
             # constructor without catching the error.
             else:
                 value = obspy.UTCDateTime(value)
-            params[key] = native_str(value)
+            params[key] = value
 
         # These all have to be lists of floats. Otherwise it fails.
         source_mecs = ["sourcemomenttensor",

--- a/obspy/clients/syngine/tests/__init__.py
+++ b/obspy/clients/syngine/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -156,12 +156,12 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "components": native_str("Z"),
-            "endtime": native_str(1800.0),
-            "eventid": native_str("GCMT:M110302J"),
-            "format": native_str("miniseed"),
-            "model": native_str("ak135f_5s"),
-            "network": native_str("_GSN")})
+            "components": "Z",
+            "endtime": 1800.0,
+            "eventid": "GCMT:M110302J",
+            "format": "miniseed",
+            "model": "ak135f_5s",
+            "network": "_GSN"})
         self.assertEqual(p.call_args[1]["headers"],
                          {"User-Agent": DEFAULT_TESTING_USER_AGENT})
 
@@ -182,13 +182,13 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "components": native_str("Z"),
-            "starttime": native_str("P-10"),
-            "endtime": native_str("ScS+60"),
-            "eventid": native_str("GCMT:M110302J"),
-            "format": native_str("miniseed"),
-            "model": native_str("ak135f_5s"),
-            "network": native_str("_GSN")})
+            "components": "Z",
+            "starttime": "P-10",
+            "endtime": "ScS+60",
+            "eventid": "GCMT:M110302J",
+            "format": "miniseed",
+            "model": "ak135f_5s",
+            "network": "_GSN"})
         self.assertEqual(p.call_args[1]["headers"],
                          {"User-Agent": DEFAULT_TESTING_USER_AGENT})
 
@@ -218,8 +218,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": native_str("ak135f_5s"),
-            "format": native_str("miniseed"),
+            "model": "ak135f_5s",
+            "format": "miniseed",
             "sourcemomenttensor": "1,2,3,4,5,6"})
 
         with mock.patch("requests.get") as p:
@@ -230,8 +230,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": native_str("ak135f_5s"),
-            "format": native_str("miniseed"),
+            "model": "ak135f_5s",
+            "format": "miniseed",
             "sourcedoublecouple": "1,2,3,4"})
 
         with mock.patch("requests.get") as p:
@@ -242,8 +242,8 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(p.call_args[1]["url"],
                          "http://service.iris.edu/irisws/syngine/1/query")
         self.assertEqual(p.call_args[1]["params"], {
-            "model": native_str("ak135f_5s"),
-            "format": native_str("miniseed"),
+            "model": "ak135f_5s",
+            "format": "miniseed",
             "sourceforce": "3.32,4.23,5.11"})
 
     def test_error_handling(self):

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -2,10 +2,7 @@
 """
 The obspy.clients.syngine test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import unittest

--- a/obspy/core/__init__.py
+++ b/obspy/core/__init__.py
@@ -109,9 +109,7 @@ See :mod:`obspy.core.inventory` for more details.
 
 .. _NumPy: http://www.numpy.org
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # don't change order
 from obspy.core.utcdatetime import UTCDateTime

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -3,6 +3,7 @@
 Py3k compatibility module
 """
 import io
+import sys
 
 import numpy as np
 

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -2,11 +2,12 @@
 """
 Py3k compatibility module
 """
-from future.utils import PY2
-
 import io
 
 import numpy as np
+
+PY2 = sys.version_info.major == 2
+
 
 # optional dependencies
 try:
@@ -21,6 +22,14 @@ if PY2:
     from string import maketrans
 else:
     maketrans = bytes.maketrans
+
+
+if PY2:
+    string_types = (bytes, str, unicode)  # NOQA
+    unicode_type = unicode  # NOQA
+else:
+    string_types = (bytes, str)  # NOQA
+    unicode_type = str  # NOQA
 
 
 # NumPy does not offer the from_buffer method under Python 3 and instead

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -126,3 +126,17 @@ def round_away(number):
         return int(int(number) + int(np.sign(number)))
     else:
         return int(np.round(number))
+
+
+def python_2_unicode_compatible(cls):
+    """
+    A class decorator that defines __unicode__ and __str__ methods under Python
+    2. Under Python 3, this decorator is a no-op.
+
+    Take from the future package, original implementation comes from
+    django.utils.encoding.
+    """
+    if PY2:
+        cls.__unicode__ = cls.__str__
+        cls.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return cls

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -20,9 +20,27 @@ except ImportError:
     pass
 
 if PY2:
+    import Queue as queue
     from string import maketrans
+
+    from urllib import urlencode
+    from urllib2 import (HTTPRedirectHandler, Request,
+                         HTTPPasswordMgrWithDefaultRealm,
+                         HTTPDigestAuthHandler, build_opener)
+    import BaseHTTPServer as http_server
+
+    from itertools import izip_longest as zip_longest
 else:
+    import queue
     maketrans = bytes.maketrans
+
+    from urllib.parse import urlencode
+    from urllib.request import (HTTPRedirectHandler, Request,
+                                HTTPPasswordMgrWithDefaultRealm,
+                                HTTPDigestAuthHandler, build_opener)
+    import http.server as http_server
+
+    from itertools import zip_longest
 
 
 if PY2:

--- a/obspy/core/event/__init__.py
+++ b/obspy/core/event/__init__.py
@@ -19,9 +19,7 @@ format `QuakeML <https://quake.ethz.ch/quakeml/>`_.
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .base import (
     Comment, CompositeTime, ConfidenceEllipsoid, CreationInfo, DataUsed,

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -19,10 +19,7 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy
@@ -35,6 +32,7 @@ from uuid import uuid4
 
 import numpy as np
 
+from obspy.core.compatibility import string_types
 from obspy.core.event.header import DataUsedWaveType, ATTRIBUTE_HAS_ERRORS
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict
@@ -101,7 +99,7 @@ def _bool(value):
     True for any value (including zero) of int and float,
     and for (empty) strings.
     """
-    if value == 0 or isinstance(value, (str, native_str)):
+    if value == 0 or isinstance(value, string_types):
         return True
     return bool(value)
 
@@ -267,8 +265,8 @@ def _event_type_class_factory(class_name, class_attributes=[],
 
             def get_value_repr(key):
                 value = getattr(self, key)
-                if isinstance(value, (str, native_str)):
-                    value = native_str(value)
+                if isinstance(value, string_types):
+                    value = str(value)
                 repr_str = value.__repr__()
                 # Print any associated errors.
                 error_key = key + "_errors"
@@ -422,7 +420,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
         base_class = AbstractEventType
 
     # Set the class type name.
-    setattr(base_class, "__name__", native_str(class_name))
+    setattr(base_class, "__name__", str(class_name))
     return base_class
 
 
@@ -847,7 +845,7 @@ class ResourceIdentifier(object):
     def id(self, value):
         self.fixed = True
         # XXX: no idea why I had to add bytes for PY2 here
-        if not isinstance(value, (str, bytes)):
+        if not isinstance(value, string_types):
             msg = "attribute id needs to be a string."
             raise TypeError(msg)
         self.__dict__["id"] = value
@@ -862,7 +860,7 @@ class ResourceIdentifier(object):
 
     @prefix.setter
     def prefix(self, value):
-        if not isinstance(value, (str, native_str)):
+        if not isinstance(value, string_types):
             msg = "prefix id needs to be a string."
             raise TypeError(msg)
         self._prefix = value

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -17,10 +17,7 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import glob
 import io
@@ -31,6 +28,7 @@ import warnings
 import numpy as np
 from pkg_resources import load_entry_point
 
+from obspy.core.compatibility import string_types
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, _read_from_plugin
 from obspy.core.util.base import ENTRY_POINTS, download_to_file
@@ -212,7 +210,7 @@ class Catalog(object):
         """
         __setitem__ method of the Catalog object.
         """
-        if not isinstance(index, (str, native_str)):
+        if not isinstance(index, string_types):
             self.events.__setitem__(index, event)
         else:
             super(Catalog, self).__setitem__(index, event)
@@ -801,7 +799,7 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
     if pathname_or_url is None:
         # if no pathname or URL specified, return example catalog
         return _create_example_catalog()
-    elif not isinstance(pathname_or_url, (str, native_str)):
+    elif not isinstance(pathname_or_url, string_types):
         # not a string - we assume a file-like object
         try:
             # first try reading directly

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -17,16 +17,14 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
+
 import copy
 
 from obspy.core.event.header import (
     EventType, EventTypeCertainty, EventDescriptionType)
 from obspy.core.util.decorator import rlock
 from obspy.imaging.source import plot_radiation_pattern, _setup_figure_and_axes
-
 
 from .base import (_event_type_class_factory,
                    CreationInfo, ResourceIdentifier)

--- a/obspy/core/event/header.py
+++ b/obspy/core/event/header.py
@@ -11,9 +11,7 @@ This module provides enumerations defined in the
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy.core.util import Enum
 

--- a/obspy/core/event/magnitude.py
+++ b/obspy/core/event/magnitude.py
@@ -17,9 +17,7 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 from obspy.core.event.base import (

--- a/obspy/core/event/origin.py
+++ b/obspy/core/event/origin.py
@@ -17,9 +17,7 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 from obspy.core.event.base import (

--- a/obspy/core/event/source.py
+++ b/obspy/core/event/source.py
@@ -19,9 +19,7 @@ This class hierarchy is closely modelled after the de-facto standard format
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -195,9 +195,7 @@ StationXML files, e.g. after making modifications.
 
 >>> inv.write('my_inventory.xml', format='STATIONXML')  # doctest: +SKIP
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # Don't change order! .util must be first.
 from .util import (Angle, Azimuth, BaseNode, ClockDrift, Comment, Dip,

--- a/obspy/core/inventory/channel.py
+++ b/obspy/core/inventory/channel.py
@@ -9,11 +9,9 @@ Provides the Channel class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import python_2_unicode_compatible
+from __future__ import absolute_import, division, print_function
 
+from obspy.core.compatibility import python_2_unicode_compatible
 from obspy.core.util.obspy_types import FloatWithUncertainties
 from . import BaseNode
 from .util import Azimuth, ClockDrift, Dip, Distance, Latitude, Longitude

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -9,10 +9,7 @@ Provides the Inventory class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import python_2_unicode_compatible, native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import fnmatch
@@ -22,6 +19,7 @@ import textwrap
 import warnings
 
 import obspy
+from obspy.core.compatibility import string_types, python_2_unicode_compatible
 from obspy.core.util.base import (ENTRY_POINTS, ComparingObject,
                                   _read_from_plugin, NamedTemporaryFile,
                                   download_to_file)
@@ -66,7 +64,7 @@ def read_inventory(path_or_file_object=None, format=None):
     if path_or_file_object is None:
         # if no pathname or URL specified, return example catalog
         return _create_example_inventory()
-    elif isinstance(path_or_file_object, (str, native_str)) and \
+    elif isinstance(path_or_file_object, string_types) and \
             "://" in path_or_file_object:
         # some URL
         # extract extension if any

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -9,15 +9,13 @@ Provides the Network class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import python_2_unicode_compatible
+from __future__ import absolute_import, division, print_function
 
 import copy
 import fnmatch
 import warnings
 
+from obspy.core.compatibility import python_2_unicode_compatible
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .station import Station

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -9,9 +9,7 @@ Classes related to instrument responses.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import warnings

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -9,10 +9,7 @@ Provides the Station class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import python_2_unicode_compatible
+from __future__ import absolute_import, division, print_function
 
 import copy
 import fnmatch
@@ -21,6 +18,7 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime
+from obspy.core.compatibility import python_2_unicode_compatible
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .util import (BaseNode, Equipment, Operator, Distance, Latitude,

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -9,9 +9,7 @@ Utility objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import re

--- a/obspy/core/preview.py
+++ b/obspy/core/preview.py
@@ -8,10 +8,7 @@ Tools for creating and merging previews.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from copy import copy
 
@@ -129,7 +126,7 @@ def merge_previews(stream):
             raise Exception(msg)
         delta = value[0].stats.delta
         # Check dtype.
-        dtypes = {native_str(tr.data.dtype) for tr in value}
+        dtypes = {str(tr.data.dtype) for tr in value}
         if len(dtypes) > 1:
             msg = 'Different dtypes for traces with id %s' % value[0].id
             raise Exception(msg)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -8,10 +8,7 @@ Module for handling ObsPy Stream objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY3, native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import fnmatch
@@ -202,7 +199,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     if pathname_or_url is None:
         # if no pathname or URL specified, return example stream
         st = _create_example_stream(headonly=headonly)
-    elif not isinstance(pathname_or_url, (str, native_str)):
+    elif not isinstance(pathname_or_url, str):
         # not a string - we assume a file-like object
         pathname_or_url.seek(0)
         try:
@@ -252,9 +249,6 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         st._rtrim(endtime, nearest_sample=nearest_sample)
     # convert to dtype if given
     if dtype:
-        # For compatibility with NumPy 1.4
-        if isinstance(dtype, str):
-            dtype = native_str(dtype)
         for tr in st:
             tr.data = np.require(tr.data, dtype)
     # applies calibration factor
@@ -2247,7 +2241,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z ... | 10.0 Hz, 300 samples
         """
         for tr in self:
-            tr.resample(sampling_rate, window=native_str(window),
+            tr.resample(sampling_rate, window=window,
                         no_filter=no_filter, strict_length=strict_length)
         return self
 
@@ -3116,7 +3110,7 @@ def _is_pickle(filename):  # @UnusedVariable
     >>> _is_pickle('/path/to/pickle.file')  # doctest: +SKIP
     True
     """
-    if isinstance(filename, (str, native_str)):
+    if isinstance(filename, str):
         try:
             with open(filename, 'rb') as fp:
                 st = pickle.load(fp)
@@ -3144,14 +3138,14 @@ def _read_pickle(filename, **kwargs):  # @UnusedVariable
     :return: A ObsPy Stream object.
     """
     kwargs = {}
-    if PY3:
+    if not compatibility.PY2:
         # see seishub/client.py
         # https://api.mongodb.org/python/current/\
         # python3.html#why-can-t-i-share-pickled-objectids-\
         # between-some-versions-of-python-2-and-3
         kwargs['encoding'] = "latin-1"
 
-    if isinstance(filename, (str, native_str)):
+    if isinstance(filename, str):
         with open(filename, 'rb') as fp:
             return pickle.load(fp, **kwargs)
     else:
@@ -3178,7 +3172,7 @@ def _write_pickle(stream, filename, protocol=2, **kwargs):  # @UnusedVariable
     :type protocol: int, optional
     :param protocol: Pickle protocol, defaults to ``2``.
     """
-    if isinstance(filename, (str, native_str)):
+    if isinstance(filename, str):
         with open(filename, 'wb') as fp:
             pickle.dump(stream, fp, protocol=protocol)
     else:

--- a/obspy/core/tests/__init__.py
+++ b/obspy/core/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -9,9 +9,7 @@ Test suite for the channel handling.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import codecs
 import fnmatch

--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -130,15 +130,13 @@ class FutureUsageTestCase(unittest.TestCase):
         exceptions = [os.path.join("*", "obspy", i) for i in exceptions]
 
         future_import_line = (
-            "from __future__ import (absolute_import, division, "
-
+            "from __future__ import absolute_import, division, print_function")
         future_imports_pattern = re.compile(
-            r"^from __future__ import \(absolute_import,\s*"
+            r"^from __future__ import absolute_import,\s*"
+            r"division,\s*print_function$",
             flags=re.MULTILINE)
 
-        builtin_pattern = re.compile(
-            r"^from future\.builtins import \*  # NOQA",
-            flags=re.MULTILINE)
+        builtin_pattern = re.compile(r"^from future.*", flags=re.MULTILINE)
 
         failures = []
         for filename in get_all_py_files():
@@ -151,9 +149,8 @@ class FutureUsageTestCase(unittest.TestCase):
                 failures.append("File '%s' misses imports: %s" %
                                 (filename, future_import_line))
 
-            if re.search(builtin_pattern, content) is None:
-                failures.append("File '%s' misses imports: %s" %
-                                (filename, builtins_line))
+            if re.search(builtin_pattern, content):
+                failures.append("File '%s' has a future import." % filename)
         self.assertEqual(len(failures), 0, "\n" + "\n".join(failures))
 
 

--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -131,12 +131,9 @@ class FutureUsageTestCase(unittest.TestCase):
 
         future_import_line = (
             "from __future__ import (absolute_import, division, "
-            "print_function, unicode_literals)")
-        builtins_line = "from future.builtins import *  # NOQA"
 
         future_imports_pattern = re.compile(
             r"^from __future__ import \(absolute_import,\s*"
-            r"division,\s*print_function,\s*unicode_literals\)$",
             flags=re.MULTILINE)
 
         builtin_pattern = re.compile(

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import os

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -9,9 +9,7 @@ Test suite for the inventory class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -9,9 +9,7 @@ Test suite for the network class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/core/tests/test_preview.py
+++ b/obspy/core/tests/test_preview.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -9,9 +9,7 @@ Test suite for the response handling.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -9,9 +9,7 @@ Test suite for the station handling.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/core/tests/test_stats.py
+++ b/obspy/core/tests/test_stats.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import pickle

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import pickle

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import os

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import copy
 import datetime

--- a/obspy/core/tests/test_util_attribdict.py
+++ b/obspy/core/tests/test_util_attribdict.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import shutil

--- a/obspy/core/tests/test_util_decorator.py
+++ b/obspy/core/tests/test_util_decorator.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import platform

--- a/obspy/core/tests/test_util_types.py
+++ b/obspy/core/tests/test_util_types.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -8,10 +8,7 @@ Module for handling ObsPy Trace objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import math
@@ -220,10 +217,10 @@ def _add_processing_info(func, *args, **kwargs):
         function=func.__name__)
     arguments = []
     arguments += \
-        ["%s=%s" % (k, repr(v)) if not isinstance(v, native_str) else
+        ["%s=%s" % (k, repr(v)) if not isinstance(v, str) else
          "%s='%s'" % (k, v) for k, v in callargs.items()]
     arguments += \
-        ["%s=%s" % (k, repr(v)) if not isinstance(v, native_str) else
+        ["%s=%s" % (k, repr(v)) if not isinstance(v, str) else
          "%s='%s'" % (k, v) for k, v in kwargs_.items()]
     arguments.sort()
     info = info % "::".join(arguments)
@@ -1688,8 +1685,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     raise ValueError(msg)
                 large_w = window
             else:
-                large_w = np.fft.ifftshift(get_window(native_str(window),
-                                                      self.stats.npts))
+                large_w = np.fft.ifftshift(get_window(window, self.stats.npts))
             x_r *= large_w[:self.stats.npts // 2 + 1]
             x_i *= large_w[:self.stats.npts // 2 + 1]
 
@@ -2532,7 +2528,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if isinstance(inventories, Inventory) or \
            isinstance(inventories, Network):
             inventories = [inventories]
-        elif isinstance(inventories, (str, native_str)):
+        elif isinstance(inventories, str):
             inventories = [read_inventory(inventories)]
         responses = []
         for inv in inventories:

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -8,14 +8,13 @@ Module containing a UTC-based datetime class.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import datetime
 import math
 import time
+
+from .compatibility import string_types, unicode_type
 
 
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
@@ -265,8 +264,8 @@ class UTCDateTime(object):
                 dt = datetime.datetime(value.year, value.month, value.day)
                 self._from_datetime(dt)
                 return
-            elif isinstance(value, (bytes, str)):
-                if not isinstance(value, (str, native_str)):
+            elif isinstance(value, string_types):
+                if not isinstance(value, unicode_type):
                     value = value.decode()
                 # got a string instance
                 value = value.strip()
@@ -1333,7 +1332,7 @@ class UTCDateTime(object):
         >>> dt.isoformat()
         '2008-10-01T00:00:00'
         """
-        return self.datetime.isoformat(sep=native_str(sep))
+        return self.datetime.isoformat(sep=sep)
 
     def format_fissures(self):
         """

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -18,9 +18,7 @@ obspy.core.util - Various utilities for ObsPy
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # import order matters - NamedTemporaryFile must be one of the first!
 from obspy.core.util.attribdict import AttribDict

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -8,9 +8,7 @@ AttribDict class for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import collections
 import copy

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -8,11 +8,9 @@ Base utilities and constants for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
+import collections
 import doctest
 import inspect
 import io
@@ -20,7 +18,6 @@ import os
 import pkg_resources
 import sys
 import tempfile
-from collections import OrderedDict
 
 from pkg_resources import iter_entry_points, load_entry_point
 import numpy as np
@@ -148,9 +145,6 @@ def create_empty_data_chunk(delta, dtype, fill_value=None):
                  mask = ...,
                  ...)
     """
-    # For compatibility with NumPy 1.4
-    if isinstance(dtype, str):
-        dtype = native_str(dtype)
     if fill_value is None:
         temp = np.ma.masked_all(delta, dtype=np.dtype(dtype))
         # fill with nan if float number and otherwise with a very small number
@@ -198,8 +192,7 @@ def get_example_file(filename):
     """
     for module in ALL_MODULES:
         try:
-            mod = __import__("obspy.%s" % module,
-                             fromlist=[native_str("obspy")])
+            mod = __import__("obspy.%s" % module, fromlist=["obspy"])
         except ImportError:
             continue
         file_ = os.path.join(mod.__path__[0], "tests", "data", filename)
@@ -247,7 +240,7 @@ def _get_ordered_entry_points(group, subgroup=None, order_list=[]):
     ep_dict = _get_entry_points(group, subgroup)
     # loop through official supported waveform plug-ins and add them to
     # ordered dict of entry points
-    entry_points = OrderedDict()
+    entry_points = collections.OrderedDict()
     for name in order_list:
         try:
             entry_points[name] = ep_dict.pop(name)

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -8,10 +8,7 @@ Decorator used in ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
+from __future__ import absolute_import, division, print_function
 
 import functools
 import inspect
@@ -27,6 +24,7 @@ import zipfile
 import numpy as np
 from decorator import decorator
 
+from obspy.core.compatibility import PY2, string_types
 from obspy.core.util import get_example_file
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
@@ -145,7 +143,7 @@ def uncompress_file(func, filename, *args, **kwargs):
     """
     Decorator used for temporary uncompressing file if .gz or .bz2 archive.
     """
-    if not isinstance(filename, (str, native_str)):
+    if not isinstance(filename, string_types):
         return func(filename, *args, **kwargs)
     elif not os.path.exists(filename):
         msg = "File not found '%s'" % (filename)
@@ -263,7 +261,7 @@ def map_example_filename(arg_kwarg_name):
         prefix = '/path/to/'
         # check kwargs
         if arg_kwarg_name in kwargs:
-            if isinstance(kwargs[arg_kwarg_name], (str, native_str)):
+            if isinstance(kwargs[arg_kwarg_name], string_types):
                 if re.match(prefix, kwargs[arg_kwarg_name]):
                     try:
                         kwargs[arg_kwarg_name] = \
@@ -285,8 +283,7 @@ def map_example_filename(arg_kwarg_name):
             except ValueError:
                 pass
             else:
-                if ind < len(args) and isinstance(args[ind], (str,
-                                                              native_str)):
+                if ind < len(args) and isinstance(args[ind], string_types):
                     # need to check length of args from inspect
                     if re.match(prefix, args[ind]):
                         try:

--- a/obspy/core/util/deprecation_helpers.py
+++ b/obspy/core/util/deprecation_helpers.py
@@ -8,9 +8,7 @@ Library name handling for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 class ObsPyDeprecationWarning(UserWarning):

--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -8,8 +8,7 @@ Library name handling for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-# NO IMPORTS FROM OBSPY OR FUTURE IN THIS FILE! (file gets used at
-# installation time)
+# NO IMPORTS FROM OBSPY IN THIS FILE! (file gets used at installation time)
 import ctypes
 import os
 import platform

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -8,9 +8,7 @@ Various additional utilities for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import itertools

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -8,11 +8,9 @@ Various types used in ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
-from collections import OrderedDict
+import collections
 
 try:
     import __builtin__
@@ -81,7 +79,8 @@ class Enum(object):
     __isabstractmethod__ = False
 
     def __init__(self, enums, replace={}):
-        self.__enums = OrderedDict((str(e).lower(), e) for e in enums)
+        self.__enums = collections.OrderedDict((
+            str(e).lower(), e) for e in enums)
         self.__replace = replace
 
     def __call__(self, enum):

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -8,10 +8,7 @@ Testing utilities for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import difflib
 import doctest
@@ -60,15 +57,13 @@ def add_unittests(testsuite, module_name):
     >>> suite = unittest.TestSuite()
     >>> add_unittests(suite, "obspy.core")
     """
-    module_tests = __import__(module_name + ".tests",
-                              fromlist=[native_str("obspy")])
+    module_tests = __import__(module_name + ".tests", fromlist=["obspy"])
     filename_pattern = os.path.join(module_tests.__path__[0], "test_*.py")
     files = glob.glob(filename_pattern)
     names = (os.path.basename(file).split(".")[0] for file in files)
     module_names = (".".join([module_name, "tests", name]) for name in names)
     for _module_name in module_names:
-        _module = __import__(_module_name,
-                             fromlist=[native_str("obspy")])
+        _module = __import__(_module_name, fromlist=["obspy"])
         testsuite.addTest(_module.suite())
 
 
@@ -90,7 +85,7 @@ def add_doctests(testsuite, module_name):
     >>> suite = unittest.TestSuite()
     >>> add_doctests(suite, "obspy.core")
     """
-    module = __import__(module_name, fromlist=[native_str("obspy")])
+    module = __import__(module_name, fromlist=["obspy"])
     module_path = module.__path__[0]
     module_path_len = len(module_path)
 
@@ -116,8 +111,7 @@ def add_doctests(testsuite, module_name):
             parts = root[module_path_len:].split(os.sep)[1:]
             _module_name = ".".join([module_name] + parts + [file[:-3]])
             try:
-                _module = __import__(_module_name,
-                                     fromlist=[native_str("obspy")])
+                _module = __import__(_module_name, fromlist=["obspy"])
                 testsuite.addTest(doctest.DocTestSuite(_module))
             except ValueError:
                 pass
@@ -143,16 +137,14 @@ def write_png(arr, filename):
 
     def png_pack(png_tag, data):
         chunk_head = png_tag + data
-        return (struct.pack(native_str("!I"), len(data)) +
-                chunk_head +
-                struct.pack(native_str("!I"),
-                            0xFFFFFFFF & zlib.crc32(chunk_head)))
+        return (struct.pack("!I", len(data)) + chunk_head +
+                struct.pack("!I", 0xFFFFFFFF & zlib.crc32(chunk_head)))
 
     with open(filename, "wb") as fh:
         fh.write(b''.join([
             b'\x89PNG\r\n\x1a\n',
-            png_pack(b'IHDR', struct.pack(native_str("!2I5B"),
-                     width, height, 8, 6, 0, 0, 0)),
+            png_pack(b'IHDR',
+                     struct.pack("!2I5B", width, height, 8, 6, 0, 0, 0)),
             png_pack(b'IDAT', zlib.compress(raw_data, 9)),
             png_pack(b'IEND', b'')]))
 
@@ -195,8 +187,8 @@ def compare_images(expected, actual, tol):
         raise IOError('Baseline image %r does not exist.' % expected)
 
     # Open the images. Will be opened as RGBA as float32 ranging from 0 to 1.
-    expected_image = matplotlib.image.imread(native_str(expected))
-    actual_image = matplotlib.image.imread(native_str(actual))
+    expected_image = matplotlib.image.imread(expected)
+    actual_image = matplotlib.image.imread(actual)
     if expected_image.shape != actual_image.shape:
         raise ImageComparisonException(
             "The shape of the received image %s is not equal to the expected "
@@ -336,11 +328,10 @@ class ImageComparison(NamedTemporaryFile):
         import locale
 
         try:
-            locale.setlocale(locale.LC_ALL, native_str('en_US.UTF-8'))
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
         except Exception:
             try:
-                locale.setlocale(locale.LC_ALL,
-                                 native_str('English_United States.1252'))
+                locale.setlocale(locale.LC_ALL, 'English_United States.1252')
             except Exception:
                 msg = "Could not set locale to English/United States. " + \
                       "Some date-related tests may fail"

--- a/obspy/db/__init__.py
+++ b/obspy/db/__init__.py
@@ -11,6 +11,4 @@ file based waveform archive and storing in into a standard SQL database.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/db/client.py
+++ b/obspy/db/client.py
@@ -8,10 +8,7 @@ Client for a database created by obspy.db.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/obspy/db/client.py
+++ b/obspy/db/client.py
@@ -40,7 +40,7 @@ class Client(object):
         :param debug: Enables verbose output.
         """
         if url:
-            self.engine = create_engine(url, encoding=native_str('utf-8'),
+            self.engine = create_engine(url, encoding='utf-8',
                                         convert_unicode=True)
             Base.metadata.create_all(self.engine,  # @UndefinedVariable
                                      checkfirst=True)

--- a/obspy/db/db.py
+++ b/obspy/db/db.py
@@ -8,9 +8,7 @@ SQLAlchemy ORM definitions (database layout) for obspy.db.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import pickle
 

--- a/obspy/db/feature.py
+++ b/obspy/db/feature.py
@@ -8,9 +8,7 @@ Optional feature generators for ObsPy Trace objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy.core.util import score_at_percentile
 

--- a/obspy/db/indexer.py
+++ b/obspy/db/indexer.py
@@ -9,9 +9,7 @@ storing in into a standard SQL database.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import os

--- a/obspy/db/scripts/__init__.py
+++ b/obspy/db/scripts/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -24,10 +24,7 @@ A command-line program that indexes seismogram files into a database.
 
        ./obspy-indexer -v -i0.0 --run-once --check-duplicates -n1 -u$DB -d$DATA
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import logging
 import multiprocessing
@@ -144,7 +141,7 @@ def _run_indexer(options):
             p.daemon = True
             p.start()
         # connect to database
-        engine = create_engine(options.db_uri, encoding=native_str('utf-8'),
+        engine = create_engine(options.db_uri, encoding='utf-8',
                                convert_unicode=True)
         metadata = Base.metadata
         # recreate database

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -32,21 +32,22 @@ import select
 import sys
 from argparse import ArgumentParser
 
-if sys.version_info.major == 2:
-    import BaseHTTPServer as http_server
-else:
-    import http.server as http_server
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import sessionmaker
 
 from obspy import __version__
+from obspy.core import compatibility
 from obspy.db.db import Base
 from obspy.db.indexer import WaveformFileCrawler, worker
 from obspy.db.util import parse_mapping_data
 
+if compatibility.PY2:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+else:
+    from from http.server import BaseHTTPRequestHandler, HTTPServer
 
-class MyHandler(http_server.BaseHTTPRequestHandler):
+
+class MyHandler(compatibility.BaseHTTPRequestHandler):
     def do_GET(self):  # noqa
         """
         Respond to a GET request.
@@ -91,7 +92,7 @@ class MyHandler(http_server.BaseHTTPRequestHandler):
         self.wfile.write(out)
 
 
-class WaveformIndexer(http_server.HTTPServer, WaveformFileCrawler):
+class WaveformIndexer(compatibility.HTTPServer, WaveformFileCrawler):
     """
     A waveform indexer server.
     """

--- a/obspy/db/tests/__init__.py
+++ b/obspy/db/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/db/tests/test_client.py
+++ b/obspy/db/tests/test_client.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/db/tests/test_util.py
+++ b/obspy/db/tests/test_util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/db/util.py
+++ b/obspy/db/util.py
@@ -8,9 +8,7 @@ Additional utilities for obspy.db.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 

--- a/obspy/geodetics/__init__.py
+++ b/obspy/geodetics/__init__.py
@@ -9,9 +9,7 @@ obspy.geodetics - Various geodetic utilities for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .base import (calc_vincenty_inverse, degrees2kilometers, gps2dist_azimuth,
                    kilometer2degrees, kilometers2degrees, locations2degrees)

--- a/obspy/geodetics/base.py
+++ b/obspy/geodetics/base.py
@@ -8,9 +8,7 @@ Various geodetic utilities for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import warnings

--- a/obspy/geodetics/flinnengdahl.py
+++ b/obspy/geodetics/flinnengdahl.py
@@ -86,8 +86,7 @@ class FlinnEngdahl(object):
             self.fenums[quad] = fenums
 
         with open(self.numbers_file, 'rt') as csvfile:
-            fe_csv = csv.reader(csvfile, delimiter=native_str(';'),
-                                quotechar=native_str('#'),
+            fe_csv = csv.reader(csvfile, delimiter=';', quotechar='#',
                                 skipinitialspace=True)
             self.by_number = \
                 {int(row[0]): row[1] for row in fe_csv if len(row) > 1}

--- a/obspy/geodetics/flinnengdahl.py
+++ b/obspy/geodetics/flinnengdahl.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import csv
 import os

--- a/obspy/geodetics/tests/__init__.py
+++ b/obspy/geodetics/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/geodetics/tests/test_util_flinnengdahl.py
+++ b/obspy/geodetics/tests/test_util_flinnengdahl.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/geodetics/tests/test_util_geodetics.py
+++ b/obspy/geodetics/tests/test_util_geodetics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import unittest

--- a/obspy/imaging/__init__.py
+++ b/obspy/imaging/__init__.py
@@ -191,9 +191,7 @@ Common formats are png, svg, pdf or ps.
 >>> st = read()
 >>> st.plot(outfile='graph.png') #doctest: +SKIP
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # Please do not import any modules using matplotlib - otherwise it will disturb
 # the test suite (running without X11 or any other display)

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -25,9 +25,7 @@ Most source code provided here are adopted from
 .. _`Generic Mapping Tools (GMT)`: https://gmt.soest.hawaii.edu
 .. _`bb.m`: http://www.ceri.memphis.edu/people/olboyd/Software/Software.html
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import io
 import warnings

--- a/obspy/imaging/cm.py
+++ b/obspy/imaging/cm.py
@@ -199,9 +199,7 @@ Colormap defined and used in PQLX (see [McNamara2004]_).
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import glob
 import inspect

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -8,10 +8,7 @@ Module for basemap related plotting in ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import datetime
 import warnings

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -179,7 +179,7 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
     # present.
     if colorbar is None:
         if len(lons) > 1 and hasattr(color, "__len__") and \
-                not isinstance(color, (str, native_str)):
+                not isinstance(color, str):
             colorbar = True
         else:
             colorbar = False
@@ -234,7 +234,7 @@ def plot_basemap(lons, lats, size, color, labels=None, projection='global',
 
     if colorbar:
         if colorbar_ticklabel_format is not None:
-            if isinstance(colorbar_ticklabel_format, (str, native_str)):
+            if isinstance(colorbar_ticklabel_format, str):
                 formatter = FormatStrFormatter(colorbar_ticklabel_format)
             elif hasattr(colorbar_ticklabel_format, '__call__'):
                 formatter = FuncFormatter(colorbar_ticklabel_format)
@@ -554,7 +554,7 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
         show_colorbar = colorbar
     else:
         if len(lons) > 1 and hasattr(color, "__len__") and \
-                not isinstance(color, (str, native_str)):
+                not isinstance(color, str):
             show_colorbar = True
         else:
             show_colorbar = False
@@ -704,7 +704,7 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
     # Only show the colorbar for more than one event.
     if show_colorbar:
         if colorbar_ticklabel_format is not None:
-            if isinstance(colorbar_ticklabel_format, (str, native_str)):
+            if isinstance(colorbar_ticklabel_format, str):
                 formatter = FormatStrFormatter(colorbar_ticklabel_format)
             elif hasattr(colorbar_ticklabel_format, '__call__'):
                 formatter = FuncFormatter(colorbar_ticklabel_format)

--- a/obspy/imaging/mopad_wrapper.py
+++ b/obspy/imaging/mopad_wrapper.py
@@ -23,9 +23,7 @@ written by Lars Krieger and Sebastian Heimann.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import matplotlib.collections as mpl_collections

--- a/obspy/imaging/scripts/__init__.py
+++ b/obspy/imaging/scripts/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -67,9 +67,7 @@ USAGE: obspy-mopad [plot,decompose,gmt,convert] SOURCE_MECHANISM [OPTIONS]
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     02110-1301, USA.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import math

--- a/obspy/imaging/scripts/plot.py
+++ b/obspy/imaging/scripts/plot.py
@@ -3,9 +3,7 @@
 """
 Wiggle plot of the data in files
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from argparse import ArgumentParser
 

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -28,9 +28,7 @@ the format is autodetected.
 See also the example in the Tutorial section:
 https://tutorial.obspy.org
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -13,9 +13,7 @@ Functions to compute and plot radiation patterns
     (http://www.gnu.org/copyleft/lesser.html)
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D  # NOQA

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -16,9 +16,7 @@ Plotting spectrogram of seismograms.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import math as M
 

--- a/obspy/imaging/tests/__init__.py
+++ b/obspy/imaging/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/imaging/tests/test_backend.py
+++ b/obspy/imaging/tests/test_backend.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.backend test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/imaging/tests/test_beachball.py
+++ b/obspy/imaging/tests/test_beachball.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.beachball test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/tests/test_mopad.py
+++ b/obspy/imaging/tests/test_mopad.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.mopad test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -10,13 +10,9 @@ import sys
 import unittest
 from itertools import product
 
-if sys.version_info.major == 2:
-    from itertools import izip_longest as zip_longest
-else:
-    from itertools import zip_longest
-
 import numpy as np
 
+from obspy.core import compatibility
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 from obspy.imaging.scripts.mopad import main as obspy_mopad
@@ -191,9 +187,10 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         with open(expected, 'rt') as expf:
             bio = out.stdout.decode('utf-8')
             # expf.read().splitlines() differs to expf.readlines() ?!?!?!
-            for exp_line, out_line in zip_longest(expf.read().splitlines(),
-                                                  bio.splitlines(),
-                                                  fillvalue=''):
+            for exp_line, out_line in compatibility.zip_longest(
+                    expf.read().splitlines(),
+                    bio.splitlines(),
+                    fillvalue=''):
                 if exp_line.startswith('>') or out_line.startswith('>'):
                     self.assertEqual(exp_line, out_line,
                                      msg='Headers do not match!')

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -2,9 +2,7 @@
 """
 The obspy-mopad script test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/imaging/tests/test_plot.py
+++ b/obspy/imaging/tests/test_plot.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.scripts.plot / obspy-plot test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import shutil

--- a/obspy/imaging/tests/test_ppsd.py
+++ b/obspy/imaging/tests/test_ppsd.py
@@ -2,9 +2,7 @@
 """
 Image test(s) for obspy.signal.spectral_exstimation.PPSD.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.scripts.scan / obspy-scan test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import shutil

--- a/obspy/imaging/tests/test_source.py
+++ b/obspy/imaging/tests/test_source.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.source test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/tests/test_spectrogram.py
+++ b/obspy/imaging/tests/test_spectrogram.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.spectrogram test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -2,9 +2,7 @@
 """
 The obspy.imaging.waveform test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/imaging/util.py
+++ b/obspy/imaging/util.py
@@ -8,10 +8,7 @@ Waveform plotting utilities.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import re
 

--- a/obspy/imaging/util.py
+++ b/obspy/imaging/util.py
@@ -133,7 +133,7 @@ class ObsPyAutoDateFormatter(AutoDateFormatter):
                 fmt = self.scaled[k]
                 break
 
-        if isinstance(fmt, (str, native_str)):
+        if isinstance(fmt, str):
             self._formatter = DateFormatter(fmt, self._tz)
             return self._formatter(x, pos)
         elif hasattr(fmt, '__call__'):

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -16,10 +16,7 @@ Waveform plotting for obspy.Stream objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import warnings

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -169,7 +169,7 @@ class WaveformPlotting(object):
         if self.type == 'dayplot':
             self.color = kwargs.get('color', ('#B2000F', '#004C12', '#847200',
                                               '#0E01FF'))
-            if isinstance(self.color, (str, native_str)):
+            if isinstance(self.color, str):
                 self.color = (self.color,)
             self.number_of_ticks = kwargs.get('number_of_ticks', None)
         else:

--- a/obspy/io/__init__.py
+++ b/obspy/io/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/ah/__init__.py
+++ b/obspy/io/ah/__init__.py
@@ -12,9 +12,7 @@ introduced by the Lamont-Doherty Geological Observatory.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -15,9 +15,7 @@ a number of values followed by the time series data.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import xdrlib
 

--- a/obspy/io/ah/tests/__init__.py
+++ b/obspy/io/ah/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/ah/tests/test_core.py
+++ b/obspy/io/ah/tests/test_core.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/ascii/__init__.py
+++ b/obspy/io/ascii/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -31,9 +31,7 @@ Simple ASCII time series formats
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 

--- a/obspy/io/ascii/tests/__init__.py
+++ b/obspy/io/ascii/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/ascii/tests/test_ascii.py
+++ b/obspy/io/ascii/tests/test_ascii.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/cmtsolution/__init__.py
+++ b/obspy/io/cmtsolution/__init__.py
@@ -41,9 +41,7 @@ This module also offers write support for the CMTSOLUTION format.
 >>> cat.write("output/CMTSOLUTION")  # doctest: +SKIP
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/cmtsolution/core.py
+++ b/obspy/io/cmtsolution/core.py
@@ -9,9 +9,7 @@ CMTSOLUTION file format support for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import math
 import uuid

--- a/obspy/io/cmtsolution/tests/__init__.py
+++ b/obspy/io/cmtsolution/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/cmtsolution/tests/test_core.py
+++ b/obspy/io/cmtsolution/tests/test_core.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import io

--- a/obspy/io/cnv/__init__.py
+++ b/obspy/io/cnv/__init__.py
@@ -12,9 +12,7 @@ format as used by VELEST program.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/cnv/core.py
+++ b/obspy/io/cnv/core.py
@@ -8,9 +8,7 @@ CNV file format support for ObsPy
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 from bisect import bisect_right
 import warnings

--- a/obspy/io/cnv/tests/__init__.py
+++ b/obspy/io/cnv/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/cnv/tests/test_core.py
+++ b/obspy/io/cnv/tests/test_core.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/io/css/__init__.py
+++ b/obspy/io/css/__init__.py
@@ -11,9 +11,7 @@ This module provides read support for CSS waveform data.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/css/contrib/css28fix.py
+++ b/obspy/io/css/contrib/css28fix.py
@@ -9,9 +9,7 @@ Quick and dirty conversion routine from CSS 2.8 to Seismic Handler ASCII format
 - output written to stdout
 - shows plot for inspection (if matplotlib installed)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import struct
 import sys

--- a/obspy/io/css/contrib/css2asc.py
+++ b/obspy/io/css/contrib/css2asc.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import locale
 import os

--- a/obspy/io/css/core.py
+++ b/obspy/io/css/core.py
@@ -2,9 +2,7 @@
 """
 CSS bindings to ObsPy core module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/obspy/io/css/station.py
+++ b/obspy/io/css/station.py
@@ -8,10 +8,7 @@ CSS bindings to ObsPy station module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 

--- a/obspy/io/css/station.py
+++ b/obspy/io/css/station.py
@@ -65,7 +65,7 @@ def _write_css(inventory, basename):
             Stores free-form comments that embellish records of other
             relations.
     """
-    if not isinstance(basename, (str, native_str)):
+    if not isinstance(basename, str):
         raise TypeError('Writing an Inventory to a file-like object in CSS '
                         'format is unsupported.')
 

--- a/obspy/io/css/tests/__init__.py
+++ b/obspy/io/css/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/css/tests/test_core.py
+++ b/obspy/io/css/tests/test_core.py
@@ -3,9 +3,7 @@
 """
 The obspy.io.css.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os

--- a/obspy/io/css/tests/test_station.py
+++ b/obspy/io/css/tests/test_station.py
@@ -9,9 +9,7 @@ Test suite for the CSS station writer.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import inspect

--- a/obspy/io/gcf/tests/__init__.py
+++ b/obspy/io/gcf/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/gse2/__init__.py
+++ b/obspy/io/gse2/__init__.py
@@ -151,9 +151,7 @@ Data example::
 
     STOP
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/gse2/core.py
+++ b/obspy/io/gse2/core.py
@@ -2,9 +2,7 @@
 """
 GSE2/GSE1 bindings to ObsPy core module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/gse2/libgse1.py
+++ b/obspy/io/gse2/libgse1.py
@@ -16,9 +16,7 @@ Low-level module internally used for handling GSE1 files
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import doctest
 

--- a/obspy/io/gse2/libgse2.py
+++ b/obspy/io/gse2/libgse2.py
@@ -23,10 +23,7 @@ See: http://www.orfeus-eu.org/software/seismo_softwarelibrary.html#gse
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import doctest

--- a/obspy/io/gse2/libgse2.py
+++ b/obspy/io/gse2/libgse2.py
@@ -41,31 +41,31 @@ clibgse2 = _load_cdll("gse2")
 clibgse2.decomp_6b_buffer.argtypes = [
     C.c_int,
     np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags="C_CONTIGUOUS"),
     C.CFUNCTYPE(C.c_char_p, C.POINTER(C.c_char), C.c_void_p), C.c_void_p]
 clibgse2.decomp_6b_buffer.restype = C.c_int
 
 clibgse2.rem_2nd_diff.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags="C_CONTIGUOUS"),
     C.c_int]
 clibgse2.rem_2nd_diff.restype = C.c_int
 
 clibgse2.check_sum.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags="C_CONTIGUOUS"),
     C.c_int, C.c_int32]
 clibgse2.check_sum.restype = C.c_int  # do not know why not C.c_int32
 
 clibgse2.diff_2nd.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags="C_CONTIGUOUS"),
     C.c_int, C.c_int]
 clibgse2.diff_2nd.restype = C.c_void_p
 
 clibgse2.compress_6b_buffer.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags="C_CONTIGUOUS"),
     C.c_int,
     C.CFUNCTYPE(C.c_int, C.c_char)]
 clibgse2.compress_6b_buffer.restype = C.c_int
@@ -275,7 +275,7 @@ def compress_cm6(data):
     n = len(data)
     count = [0]  # closure, must be container
     # 4 character bytes per int32_t
-    carr = np.zeros(n * 4, dtype=native_str('c'))
+    carr = np.zeros(n * 4, dtype='c')
 
     def writer(char):
         carr[count[0]] = char
@@ -288,9 +288,9 @@ def compress_cm6(data):
         raise GSEUtiError(msg % ierr)
     cnt = count[0]
     if cnt < 80:
-        return carr[:cnt].view(native_str('|S%d' % cnt))
+        return carr[:cnt].view('|S%d' % cnt)
     else:
-        return carr[:(cnt // 80 + 1) * 80].view(native_str('|S80'))
+        return carr[:(cnt // 80 + 1) * 80].view('|S80')
 
 
 def verify_checksum(fh, data, version=2):

--- a/obspy/io/gse2/paz.py
+++ b/obspy/io/gse2/paz.py
@@ -55,7 +55,7 @@ def read_paz(paz_file):
     poles = []
     zeros = []
 
-    if isinstance(paz_file, (str, native_str)):
+    if isinstance(paz_file, str):
         with open(paz_file, 'rt') as fh:
             paz = fh.readlines()
     else:

--- a/obspy/io/gse2/paz.py
+++ b/obspy/io/gse2/paz.py
@@ -19,10 +19,7 @@ The read in PAZ information can be used with
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import doctest
 

--- a/obspy/io/gse2/tests/__init__.py
+++ b/obspy/io/gse2/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/gse2/tests/test_core.py
+++ b/obspy/io/gse2/tests/test_core.py
@@ -3,9 +3,7 @@
 """
 The gse2.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import os

--- a/obspy/io/gse2/tests/test_libgse1.py
+++ b/obspy/io/gse2/tests/test_libgse1.py
@@ -3,9 +3,7 @@
 """
 The libgse1 test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -3,9 +3,7 @@
 """
 The libgse2 test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/gse2/tests/test_paz.py
+++ b/obspy/io/gse2/tests/test_paz.py
@@ -3,9 +3,7 @@
 """
 The paz test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import unittest

--- a/obspy/io/json/__init__.py
+++ b/obspy/io/json/__init__.py
@@ -13,9 +13,7 @@ A write function for files and a utility for compact string serialization using
 the Default class are located in :mod:`obspy.io.json.core`.
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .default import Default
 from .core import get_dump_kwargs, _write_json

--- a/obspy/io/json/core.py
+++ b/obspy/io/json/core.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import json
 

--- a/obspy/io/json/default.py
+++ b/obspy/io/json/default.py
@@ -18,9 +18,7 @@ Example
 >>> s = json.dumps(c, default=d)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 from obspy.core.event import Catalog, ResourceIdentifier

--- a/obspy/io/json/tests/__init__.py
+++ b/obspy/io/json/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/json/tests/test_json.py
+++ b/obspy/io/json/tests/test_json.py
@@ -26,7 +26,7 @@ class JSONTestCase(unittest.TestCase):
 
     def verify_json(self, s):
         """Test an output is a string and is JSON"""
-        self.assertTrue(isinstance(s, (str, native_str)))
+        self.assertTrue(isinstance(s, str):
         j = json.loads(s)
         self.assertTrue(isinstance(j, dict))
 

--- a/obspy/io/json/tests/test_json.py
+++ b/obspy/io/json/tests/test_json.py
@@ -26,7 +26,7 @@ class JSONTestCase(unittest.TestCase):
 
     def verify_json(self, s):
         """Test an output is a string and is JSON"""
-        self.assertTrue(isinstance(s, str):
+        self.assertTrue(isinstance(s, str))
         j = json.loads(s)
         self.assertTrue(isinstance(j, dict))
 

--- a/obspy/io/json/tests/test_json.py
+++ b/obspy/io/json/tests/test_json.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import json

--- a/obspy/io/kinemetrics/__init__.py
+++ b/obspy/io/kinemetrics/__init__.py
@@ -107,9 +107,7 @@ Not implemented
 
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/kinemetrics/core.py
+++ b/obspy/io/kinemetrics/core.py
@@ -8,9 +8,7 @@ Evt (Kinemetrics files) bindings to ObsPy's core classes.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from . import evt
 from .evt_base import EvtBaseError

--- a/obspy/io/kinemetrics/evt.py
+++ b/obspy/io/kinemetrics/evt.py
@@ -8,9 +8,7 @@ Evt (Kinemetrics) format support for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from struct import unpack
 

--- a/obspy/io/kinemetrics/evt_base.py
+++ b/obspy/io/kinemetrics/evt_base.py
@@ -9,9 +9,7 @@ Base classes (cannot be directly called)
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 

--- a/obspy/io/kinemetrics/tests/__init__.py
+++ b/obspy/io/kinemetrics/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -3,9 +3,7 @@
 """
 The obspy.io.kinemetrics.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/kml/__init__.py
+++ b/obspy/io/kml/__init__.py
@@ -25,6 +25,4 @@ For details on further parameters see
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/kml/core.py
+++ b/obspy/io/kml/core.py
@@ -8,9 +8,7 @@ Keyhole Markup Language (KML) output support in ObsPy
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from math import log
 

--- a/obspy/io/kml/tests/__init__.py
+++ b/obspy/io/kml/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/kml/tests/test_kml.py
+++ b/obspy/io/kml/tests/test_kml.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/kml/tests/test_kml.py
+++ b/obspy/io/kml/tests/test_kml.py
@@ -24,7 +24,7 @@ class KMLTestCase(unittest.TestCase):
         # write the example inventory to KML and read it into a string
         inv = read_inventory()
         with NamedTemporaryFile(suffix=".kml") as tf:
-            inv.write(native_str(tf.name), format="KML")
+            inv.write(tf.name, format="KML")
             with open(tf.name, "rb") as fh:
                 got = fh.read()
         # read expected result into string
@@ -41,7 +41,7 @@ class KMLTestCase(unittest.TestCase):
         # write the example catalog to KML and read it into a string
         cat = read_events()
         with NamedTemporaryFile(suffix=".kml") as tf:
-            cat.write(native_str(tf.name), format="KML")
+            cat.write(tf.name, format="KML")
             with open(tf.name, "rb") as fh:
                 got = fh.read()
         # read expected result into string

--- a/obspy/io/mseed/__init__.py
+++ b/obspy/io/mseed/__init__.py
@@ -141,9 +141,7 @@ some purposes. Refer to the documentation of each for details.
 | :func:`~obspy.io.mseed.util.set_flags_in_fixed_headers`  | Updates a given miniSEED file with some fixed header flags.              |
 +----------------------------------------------------------+--------------------------------------------------------------------------+
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import ObsPyException, ObsPyReadingError
 

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -2,10 +2,7 @@
 """
 Defines the libmseed structures and blockettes.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import warnings
@@ -55,7 +52,7 @@ VALID_RECORD_LENGTHS = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
 
 # allowed encodings:
 # id: (name, sampletype a/i/f/d, default NumPy type, write support)
-ENCODINGS = {0: ("ASCII", "a", np.dtype(native_str("|S1")).type, True),
+ENCODINGS = {0: ("ASCII", "a", np.dtype("|S1").type, True),
              1: ("INT16", "i", np.dtype(np.int16), True),
              3: ("INT32", "i", np.dtype(np.int32), True),
              4: ("FLOAT32", "f", np.dtype(np.float32), True),
@@ -117,7 +114,7 @@ SAMPLETYPE = {"|S1": "a",
               "int32": "i",
               "float32": "f",
               "float64": "d",
-              np.dtype(native_str("|S1")).type: "a",
+              np.dtype("|S1").type: "a",
               np.dtype(np.int16).type: "i",
               np.dtype(np.int32).type: "i",
               np.dtype(np.float32).type: "f",
@@ -706,9 +703,8 @@ __clibmseed.msr_parse.restype = C.c_int
 
 
 # Set the necessary arg- and restypes.
-__clibmseed.readMSEEDBuffer.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.int8, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+_clibmseed.readMSEEDBuffer.argtypes = [
+    np.ctypeslib.ndpointer(dtype=np.int8, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int,
     C.POINTER(Selections),
     C.c_int8,

--- a/obspy/io/mseed/msstruct.py
+++ b/obspy/io/mseed/msstruct.py
@@ -2,9 +2,7 @@
 """
 Convenience class for handling MSRecord and MSFileparam.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import os

--- a/obspy/io/mseed/scripts/__init__.py
+++ b/obspy/io/mseed/scripts/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/mseed/scripts/recordanalyzer.py
+++ b/obspy/io/mseed/scripts/recordanalyzer.py
@@ -18,10 +18,7 @@ A command-line tool to analyze Mini-SEED records.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import sys
 from argparse import ArgumentParser
@@ -141,7 +138,7 @@ class RecordAnalyser(object):
         # Get the year
         year_raw = self.file.read(2)
         try:
-            year = unpack(native_str('>H'), year_raw)[0]
+            year = unpack('>H', year_raw)[0]
         except:
             if len(year_raw) == 0:
                 msg = "Unexpected end of file."
@@ -165,7 +162,7 @@ class RecordAnalyser(object):
         # Read and unpack.
         self.file.seek(self.record_offset, 0)
         fixed_header = self.file.read(48)
-        encoding = native_str('%s20c2H3Bx4H4Bl2H' % self.endian)
+        encoding = '%s20c2H3Bx4H4Bl2H' % self.endian
         try:
             header_item = unpack(encoding, fixed_header)
         except:
@@ -221,7 +218,7 @@ class RecordAnalyser(object):
             self.file.seek(self.record_offset + cur_blkt_offset, 0)
             # Unpack the first two values. This is always the blockette type
             # and the beginning of the next blockette.
-            encoding = native_str('%s2H' % self.endian)
+            encoding = '%s2H' % self.endian
             _tmp = self.file.read(4)
             try:
                 blkt_type, next_blockette = unpack(encoding, _tmp)
@@ -249,7 +246,7 @@ class RecordAnalyser(object):
         if blkt_type == 100:
             _tmp = self.file.read(8)
             try:
-                unpack_values = unpack(native_str('%sfxxxx' % self.endian),
+                unpack_values = unpack('%sfxxxx' % self.endian,
                                        _tmp)
             except:
                 if len(_tmp) == 0:
@@ -260,7 +257,7 @@ class RecordAnalyser(object):
         elif blkt_type == 1000:
             _tmp = self.file.read(4)
             try:
-                unpack_values = unpack(native_str('%sBBBx' % self.endian),
+                unpack_values = unpack('%sBBBx' % self.endian,
                                        _tmp)
             except:
                 if len(_tmp) == 0:
@@ -273,7 +270,7 @@ class RecordAnalyser(object):
         elif blkt_type == 1001:
             _tmp = self.file.read(4)
             try:
-                unpack_values = unpack(native_str('%sbbxb' % self.endian),
+                unpack_values = unpack('%sbbxb' % self.endian,
                                        _tmp)
             except:
                 if len(_tmp) == 0:

--- a/obspy/io/mseed/tests/__init__.py
+++ b/obspy/io/mseed/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import glob
@@ -131,7 +128,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
                     this_stream = copy.deepcopy(stream)
                     this_stream[0].data = \
                         np.require(this_stream[0].data,
-                                   dtype=native_str(encoding_values[encoding]))
+                                   dtype=encoding_values[encoding])
                     with NamedTemporaryFile() as tf:
                         temp_file = tf.name
                         _write_mseed(this_stream, temp_file, encoding=encoding,
@@ -665,7 +662,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         # Special handling for ASCII encoded files.
         for value in ENCODINGS.values():
             if value[0] == 'ASCII':
-                np_encodings[value[0]] = np.dtype(native_str("|S1"))
+                np_encodings[value[0]] = np.dtype("|S1")
             else:
                 np_encodings[value[0]] = value[2]
         st = Stream([Trace(data=data)])
@@ -747,7 +744,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         for byteorder, btype in byteorders.items():
             for encoding, dtype in encodings.items():
                 # Convert data to floats and write them again
-                st[0].data = data_copy.astype(native_str(dtype))
+                st[0].data = data_copy.astype(dtype)
                 with NamedTemporaryFile() as tf:
                     tempfile = tf.name
                     st.write(tempfile, format="MSEED", encoding=encoding,
@@ -757,7 +754,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
                     with open(tempfile, "rb") as fp:
                         s = fp.read()
                     data = np.fromstring(s[56:256],
-                                         dtype=native_str(btype + dtype))
+                                         dtype=btype + dtype)
                     np.testing.assert_array_equal(data, st[0].data[:len(data)])
                     # Read the binary chunk of data with ObsPy
                     st2 = read(tempfile)
@@ -768,7 +765,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         Tests writing small ASCII strings.
         """
         st = Stream()
-        st.append(Trace(data=np.fromstring("A" * 8, native_str("|S1"))))
+        st.append(Trace(data=np.fromstring("A" * 8, "|S1")))
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             st.write(tempfile, format="MSEED")
@@ -783,7 +780,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
             data = np.random.randint(-1000, 1000, 500)
             for dtype in ["i2", "i4", "f4", "f8", "S1"]:
                 for enc in ["<", ">", "="]:
-                    typed_data = data.astype(np.dtype(native_str(enc + dtype)))
+                    typed_data = data.astype(np.dtype(enc + dtype))
                     st1.append(Trace(data=typed_data))
             # this will raise a UserWarning - ignoring for test
             with warnings.catch_warnings(record=True):
@@ -798,7 +795,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
                                          str(tr.dtype.itemsize),
                                          dtype)
                         # byte order is always native (=)
-                        typed_data = data.astype(native_str("=" + dtype))
+                        typed_data = data.astype("=" + dtype)
                         np.testing.assert_array_equal(tr, typed_data)
 
     def test_enforce_steim2_with_steim1_as_encoding(self):
@@ -828,15 +825,15 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         def_content = np.arange(1, 51, dtype=np.int32)
         files = {
             os.path.join(path, "smallASCII.mseed"):
-            (native_str('|S1'), 'a', 0,
-             np.fromstring('ABCDEFGH', dtype=native_str('|S1'))),
+            ('|S1', 'a', 0,
+             np.fromstring('ABCDEFGH', dtype='|S1')),
             # Tests all ASCII letters.
             os.path.join(path, "fullASCII.mseed"):
-            (native_str('|S1'), 'a', 0, np.fromstring(
+            ('|S1', 'a', 0, np.fromstring(
                 """ !"#$%&'()*+,-./""" +
                 """0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`""" +
                 """abcdefghijklmnopqrstuvwxyz{|}~""",
-                dtype=native_str('|S1'))),
+                dtype='|S1')),
             # Note: int16 array will also be returned as int32.
             os.path.join(path, "int16_INT16.mseed"):
             (np.int32, 'i', 1, def_content.astype(np.int16)),
@@ -1039,7 +1036,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
             # default dtype of numpy.string_ from "|S1" to "|S32". Enforce
             # "|S1|" here to be consistent across NumPy versions.
             if encoding == 0:
-                seed_dtype = native_str("|S1")
+                seed_dtype = "|S1"
             with NamedTemporaryFile() as tf:
                 tempfile = tf.name
                 # Write it once with the encoding key and once with the value.
@@ -1100,8 +1097,8 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         """
         filename = os.path.join(self.path, 'data', 'timingquality.mseed')
         st = read(filename, details=True)
-        dt = np.dtype([(native_str('npts'), native_str('i4')),
-                       (native_str('qual'), native_str('i4'))])
+        dt = np.dtype([('npts', 'i4'),
+                       ('qual', 'i4')])
         res = np.array([(tr.stats.npts, tr.stats.mseed.blkt1001.timing_quality)
                         for tr in st], dtype=dt)
         one_big_st = read(filename)  # do not read timing quality info
@@ -1276,17 +1273,17 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
             for recnum in range(0, 3):
                 rec_start = 512 * recnum
                 tf.seek(rec_start + 46, os.SEEK_SET)
-                next_blockette = unpack(native_str(">H"), tf.read(2))[0]
+                next_blockette = unpack(">H", tf.read(2))[0]
                 while next_blockette != 0:
                     tf.seek(rec_start + next_blockette, os.SEEK_SET)
-                    blkt_nbr = unpack(native_str(">H"), tf.read(2))[0]
+                    blkt_nbr = unpack(">H", tf.read(2))[0]
                     if blkt_nbr == 1001:
                         tf.seek(2, os.SEEK_CUR)
-                        timing_qual = unpack(native_str("B"), tf.read(1))[0]
+                        timing_qual = unpack("B", tf.read(1))[0]
                         self.assertEqual(timing_qual, 63, "timing_qual")
                         break
                     else:
-                        next_blockette = unpack(native_str(">H"),
+                        next_blockette = unpack(">H",
                                                 tf.read(2))[0]
 
         # Test invalid data: string

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import io
@@ -187,7 +184,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             # read temp file directly without libmseed
             with open(tempfile, 'rb') as fp:
                 fp.seek(56)
-                dtype = np.dtype(native_str('>f4'))
+                dtype = np.dtype('>f4')
                 bin_data = from_buffer(fp.read(7 * dtype.itemsize),
                                        dtype=dtype)
             np.testing.assert_array_equal(data, bin_data)
@@ -409,7 +406,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             # 5 - transform to ASCII values
             st = read()
             for tr in st:
-                tr.data = tr.data.astype(native_str('|S1'))
+                tr.data = tr.data.astype('|S1')
             # write a single trace automatically detecting encoding
             st[0].write(tempfile, format="MSEED")
             # write a single trace automatically detecting encoding

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import io
@@ -863,7 +860,7 @@ class MSEEDUtilTestCase(unittest.TestCase):
                 read_bytes = util._search_flag_in_blockette(
                     file_desc, 48, 1001, 4, 1)
                 self.assertFalse(read_bytes is None)
-                self.assertEqual(unpack(native_str(">B"), read_bytes)[0], 63)
+                self.assertEqual(unpack(">B", read_bytes)[0], 63)
 
                 # Test from middle of a record header
                 file_desc.seek(14, os.SEEK_CUR)
@@ -871,7 +868,7 @@ class MSEEDUtilTestCase(unittest.TestCase):
                 read_bytes = util._search_flag_in_blockette(
                     file_desc, 34, 1000, 6, 1)
                 self.assertFalse(read_bytes is None)
-                self.assertEqual(unpack(native_str(">B"), read_bytes)[0], 9)
+                self.assertEqual(unpack(">B", read_bytes)[0], 9)
                 # Check that file_desc position has not changed
                 self.assertEqual(file_desc.tell(), file_pos)
 
@@ -880,14 +877,14 @@ class MSEEDUtilTestCase(unittest.TestCase):
                 read_bytes = util._search_flag_in_blockette(
                     file_desc, -26, 1001, 5, 1)
                 self.assertFalse(read_bytes is None)
-                self.assertEqual(unpack(native_str(">B"), read_bytes)[0], 42)
+                self.assertEqual(unpack(">B", read_bytes)[0], 42)
 
                 # Test another record. There is at least 3 records in a
                 # mseed with 2000 data points and 512 bytes record length
                 file_desc.seek(1040, os.SEEK_SET)
                 read_bytes = util._search_flag_in_blockette(file_desc,
                                                             32, 1001, 4, 1)
-                self.assertEqual(unpack(native_str(">B"), read_bytes)[0], 63)
+                self.assertEqual(unpack(">B", read_bytes)[0], 63)
 
                 # Test missing blockette
                 read_bytes = util._search_flag_in_blockette(file_desc,
@@ -1002,9 +999,9 @@ class MSEEDUtilTestCase(unittest.TestCase):
                                  'glitches_detected': True,
                                  'time_tag_questionable': True}}
 
-            expected_classic = pack(native_str('BBB'), 0x15, 0x28, 0x88)
-            expected_leap_mod = pack(native_str('BBB'), 0x05, 0x28, 0x88)
-            expected_glitch_mod = pack(native_str('BBB'), 0x15, 0x28, 0x88)
+            expected_classic = pack('BBB', 0x15, 0x28, 0x88)
+            expected_leap_mod = pack('BBB', 0x05, 0x28, 0x88)
+            expected_glitch_mod = pack('BBB', 0x15, 0x28, 0x88)
 
             # Test update all traces
             all_traces = {'...': copy.deepcopy(classic_flags)}
@@ -1091,10 +1088,10 @@ class MSEEDUtilTestCase(unittest.TestCase):
                                   datetime(2012, 8, 1, 12, 13, 20, 0)]},
                 'negative_leap': False}}
 
-            expected_first = pack(native_str('BBB'), 0x11, 0x00, 0x00)
-            expected_second = pack(native_str('BBB'), 0x10, 0x00, 0x00)
-            expected_fourth = pack(native_str('BBB'), 0x14, 0x00, 0x00)
-            expected_afterfourth = pack(native_str('BBB'), 0x00, 0x00, 0x00)
+            expected_first = pack('BBB', 0x11, 0x00, 0x00)
+            expected_second = pack('BBB', 0x10, 0x00, 0x00)
+            expected_fourth = pack('BBB', 0x14, 0x00, 0x00)
+            expected_afterfourth = pack('BBB', 0x00, 0x00, 0x00)
             # Test update all traces
             dated_traces = {'NE.STATI.LO.CHA': copy.deepcopy(dated_flags)}
             set_flags_in_fixed_headers(file_name, dated_traces)

--- a/obspy/io/mseed/tests/test_recordanalyzer.py
+++ b/obspy/io/mseed/tests/test_recordanalyzer.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/ndk/__init__.py
+++ b/obspy/io/ndk/__init__.py
@@ -106,9 +106,7 @@ To see all events call 'print(CatalogObject.__str__(print_all=True))'
 .. figure:: /_images/expensive_plots/GCMT_Catalog_1976-2010.png
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -11,9 +11,7 @@ The format is an ASCII format but will internally handled by unicode routines.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import math
 import re

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -20,12 +20,8 @@ import traceback
 import uuid
 import warnings
 
-if sys.version_info.major == 2:
-    from itertools import izip_longest as zip_longest
-else:
-    from itertools import zip_longest
-
 from obspy import UTCDateTime
+from obspy.core import compatibility
 from obspy.core.event import (Axis, Catalog, Comment, CreationInfo, DataUsed,
                               Event, EventDescription, FocalMechanism,
                               Magnitude, MomentTensor, NodalPlane, NodalPlanes,
@@ -183,7 +179,7 @@ def _read_ndk(filename, *args, **kwargs):  # @UnusedVariable
     cat = Catalog(resource_id=_get_resource_id("catalog", str(uuid.uuid4())))
 
     # Loop over 5 lines at once.
-    for _i, lines in enumerate(zip_longest(*[lines_iter()] * 5)):
+    for _i, lines in enumerate(compatibility.zip_longest(*[lines_iter()] * 5)):
         if None in lines:
             msg = "Skipped last %i lines. Not a multiple of 5 lines." % (
                 lines.count(None))

--- a/obspy/io/ndk/tests/__init__.py
+++ b/obspy/io/ndk/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/ndk/tests/test_ndk.py
+++ b/obspy/io/ndk/tests/test_ndk.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import io

--- a/obspy/io/nied/__init__.py
+++ b/obspy/io/nied/__init__.py
@@ -146,9 +146,7 @@ The meaning of the entries in the 'knet' dictionary is as follows:
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/nied/fnetmt.py
+++ b/obspy/io/nied/fnetmt.py
@@ -8,9 +8,7 @@ F-net moment tensor file format support for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import re
 import uuid

--- a/obspy/io/nied/knet.py
+++ b/obspy/io/nied/knet.py
@@ -3,9 +3,7 @@
 Reading of the K-NET and KiK-net ASCII format as defined on
 http://www.kyoshin.bosai.go.jp.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import re
 

--- a/obspy/io/nied/tests/__init__.py
+++ b/obspy/io/nied/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/nied/tests/test_fnetmt_reading.py
+++ b/obspy/io/nied/tests/test_fnetmt_reading.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import io

--- a/obspy/io/nied/tests/test_knet_reading.py
+++ b/obspy/io/nied/tests/test_knet_reading.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import io

--- a/obspy/io/nied/util.py
+++ b/obspy/io/nied/util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 def gen_sc3_id(dt, numenc=6, sym="abcdefghijklmnopqrstuvwxyz"):

--- a/obspy/io/nlloc/__init__.py
+++ b/obspy/io/nlloc/__init__.py
@@ -116,9 +116,7 @@ Origin
           comments: 1 Elements
           arrivals: 8 Elements
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -9,9 +9,7 @@ NonLinLoc file format support for ObsPy
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import warnings
 from math import sqrt

--- a/obspy/io/nlloc/tests/__init__.py
+++ b/obspy/io/nlloc/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/io/nlloc/tests/test_util.py
+++ b/obspy/io/nlloc/tests/test_util.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/io/nlloc/util.py
+++ b/obspy/io/nlloc/util.py
@@ -41,10 +41,10 @@ def read_nlloc_scatter(filename, coordinate_converter=None):
     """
     # omit the first 4 values (header information) and reshape
     dtype = np.dtype([
-        (native_str("x"), native_str("<f4")),
-        (native_str("y"), native_str("<f4")),
-        (native_str("z"), native_str("<f4")),
-        (native_str("pdf"), native_str("<f4"))])
+        ("x", "<f4"),
+        ("y", "<f4"),
+        ("z", "<f4"),
+        ("pdf", "<f4")])
     data = np.fromfile(filename, dtype=dtype)[4:]
     if coordinate_converter:
         data["x"], data["y"], data["z"] = coordinate_converter(

--- a/obspy/io/nlloc/util.py
+++ b/obspy/io/nlloc/util.py
@@ -9,10 +9,7 @@ NonLinLoc file format support for ObsPy
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/pdas/__init__.py
+++ b/obspy/io/pdas/__init__.py
@@ -13,9 +13,7 @@ file format.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 from .core import _is_pdas, _read_pdas
 

--- a/obspy/io/pdas/core.py
+++ b/obspy/io/pdas/core.py
@@ -8,9 +8,7 @@ PDAS bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/pdas/tests/__init__.py
+++ b/obspy/io/pdas/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/pdas/tests/test_core.py
+++ b/obspy/io/pdas/tests/test_core.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/pde/__init__.py
+++ b/obspy/io/pde/__init__.py
@@ -17,9 +17,7 @@ format is supported.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/pde/mchedr.py
+++ b/obspy/io/pde/mchedr.py
@@ -12,10 +12,7 @@ Only supports file format revision of February 24, 2004.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from datetime import timedelta
 import io

--- a/obspy/io/pde/mchedr.py
+++ b/obspy/io/pde/mchedr.py
@@ -53,7 +53,7 @@ def _is_mchedr(filename):
     >>> _is_mchedr('/path/to/mchedr.dat')  # doctest: +SKIP
     True
     """
-    if not isinstance(filename, (str, native_str)):
+    if not isinstance(filename, str):
         return False
     with open(filename, 'rb') as fh:
         for line in fh.readlines():
@@ -83,7 +83,7 @@ class Unpickler(object):
         :rtype: :class:`~obspy.core.event.Catalog`
         :returns: ObsPy Catalog object.
         """
-        if not isinstance(filename, (str, native_str)):
+        if not isinstance(filename, str):
             raise TypeError('File name must be a string.')
         self.filename = filename
         self.fh = open(filename, 'rb')

--- a/obspy/io/pde/tests/__init__.py
+++ b/obspy/io/pde/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/pde/tests/test_mchedr.py
+++ b/obspy/io/pde/tests/test_mchedr.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/quakeml/__init__.py
+++ b/obspy/io/quakeml/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -20,9 +20,7 @@ by a distributed team in a transparent collaborative manner.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import io

--- a/obspy/io/quakeml/tests/__init__.py
+++ b/obspy/io/quakeml/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import io
 import math

--- a/obspy/io/sac/__init__.py
+++ b/obspy/io/sac/__init__.py
@@ -71,9 +71,7 @@ endianness of the resulting SAC-file. It must be either ``0`` or ``'<'``
 for LSBF or little-endian, ``1`` or ``'>'`` for MSBF or big-endian.
 Defaults to little endian.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .sacpz import attach_paz, attach_resp
 from .util import SacError, SacIOError

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -13,10 +13,7 @@ checking, except for byteorder and header/data array length.  File- and array-
 based checking routines are provided for additional checks where desired.
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.utils import native_str
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -48,12 +48,12 @@ def init_header_arrays(arrays=('float', 'int', 'str'), byteorder='='):
     for itype in arrays:
         if itype == 'float':
             # null float header array
-            hf = np.empty(70, dtype=native_str(byteorder + 'f4'))
+            hf = np.empty(70, dtype=byteorder + 'f4')
             hf.fill(HD.FNULL)
             out.append(hf)
         elif itype == 'int':
             # null integer header array
-            hi = np.empty(40, dtype=native_str(byteorder + 'i4'))
+            hi = np.empty(40, dtype=byteorder + 'i4')
             hi.fill(HD.INULL)
             # set logicals to 0, not -1234whatever
             for i, hdr in enumerate(HD.INTHDRS):
@@ -66,7 +66,7 @@ def init_header_arrays(arrays=('float', 'int', 'str'), byteorder='='):
             out.append(hi)
         elif itype == 'str':
             # null string header array
-            hs = np.empty(24, dtype=native_str('|S8'))
+            hs = np.empty(24, dtype='|S8')
             hs.fill(HD.SNULL)
             out.append(hs)
         else:
@@ -129,9 +129,9 @@ def read_sac(source, headonly=False, byteorder=None, checksize=False):
     #    in strings. Store them in array (and convert the char to a
     #    list). That's a total of 632 bytes.
     # --------------------------------------------------------------
-    hf = from_buffer(f.read(4 * 70), dtype=native_str(endian_str + 'f4'))
-    hi = from_buffer(f.read(4 * 40), dtype=native_str(endian_str + 'i4'))
-    hs = from_buffer(f.read(24 * 8), dtype=native_str('|S8'))
+    hf = from_buffer(f.read(4 * 70), dtype=endian_str + 'f4')
+    hi = from_buffer(f.read(4 * 40), dtype=endian_str + 'i4')
+    hs = from_buffer(f.read(24 * 8), dtype='|S8')
 
     if not is_valid_byteorder(hi):
         if is_byteorder_specified:
@@ -176,7 +176,7 @@ def read_sac(source, headonly=False, byteorder=None, checksize=False):
         data = None
     else:
         data = from_buffer(f.read(int(npts) * 4),
-                           dtype=native_str(endian_str + 'f4'))
+                           dtype=endian_str + 'f4')
 
         if len(data) != npts:
             f.close()
@@ -232,10 +232,10 @@ def read_sac_ascii(source, headonly=False):
     # read in the float values
     # TODO: use native '=' dtype byteorder instead of forcing little endian?
     hf = np.array([i.split() for i in contents[:14]],
-                  dtype=native_str('<f4')).ravel()
+                  dtype='<f4').ravel()
     # read in the int values
     hi = np.array([i.split() for i in contents[14: 14 + 8]],
-                  dtype=native_str('<i4')).ravel()
+                  dtype='<i4').ravel()
     # reading in the string part is a bit more complicated
     # because every string field has to be 8 characters long
     # apart from the second field which is 16 characters long
@@ -243,7 +243,7 @@ def read_sac_ascii(source, headonly=False):
     hs, = init_header_arrays(arrays=('str',))
     for i, j in enumerate(range(0, 24, 3)):
         line = contents[14 + 8 + i]
-        hs[j:j + 3] = np.fromstring(line, dtype=native_str('|S8'), count=3)
+        hs[j:j + 3] = np.fromstring(line, dtype='|S8', count=3)
     # --------------------------------------------------------------
     # read in the seismogram points
     # --------------------------------------------------------------
@@ -251,7 +251,7 @@ def read_sac_ascii(source, headonly=False):
         data = None
     else:
         data = np.array([i.split() for i in contents[30:]],
-                        dtype=native_str('<f4')).ravel()
+                        dtype='<f4').ravel()
 
         npts = hi[HD.INTHDRS.index('npts')]
         if len(data) != npts:
@@ -307,10 +307,10 @@ def write_sac(dest, hf, hi, hs, data=None, byteorder=None):
         else:
             raise ValueError("Unrecognized byteorder. Use {'little', 'big'}")
 
-        hf = hf.astype(native_str(endian_str + 'f4'))
-        hi = hi.astype(native_str(endian_str + 'i4'))
+        hf = hf.astype(endian_str + 'f4')
+        hi = hi.astype(endian_str + 'i4')
         if data is not None:
-            data = data.astype(native_str(endian_str + 'f4'))
+            data = data.astype(endian_str + 'f4')
 
     # TODO: make sure all arrays have same byte order
 
@@ -388,12 +388,12 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
         is_file_name = False
 
     try:
-        np.savetxt(f, np.reshape(hf, (14, 5)), fmt=native_str("%#15.7g"),
+        np.savetxt(f, np.reshape(hf, (14, 5)), fmt="%#15.7g",
                    delimiter='')
-        np.savetxt(f, np.reshape(hi, (8, 5)), fmt=native_str("%10d"),
+        np.savetxt(f, np.reshape(hi, (8, 5)), fmt="%10d",
                    delimiter='')
         np.savetxt(f, np.reshape(hs, (8, 3)).astype('|U8'),
-                   fmt=native_str('%-8s'), delimiter='')
+                   fmt='%-8s', delimiter='')
     except Exception as e:
         if is_file_name:
             f.close()
@@ -408,7 +408,7 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
         try:
             rows = npts // 5
             np.savetxt(f, np.reshape(data[0:5 * rows], (rows, 5)),
-                       fmt=native_str("%#15.7g"), delimiter='')
+                       fmt="%#15.7g", delimiter='')
             np.savetxt(f, data[5 * rows:], delimiter=b'\t')
         except Exception:
             f.close()

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -8,10 +8,7 @@ SAC bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import os
 import struct

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -58,39 +58,39 @@ def _internal_is_sac(buf):
     try:
         # read delta (first header float)
         delta_bin = buf.read(4)
-        delta = struct.unpack(native_str('<f'), delta_bin)[0]
+        delta = struct.unpack('<f', delta_bin)[0]
         # read nvhdr (70 header floats, 6 position in header integers)
         buf.seek(4 * 70 + 4 * 6)
         nvhdr_bin = buf.read(4)
-        nvhdr = struct.unpack(native_str('<i'), nvhdr_bin)[0]
+        nvhdr = struct.unpack('<i', nvhdr_bin)[0]
         # read leven (70 header floats, 35 header integers, 0 position in
         # header bool)
         buf.seek(4 * 70 + 4 * 35)
         leven_bin = buf.read(4)
-        leven = struct.unpack(native_str('<i'), leven_bin)[0]
+        leven = struct.unpack('<i', leven_bin)[0]
         # read lpspol (70 header floats, 35 header integers, 1 position in
         # header bool)
         buf.seek(4 * 70 + 4 * 35 + 4 * 1)
         lpspol_bin = buf.read(4)
-        lpspol = struct.unpack(native_str('<i'), lpspol_bin)[0]
+        lpspol = struct.unpack('<i', lpspol_bin)[0]
         # read lovrok (70 header floats, 35 header integers, 2 position in
         # header bool)
         buf.seek(4 * 70 + 4 * 35 + 4 * 2)
         lovrok_bin = buf.read(4)
-        lovrok = struct.unpack(native_str('<i'), lovrok_bin)[0]
+        lovrok = struct.unpack('<i', lovrok_bin)[0]
         # read lcalda (70 header floats, 35 header integers, 3 position in
         # header bool)
         buf.seek(4 * 70 + 4 * 35 + 4 * 3)
         lcalda_bin = buf.read(4)
-        lcalda = struct.unpack(native_str('<i'), lcalda_bin)[0]
+        lcalda = struct.unpack('<i', lcalda_bin)[0]
         # check if file is big-endian
         if nvhdr < 0 or nvhdr > 20:
-            nvhdr = struct.unpack(native_str('>i'), nvhdr_bin)[0]
-            delta = struct.unpack(native_str('>f'), delta_bin)[0]
-            leven = struct.unpack(native_str('>i'), leven_bin)[0]
-            lpspol = struct.unpack(native_str('>i'), lpspol_bin)[0]
-            lovrok = struct.unpack(native_str('>i'), lovrok_bin)[0]
-            lcalda = struct.unpack(native_str('>i'), lcalda_bin)[0]
+            nvhdr = struct.unpack('>i', nvhdr_bin)[0]
+            delta = struct.unpack('>f', delta_bin)[0]
+            leven = struct.unpack('>i', leven_bin)[0]
+            lpspol = struct.unpack('>i', lpspol_bin)[0]
+            lovrok = struct.unpack('>i', lovrok_bin)[0]
+            lcalda = struct.unpack('>i', lcalda_bin)[0]
         # check again nvhdr
         if nvhdr < 1 or nvhdr > 20:
             return False

--- a/obspy/io/sac/header.py
+++ b/obspy/io/sac/header.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 MODULE_DOCSTRING = """
 SAC header specification, including documentation.

--- a/obspy/io/sac/sacpz.py
+++ b/obspy/io/sac/sacpz.py
@@ -7,10 +7,7 @@ Module for SAC poles and zero (SACPZ) file I/O.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/sac/sacpz.py
+++ b/obspy/io/sac/sacpz.py
@@ -153,7 +153,7 @@ seisuk_instrument_resp_removal.pdf
     poles = []
     zeros = []
 
-    if isinstance(paz_file, (str, native_str)):
+    if isinstance(paz_file, str):
         paz_file = open(paz_file, 'r')
         is_filename = True
     else:

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -327,10 +327,7 @@ scale      = 1.0
              sac: AttribDict(...)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import sys
 import warnings
@@ -468,10 +465,10 @@ def _strgetter(hdr):
     def get_str(self):
         try:
             # value is a bytes
-            value = native_str(self._hs[HD.STRHDRS.index(hdr)].decode())
+            value = self._hs[HD.STRHDRS.index(hdr)].decode()
         except AttributeError:
             # value is a str
-            value = native_str(self._hs[HD.STRHDRS.index(hdr)])
+            value = self._hs[HD.STRHDRS.index(hdr)]
 
         if value == HD.SNULL:
             value = None
@@ -785,7 +782,7 @@ class SACTrace(object):
             else:
                 # Only copy the data if they are not of the required type
                 # XXX: why require little endian instead of native byte order?
-                # data = np.require(data, native_str('<f4'))
+                # data = np.require(data, '<f4')
                 pass
 
         # --------------------------- HEADER ARRAYS ---------------------------
@@ -1159,7 +1156,7 @@ class SACTrace(object):
         if not debug_strings:
             for i, val in enumerate(hs):
                 val = _ut._clean_str(val, strip_whitespace=False)
-                if val.startswith(native_str('-12345')):
+                if val.startswith('-12345'):
                     val = HD.SNULL
                 hs[i] = val
 
@@ -1549,7 +1546,7 @@ class SACTrace(object):
 
         """
         # XXX: do I really care which byte order it is?
-        # self.data = np.require(self.data, native_str('<f4'))
+        # self.data = np.require(self.data, '<f4')
         self._hi[HD.INTHDRS.index('npts')] = self.npts
         self._hf[HD.FLOATHDRS.index('e')] = self.e
         self._hf[HD.FLOATHDRS.index('depmin')] = self.depmin

--- a/obspy/io/sac/tests/__init__.py
+++ b/obspy/io/sac/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -2,9 +2,7 @@
 """
 The sac.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import io

--- a/obspy/io/sac/tests/test_sacpz.py
+++ b/obspy/io/sac/tests/test_sacpz.py
@@ -2,9 +2,7 @@
 """
 The sac.sacpz test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -3,9 +3,7 @@
 SAC module helper functions and data.
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import sys
 import warnings

--- a/obspy/io/seg2/__init__.py
+++ b/obspy/io/seg2/__init__.py
@@ -13,9 +13,7 @@ format.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/seg2/header.py
+++ b/obspy/io/seg2/header.py
@@ -8,9 +8,7 @@ Headers for obspy.io.seg2.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 MONTHS = {'jan': 1,

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -10,10 +10,7 @@ A file format description is given by [Pullan1990]_.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2
+from __future__ import absolute_import, division, print_function
 
 from copy import deepcopy
 from struct import unpack

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -19,7 +19,7 @@ import warnings
 import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
-from obspy.core import AttribDict
+from obspy.core import AttribDict, compatibility
 from .header import MONTHS
 
 
@@ -277,7 +277,7 @@ class SEG2(object):
         # solved with a number of imports from the python-future module and
         # all kinds of subtle changes throughout this file. Separating the
         # handling for Python 2 and 3 seems the cleaner and simpler approach.
-        if PY2:
+        if compatibility.PY2:
             strings = ["".join(filter(is_good_char, _i))
                        for _i in strings
                        if len(_i) >= 3]

--- a/obspy/io/seg2/tests/__init__.py
+++ b/obspy/io/seg2/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/seg2/tests/test_seg2.py
+++ b/obspy/io/seg2/tests/test_seg2.py
@@ -2,9 +2,7 @@
 """
 The obspy.io.seg2 test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os

--- a/obspy/io/segy/__init__.py
+++ b/obspy/io/segy/__init__.py
@@ -256,9 +256,7 @@ _i + 1
     print stream.stats.binary_file_header.trace_sorting_code
     print st1.stats.binary_file_header.trace_sorting_code
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -8,9 +8,7 @@ SEG Y bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import warnings
 from copy import deepcopy

--- a/obspy/io/segy/header.py
+++ b/obspy/io/segy/header.py
@@ -3,9 +3,7 @@
 Defines the header structures and some other dictionaries needed for SEG Y read
 and write support.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/segy/pack.py
+++ b/obspy/io/segy/pack.py
@@ -11,9 +11,7 @@
 Functions that will all take a file pointer and the sample count and return a
 NumPy array with the unpacked values.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -10,9 +10,7 @@
 """
 Routines to read and write SEG Y rev 1 encoded seismic data files.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/segy/tests/__init__.py
+++ b/obspy/io/segy/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/segy/tests/header.py
+++ b/obspy/io/segy/tests/header.py
@@ -2,9 +2,7 @@
 """
 Information about files/segy useful for all tests.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -2,9 +2,7 @@
 """
 The obspy.io.segy core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -2,9 +2,7 @@
 """
 The obspy.io.segy test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/segy/tests/test_su.py
+++ b/obspy/io/segy/tests/test_su.py
@@ -2,9 +2,7 @@
 """
 The obspy.io.segy Seismic Unix test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/segy/unpack.py
+++ b/obspy/io/segy/unpack.py
@@ -11,10 +11,7 @@
 Functions that will all take a file pointer and the sample count and return a
 NumPy array with the unpacked values.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import os

--- a/obspy/io/segy/unpack.py
+++ b/obspy/io/segy/unpack.py
@@ -33,7 +33,7 @@ else:
 
 clibsegy.ibm2ieee.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags='C_CONTIGUOUS'),
     C.c_int]
 clibsegy.ibm2ieee.restype = C.c_void_p
 

--- a/obspy/io/segy/util.py
+++ b/obspy/io/segy/util.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from struct import unpack
 

--- a/obspy/io/seisan/__init__.py
+++ b/obspy/io/seisan/__init__.py
@@ -52,9 +52,7 @@ The actual data is stored as numpy.ndarray in the data attribute of each trace.
 >>> print(st[0].data)
 [  464   492   519 ..., -7042 -6960 -6858]
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/seisan/core.py
+++ b/obspy/io/seisan/core.py
@@ -165,8 +165,8 @@ def _read_seisan(filename, headonly=False, **kwargs):  # @UnusedVariable
     # now parse each event file channel header + data
     stream = Stream()
     dlen = arch // 8
-    dtype = np.dtype(native_str(byteorder + 'i' + str(dlen)))
-    stype = native_str('=i' + str(dlen))
+    dtype = np.dtype(byteorder + 'i' + str(dlen))
+    stype = '=i' + str(dlen)
     for _i in range(number_of_channels):
         # get channel header
         temp = _readline(fh, 1040).decode()

--- a/obspy/io/seisan/core.py
+++ b/obspy/io/seisan/core.py
@@ -8,10 +8,7 @@ SEISAN bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import warnings

--- a/obspy/io/seisan/tests/__init__.py
+++ b/obspy/io/seisan/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/seisan/tests/test_core.py
+++ b/obspy/io/seisan/tests/test_core.py
@@ -2,9 +2,7 @@
 """
 The seisan.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/seiscomp/__init__.py
+++ b/obspy/io/seiscomp/__init__.py
@@ -13,6 +13,4 @@ support for SeisComP3 event files.
     (http://www.gnu.org/copyleft/lesser.html)
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -13,9 +13,7 @@ This is a modified version of obspy.io.stationxml.
     GNU Lesser General Public License, Version 3
     (http://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import re

--- a/obspy/io/seiscomp/tests/__init__.py
+++ b/obspy/io/seiscomp/tests/__init__.py
@@ -1,8 +1,6 @@
 
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/seiscomp/tests/test_sc3ml.py
+++ b/obspy/io/seiscomp/tests/test_sc3ml.py
@@ -14,9 +14,7 @@ Modified after obspy.io.stationXML
     (http://www.gnu.org/copyleft/lesser.html)
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import io

--- a/obspy/io/sh/__init__.py
+++ b/obspy/io/sh/__init__.py
@@ -66,9 +66,7 @@ or
 
 >>> st.write('file.asc', format = 'SH_ASC') #doctest: +SKIP
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -8,10 +8,7 @@ SH bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -460,10 +460,10 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
                 continue
             # read data
             data = fh_data.read(npts * 4)
-            dtype = native_str(byteorder + 'f4')
+            dtype = byteorder + 'f4'
             data = np.fromstring(data, dtype=dtype)
             # convert to system byte order
-            data = np.require(data, native_str('=f4'))
+            data = np.require(data, '=f4')
             stream.append(Trace(data=data, header=header))
     if not headonly:
         fh_data.close()
@@ -571,7 +571,7 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
                 line = "%02d|\n" % ((i + 1 + count_offset) % 100)
                 fh.write(line.encode('ascii', 'strict'))
         # write data in given byte order
-        dtype = native_str(byteorder + 'f4')
+        dtype = byteorder + 'f4'
         data = np.require(trace.data, dtype=dtype)
         fh_data.write(data.data)
     fh.close()

--- a/obspy/io/sh/tests/__init__.py
+++ b/obspy/io/sh/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/sh/tests/test_core.py
+++ b/obspy/io/sh/tests/test_core.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/shapefile/__init__.py
+++ b/obspy/io/shapefile/__init__.py
@@ -25,6 +25,4 @@ Write support works via the ObsPy plugin structure for
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -48,7 +48,7 @@ def _write_shapefile(obj, filename, **kwargs):
     if not filename.endswith(".shp"):
         filename += ".shp"
 
-    driver = ogr.GetDriverByName(native_str("ESRI Shapefile"))
+    driver = ogr.GetDriverByName("ESRI Shapefile")
 
     driver.DeleteDataSource(filename)
     data_source = driver.CreateDataSource(filename)
@@ -124,36 +124,36 @@ def _add_catalog_layer(data_source, catalog):
             # setting fields with `None` results in values of `0.000`
             # need to really omit setting values if they are `None`
             if event.resource_id is not None:
-                feature.SetField(native_str("EventID"),
-                                 native_str(event.resource_id))
+                feature.SetField("EventID",
+                                 event.resource_id)
             if origin.resource_id is not None:
-                feature.SetField(native_str("OriginID"),
-                                 native_str(origin.resource_id))
+                feature.SetField("OriginID",
+                                 origin.resource_id)
             if t_origin is not None:
                 # Use timestamp for exact timing
-                feature.SetField(native_str("OriginTime"), t_origin.timestamp)
+                feature.SetField("OriginTime", t_origin.timestamp)
             if t_pick is not None:
                 # Use timestamp for exact timing
-                feature.SetField(native_str("FirstPick"), t_pick.timestamp)
+                feature.SetField("FirstPick", t_pick.timestamp)
             if date is not None:
                 # ESRI shapefile attributes are stored in dbf files, which can
                 # not store datetimes, only dates. We still need to use the
                 # GDAL API with precision up to seconds (aiming at other output
                 # drivers of GDAL; `100` stands for GMT)
-                feature.SetField(native_str("Date"), date.year, date.month,
+                feature.SetField("Date", date.year, date.month,
                                  date.day, date.hour, date.minute, date.second,
                                  100)
             if origin.latitude is not None:
-                feature.SetField(native_str("Latitude"), origin.latitude)
+                feature.SetField("Latitude", origin.latitude)
             if origin.longitude is not None:
-                feature.SetField(native_str("Longitude"), origin.longitude)
+                feature.SetField("Longitude", origin.longitude)
             if origin.depth is not None:
-                feature.SetField(native_str("Depth"), origin.depth / 1e3)
+                feature.SetField("Depth", origin.depth / 1e3)
             if magnitude.mag is not None:
-                feature.SetField(native_str("Magnitude"), magnitude.mag)
+                feature.SetField("Magnitude", magnitude.mag)
             if magnitude.resource_id is not None:
-                feature.SetField(native_str("MagID"),
-                                 native_str(magnitude.resource_id))
+                feature.SetField("MagID",
+                                 magnitude.resource_id)
 
             if origin.latitude is not None and origin.longitude is not None:
                 point = ogr.Geometry(ogr.wkbPoint)
@@ -211,24 +211,24 @@ def _add_inventory_layer(data_source, inventory):
                 # setting fields with `None` results in values of `0.000`
                 # need to really omit setting values if they are `None`
                 if net.code is not None:
-                    feature.SetField(native_str("Network"),
-                                     native_str(net.code))
+                    feature.SetField("Network",
+                                     net.code)
                 if sta.code is not None:
-                    feature.SetField(native_str("Station"),
-                                     native_str(sta.code))
+                    feature.SetField("Station",
+                                     sta.code)
                 if sta.latitude is not None:
-                    feature.SetField(native_str("Latitude"), sta.latitude)
+                    feature.SetField("Latitude", sta.latitude)
                 if sta.longitude is not None:
-                    feature.SetField(native_str("Longitude"), sta.longitude)
+                    feature.SetField("Longitude", sta.longitude)
                 if sta.elevation is not None:
-                    feature.SetField(native_str("Elevation"), sta.elevation)
+                    feature.SetField("Elevation", sta.elevation)
                 if sta.start_date is not None:
                     date = sta.start_date
                     # ESRI shapefile attributes are stored in dbf files, which
                     # can not store datetimes, only dates. We still need to use
                     # the GDAL API with precision up to seconds (aiming at
                     # other output drivers of GDAL; `100` stands for GMT)
-                    feature.SetField(native_str("StartDate"), date.year,
+                    feature.SetField("StartDate", date.year,
                                      date.month, date.day, date.hour,
                                      date.minute, date.second, 100)
                 if sta.end_date is not None:
@@ -237,12 +237,12 @@ def _add_inventory_layer(data_source, inventory):
                     # can not store datetimes, only dates. We still need to use
                     # the GDAL API with precision up to seconds (aiming at
                     # other output drivers of GDAL; `100` stands for GMT)
-                    feature.SetField(native_str("StartDate"), date.year,
+                    feature.SetField("StartDate", date.year,
                                      date.month, date.day, date.hour,
                                      date.minute, date.second, 100)
                 if channel_list:
-                    feature.SetField(native_str("Channels"),
-                                     native_str(channel_list))
+                    feature.SetField("Channels",
+                                     channel_list)
 
                 if sta.latitude is not None and sta.longitude is not None:
                     point = ogr.Geometry(ogr.wkbPoint)
@@ -283,11 +283,11 @@ def _get_wgs84_spatial_reference():
 
 def _create_layer(data_source, layer_name, field_definitions):
     sr = _get_wgs84_spatial_reference()
-    layer = data_source.CreateLayer(native_str(layer_name), sr,
+    layer = data_source.CreateLayer(layer_name, sr,
                                     ogr.wkbPoint)
     # Add the fields we're interested in
     for name, type_, width, precision in field_definitions:
-        field = ogr.FieldDefn(native_str(name), type_)
+        field = ogr.FieldDefn(name, type_)
         if width is not None:
             field.SetWidth(width)
         if precision is not None:

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from obspy import Catalog
 from obspy.core.event import Origin, Magnitude

--- a/obspy/io/shapefile/tests/__init__.py
+++ b/obspy/io/shapefile/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import filecmp
 import os

--- a/obspy/io/stationtxt/__init__.py
+++ b/obspy/io/stationtxt/__init__.py
@@ -37,9 +37,7 @@ Inventory created at ...
         Channels (6):
             AK.BAGL..LHZ, AK.BWN..LHZ (2x), AZ.BZN..LHZ (3x)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -9,10 +9,7 @@ Parsing of the text files from the FDSN station web services.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import csv
@@ -70,7 +67,7 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
 
 def utf_8_encoder(unicode_csv_data):
     for line in unicode_csv_data:
-        if isinstance(line, native_str):
+        if isinstance(line, str):
             yield line
         else:
             yield line.encode('utf-8')
@@ -129,7 +126,7 @@ def read_fdsn_station_text_file(path_or_file_object):
     :param path_or_file_object: File name or file like object.
     """
     def _read(obj):
-        r = unicode_csv_reader(obj, delimiter=native_str("|"))
+        r = unicode_csv_reader(obj, delimiter="|")
         header = next(r)
         header[0] = header[0].lstrip("#")
         header = [_i.strip().lower() for _i in header]

--- a/obspy/io/stationtxt/tests/__init__.py
+++ b/obspy/io/stationtxt/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -9,9 +9,7 @@ Test suite for the station text parser.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import io

--- a/obspy/io/stationxml/__init__.py
+++ b/obspy/io/stationxml/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -9,9 +9,7 @@ Functions dealing with reading and writing StationXML.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import inspect

--- a/obspy/io/stationxml/tests/__init__.py
+++ b/obspy/io/stationxml/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -9,9 +9,7 @@ Test suite for the StationXML reader and writer.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import inspect

--- a/obspy/io/wav/__init__.py
+++ b/obspy/io/wav/__init__.py
@@ -59,9 +59,7 @@ squeezed. Using the original sampling_rate results in an WAV file with
 frequencies which cannot be heard by a human, therefore it makes sense to
 set the framerate to a high value.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/wav/core.py
+++ b/obspy/io/wav/core.py
@@ -16,10 +16,7 @@ WAV bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import os
 import wave

--- a/obspy/io/wav/core.py
+++ b/obspy/io/wav/core.py
@@ -29,9 +29,9 @@ from obspy import Stream, Trace
 # WAVE data format is unsigned char up to 8bit, and signed int
 # for the remaining.
 WIDTH2DTYPE = {
-    1: native_str('<u1'),  # unsigned char
-    2: native_str('<i2'),  # signed short int
-    4: native_str('<i4'),  # signed int (int32)
+    1: '<u1',  # unsigned char
+    2: '<i2',  # signed short int
+    4: '<i4',  # signed int (int32)
 }
 
 

--- a/obspy/io/wav/tests/__init__.py
+++ b/obspy/io/wav/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/wav/tests/test_core.py
+++ b/obspy/io/wav/tests/test_core.py
@@ -4,9 +4,7 @@
 The audio wav.core test suite.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/win/__init__.py
+++ b/obspy/io/win/__init__.py
@@ -17,9 +17,7 @@ data format of the WIN system developed by Earthquake Research Institute
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/win/core.py
+++ b/obspy/io/win/core.py
@@ -2,10 +2,7 @@
 """
 DATAMARK bindings to ObsPy core module.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import warnings
 

--- a/obspy/io/win/core.py
+++ b/obspy/io/win/core.py
@@ -43,8 +43,8 @@ def _is_win(filename, century="20"):  # @UnusedVariable
             int('%x' % (ord(buff[2:3]) >> 4))
             ord(buff[3:4])
             idata00 = fpin.read(4)
-            np.fromstring(idata00, native_str('>i'))[0]
     except Exception:
+            np.fromstring(idata00, '>i')[0]
         return False
     return True
 
@@ -80,7 +80,7 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
             if len(pklen) < 4:
                 break
             leng = 4
-            truelen = np.fromstring(pklen, native_str('>i'))[0]
+            truelen = np.fromstring(pklen, '>i')[0]
             if truelen == 0:
                 break
             buff = fpin.read(6)
@@ -114,7 +114,7 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
 
                 idata00 = fpin.read(4)
                 leng += 4
-                idata22 = np.fromstring(idata00, native_str('>i'))[0]
+                idata22 = np.fromstring(idata00, '>i')[0]
 
                 if chanum in output:
                     output[chanum].append(idata22)
@@ -147,20 +147,18 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
                 elif datawide == 2:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[2 * i:2 * (i + 1)],
-                                          native_str('>h'))[0]
+                            np.fromstring(sdata[2 * i:2 * (i + 1)], '>h')[0]
                         output[chanum].append(idata2)
                 elif datawide == 3:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
                             np.fromstring(sdata[3 * i:3 * (i + 1)] + b' ',
-                                          native_str('>i'))[0] >> 8
+                                          '>i')[0] >> 8
                         output[chanum].append(idata2)
                 elif datawide == 4:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[4 * i:4 * (i + 1)],
-                                          native_str('>i'))[0]
+                            np.fromstring(sdata[4 * i:4 * (i + 1)], '>i')[0]
                         output[chanum].append(idata2)
                 else:
                     msg = "DATAWIDE is %s " % datawide + \

--- a/obspy/io/win/tests/test_core.py
+++ b/obspy/io/win/tests/test_core.py
@@ -3,9 +3,7 @@
 """
 The obspy.io.win.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/xseed/__init__.py
+++ b/obspy/io/xseed/__init__.py
@@ -70,9 +70,7 @@ volume will be stored in the attributes``Parser.volume``,
 related Blockettes and ``Parser.stations`` is a list of stations which contains
 all related Blockettes.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # needs to stay above import statements
 DEFAULT_XSEED_VERSION = '1.1'

--- a/obspy/io/xseed/blockette/__init__.py
+++ b/obspy/io/xseed/blockette/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 

--- a/obspy/io/xseed/blockette/blockette.py
+++ b/obspy/io/xseed/blockette/blockette.py
@@ -92,7 +92,7 @@ class Blockette(object):
         if isinstance(data, bytes):
             expected_length = len(data)
             data = io.BytesIO(data)
-        elif isinstance(data, (str, native_str)):
+        elif isinstance(data, str):
             raise TypeError("data must be bytes, not string")
         start_pos = data.tell()
         # debug

--- a/obspy/io/xseed/blockette/blockette.py
+++ b/obspy/io/xseed/blockette/blockette.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/xseed/blockette/blockette010.py
+++ b/obspy/io/xseed/blockette/blockette010.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy import UTCDateTime
 from .blockette import Blockette

--- a/obspy/io/xseed/blockette/blockette011.py
+++ b/obspy/io/xseed/blockette/blockette011.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Integer, Loop

--- a/obspy/io/xseed/blockette/blockette012.py
+++ b/obspy/io/xseed/blockette/blockette012.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette030.py
+++ b/obspy/io/xseed/blockette/blockette030.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette031.py
+++ b/obspy/io/xseed/blockette/blockette031.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette032.py
+++ b/obspy/io/xseed/blockette/blockette032.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette033.py
+++ b/obspy/io/xseed/blockette/blockette033.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette034.py
+++ b/obspy/io/xseed/blockette/blockette034.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette041.py
+++ b/obspy/io/xseed/blockette/blockette041.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import os

--- a/obspy/io/xseed/blockette/blockette041.py
+++ b/obspy/io/xseed/blockette/blockette041.py
@@ -45,7 +45,7 @@ class Blockette041(Blockette):
         if isinstance(data, bytes):
             expected_length = len(data)
             data = io.BytesIO(data)
-        elif isinstance(data, (str, native_str)):
+        elif isinstance(data, str):
             raise TypeError("Data must be bytes, not string")
         # get current lookup key
         pos = data.tell()

--- a/obspy/io/xseed/blockette/blockette043.py
+++ b/obspy/io/xseed/blockette/blockette043.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette044.py
+++ b/obspy/io/xseed/blockette/blockette044.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette047.py
+++ b/obspy/io/xseed/blockette/blockette047.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Float, Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette048.py
+++ b/obspy/io/xseed/blockette/blockette048.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Float, Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette050.py
+++ b/obspy/io/xseed/blockette/blockette050.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette051.py
+++ b/obspy/io/xseed/blockette/blockette051.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette052.py
+++ b/obspy/io/xseed/blockette/blockette052.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette053.py
+++ b/obspy/io/xseed/blockette/blockette053.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, Loop

--- a/obspy/io/xseed/blockette/blockette054.py
+++ b/obspy/io/xseed/blockette/blockette054.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, Loop

--- a/obspy/io/xseed/blockette/blockette055.py
+++ b/obspy/io/xseed/blockette/blockette055.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Float, Integer, Loop

--- a/obspy/io/xseed/blockette/blockette057.py
+++ b/obspy/io/xseed/blockette/blockette057.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Float, Integer

--- a/obspy/io/xseed/blockette/blockette058.py
+++ b/obspy/io/xseed/blockette/blockette058.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Float, Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette059.py
+++ b/obspy/io/xseed/blockette/blockette059.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import Integer, VariableString

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -73,7 +73,7 @@ class Blockette060(Blockette):
         if isinstance(data, bytes):
             length = len(data)
             data = io.BytesIO(data)
-        elif isinstance(data, (str, native_str)):
+        elif isinstance(data, str):
             raise TypeError("data must be bytes, not string")
         new_data = data.read(length)
         new_data = new_data[7:]

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import io
 import sys

--- a/obspy/io/xseed/blockette/blockette061.py
+++ b/obspy/io/xseed/blockette/blockette061.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .blockette import Blockette
 from ..fields import FixedString, Float, Integer, Loop, VariableString

--- a/obspy/io/xseed/blockette/blockette062.py
+++ b/obspy/io/xseed/blockette/blockette062.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import sys
 

--- a/obspy/io/xseed/fields.py
+++ b/obspy/io/xseed/fields.py
@@ -8,9 +8,7 @@ Helper module containing xseed fields.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import re
 import warnings

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -153,7 +153,7 @@ class Parser(object):
             warnings.warn("Clearing parser before every subsequent read()")
             self.__init__()
         # try to transform everything into BytesIO object
-        if isinstance(data, (str, native_str)):
+        if isinstance(data, str):
             if re.search(r"://", data) is not None:
                 url = data
                 data = io.BytesIO()
@@ -715,7 +715,7 @@ class Parser(object):
                 if blkt.id == 50:
                     current_network = blkt.network_code.strip()
                     network_id = blkt.network_identifier_code
-                    if isinstance(network_id, (str, native_str)):
+                    if isinstance(network_id, str):
                         new_id = ""
                         for _i in network_id:
                             if _i.isdigit():

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -8,10 +8,7 @@ Main module containing XML-SEED parser.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import datetime

--- a/obspy/io/xseed/scripts/__init__.py
+++ b/obspy/io/xseed/scripts/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/io/xseed/scripts/dataless2resp.py
+++ b/obspy/io/xseed/scripts/dataless2resp.py
@@ -3,9 +3,7 @@
 """
 A command-line program that converts Dataless SEED into RESP files.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/io/xseed/scripts/dataless2xseed.py
+++ b/obspy/io/xseed/scripts/dataless2xseed.py
@@ -3,9 +3,7 @@
 """
 A command-line program that converts Dataless SEED into XML-SEED files.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/io/xseed/scripts/xseed2dataless.py
+++ b/obspy/io/xseed/scripts/xseed2dataless.py
@@ -3,9 +3,7 @@
 """
 A command-line program that converts XML-SEED into Dataless SEED files.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/io/xseed/tests/__init__.py
+++ b/obspy/io/xseed/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/obspy/io/xseed/tests/test_fields.py
+++ b/obspy/io/xseed/tests/test_fields.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import io
 import unittest

--- a/obspy/io/xseed/tests/test_parser.py
+++ b/obspy/io/xseed/tests/test_parser.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import io

--- a/obspy/io/xseed/tests/test_scripts.py
+++ b/obspy/io/xseed/tests/test_scripts.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/xseed/tests/test_utils.py
+++ b/obspy/io/xseed/tests/test_utils.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
+from __future__ import absolute_import, division, print_function
 
 import glob
 import inspect

--- a/obspy/io/xseed/utils.py
+++ b/obspy/io/xseed/utils.py
@@ -51,7 +51,7 @@ def datetime_2_string(dt, compact=False):
     """
     if isinstance(dt, UTCDateTime):
         return dt.format_seed(compact)
-    elif isinstance(dt, (str, native_str)):
+    elif isinstance(dt, str):
         dt = dt.strip()
     if not dt:
         return ""

--- a/obspy/io/xseed/utils.py
+++ b/obspy/io/xseed/utils.py
@@ -8,10 +8,7 @@ Various additional utilities for ObsPy xseed.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import re
 import sys

--- a/obspy/io/y/__init__.py
+++ b/obspy/io/y/__init__.py
@@ -13,9 +13,7 @@ Nanometrics Y file format.
     (https://www.gnu.org/copyleft/lesser.html)
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/y/core.py
+++ b/obspy/io/y/core.py
@@ -8,9 +8,7 @@ Y bindings to ObsPy core module.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import re
 import warnings

--- a/obspy/io/y/tests/__init__.py
+++ b/obspy/io/y/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/y/tests/test_core.py
+++ b/obspy/io/y/tests/test_core.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/io/zmap/__init__.py
+++ b/obspy/io/zmap/__init__.py
@@ -111,9 +111,7 @@ Column #            Value
 13                  Magnitude error
 =================   ==============================================
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 
 if __name__ == '__main__':

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -11,9 +11,7 @@ data (see [Wiemer2001]_).
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 

--- a/obspy/io/zmap/tests/__init__.py
+++ b/obspy/io/zmap/tests/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/io/zmap/tests/test_zmap.py
+++ b/obspy/io/zmap/tests/test_zmap.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/lib/__init__.py
+++ b/obspy/lib/__init__.py
@@ -2,6 +2,4 @@
 # -----------------------------------------------------------------------------
 #  Purpose: Compiled libraries for ObsPy
 # -----------------------------------------------------------------------------
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/realtime/__init__.py
+++ b/obspy/realtime/__init__.py
@@ -19,9 +19,7 @@ Mitigation" under the European Community's Seventh Framework Programme
 activities of the JRA2/WP12 "Tools for real-time seismology, acquisition and
 mining".
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from obspy.realtime.rtmemory import RtMemory
 from obspy.realtime.rttrace import RtTrace

--- a/obspy/realtime/rtmemory.py
+++ b/obspy/realtime/rtmemory.py
@@ -8,9 +8,7 @@ Module for handling ObsPy RtMemory objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/realtime/rttrace.py
+++ b/obspy/realtime/rttrace.py
@@ -8,9 +8,7 @@ Module for handling ObsPy RtTrace objects.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import warnings

--- a/obspy/realtime/signal.py
+++ b/obspy/realtime/signal.py
@@ -20,9 +20,7 @@ in a previous packet, so has to be retrieved from memory see
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import sys

--- a/obspy/realtime/tests/__init__.py
+++ b/obspy/realtime/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/realtime/tests/test_rttrace.py
+++ b/obspy/realtime/tests/test_rttrace.py
@@ -165,7 +165,7 @@ class RtTraceTestCase(unittest.TestCase):
         Test for not using float32.
         """
         tr = read()[0]
-        tr.data = np.require(tr.data, dtype=native_str('>f4'))
+        tr.data = np.require(tr.data, dtype='>f4')
         traces = tr / 3
         rtr = RtTrace()
         for trace in traces:

--- a/obspy/realtime/tests/test_rttrace.py
+++ b/obspy/realtime/tests/test_rttrace.py
@@ -2,10 +2,7 @@
 """
 The obspy.realtime.rttrace test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import warnings

--- a/obspy/realtime/tests/test_signal.py
+++ b/obspy/realtime/tests/test_signal.py
@@ -2,9 +2,7 @@
 """
 The obspy.realtime.signal test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/scripts/__init__.py
+++ b/obspy/scripts/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function

--- a/obspy/scripts/flinnengdahl.py
+++ b/obspy/scripts/flinnengdahl.py
@@ -3,9 +3,7 @@
 """
 Get Flinn-Engdahl region name from longitude and latitude
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from argparse import ArgumentParser
 

--- a/obspy/scripts/print.py
+++ b/obspy/scripts/print.py
@@ -3,9 +3,7 @@
 """
 Print stream information for waveform data in local files
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from argparse import ArgumentParser
 

--- a/obspy/scripts/reftekrescue.py
+++ b/obspy/scripts/reftekrescue.py
@@ -37,9 +37,7 @@ conversion tools.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import contextlib
 import mmap

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -82,10 +82,7 @@ verbose output and report everything, you would run::
 
         $ obspy-runtests -r -v -x clients.seishub -x io.sh --all
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA @UnusedWildImport
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import copy
 import doctest

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -290,8 +290,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
             module_ = module
         temp = module_.split('.')
         try:
-            mod = __import__(module_,
-                             fromlist=[native_str(temp[1:])])
+            mod = __import__(module_, fromlist=[temp[1:]])
         except ImportError:
             version_ = '---'
         else:
@@ -353,9 +352,9 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
                 child = ElementTree.SubElement(doc, key)
                 _dict2xml(child, value)
             elif value is not None:
-                if isinstance(value, (str, native_str)):
+                if isinstance(value, str):
                     ElementTree.SubElement(doc, key).text = value
-                elif isinstance(value, (str, native_str)):
+                elif isinstance(value, str):
                     ElementTree.SubElement(doc, key).text = str(value, 'utf-8')
                 else:
                     ElementTree.SubElement(doc, key).text = str(value)

--- a/obspy/scripts/sds_html_report.py
+++ b/obspy/scripts/sds_html_report.py
@@ -27,9 +27,7 @@ Screenshot of resulting html page (cut off at the bottom):
 .. image:: /_static/sds_report.png
 
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 from argparse import ArgumentParser, RawDescriptionHelpFormatter

--- a/obspy/scripts/tests/__init__.py
+++ b/obspy/scripts/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/scripts/tests/test_print.py
+++ b/obspy/scripts/tests/test_print.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/__init__.py
+++ b/obspy/signal/__init__.py
@@ -191,9 +191,7 @@ and the same page in the `Tutorial`_. For automated use see the following
 .. _`Tutorial`: https://tutorial.obspy.org
 .. _`stalta`: https://github.com/obspy/branches/tree/master/sandbox/stalta
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 if "filter" in locals():
     del filter

--- a/obspy/signal/_sosfilt.py
+++ b/obspy/signal/_sosfilt.py
@@ -14,9 +14,7 @@ Backport of Second-Order Section Filtering from SciPy 0.16.0
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from scipy.signal import lfilter, zpk2tf

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -17,9 +17,7 @@ Functions for Array Analysis
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import warnings

--- a/obspy/signal/calibration.py
+++ b/obspy/signal/calibration.py
@@ -16,10 +16,7 @@ Functions for relative calibration.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/signal/calibration.py
+++ b/obspy/signal/calibration.py
@@ -128,10 +128,10 @@ def rel_calib_stack(st1, st2, calib_file, window_len, overlap_frac=0.5,
         temp[:, 0] = freq
         temp[:, 1] = amp
         temp[:, 2] = phase
-        np.savetxt(trans_new, temp, fmt=native_str('%.10f'))
+        np.savetxt(trans_new, temp, fmt='%.10f')
         temp[:, 1] = ra
         temp[:, 2] = rpha
-        np.savetxt(trans_ref, temp, fmt=native_str('%.10f'))
+        np.savetxt(trans_ref, temp, fmt='%.10f')
 
     return freq, amp, phase
 

--- a/obspy/signal/cpxtrace.py
+++ b/obspy/signal/cpxtrace.py
@@ -15,9 +15,7 @@ Complex Trace Analysis
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from scipy import signal

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -500,7 +500,7 @@ def templates_max_similarity(st, time, streams_templates):
                 data_long = tr2.data
             data_short = (data_short - data_short.mean()) / data_short.std()
             data_long = (data_long - data_long.mean()) / data_long.std()
-            tmp = np.correlate(data_long, data_short, native_str("valid"))
+            tmp = np.correlate(data_long, data_short, "valid")
             try:
                 cc += tmp
             except TypeError:

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -16,10 +16,7 @@ Signal processing routines based on cross correlation techniques.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import warnings

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -9,9 +9,7 @@ Python module containing detrend methods.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from scipy.interpolate import LSQUnivariateSpline

--- a/obspy/signal/differentiate_and_integrate.py
+++ b/obspy/signal/differentiate_and_integrate.py
@@ -9,9 +9,7 @@ Integration and differentiation routines.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import scipy.integrate

--- a/obspy/signal/evrespwrapper.py
+++ b/obspy/signal/evrespwrapper.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 

--- a/obspy/signal/evrespwrapper.py
+++ b/obspy/signal/evrespwrapper.py
@@ -236,11 +236,11 @@ clibevresp._obspy_calc_resp.argtypes = [
     C.POINTER(Channel),
     np.ctypeslib.ndpointer(dtype=np.float64,  # freqs
                            ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags='C_CONTIGUOUS'),
     C.c_int,
     np.ctypeslib.ndpointer(dtype=np.complex128,  # output
                            ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+                           flags='C_CONTIGUOUS'),
     C.c_char_p,
     C.c_int,
     C.c_int,

--- a/obspy/signal/filter.py
+++ b/obspy/signal/filter.py
@@ -17,9 +17,7 @@ Various Seismogram Filtering Functions
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import warnings
 

--- a/obspy/signal/freqattributes.py
+++ b/obspy/signal/freqattributes.py
@@ -15,9 +15,7 @@ Frequency Attributes
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from operator import itemgetter
 

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -2,10 +2,7 @@
 """
 Defines the libsignal and evalresp structures and blockettes.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -18,22 +18,16 @@ clibevresp = _load_cdll("evresp")
 
 clibsignal.calcSteer.argtypes = [
     C.c_int, C.c_int, C.c_int, C.c_int, C.c_int, C.c_float,
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=3,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=4,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=3, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=4, flags='C_CONTIGUOUS'),
 ]
 clibsignal.calcSteer.restype = C.c_void_p
 
 clibsignal.generalizedBeamformer.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=4,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=3,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=4, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.complex128, ndim=3, flags='C_CONTIGUOUS'),
     C.c_int, C.c_int, C.c_int, C.c_int, C.c_int,
     C.c_double,
     C.c_int,
@@ -41,38 +35,29 @@ clibsignal.generalizedBeamformer.argtypes = [
 clibsignal.generalizedBeamformer.restype = C.c_int
 
 clibsignal.X_corr.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int, C.c_int, C.c_int,
     C.POINTER(C.c_int), C.POINTER(C.c_double)]
 clibsignal.X_corr.restype = C.c_int
 
 clibsignal.recstalta.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int, C.c_int, C.c_int]
 clibsignal.recstalta.restype = C.c_void_p
 
 clibsignal.ppick.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int, C.POINTER(C.c_int), C.c_char_p, C.c_float, C.c_int, C.c_int,
     C.c_float, C.c_float, C.c_int, C.c_int]
 clibsignal.ppick.restype = C.c_int
 
 clibsignal.ar_picker.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float32, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int, C.c_float, C.c_float, C.c_float, C.c_float, C.c_float,
     C.c_float, C.c_float, C.c_int, C.c_int, C.POINTER(C.c_float),
     C.POINTER(C.c_float), C.c_double, C.c_double, C.c_int]
@@ -84,40 +69,31 @@ clibsignal.utl_geo_km.argtypes = [C.c_double, C.c_double, C.c_double,
 clibsignal.utl_geo_km.restype = C.c_void_p
 
 head_stalta_t = np.dtype([
-    (native_str('N'), np.uint32, 1),
-    (native_str('nsta'), np.uint32, 1),
-    (native_str('nlta'), np.uint32, 1),
+    ('N', np.uint32, 1),
+    ('nsta', np.uint32, 1),
+    ('nlta', np.uint32, 1),
 ], align=True)
 
 clibsignal.stalta.argtypes = [
-    np.ctypeslib.ndpointer(dtype=head_stalta_t, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=head_stalta_t, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
 ]
 clibsignal.stalta.restype = C.c_int
 
 clibsignal.hermite_interpolation.argtypes = [
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int, C.c_int, C.c_double, C.c_double]
 clibsignal.hermite_interpolation.restype = C.c_void_p
 
 clibsignal.lanczos_resample.argtypes = [
     # y_in
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # y_out
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # dt
     C.c_double,
     # offset
@@ -134,11 +110,9 @@ clibsignal.lanczos_resample.restype = None
 
 clibsignal.calculate_kernel.argtypes = [
     # double *x
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # double *y
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # int len
     C.c_int,
     # int a,
@@ -181,9 +155,7 @@ clibevresp.evresp.argtypes = [
     C.c_char_p,
     C.c_char_p,
     C.c_char_p,
-    np.ctypeslib.ndpointer(dtype=np.float64,
-                           ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     C.c_int,
     C.c_char_p,
     C.c_char_p,

--- a/obspy/signal/hoctavbands.py
+++ b/obspy/signal/hoctavbands.py
@@ -15,9 +15,7 @@ Half Octave Bands
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from scipy import fftpack

--- a/obspy/signal/interpolation.py
+++ b/obspy/signal/interpolation.py
@@ -9,9 +9,7 @@ Some Seismogram Interpolating Functions.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import scipy.interpolate

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -242,7 +242,7 @@ def evalresp_for_frequencies(t_samp, frequencies, filename, date, station='*',
     :rtype: :class:`numpy.ndarray` complex128
     :return: Frequency response from SEED RESP-file for given frequencies
     """
-    if isinstance(filename, (str, native_str)):
+    if isinstance(filename, str):
         with open(filename, 'rb') as fh:
             data = fh.read()
     elif hasattr(filename, 'read'):

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -19,10 +19,7 @@ to m/s.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import math as M

--- a/obspy/signal/konnoohmachismoothing.py
+++ b/obspy/signal/konnoohmachismoothing.py
@@ -18,9 +18,7 @@ Functions to smooth spectra with the so called Konno & Ohmachi method.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import warnings
 

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -8,9 +8,7 @@ Functions for polarization analysis.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 import warnings

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -17,9 +17,7 @@ Various Seismogram Rotation Functions
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from math import cos, sin, radians
 

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -17,10 +17,7 @@ Various Routines Related to Spectral Estimation
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import bisect
 import glob

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -815,11 +815,11 @@ class PPSD(object):
         # otherwise compute it and store it for subsequent stacks on the
         # same data (has to be recomputed when additional data gets added)
         else:
-            dtype = np.dtype([(native_str('time_of_day'), np.float32),
-                              (native_str('iso_weekday'), np.int8),
-                              (native_str('iso_week'), np.int8),
-                              (native_str('year'), np.int16),
-                              (native_str('month'), np.int8)])
+            dtype = np.dtype([('time_of_day', np.float32),
+                              ('iso_weekday', np.int8),
+                              ('iso_week', np.int8),
+                              ('year', np.int16),
+                              ('month', np.int8)])
             times_all_details = np.empty(shape=len(self._times_processed),
                                          dtype=dtype)
             utc_times_all = [UTCDateTime(t) for t in self._times_processed]
@@ -1063,7 +1063,7 @@ class PPSD(object):
             return self._get_response_from_parser(tr)
         elif isinstance(self.metadata, dict):
             return self._get_response_from_paz_dict(tr)
-        elif isinstance(self.metadata, (str, native_str)):
+        elif isinstance(self.metadata, str):
             return self._get_response_from_resp(tr)
         else:
             msg = "Unexpected type for `metadata`: %s" % type(self.metadata)

--- a/obspy/signal/tests/__init__.py
+++ b/obspy/signal/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/signal/tests/test_array_analysis.py
+++ b/obspy/signal/tests/test_array_analysis.py
@@ -3,9 +3,7 @@
 """
 The array_analysis test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/signal/tests/test_calibration.py
+++ b/obspy/signal/tests/test_calibration.py
@@ -3,9 +3,7 @@
 """
 The calibration test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_cpxtrace.py
+++ b/obspy/signal/tests/test_cpxtrace.py
@@ -3,9 +3,7 @@
 """
 The cpxtrace.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_cross_correlation.py
+++ b/obspy/signal/tests/test_cross_correlation.py
@@ -2,9 +2,7 @@
 """
 The cross correlation test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_detrend.py
+++ b/obspy/signal/tests/test_detrend.py
@@ -3,9 +3,7 @@
 """
 Tests for data detrending.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_differentiate_and_integrate.py
+++ b/obspy/signal/tests/test_differentiate_and_integrate.py
@@ -3,9 +3,7 @@
 """
 Tests for differentiation and integration functions.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/signal/tests/test_filter.py
+++ b/obspy/signal/tests/test_filter.py
@@ -3,9 +3,7 @@
 """
 The Filter test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -3,9 +3,7 @@
 """
 The freqattributes.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_hoctavbands.py
+++ b/obspy/signal/tests/test_hoctavbands.py
@@ -3,9 +3,7 @@
 """
 The hoctavbands.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_interpolation.py
+++ b/obspy/signal/tests/test_interpolation.py
@@ -3,9 +3,7 @@
 """
 The interpolation test suite for ObsPy.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -3,10 +3,7 @@
 """
 The InvSim test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import gzip

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -478,13 +478,13 @@ class InvSimTestCase(unittest.TestCase):
         clibevresp.evr_spline.argtypes = [
             C.c_int,  # num_points
             np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                                   flags=native_str('C_CONTIGUOUS')),
+                                   flags='C_CONTIGUOUS'),
             np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                                   flags=native_str('C_CONTIGUOUS')),
+                                   flags='C_CONTIGUOUS'),
             C.c_double,  # tension
             C.c_double,  # k
             np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                                   flags=native_str('C_CONTIGUOUS')),
+                                   flags='C_CONTIGUOUS'),
             C.c_int,  # num_xvals
             C.POINTER(C.POINTER(C.c_double)),
             C.POINTER(C.c_int)

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -3,9 +3,7 @@
 """
 The polarization.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import warnings

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -3,9 +3,7 @@
 """
 The polarization.core test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 from os.path import dirname, join

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -3,10 +3,7 @@
 """
 The Rotate test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import PY2
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os
@@ -14,6 +11,7 @@ import unittest
 
 import numpy as np
 
+from obspy.core.compatibility import PY2
 from obspy.signal.rotate import (rotate_lqt_zne, rotate_ne_rt, rotate_rt_ne,
                                  rotate_zne_lqt, _dip_azimuth2zse_base_vector,
                                  rotate2zne)

--- a/obspy/signal/tests/test_sonic.py
+++ b/obspy/signal/tests/test_sonic.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import io
 import unittest

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -3,10 +3,7 @@
 """
 The psd test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -249,9 +249,9 @@ class PsdTestCase(unittest.TestCase):
         file_data_iris = os.path.join(self.path, 'IRISpdfExample')
         data = np.genfromtxt(
             file_data_iris, comments='#', delimiter=',',
-            dtype=[(native_str("freq"), np.float64),
-                   (native_str("power"), np.int32),
-                   (native_str("hits"), np.int32)])
+            dtype=[("freq", np.float64),
+                   ("power", np.int32),
+                   ("hits", np.int32)])
         freq = data["freq"]
         power = data["power"]
         hits = data["hits"]

--- a/obspy/signal/tests/test_stream.py
+++ b/obspy/signal/tests/test_stream.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 from copy import deepcopy

--- a/obspy/signal/tests/test_tf_misfit.py
+++ b/obspy/signal/tests/test_tf_misfit.py
@@ -3,9 +3,7 @@
 """
 The tf_misfit test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/signal/tests/test_trace.py
+++ b/obspy/signal/tests/test_trace.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 from copy import deepcopy

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -2,9 +2,7 @@
 """
 The obspy.signal.trigger test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import gzip
 import os

--- a/obspy/signal/tests/test_util.py
+++ b/obspy/signal/tests/test_util.py
@@ -3,9 +3,7 @@
 """
 The Filter test suite.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import unittest

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -18,9 +18,7 @@ Various Time Frequency Misfit Functions based on [Kristekova2006]_ and
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -25,9 +25,7 @@ characteristic functions and a coincidence triggering routine.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from collections import deque
 import ctypes as C

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -9,10 +9,7 @@ Various additional utilities for obspy.signal.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import math as M

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -89,7 +89,7 @@ def next_pow_2(i):
     """
     # do not use NumPy here, math is much faster for single values
     buf = M.ceil(M.log(i) / M.log(2))
-    return native(int(M.pow(2, buf)))
+    return int(M.pow(2, buf))
 
 
 def prev_pow_2(i):

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -360,9 +360,7 @@ Building custom models
 Custom models can be built from ``.tvel`` and ``.nd`` files using the
 :func:`~obspy.taup.taup_create.build_taup_model` function.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 # Module wide default settings.
 _DEFAULT_VALUES = {

--- a/obspy/taup/c_wrappers.py
+++ b/obspy/taup/c_wrappers.py
@@ -16,20 +16,15 @@ clibtau = _load_cdll("tau")
 
 clibtau.tau_branch_calc_time_dist_inner_loop.argtypes = [
     # ray_params
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='C_CONTIGUOUS'),
     # time
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='C_CONTIGUOUS'),
     # dist
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=2, flags='C_CONTIGUOUS'),
     # layer, record array, 64bit floats. 2D array in memory
-    np.ctypeslib.ndpointer(dtype=SlownessLayer, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=SlownessLayer, ndim=1, flags='C_CONTIGUOUS'),
     # time_dist, record array, 64bit floats. 2D array in memory
-    np.ctypeslib.ndpointer(dtype=TimeDist, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=TimeDist, ndim=1, flags='C_CONTIGUOUS'),
     # max_i
     C.c_int32,
     # max_j
@@ -48,17 +43,13 @@ clibtau.seismic_phase_calc_time_inner_loop.argtypes = [
     # max_distance
     C.c_double,
     # dist
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # ray_param
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # search_dist_results
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # ray_num_results
-    np.ctypeslib.ndpointer(dtype=np.int32, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.int32, ndim=1, flags='C_CONTIGUOUS'),
     # count
     C.c_int
 ]
@@ -67,17 +58,13 @@ clibtau.seismic_phase_calc_time_inner_loop.restype = C.c_int
 
 clibtau.bullen_radial_slowness_inner_loop.argtypes = [
     # layer, record array, 64bit floats. 2D array in memory
-    np.ctypeslib.ndpointer(dtype=SlownessLayer, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=SlownessLayer, ndim=1, flags='C_CONTIGUOUS'),
     # p
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # time
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # dist
-    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
-                           flags=native_str('C_CONTIGUOUS')),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1, flags='C_CONTIGUOUS'),
     # radius
     C.c_double,
     # max_i

--- a/obspy/taup/c_wrappers.py
+++ b/obspy/taup/c_wrappers.py
@@ -2,10 +2,7 @@
 """
 C wrappers for some crucial inner loops of TauPy written in C.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import ctypes as C
 import numpy as np

--- a/obspy/taup/helper_classes.py
+++ b/obspy/taup/helper_classes.py
@@ -3,10 +3,7 @@
 """
 Holds various helper classes to keep the file number manageable.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
 

--- a/obspy/taup/helper_classes.py
+++ b/obspy/taup/helper_classes.py
@@ -19,10 +19,10 @@ class TauModelError(Exception):
 
 
 SlownessLayer = np.dtype([
-    (native_str('top_p'), np.float_),
-    (native_str('top_depth'), np.float_),
-    (native_str('bot_p'), np.float_),
-    (native_str('bot_depth'), np.float_),
+    ('top_p', np.float_),
+    ('top_depth', np.float_),
+    ('bot_p', np.float_),
+    ('bot_depth', np.float_),
 ])
 
 
@@ -31,10 +31,10 @@ Holds the ray parameter, time and distance increments, and optionally a
 depth, for a ray passing through some layer.
 """
 TimeDist = np.dtype([
-    (native_str('p'), np.float_),
-    (native_str('time'), np.float_),
-    (native_str('dist'), np.float_),
-    (native_str('depth'), np.float_),
+    ('p', np.float_),
+    ('time', np.float_),
+    ('dist', np.float_),
+    ('depth', np.float_),
 ])
 
 
@@ -43,12 +43,12 @@ Holds the ray parameter, time and distance increments, and optionally a
 depth, latitude and longitude for a ray passing through some layer.
 """
 TimeDistGeo = np.dtype([
-    (native_str('p'), np.float_),
-    (native_str('time'), np.float_),
-    (native_str('dist'), np.float_),
-    (native_str('depth'), np.float_),
-    (native_str('lat'), np.float_),
-    (native_str('lon'), np.float_)
+    ('p', np.float_),
+    ('time', np.float_),
+    ('dist', np.float_),
+    ('depth', np.float_),
+    ('lat', np.float_),
+    ('lon', np.float_)
 ])
 
 
@@ -57,10 +57,10 @@ Tracks critical points (discontinuities or reversals in slowness gradient)
 within slowness and velocity models.
 """
 CriticalDepth = np.dtype([
-    (native_str('depth'), np.float_),
-    (native_str('vel_layer_num'), np.int_),
-    (native_str('p_layer_num'), np.int_),
-    (native_str('s_layer_num'), np.int_),
+    ('depth', np.float_),
+    ('vel_layer_num', np.int_),
+    ('p_layer_num', np.int_),
+    ('s_layer_num', np.int_),
 ])
 
 

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -3,10 +3,7 @@
 """
 Objects and functions dealing with seismic phases.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import raise_from
+from __future__ import absolute_import, division, print_function
 
 from itertools import count
 import math

--- a/obspy/taup/slowness_layer.py
+++ b/obspy/taup/slowness_layer.py
@@ -3,9 +3,7 @@
 """
 Functions acting on slowness layers.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import math
 

--- a/obspy/taup/slowness_model.py
+++ b/obspy/taup/slowness_model.py
@@ -3,9 +3,7 @@
 """
 Slowness model class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from copy import deepcopy
 import math

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -3,9 +3,7 @@
 """
 High-level interface to travel-time calculation routines.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import copy
 import warnings

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -445,16 +445,16 @@ class TauBranch(object):
         """
         Store all attributes for serialization in a structured array.
         """
-        dtypes = [(native_str('debug'), np.bool_),
-                  (native_str('bot_depth'), np.float_),
-                  (native_str('dist'), np.float_, self.dist.shape),
-                  (native_str('is_p_wave'), np.bool_),
-                  (native_str('max_ray_param'), np.float_),
-                  (native_str('min_ray_param'), np.float_),
-                  (native_str('min_turn_ray_param'), np.float_),
-                  (native_str('tau'), np.float_, self.tau.shape),
-                  (native_str('time'), np.float_, self.time.shape),
-                  (native_str('top_depth'), np.float_)]
+        dtypes = [('debug', np.bool_),
+                  ('bot_depth', np.float_),
+                  ('dist', np.float_, self.dist.shape),
+                  ('is_p_wave', np.bool_),
+                  ('max_ray_param', np.float_),
+                  ('min_ray_param', np.float_),
+                  ('min_turn_ray_param', np.float_),
+                  ('tau', np.float_, self.tau.shape),
+                  ('time', np.float_, self.time.shape),
+                  ('top_depth', np.float_)]
         arr = np.empty(shape=(), dtype=dtypes)
         for dtype in dtypes:
             key = dtype[0]

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -3,10 +3,7 @@
 """
 Object dealing with branches in the model.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/taup/tau_model.py
+++ b/obspy/taup/tau_model.py
@@ -487,17 +487,17 @@ class TauModel(object):
                 arrays[key] = self.tau_branches[i_][j_]._to_array()
 
         # c) handle simple contents of .s_mod
-        dtypes = [(native_str('debug'), np.bool_),
-                  (native_str('p_wave'), np.bool_),
-                  (native_str('s_wave'), np.bool_),
-                  (native_str('allow_inner_core_s'), np.bool_),
-                  (native_str('max_delta_p'), np.float_),
-                  (native_str('max_depth_interval'), np.float_),
-                  (native_str('max_interp_error'), np.float_),
-                  (native_str('max_range_interval'), np.float_),
-                  (native_str('min_delta_p'), np.float_),
-                  (native_str('radius_of_planet'), np.float_),
-                  (native_str('slowness_tolerance'), np.float_)]
+        dtypes = [('debug', np.bool_),
+                  ('p_wave', np.bool_),
+                  ('s_wave', np.bool_),
+                  ('allow_inner_core_s', np.bool_),
+                  ('max_delta_p', np.float_),
+                  ('max_depth_interval', np.float_),
+                  ('max_interp_error', np.float_),
+                  ('max_range_interval', np.float_),
+                  ('min_delta_p', np.float_),
+                  ('radius_of_planet', np.float_),
+                  ('slowness_tolerance', np.float_)]
         slowness_model = np.empty(shape=(), dtype=dtypes)
         for dtype in dtypes:
             key = dtype[0]
@@ -518,15 +518,15 @@ class TauModel(object):
             arrays['s_mod.' + key] = arr_
 
         # e) handle .s_mod.v_mod
-        dtypes = [(native_str('cmb_depth'), np.float_),
-                  (native_str('iocb_depth'), np.float_),
-                  (native_str('is_spherical'), np.bool_),
-                  (native_str('max_radius'), np.float_),
-                  (native_str('min_radius'), np.int_),
-                  (native_str('model_name'), np.str_,
+        dtypes = [('cmb_depth', np.float_),
+                  ('iocb_depth', np.float_),
+                  ('is_spherical', np.bool_),
+                  ('max_radius', np.float_),
+                  ('min_radius', np.int_),
+                  ('model_name', np.str_,
                    len(self.s_mod.v_mod.model_name)),
-                  (native_str('moho_depth'), np.float_),
-                  (native_str('radius_of_planet'), np.float_)]
+                  ('moho_depth', np.float_),
+                  ('radius_of_planet', np.float_)]
         velocity_model = np.empty(shape=(), dtype=dtypes)
         for dtype in dtypes:
             key = dtype[0]
@@ -608,7 +608,7 @@ class TauModel(object):
 
             # e) handle .s_mod.v_mod
             velocity_model = VelocityModel(
-                model_name=native_str(npz["v_mod"]["model_name"]),
+                model_name=npz["v_mod"]["model_name"],
                 radius_of_planet=float(npz["v_mod"]["radius_of_planet"]),
                 min_radius=float(npz["v_mod"]["min_radius"]),
                 max_radius=float(npz["v_mod"]["max_radius"]),

--- a/obspy/taup/tau_model.py
+++ b/obspy/taup/tau_model.py
@@ -3,10 +3,7 @@
 """
 Internal TauModel class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 from collections import OrderedDict
 import os

--- a/obspy/taup/taup_create.py
+++ b/obspy/taup/taup_create.py
@@ -3,9 +3,7 @@
 """
 Class to create new models.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import glob
 import inspect

--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -12,9 +12,7 @@ in the distance for the ray to pass through each layer has a larger effect.
 We do not make the larger correction.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 import warnings
 
 import numpy as np

--- a/obspy/taup/taup_path.py
+++ b/obspy/taup/taup_path.py
@@ -3,9 +3,7 @@
 """
 Ray path calculations.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .taup_pierce import TauPPierce
 

--- a/obspy/taup/taup_pierce.py
+++ b/obspy/taup/taup_pierce.py
@@ -3,9 +3,7 @@
 """
 Pierce point calculations.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .taup_time import TauPTime
 

--- a/obspy/taup/taup_time.py
+++ b/obspy/taup/taup_time.py
@@ -3,9 +3,7 @@
 """
 Travel time calculations.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 from .helper_classes import TauModelError
 from .seismic_phase import SeismicPhase

--- a/obspy/taup/tests/__init__.py
+++ b/obspy/taup/tests/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/taup/tests/test_misc.py
+++ b/obspy/taup/tests/test_misc.py
@@ -3,9 +3,7 @@
 """
 Tests the high level obspy.taup.tau interface.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/taup/tests/test_plotting.py
+++ b/obspy/taup/tests/test_plotting.py
@@ -3,9 +3,7 @@
 """
 Tests the high level obspy.taup.tau interface.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 import unittest

--- a/obspy/taup/tests/test_seismic_phase.py
+++ b/obspy/taup/tests/test_seismic_phase.py
@@ -3,9 +3,7 @@
 """
 Tests the SeismicPhase class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/taup/tests/test_slowness_model.py
+++ b/obspy/taup/tests/test_slowness_model.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/taup/tests/test_split_model.py
+++ b/obspy/taup/tests/test_split_model.py
@@ -3,9 +3,7 @@
 """
 Tests the SeismicPhase class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -3,10 +3,7 @@
 """
 Tests the high level obspy.taup.tau interface.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import collections
 import inspect

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -44,15 +44,15 @@ class TauPyModelTestCase(unittest.TestCase):
             output = np.genfromtxt(
                 fh,
                 usecols=[0, 1, 2, 3, 4, 5, 6, 7, 9],
-                dtype=[(native_str('distance'), np.float_),
-                       (native_str('depth'), np.float_),
-                       (native_str('name'), (np.str_, 10)),
-                       (native_str('time'), np.float_),
-                       (native_str('ray_param_sec_degree'), np.float_),
-                       (native_str('takeoff_angle'), np.float_),
-                       (native_str('incident_angle'), np.float_),
-                       (native_str('purist_distance'), np.float_),
-                       (native_str('purist_name'), (np.str_, 10))])
+                dtype=[('distance', np.float_),
+                       ('depth', np.float_),
+                       ('name', (np.str_, 10)),
+                       ('time', np.float_),
+                       ('ray_param_sec_degree', np.float_),
+                       ('takeoff_angle', np.float_),
+                       ('incident_angle', np.float_),
+                       ('purist_distance', np.float_),
+                       ('purist_name', (np.str_, 10))])
 
         output = np.atleast_1d(output)
         return output
@@ -664,10 +664,10 @@ class TauPyModelTestCase(unittest.TestCase):
         time = time[:, ::2] * 60.0 + time[:, 1::2]
 
         values = np.empty(np.size(ray_param),
-                          dtype=[(native_str('depth'), np.float_),
-                                 (native_str('dist'), np.float_),
-                                 (native_str('ray_param'), np.float_),
-                                 (native_str('time'), np.float_)])
+                          dtype=[('depth', np.float_),
+                                 ('dist', np.float_),
+                                 ('ray_param', np.float_),
+                                 ('time', np.float_)])
 
         values['depth'] = np.tile(depths, len(dist))
         values['dist'] = np.repeat(dist, len(depths))

--- a/obspy/taup/tests/test_taup_geo.py
+++ b/obspy/taup/tests/test_taup_geo.py
@@ -3,9 +3,7 @@
 """
 Tests the SeismicPhase class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import unittest
 

--- a/obspy/taup/tests/test_velocity_model.py
+++ b/obspy/taup/tests/test_velocity_model.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/taup/utils.py
+++ b/obspy/taup/utils.py
@@ -3,9 +3,7 @@
 """
 Misc functionality.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import inspect
 import os

--- a/obspy/taup/velocity_layer.py
+++ b/obspy/taup/velocity_layer.py
@@ -24,18 +24,18 @@ import numpy as np
 #: * ``top_qs``: The S wave attenuation at the top.
 #: * ``bot_qs``: The S wave attenuation at the bottom.
 VelocityLayer = np.dtype([
-    (native_str('top_depth'), np.float_),
-    (native_str('bot_depth'), np.float_),
-    (native_str('top_p_velocity'), np.float_),
-    (native_str('bot_p_velocity'), np.float_),
-    (native_str('top_s_velocity'), np.float_),
-    (native_str('bot_s_velocity'), np.float_),
-    (native_str('top_density'), np.float_),
-    (native_str('bot_density'), np.float_),
-    (native_str('top_qp'), np.float_),
-    (native_str('bot_qp'), np.float_),
-    (native_str('top_qs'), np.float_),
-    (native_str('bot_qs'), np.float_),
+    ('top_depth', np.float_),
+    ('bot_depth', np.float_),
+    ('top_p_velocity', np.float_),
+    ('bot_p_velocity', np.float_),
+    ('top_s_velocity', np.float_),
+    ('bot_s_velocity', np.float_),
+    ('top_density', np.float_),
+    ('bot_density', np.float_),
+    ('top_qp', np.float_),
+    ('bot_qp', np.float_),
+    ('top_qs', np.float_),
+    ('bot_qs', np.float_),
 ])
 
 

--- a/obspy/taup/velocity_layer.py
+++ b/obspy/taup/velocity_layer.py
@@ -3,10 +3,7 @@
 """
 Functionality for dealing with a single velocity layer.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
-from future.utils import native_str
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 

--- a/obspy/taup/velocity_model.py
+++ b/obspy/taup/velocity_model.py
@@ -3,9 +3,7 @@
 """
 Velocity model class.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from future.builtins import *  # NOQA
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ KEYWORDS = [
 
 # when bumping to numpy 1.9.0: replace bytes() in io.reftek with np.tobytes()
 INSTALL_REQUIRES = [
-    'future>=0.12.4',
     'numpy>=1.6.1',
     'scipy>=0.9.0',
     'matplotlib>=1.1.0',


### PR DESCRIPTION
This is a branch of mine that removes the `future` dependency. It is just a bit too invasive and a big liability for us, especially as it does not appear to be updated a lot anymore so we really have to remove it.

I likely won't have time to finish this until after christmas but due to recent issues I think its a good idea to push this and maybe somebody else feels like taking over.

This PR mainly does two things:

* Remove future imports.
* Removes the `unicode_literals` imports from `__future__`. There are various reasons why this is not a good idea so now its mostly gone.


What works last time I tested it:

* Most of `core`, `io`, and `taup`.


Most clients don't yet work and I think the best way forward it to just make all of them depend on the `requests` library which will take care of Py2/3 compatibility for us.