### PR TITLE
How to implement ordering of "extra" tags.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,8 @@ master: (doi: 10.5281/zenodo.165135)
      objects (see #1514).
    * Instrument responses can now also be calculated for a given list of
      frequencies (see #1598).
+   * Order of extra tags for event type classes serialized to QuakeML can now
+     be controlled by using an OrderedDict (see #1617)
  - obspy.clients.fdsn:
    * empty SEED codes (e.g. ``network=''``) will now be properly sent to the
      server as options and not omitted, which led to wildcard matching (for

--- a/misc/docs/source/tutorial/code_snippets/quakeml_custom_tags.rst
+++ b/misc/docs/source/tutorial/code_snippets/quakeml_custom_tags.rst
@@ -158,3 +158,25 @@ retrieved in the following way:
 
     12300000000.0
     true
+
+The order of extra tags can be controlled by using an
+:py:class:`~collections.OrderedDict` for the extra attribute (using a plain
+`dict` or :class:`~obspy.core.util.attribdict.AttribDict` can result in
+arbitrary order of tags):
+
+.. code-block:: python
+
+    from collections import OrderedDict
+    from obspy.core.event import Catalog, Event
+
+    ns = 'http://some-page.de/xmlns/1.0'
+
+    my_tag1 = {'namespace': ns, 'value': 'some value 1'}
+    my_tag2 = {'namespace': ns, 'value': 'some value 2'}
+
+    event = Event()
+    cat = Catalog(events=[event])
+    event.extra = OrderedDict()
+    event.extra['myFirstExtraTag'] = my_tag2
+    event.extra['mySecondExtraTag'] = my_tag1
+    cat.write('my_catalog.xml', 'QUAKEML')

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -353,6 +353,12 @@ def _event_type_class_factory(class_name, class_attributes=[],
             Custom property implementation that works if the class is
             inheriting from AttribDict.
             """
+            # avoid type casting of 'extra' attribute, to make it possible to
+            # control ordering of extra tags by using an OrderedDict for
+            # 'extra'.
+            if name == 'extra':
+                dict.__setattr__(self, name, value)
+                return
             # Pass to the parent method if not a custom property.
             if name not in self._property_dict.keys():
                 AttribDict.__setattr__(self, name, value)


### PR DESCRIPTION
When [custom defined tags](https://docs.obspy.org/tutorial/code_snippets/quakeml_custom_tags.html) are added to a catalog or its children and then this catalog is written to QuakeML, the order of these "extra" is random. 

This is not unexpected, as the "extra" info is essentially a dictionary and thus has no order, but it is an annoyance when trying to compare two QuakeML files, for example during unit testing.

How can I enforce an order when the "extra" tags are written to QuakeML? A simple sorting would be fine. If I need to define an order via a schema, can someone give me a simple example, assuming for example that all the fields are simple text?