### PR TITLE
Missing preferred_origin (but it is defined)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@
      dayplot of a trace, see #1566)
    * properly pass through kwargs from Stream.detrend() to Trace.detrend()
      (see #1607)
+   * Resource identifiers will now always point to the newest object in case
+     they are created multiple times with identical objects. (see #1629)
  - obspy.core.event.source:
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
  - obspy.clients.earthworm:

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -623,17 +623,21 @@ class ResourceIdentifier(object):
         Will also append self again to the global class level reference list so
         everything stays consistent.
         """
-        # If it does not yet exists simply set it.
-        if self.id not in ResourceIdentifier.__resource_id_weak_dict:
+        # If it does not yet exists, set it.
+        #
+        # If it already exists, set the referred object to the current one if
+        # the existing referred object is identical to the new one.
+        # Use the new one as the old might be more readily garbage collected.
+        # This is a weak heuristic but it is all we can do from here.
+        if self.id not in ResourceIdentifier.__resource_id_weak_dict or \
+                ResourceIdentifier.__resource_id_weak_dict[self.id] == \
+                referred_object:
             ResourceIdentifier.__resource_id_weak_dict[self.id] = \
                 referred_object
             return
-        # Otherwise check if the existing element the same as the new one. If
-        # it is do nothing, otherwise raise a warning and set the new object as
-        # the referred object.
-        if ResourceIdentifier.__resource_id_weak_dict[self.id] == \
-                referred_object:
-            return
+
+        # Otherwise raise a warning and set the new object as the referred
+        # object.
         msg = "The resource identifier '%s' already exists and points to " + \
               "another object: '%s'." +\
               "It will now point to the object referred to by the new " + \

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -909,6 +909,22 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         self.assertEqual(rid, rid2)
         self.assertEqual(rid, rid3)
 
+    def test_resource_ids_refer_to_newest_object(self):
+        """
+        Tests that resource ids which are assigned multiple times but point to
+        identical objects always point to the newest object. This prevents some
+        odd behaviour.
+        """
+        t1 = UTCDateTime(2010, 1, 1)
+        t2 = UTCDateTime(2010, 1, 1)
+
+        rid = ResourceIdentifier("a", referred_object=t1)
+        rid = ResourceIdentifier("a", referred_object=t2)
+
+        del t1
+
+        self.assertEqual(rid.get_referred_object(), t2)
+
 
 class BaseTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
When I retrieve events via the FDSN web client, I occasionally get an event that has a `preferred_origin_id` (and a corresponding entry in `origins`) but `preferred_origin()` returns None.

```python
from obspy.clients import fdsn
client = fdsn.Client('IRIS')

catalog = client.get_events(starttime='2016-12-01', minmagnitude=4)
bad_events = [event for event in catalog if not event.preferred_origin()]
len(bad_events)
```
> 1

```python
bad_event = bad_events[0]
bad_event.preferred_origin_id
```

> smi:service.iris.edu/fdsnws/event/1/query?originid=17807622

```python
bad_event.origins[0].resource_id
```

> smi:service.iris.edu/fdsnws/event/1/query?originid=17807622

But the same event retrieved in a different way appears fine.

```python
catalog = client.get_events(eventid=5199371)
event = catalog[0]
event.preferred_origin()
```

> Origin
    	   resource_id: ResourceIdentifier(id="smi:service.iris.edu/fdsnws/event/1/query?originid=17807622")
    	          time: UTCDateTime(2016, 12, 1, 0, 21, 40, 290000)
    	     longitude: -70.3105
    	      latitude: -28.715
    	         depth: 114950.0
    	 creation_info: CreationInfo(author='us')

Actually, it looks like there is some sort of stateful behavior here, when making repeated requests this behavior oscillates. (The exact values produced here are somewhat unpredictable but the oscillation itself is consistent.)

```python
for _ in range(4):
    catalog = client.get_events(starttime='2016-12-01', minmagnitude=4)
    bad_events = [event for event in catalog if not event.preferred_origin()]
    print "%d of %d bad events" % (len(bad_events), len(catalog))
```

> 768 of 807 bad events
17 of 807 bad events
768 of 807 bad events
17 of 807 bad events
