### PR TITLE
ObsPy broken on Windows when using new Python 2.7.13

### DIFF
--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -91,7 +91,7 @@ def _load_cdll(name):
                           'lib')
     libpath = os.path.join(libdir, libname)
     try:
-        cdll = ctypes.CDLL(libpath)
+        cdll = ctypes.CDLL(str(libpath))
     except Exception as e:
         msg = 'Could not load shared library "%s".\n\n %s' % (libname, str(e))
         raise ImportError(msg)


### PR DESCRIPTION
ObsPy currently is completely broken on Windows when using Python 2.7.13 which was released 24 days ago. Mac and Linux seem to be not affected.

```
C:\Miniconda-x64\envs\test\python.exe: Could not load shared library "libmseed_Windows_64bit_py27.pyd".
 LoadLibrary() argument 1 must be string, not unicode
```

Last good appveyor run (on Python 2.7.12), dating from 2016-12-18: https://ci.appveyor.com/project/obspy/obspy/build/1.0.3911-master#L25

First bad appveyor run (on Python 2.7.13), dating from 2016-12-19: https://ci.appveyor.com/project/obspy/obspy/build/1.0.3912-master#L25

Upstream bug report for Python: https://bugs.python.org/issue29082

Other projects experiencing the same issue: rg3/youtube-dl#11540 

In principle we could just wait for Python 2.7.14 and tell Windows users to avoid 2.7.13 but it would be better to fix it on our end, I guess.