### PR TITLE
Can't get interactive plots in Jupyter Notebook

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -135,6 +135,8 @@
    * The functionality behind the `obspy-scan` command line script has been
      refactored into a `Scanner` class so that it can be reused in custom
      workflows. (see #1444)
+   * Almost always return the figure handle for the plots to make it work with
+     the jupyter notebooks (see #1615).
  - obspy.imaging.cm:
    * new colormap: viridis_white. This is a modification of viridis that
      goes to white instead of yellow but remains perceptually uniform. It

--- a/obspy/imaging/__init__.py
+++ b/obspy/imaging/__init__.py
@@ -32,9 +32,10 @@ Examples files may be retrieved via https://examples.obspy.org.
 BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z - ... | 100.0 Hz, 3000 samples
 BW.RJOB..EHN | 2009-08-24T00:20:03.000000Z - ... | 100.0 Hz, 3000 samples
 BW.RJOB..EHE | 2009-08-24T00:20:03.000000Z - ... | 100.0 Hz, 3000 samples
->>> st.plot(color='gray', tick_format='%I:%M %p',
+>>> st.plot(color='gray', tick_format='%I:%M %p',  # doctest: +ELLIPSIS
 ...         starttime=st[0].stats.starttime,
 ...         endtime=st[0].stats.starttime+20)
+<...Figure ...>
 
 .. plot::
 
@@ -54,7 +55,7 @@ size of 4096 points. For more info see
 
 >>> from obspy import read
 >>> st = read()
->>> st[0].spectrogram(log=True) #doctest: +SKIP
+>>> st[0].spectrogram(log=True)  # doctest: +SKIP
 
 .. plot::
 

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -325,6 +325,9 @@ class WaveformPlotting(object):
                             plt.show(block=self.block)
                         except Exception:
                             plt.show()
+                    # Also return the figure to make it work the jupyter
+                    # notebooks.
+                    return self.fig
 
     def plot(self, *args, **kwargs):
         """


### PR DESCRIPTION
Hello,

If I run the following code in a Jupyter Notebook Python3 cell I get a static image plot instead of the more useful interactive plot.

```python
%matplotlib notebook

import matplotlib.pyplot as plt
import numpy as np

import obspy
st = obspy.read()
st.plot()
```

If in a following cell I execute

```python
t = np.arange(0.0, 2.0, 0.01)
s = np.sin(2*np.pi*t)
plt.plot(t, s)
```

I get the interactive plot, as expected.
Is there a problem with ObsPy?

I'm using obspy-python3 compiled from a reasonably up-to-date git snapshot on a Debian system.

python3-obspy 1.0.2.post0+794.ge647893002
jupyter-notebook 4.2.3
python3-jupyter-client 4.4.0
python3-jupyter-core 4.2.0
python3 3.5.2

Thanks!
