### PR TITLE
Problem with trace endtime reading mSEED

### DIFF
--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -664,6 +664,7 @@ ContinuousSegment._fields_ = [
     ('samprate', C.c_double),
     ('sampletype', C.c_char),
     ('hpdelta', C.c_longlong),
+    ('leapseconds', C.c_longlong),
     ('samplecnt', C.c_int64),
     ('timing_quality', C.c_uint8),
     ('calibration_type', C.c_int8),


### PR DESCRIPTION
Hi all.. I am having a little problem with a mSEED file. When i read a file without specifying a starttime the end of the trace somehow becomes shorter. File is here: ftp://www.orfeus-eu.org/pub/outgoing/NL.VLW1.00.HHE.D.2016.143

here is what is happening:

    print read("NL.VLW1.00.HHE.D.2016.143")
        >>> 1 Trace(s) in Stream:
        >>> NL.VLW1.00.HHE | 2016-05-22T00:00:03.001557Z - 2016-05-23T00:00:05.851557Z | 100.0 Hz, 8640286 samples

    print read("NL.VLW1.00.HHE.D.2016.143", starttime=UTCDateTime("2016-05-23"))
        >>> 1 Trace(s) in Stream:
        >>> NL.VLW1.00.HHE | 2016-05-23T00:00:00.001878Z - 2016-05-23T00:00:06.411878Z | 100.0 Hz, 642 samples

Pay close attention to the trace enditme.

I looked through the records using libmseed and I think the correct trace endtime is the second one. So the trace endtime is incorrect when reading without a window selection.

`msi -T` gives the same as the expected result:

       Source                Start sample             End sample        Hz  Samples
    NL_VLW1_00_HHE    2016,143,00:00:03.001557 2016,144,00:00:06.411878 100 8640286

Also notice how the start time and number of samples are equal but the end time is not.

Best!