### PR TITLE
docker: install geographiclib

### DIFF
--- a/misc/docker/base_images/centos_7/Dockerfile
+++ b/misc/docker/base_images/centos_7/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Lion Krischer
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 # Can fail on occasion.
 RUN yum -y upgrade || true
-RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-pip python-requests python-decorator
+RUN yum install -y gcc numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-pip python-requests python-decorator python-geographiclib
 RUN easy_install -U setuptools pip
 RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
 RUN apt-get install -y debhelper python-all devscripts
 
 # install fake future packages, so that we can properly install built obspy deb

--- a/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \

--- a/misc/docker/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \

--- a/misc/docker/base_images/fedora_23/Dockerfile
+++ b/misc/docker/base_images/fedora_23/Dockerfile
@@ -4,5 +4,5 @@ MAINTAINER Lion Krischer
 
 # Can fail on occasion.
 RUN dnf -y upgrade || true
-RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future
+RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future python-geographiclib
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker/base_images/fedora_24/Dockerfile
+++ b/misc/docker/base_images/fedora_24/Dockerfile
@@ -4,5 +4,5 @@ MAINTAINER Lion Krischer
 
 # Can fail on occasion.
 RUN dnf -y upgrade || true
-RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future
+RUN dnf install -y gcc redhat-rpm-config numpy scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-basemap python-basemap-data python-tornado python-pip python-decorator python-requests python-future python-geographiclib
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker/base_images/opensuse_13_2/Dockerfile
+++ b/misc/docker/base_images/opensuse_13_2/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Lion Krischer
 RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_13.2/Application:Geo.repo
 RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
-RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose ca-certificates-mozilla
+RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose ca-certificates-mozilla python-geographiclib
 RUN pip install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip

--- a/misc/docker/base_images/opensuse_leap_42_1/Dockerfile
+++ b/misc/docker/base_images/opensuse_leap_42_1/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Lion Krischer
 RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/Application:/Geo/openSUSE_Leap_42.1/Application:Geo.repo
 RUN zypper --non-interactive --no-gpg-checks refresh
 RUN zypper --non-interactive update
-RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose
+RUN zypper --non-interactive install gcc python-devel python-numpy python-scipy python-matplotlib python-SQLAlchemy python-lxml python-mock python-pip python-tornado python-requests python-decorator python-basemap python-basemap-data python-nose python-geographiclib
 RUN pip install --index-url=http://pypi.python.org/simple/ --trusted-host pypi.python.org future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 RUN zypper --non-interactive install ca-certificates-mozilla

--- a/misc/docker/base_images/ubuntu_12_04_precise/Dockerfile
+++ b/misc/docker/base_images/ubuntu_12_04_precise/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
 RUN apt-get install -y debhelper python-all devscripts
 
 # install fake future packages, so that we can properly install built obspy deb

--- a/misc/docker/base_images/ubuntu_12_04_precise_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_12_04_precise_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \

--- a/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-decorator \
     python-dev \
     python-flake8 \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \

--- a/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \

--- a/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-geographiclib \
     python-imaging \
     python-lxml \
     python-matplotlib \


### PR DESCRIPTION
Install `geographiclib` in docker base images for testing of geodetic stuff, see #1236.