### PR TITLE
Calibration using poles and zeros dictionary

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -7,6 +7,7 @@ Barsch, Robert
 Behr, Yannik
 Bernardi, Fabrizio
 Bernauer, Felix
+Bes de Berc, Maxime
 Beyreuther, Moritz
 Bonaimé, Sébastien
 Carothers, Lloyd

--- a/obspy/signal/calibration.py
+++ b/obspy/signal/calibration.py
@@ -39,9 +39,10 @@ def rel_calib_stack(st1, st2, calib_file, window_len, overlap_frac=0.5,
 
     :param st1: Stream or Trace object, (known)
     :param st2: Stream or Trace object, (unknown)
-    :type calib_file: str
+    :type calib_file: str or dict
     :param calib_file: file name of calibration file containing the PAZ of the
-        known instrument in GSE2 standard.
+        known instrument in GSE2 standard or a dictionary with poles and zeros
+        information (with keys ``'poles'``, ``'zeros'`` and ``'sensitivity'``).
     :type window_len: float
     :param window_len: length of sliding window in seconds
     :type overlap_frac: float
@@ -144,13 +145,20 @@ def _calc_resp(calfile, nfft, sampfreq):
 
     :type calfile: str
     :param calfile: file containing poles, zeros and scale factor for known
-        system
+        system or a dictionary with poles and zeros information (with keys
+        ``'poles'``, ``'zeros'`` and ``'sensitivity'``).
     :returns: complex transfer function, array of frequencies
     """
+    # test if calfile is a paz dict
+    if isinstance(calfile, dict):
+        paz = calfile
+    # or read paz file if a filename is specified
+    else:
+        paz = dict()
+        paz['poles'], paz['zeros'], paz['sensitivity'] = read_paz(calfile)
     # calculate transfer function
-    poles, zeros, scale_fac = read_paz(calfile)
-    h, f = paz_to_freq_resp(poles, zeros, scale_fac, 1.0 / sampfreq,
-                            nfft, freq=True)
+    h, f = paz_to_freq_resp(paz['poles'], paz['zeros'], paz['sensitivity'],
+                            1.0 / sampfreq, nfft, freq=True)
     return h, f
 
 

--- a/obspy/signal/tests/test_calibration.py
+++ b/obspy/signal/tests/test_calibration.py
@@ -89,6 +89,28 @@ class CalibrationTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(amp, amp2, decimal=4)
         np.testing.assert_array_almost_equal(phase, phase2, decimal=4)
 
+    def test_relcal_using_dict(self):
+        """
+        Tests using paz dictionary instead of a gse2 file.
+        """
+        st1 = read(os.path.join(self.path, 'ref_STS2'))
+        st2 = read(os.path.join(self.path, 'ref_unknown'))
+        calfile = os.path.join(self.path, 'STS2_simp.cal')
+        calpaz = dict()
+        calpaz['poles'] = [-0.03677+0.03703j, -0.03677-0.03703j]
+        calpaz['zeros'] = [0+0j, 0-0j]
+        calpaz['sensitivity'] = 1500
+
+        # stream
+        freq, amp, phase = rel_calib_stack(st1, st2, calfile, 20, smooth=10,
+                                           save_data=False)
+        # traces
+        freq2, amp2, phase2 = rel_calib_stack(st1, st2, calpaz, 20,
+                                              smooth=10, save_data=False)
+        np.testing.assert_array_almost_equal(freq, freq2, decimal=4)
+        np.testing.assert_array_almost_equal(amp, amp2, decimal=4)
+        np.testing.assert_array_almost_equal(phase, phase2, decimal=4)
+
 
 def suite():
     return unittest.makeSuite(CalibrationTestCase, 'test')


### PR DESCRIPTION
Dear all,

I propose a short PR related to calibration.py in signal module.
This file currently takes a calib_file in gse2 format. This PR changes this for use a standard paz dictionary. It becomes the user's responsibility to get or write the correct paz.

Best regards,
Maxime Bes de Berc