### PR TITLE
Correctly writing zero station magnitude contributions and reading/writing event regions in QuakeML

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,13 +21,16 @@
    * ObsPy can now read MiniSEED files with no blockette 1000. (see #1544)
    * ObsPy now always writes Blockette 100 if sampling rate accuracy is
      otherwise lost. (see #1550)
+ - obspy.io.quakeml:
+   * write StationMagnitude.residual even when it is zero (see #1625)
+   * read & write Event.region
  - obspy.io.sac:
    * `SACTrace.lpspol` and `lcalda` are `True` and `False` by default, when
       created via `SACTrace.from_obspy_trace` with a `Trace` that has no SAC
       inheritance. (see #1507)
    * Reference time not written to SAC file when made from scratch
      (see #1575)
-- obspy.io.sh:
+ - obspy.io.sh:
    * Fix writing of long headers for python3
    * Whitespace in header fields is not ignored anymore (see #1552)
  - obspy.io.stationxml:

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
+Nick Ackerley
 Charles J. Ammon
 Emanuel Antunes
 Ólafur St. Arnarsson

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1153,7 +1153,7 @@ class Pickler(object):
     def _station_magnitude_contributions(self, stat_contrib, element):
         for contrib in stat_contrib:
             contrib_el = etree.Element('stationMagnitudeContribution')
-            self._str(contrib.station_magnitude_id.id, contrib_el, 
+            self._str(contrib.station_magnitude_id.id, contrib_el,
                       'stationMagnitudeID')
             self._str(contrib.weight, contrib_el, 'weight')
             self._str(contrib.residual, contrib_el, 'residual')

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -563,6 +563,7 @@ class Unpickler(object):
         obj.composite_times = self._composite_times(element)
         obj.quality = self._origin_quality(element)
         obj.origin_type = self._xpath2obj('type', element)
+        obj.region = self._xpath2obj('region', element)
         obj.evaluation_mode = self._xpath2obj('evaluationMode', element)
         obj.evaluation_status = self._xpath2obj('evaluationStatus', element)
         obj.creation_info = self._creation_info(element)
@@ -1152,14 +1153,10 @@ class Pickler(object):
     def _station_magnitude_contributions(self, stat_contrib, element):
         for contrib in stat_contrib:
             contrib_el = etree.Element('stationMagnitudeContribution')
-            etree.SubElement(contrib_el, 'stationMagnitudeID').text = \
-                contrib.station_magnitude_id.id
-            if contrib.weight:
-                etree.SubElement(contrib_el, 'weight').text = \
-                    str(contrib.weight)
-            if contrib.residual:
-                etree.SubElement(contrib_el, 'residual').text = \
-                    str(contrib.residual)
+            self._str(contrib.station_magnitude_id.id, contrib_el, 
+                      'stationMagnitudeID')
+            self._str(contrib.weight, contrib_el, 'weight')
+            self._str(contrib.residual, contrib_el, 'residual')
             self._extra(contrib, contrib_el)
             element.append(contrib_el)
 
@@ -1395,6 +1392,7 @@ class Pickler(object):
             if len(qu_el) > 0:
                 element.append(qu_el)
         self._str(origin.origin_type, element, 'type')
+        self._str(origin.region, element, 'region')
         self._str(origin.evaluation_mode, element, 'evaluationMode')
         self._str(origin.evaluation_status, element, 'evaluationStatus')
         self._comments(origin.comments, element)

--- a/obspy/io/quakeml/tests/data/quakeml_1.2_origin.xml
+++ b/obspy/io/quakeml/tests/data/quakeml_1.2_origin.xml
@@ -50,6 +50,7 @@
           <maximumDistance>53.03</maximumDistance>
         </quality>
         <type>hypocenter</type>
+        <region>Kalamazoo</region>
         <evaluationMode>manual</evaluationMode>
         <evaluationStatus>preliminary</evaluationStatus>
         <comment id="smi:some/comment/reference">

--- a/obspy/io/quakeml/tests/data/quakeml_1.2_stationmagnitudecontributions.xml
+++ b/obspy/io/quakeml/tests/data/quakeml_1.2_stationmagnitudecontributions.xml
@@ -15,8 +15,8 @@
         </stationMagnitudeContribution>
         <stationMagnitudeContribution>
             <stationMagnitudeID>smi:ch.ethz.sed/magnitude/station/881334</stationMagnitudeID>
-            <weight>0.55</weight>
-            <residual>0.11</residual>
+            <weight>0.0</weight>
+            <residual>0.0</residual>
         </stationMagnitudeContribution>
       </magnitude>
     </event>

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -159,6 +159,7 @@ class QuakeMLTestCase(unittest.TestCase):
         self.assertEqual(
             origin.earth_model_id,
             ResourceIdentifier(id="smi:same/model/maeh"))
+        self.assertEqual(origin.region, 'Kalamazoo')
         self.assertEqual(origin.evaluation_mode, "manual")
         self.assertEqual(origin.evaluation_status, "preliminary")
         self.assertEqual(origin.origin_type, "hypocenter")
@@ -298,8 +299,8 @@ class QuakeMLTestCase(unittest.TestCase):
         self.assertEqual(
             stat_contrib.station_magnitude_id.id,
             "smi:ch.ethz.sed/magnitude/station/881334")
-        self.assertEqual(stat_contrib.weight, 0.55)
-        self.assertEqual(stat_contrib.residual, 0.11)
+        self.assertEqual(stat_contrib.weight, 0.)
+        self.assertEqual(stat_contrib.residual, 0.)
 
         # exporting back to XML should result in the same document
         with open(filename, "rt") as fp:


### PR DESCRIPTION
Fixed #1621 by bringing Pickler._station_magnitude_contributions() into line with other Pickler methods, such as Pickler._arrival(), in particular by making use of Pickler._str(). This means that residual and weight are written even if they are both zero, and not written only when they are `None`.

I suspect that Pickler._station_magnitude_contributions() was missed when other methods were updated a while back to use Pickler._str() mainly because it is out-of-order with the rest which do use Pickler._str(). A more natural place for it among the methods would be between Pickler._station_magnitude() and Pickler._origin(), but that would have made the diff less clear.

Also fixed a bug whereby Event.region was neither written to QuakeML nor read.

Updated regression tests to reflect these changes, and added myself to contributors, even this is a very minor contribution. 