### PR TITLE
Seedlink client, error in reconnection routine

### DIFF
--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -1737,15 +1737,17 @@ class SeedLinkConnection(object):
             if self.lastpkttime and self.check_version(2.93) >= 0 and \
                curstream.btime is not None:
                 # Increment sequence number by 1
-                send_str += b" " + hex(curstream.seqnum + 1) + b" " + \
-                    curstream.get_sl_time_stamp()
+                send_str += b" " + \
+                    hex(curstream.seqnum + 1).encode('ascii', 'strict') + \
+                    b" " + curstream.get_sl_time_stamp()
                 msg = "requesting resume data from 0x%s (decimal: %s) at %s"
                 logger.info(msg % (hex(curstream.seqnum + 1).upper(),
                             curstream.seqnum + 1),
                             curstream.get_sl_time_stamp())
             else:
                 # Increment sequence number by 1
-                send_str += b" " + hex(curstream.seqnum + 1)
+                send_str += b" " + \
+                    hex(curstream.seqnum + 1).encode('ascii', 'strict')
                 msg = "requesting resume data from 0x%s (decimal: %s)"
                 logger.info(msg % (hex(curstream.seqnum + 1).upper(),
                                    curstream.seqnum + 1))


### PR DESCRIPTION
In file `obspy/clients/seedlink/client/seedlinkconnection.py` at lines 1409 and 1417 concatination of `bytes` and `str` errors occurred.

Steps to reproduce error:
- Create SeedLink with `obspy.clients.seedlink.easyseedlink.create_client`
- Connect to server and get any data
- Shutdown SeedLink server
- Client fall into infinite loop with messages:

```
network timeout (120), reconnecting in 30s
can't concat bytes to str
negotiation with remote SeedLink failed: 'no stations accepted'
```

To fix it change `hex(...)` call in those lines to `hex(...).encode('ascii', 'strict')`.