### PR TITLE
Object aware ResourceIdentifier

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,11 @@ master: (doi: 10.5281/zenodo.165135)
      obspy.io.reftek (see #1433)
    * Add Nordic format (s-file) read/write (see #1517)
  - obspy.core:
+   * Event/ResourceIdentifier is now object aware, meaning even if two
+     objects share a resource_id the distinct objects will be returned with
+     the get_referred_object method provided both are still in scope. If one
+     of the objects gets garbage collected, however, a warning will be issued
+     and the behavior will be the same as before.
    * Stream/Trace.write() can now autodetect file format from file extension
      (see #1321).
    * New convenience property `.matplotlib_date` for `UTCDateTime` objects to

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -12,6 +12,7 @@ Beyreuther, Moritz
 Bonaimé, Sébastien
 Carothers, Lloyd
 Chamberlain, Calum
+Chambers, Derrick
 Clark, Adam
 Danecek, Peter
 van Driel, Martin

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -38,7 +38,6 @@ import numpy as np
 from obspy.core.event.header import DataUsedWaveType, ATTRIBUTE_HAS_ERRORS
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict
-from obspy.core.util.decorator import rlock
 
 
 class QuantityError(AttribDict):

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -401,6 +401,23 @@ def _event_type_class_factory(class_name, class_attributes=[],
             super(AbstractEventTypeWithResourceID, self).__init__(*args,
                                                                   **kwargs)
 
+        def __deepcopy__(self, memodict=None):
+            """
+            reset resource_id's object_id after deep copy to allow the
+            object specific behavior of get_referred_object
+            """
+            memodict = memodict or {}
+            cls = self.__class__
+            result = cls.__new__(cls)
+            memodict[id(self)] = result
+            for k, v in self.__dict__.items():
+                setattr(result, k, deepcopy(v, memodict))
+            result.resource_id.object_id = id(result)
+            return result
+
+
+
+
     if "resource_id" in [item[0] for item in class_attributes]:
         base_class = AbstractEventTypeWithResourceID
     else:
@@ -451,7 +468,11 @@ class ResourceIdentifier(object):
     :type referred_object: Python object, optional
     :param referred_object: The object this instance refers to. All instances
         created with the same resource_id will be able to access the object as
-        long as at least one instance actual has a reference to it.
+        long as at least one instance actually has a reference to it.
+        Additionally, ResourceIdentifier instances that have the same id but
+        different referred_objects will still return the referred object,
+        provided it doesn't get garbage collected. If the referred object no
+        longer exists any object with the same id will be returned.
 
     .. rubric:: General Usage
 
@@ -565,10 +586,10 @@ class ResourceIdentifier(object):
     ...'foo' bar2
     """
     # Class (not instance) attribute that keeps track of all resource
-    # identifier throughout one Python run. Will only store weak references and
-    # therefore does not interfere with the garbage collection.
+    # identifier throughout one Python run. Will only store weak references
+    # and therefore does not interfere with the garbage collection.
     # DO NOT CHANGE THIS FROM OUTSIDE THE CLASS.
-    __resource_id_weak_dict = weakref.WeakValueDictionary()
+    __resource_id_weak_dict = {}  # a nested dict for weak object references
     # Use an additional dictionary to track all resource ids.
     __resource_id_tracker = collections.defaultdict(int)
 
@@ -587,6 +608,7 @@ class ResourceIdentifier(object):
             self.id = id
         # Append the referred object in case one is given to the class level
         # reference dictionary.
+        self.object_id = None  # the object specific ID
         if referred_object is not None:
             self.set_referred_object(referred_object)
 
@@ -617,8 +639,39 @@ class ResourceIdentifier(object):
         Will return None if no object could be found.
         """
         try:
-            return ResourceIdentifier.__resource_id_weak_dict[self.id]
+            rdic = ResourceIdentifier.__resource_id_weak_dict[self.id]
         except KeyError:
+            return None
+        else:
+            if self.object_id in rdic and rdic[self.object_id]() is not None:
+                return rdic[self.object_id]()
+            else:  # find last added obj that is not None
+                return self._get_similar_referred_object()
+
+    def _get_similar_referred_object(self):
+        """
+        Find an object with the same resource_id that is not None and
+        return it. Also pop all keys that have None values in the
+        __resource_id_weak_dict
+        """
+        rdic = ResourceIdentifier.__resource_id_weak_dict[self.id]
+        if self.object_id is not None:
+            msg = ("The object with identity of: %d no longer exists, "
+                   "returning the most recently created object with a"
+                   " resource id of: %s.") % (self.object_id, self.id)
+            line_number = inspect.currentframe().f_back.f_lineno
+            warnings.warn_explicit(msg, UserWarning, __file__,
+                                   line_number)
+            self.object_id = None  # reset object id
+        # find a obj that is not None starting at last in ordered dict
+        for key in reversed(rdic):
+            obj = rdic[key]
+            if obj is not None:
+                return obj()
+            else:  # remove references that are None
+                rdic.pop(key)
+        else:  # if iter runs out all objects are none; pop rid, return None
+            ResourceIdentifier.__resource_id_weak_dict.pop(self.id)
             return None
 
     def set_referred_object(self, referred_object):
@@ -628,32 +681,17 @@ class ResourceIdentifier(object):
         If it already a weak reference it will be used, otherwise one will be
         created. If the object is None, None will be set.
 
-        Will also append self again to the global class level reference list so
-        everything stays consistent.
+        Will also append self again to the global class level reference list
+        so everything stays consistent.
         """
-        # If it does not yet exists simply set it.
-        if self.id not in ResourceIdentifier.__resource_id_weak_dict:
-            ResourceIdentifier.__resource_id_weak_dict[self.id] = \
-                referred_object
-            return
-        # Otherwise check if the existing element the same as the new one. If
-        # it is do nothing, otherwise raise a warning and set the new object as
-        # the referred object.
-        if ResourceIdentifier.__resource_id_weak_dict[self.id] == \
-                referred_object:
-            return
-        msg = "The resource identifier '%s' already exists and points to " + \
-              "another object: '%s'." +\
-              "It will now point to the object referred to by the new " + \
-              "resource identifier."
-        msg = msg % (
-            self.id,
-            repr(ResourceIdentifier.__resource_id_weak_dict[self.id]))
-        # Always raise the warning!
-        warnings.warn_explicit(msg, UserWarning, __file__,
-                               inspect.currentframe().f_back.f_lineno)
-        ResourceIdentifier.__resource_id_weak_dict[self.id] = \
-            referred_object
+        self.object_id = id(referred_object)  # identity of object
+        rdic = ResourceIdentifier.__resource_id_weak_dict
+        # if the resource_id is in the rid_dict but not object identity set it
+        if self.id in rdic and self.object_id not in rdic[self.id]:
+            rdic[self.id][self.object_id] = weakref.ref(referred_object)
+        else:
+            rdic[self.id] = collections.OrderedDict()
+            rdic[self.id][self.object_id] = weakref.ref(referred_object)
 
     def convert_id_to_quakeml_uri(self, authority_id="local"):
         """

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -664,10 +664,10 @@ class ResourceIdentifier(object):
                                    line_number)
             self.object_id = None  # reset object id
         # find a obj that is not None starting at last in ordered dict
-        for key in reversed(rdic):
-            obj = rdic[key]
+        for key in list(reversed(rdic)):
+            obj = rdic[key]()
             if obj is not None:
-                return obj()
+                return obj
             else:  # remove references that are None
                 rdic.pop(key)
         else:  # if iter runs out all objects are none; pop rid, return None

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -390,10 +390,12 @@ def _event_type_class_factory(class_name, class_attributes=[],
                     raise ValueError(msg)
 
             AttribDict.__setattr__(self, name, value)
-            # If "name" is resource_id and value is not None, set the referred
-            # object of the ResourceIdentifier to self.
-            if name == "resource_id" and value is not None:
-                self.resource_id.set_referred_object(self)
+            # if value is a resource id bind or unbind the resource_id
+            if isinstance(value, ResourceIdentifier):
+                if name == "resource_id":  # bind the resource_id to self
+                    self.resource_id.set_referred_object(self, warn=False)
+                else:  # else unbind to allow event scoping later
+                    value.object_id = None
 
     class AbstractEventTypeWithResourceID(AbstractEventType):
         def __init__(self, force_resource_id=True, *args, **kwargs):
@@ -412,11 +414,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
             memodict[id(self)] = result
             for k, v in self.__dict__.items():
                 setattr(result, k, deepcopy(v, memodict))
-            result.resource_id.object_id = id(result)
             return result
-
-
-
 
     if "resource_id" in [item[0] for item in class_attributes]:
         base_class = AbstractEventTypeWithResourceID
@@ -532,6 +530,28 @@ class ResourceIdentifier(object):
     >>> assert(id(ref_b.get_referred_object()) == obj_id)
     >>> assert(id(ref_c.get_referred_object()) == obj_id)
 
+    Resource identifiers are bound to an object once the get_referred_object
+    method has been called. The results is that  get_referred_object will
+    always return the same object it did on the first call as long as the
+    object still exists. If the bound object gets garage collected a warning
+    will be issued and another object with the same resource_id will be
+    returned if one exists. If no other object has the same resource_id, an
+    additional warning will be issued and None returned.
+
+    >>> res_id = 'obspy.org/tests/test_resource_doc_example'
+    >>> obj_a = UTCDateTime(10)
+    >>> obj_b = UTCDateTime(10)
+    >>> ref_a = ResourceIdentifier(res_id, referred_object=obj_a)
+    >>> ref_b = ResourceIdentifier(res_id, referred_object=obj_b)
+    >>> assert ref_a.get_referred_object() == ref_b.get_referred_object()
+    >>> assert ref_a.get_referred_object() is not ref_b.get_referred_object()
+    >>> assert ref_a.get_referred_object() is obj_a
+    >>> assert ref_b.get_referred_object() is obj_b
+    >>> del obj_b  # if obj_b gets garbage collected
+    >>> assert ref_b.get_referred_object() is obj_a
+    >>> del obj_a  # now no object with res_id exists
+    >>> assert ref_b.get_referred_object() is None
+
     The id can be converted to a valid QuakeML ResourceIdentifier by calling
     the convert_id_to_quakeml_uri() method. The resulting id will be of the
     form::
@@ -592,6 +612,9 @@ class ResourceIdentifier(object):
     __resource_id_weak_dict = {}  # a nested dict for weak object references
     # Use an additional dictionary to track all resource ids.
     __resource_id_tracker = collections.defaultdict(int)
+    # yet another dictionary for keep track of resources id that are not bound
+    # keys are the id and values are a weak ref to the resource identifier
+    __unbound_resource_id = weakref.WeakValueDictionary()
 
     def __init__(self, id=None, prefix="smi:local",
                  referred_object=None):
@@ -628,6 +651,17 @@ class ResourceIdentifier(object):
                 del ResourceIdentifier.__resource_id_weak_dict[self.id]
             except KeyError:
                 pass
+
+    @classmethod
+    def bind_resource_ids(cls):
+        """
+        bind all of the unbound resource_ids to the objects returned from
+        the get_referred_object method
+        """
+        for rid_id in list(cls.__unbound_resource_id):
+            rid = cls.__unbound_resource_id.pop(rid_id, None)
+            if rid is not None:  # if the resource id still exists
+                rid.get_referred_object()  # will bind rid to referred object
 
     def get_referred_object(self):
         """
@@ -667,27 +701,41 @@ class ResourceIdentifier(object):
         for key in list(reversed(rdic)):
             obj = rdic[key]()
             if obj is not None:
+                self.object_id = id(obj)  # bind object ID
                 return obj
             else:  # remove references that are None
                 rdic.pop(key)
         else:  # if iter runs out all objects are none; pop rid, return None
             ResourceIdentifier.__resource_id_weak_dict.pop(self.id)
+            msg = ('no object found with resource id %s, returning None'
+                   % self.id)
+            line_number = inspect.currentframe().f_back.f_lineno
+            warnings.warn_explicit(msg, UserWarning, __file__, line_number)
             return None
 
-    def set_referred_object(self, referred_object):
+    def set_referred_object(self, referred_object, warn=True):
         """
-        Sets the object the ResourceIdentifier refers to.
+        Binds a ResourceIdentifier instance to an object.
 
         If it already a weak reference it will be used, otherwise one will be
         created. If the object is None, None will be set.
 
         Will also append self again to the global class level reference list
-        so everything stays consistent.
+        so everything stays consistent. Warning can be ignored by setting
+        the warn parameter to False.
         """
         self.object_id = id(referred_object)  # identity of object
         rdic = ResourceIdentifier.__resource_id_weak_dict
-        # if the resource_id is in the rid_dict but not object identity set it
+        # if the resource_id is in the rid_dict
         if self.id in rdic and self.object_id not in rdic[self.id]:
+            last_obj = rdic[self.id][next(reversed(rdic[self.id]))]()
+            if warn and last_obj is not None and last_obj != referred_object:
+                msg = ('Warning, binding object to resource ID %s which '
+                       'is not equal to the last object bound to this '
+                       'resource_id') % self.id
+                line_number = inspect.currentframe().f_back.f_lineno
+                warnings.warn_explicit(msg, UserWarning, __file__,
+                                       line_number)
             rdic[self.id][self.object_id] = weakref.ref(referred_object)
         else:
             rdic[self.id] = collections.OrderedDict()
@@ -752,6 +800,18 @@ class ResourceIdentifier(object):
         True
         """
         return deepcopy(self)
+
+    @property
+    def object_id(self):
+        return self.__dict__['object_id']
+
+    @object_id.setter
+    def object_id(self, value):
+        if value is None:  # add instance to unbound dict
+            self.__class__.__unbound_resource_id[id(self)] = self
+        else:  # binding to object, remove instance from unbound dict
+            self.__class__.__unbound_resource_id.pop(id(self), None)
+        self.__dict__['object_id'] = value
 
     @property
     def id(self):

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -38,6 +38,7 @@ import numpy as np
 from obspy.core.event.header import DataUsedWaveType, ATTRIBUTE_HAS_ERRORS
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict
+from obspy.core.util.decorator import rlock
 
 
 class QuantityError(AttribDict):
@@ -206,6 +207,7 @@ def _event_type_class_factory(class_name, class_attributes=[],
         defaults.update(dict.fromkeys(_property_keys, None))
         do_not_warn_on = ["extra"]
 
+        @rlock
         def __init__(self, *args, **kwargs):
             # Make sure the args work as expected. Therefore any specified
             # arg will overwrite a potential kwarg, e.g. arg at position 0 will

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -658,7 +658,7 @@ class ResourceIdentifier(object):
         if self.object_id is not None:
             msg = ("The object with identity of: %d no longer exists, "
                    "returning the most recently created object with a"
-                   " resource id of: %s.") % (self.object_id, self.id)
+                   " resource id of: %s") % (self.object_id, self.id)
             line_number = inspect.currentframe().f_back.f_lineno
             warnings.warn_explicit(msg, UserWarning, __file__,
                                    line_number)

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -207,7 +207,6 @@ def _event_type_class_factory(class_name, class_attributes=[],
         defaults.update(dict.fromkeys(_property_keys, None))
         do_not_warn_on = ["extra"]
 
-        @rlock
         def __init__(self, *args, **kwargs):
             # Make sure the args work as expected. Therefore any specified
             # arg will overwrite a potential kwarg, e.g. arg at position 0 will

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -762,6 +762,7 @@ class Catalog(object):
         return fig
 
 
+@rlock
 @map_example_filename("pathname_or_url")
 def read_events(pathname_or_url=None, format=None, **kwargs):
     """

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -854,7 +854,7 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
         if len(pathnames) > 1:
             for filename in pathnames[1:]:
                 catalog.extend(_read(filename, format, **kwargs).events)
-        catalog.resource_id.bind_resource_ids()
+        ResourceIdentifier.bind_resource_ids()
         return catalog
 
 

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -34,7 +34,7 @@ from pkg_resources import load_entry_point
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, _read_from_plugin
 from obspy.core.util.base import ENTRY_POINTS, download_to_file
-from obspy.core.util.decorator import (map_example_filename,
+from obspy.core.util.decorator import (map_example_filename, rlock,
                                        uncompress_file)
 from obspy.imaging.cm import obspy_sequential
 
@@ -216,20 +216,6 @@ class Catalog(object):
             self.events.__setitem__(index, event)
         else:
             super(Catalog, self).__setitem__(index, event)
-
-    def __deepcopy__(self, memodict=None):
-        """
-        reset resource_id's object_id after deep copy to allow the
-        object specific behavior of get_referred_object
-        """
-        memodict = memodict or {}
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memodict[id(self)] = result
-        for k, v in self.__dict__.items():
-            setattr(result, k, copy.deepcopy(v, memodict))
-        result.resource_id.bind_resource_ids()  # bind all resource_ids
-        return result
 
     def __str__(self, print_all=False):
         """

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -488,6 +488,36 @@ class CatalogTestCase(unittest.TestCase):
         cat = read_events(self.neries_xml)
         self.assertEqual(str(cat.resource_id), r"smi://eu.emsc/unid")
 
+    def test_latest_in_scope_object_returned(self):
+        """
+        Test that the most recently defined object with the same resource_id,
+        that is still in scope, is returned from the get_referred_object
+        method
+        """
+        cat1 = read_events()
+        # The resource_id attached to the first event is self-pointing
+        self.assertIs(cat1[0], cat1[0].resource_id.get_referred_object())
+        # make a copy and re-read catalog
+        cat2 = cat1.copy()
+        cat3 = read_events()
+        # the resource_id on the new catalogs point to their attached objects
+        self.assertIs(cat1[0], cat1[0].resource_id.get_referred_object())
+        self.assertIs(cat2[0], cat2[0].resource_id.get_referred_object())
+        self.assertIs(cat3[0], cat3[0].resource_id.get_referred_object())
+        # now delete cat1 and make sure cat2 and cat3 still work
+        del cat1
+        self.assertIs(cat2[0], cat2[0].resource_id.get_referred_object())
+        self.assertIs(cat3[0], cat3[0].resource_id.get_referred_object())
+        # create a resource_id with the same id as the last defined object
+        # with the same resource id (that is still in scope) is returned
+        new_id = cat2[0].resource_id.id
+        rid = ResourceIdentifier(new_id)
+        self.assertIs(rid.get_referred_object(), cat3[0])
+        del cat3
+        self.assertIs(rid.get_referred_object(), cat2[0])
+        del cat2
+        self.assertIs(rid.get_referred_object(), None)
+
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')
 class CatalogBasemapTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -785,10 +785,10 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         self.assertFalse(rid1.get_referred_object() is
                          rid2.get_referred_object())
         del obj1
-        warnings.simplefilter('error', UserWarning)
-        with self.assertRaises(UserWarning):
+        warnings.simplefilter('default')
+        with warnings.catch_warnings(record=True) as w:
             rid1.get_referred_object()
-        warnings.simplefilter('ignore', UserWarning)
+            assert len(w)
         # now both rids should return the same object
         self.assertIs(rid1.get_referred_object(), rid2.get_referred_object())
         # the object id should have been reset

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -142,8 +142,8 @@ class EventTestCase(unittest.TestCase):
         self.assertIsNot(rid1, rid3)
         self.assertEqual(rid1, rid3)
         # make sure the object_id on the resource_ids are not the same
-        self.assertEqual(rid1.object_id, rid2.object_id)
-        self.assertNotEqual(rid1.object_id, rid3.object_id)
+        self.assertEqual(rid1._object_id, rid2._object_id)
+        self.assertNotEqual(rid1._object_id, rid3._object_id)
         # copy should point to the same object, deep copy should not
         self.assertIs(rob1, rob2)
         self.assertIsNot(rob1, rob3)
@@ -828,7 +828,7 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         rid2 = ResourceIdentifier(uri, referred_object=obj2)
         self.assertFalse(rid1.get_referred_object() is
                          rid2.get_referred_object())
-        self.assertNotEqual(rid1.object_id, rid2.object_id)
+        self.assertNotEqual(rid1._object_id, rid2._object_id)
         del obj1
         warnings.simplefilter('default')
         with warnings.catch_warnings(record=True) as w:
@@ -838,7 +838,7 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         # now both rids should return the same object
         self.assertIs(rid1.get_referred_object(), rid2.get_referred_object())
         # the object id should now be bound to obj2
-        self.assertEqual(rid1.object_id, rid2.object_id)
+        self.assertEqual(rid1._object_id, rid2._object_id)
 
     def test_resources_in_global_dict_get_garbage_collected(self):
         """

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -299,8 +299,6 @@ def map_example_filename(arg_kwarg_name):
 def rlock(func):
         """
         Place a threading recursive lock (Rlock) on the wrapped function
-
-        This decorator has to be called as a function!
         """
         # This lock will be instantiated at function creation time, i.e. at the
         # time the Python interpreter sees the decorated function the very

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -25,7 +25,7 @@ import warnings
 import zipfile
 
 import numpy as np
-from decorator import decorator
+from decorator import decorator, decorate
 
 from obspy.core.util import get_example_file
 from obspy.core.util.base import NamedTemporaryFile
@@ -296,14 +296,22 @@ def map_example_filename(arg_kwarg_name):
     return _map_example_filename
 
 
-@decorator
-def rlock(func, *args, **kwargs):
-    """
-    Place a threading recursive lock (Rlock) on the wrapped function
-    """
-    rlock = threading.RLock()
-    with rlock:
-        return func(*args, **kwargs)
+def rlock(func):
+        """
+        Place a threading recursive lock (Rlock) on the wrapped function
+
+        This decorator has to be called as a function!
+        """
+        # This lock will be instantiated at function creation time, i.e. at the
+        # time the Python interpreter sees the decorated function the very
+        # first time - this lock thus exists once for each decorated function.
+        _rlock = threading.RLock()
+
+        def _locked_f(f, *args, **kwargs):
+            with _rlock:
+                return func(*args, **kwargs)
+
+        return decorate(func, _locked_f)
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -19,6 +19,7 @@ import os
 import re
 import socket
 import tarfile
+import threading
 import unittest
 import warnings
 import zipfile
@@ -293,6 +294,16 @@ def map_example_filename(arg_kwarg_name):
                             pass
         return func(*args, **kwargs)
     return _map_example_filename
+
+
+@decorator
+def rlock(func, *args, **kwargs):
+    """
+    Place a threading recursive lock (Rlock) on the wrapped function
+    """
+    rlock = threading.RLock()
+    with rlock:
+        return func(*args, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

This pull request changes the default behavior of the ResourceIdentifier class slightly to allow for multiple objects to share the same resource id and still be accessible via the get_referred_object method. However, if no object was passed to either the __init__ method or the set_referred_object method, or if the original object goes out of scope, the behavior is the same as before in that the last defined object with the resource_id is returned.

### Why was it initiated?  Any relevant Issues?

Let me demonstrate with some code:

```python
import obspy
cat1 = obspy.read_events()
# The resource_id attached to the first event should point to the first event
cat1[0] is cat1[0].resource_id.get_referred_object()  # True
# but what happens if we make a copy? 
cat2 = cat1.copy()
# or perform another read operation?
cat3 = obspy.read_events()
# the resource_id on the new catalogs dont point to their attached objects
cat1[0] is cat1[0].resource_id.get_referred_object()  # True
cat2[0] is cat2[0].resource_id.get_referred_object()  # False
cat3[0] is cat3[0].resource_id.get_referred_object()  # False
# now what happens if the original catalog goes out of scope?
del cat1
cat2[0].resource_id.get_referred_object()  # None
cat3[0].resource_id.get_referred_object()  # None
# the resource_ids on the remaining objects are no longer usable
```

I have run into problems several times by using the get_referred_object method of the ResourceIdentifier class, both in testing and non-testing environments. For example, when trying to reference a pick from a phase often times the get_referred_object method returns none (even though the pick still exists in the current catalog), or harder to track yet, returns the pick from a copy of the catalog object. 

One solution, then, is to never copy an object with a resource_id or never read it in twice. This can, however, be impractical in some work flows, especially test environments that perform modifications to the object. The proposed modifications remove the surprising behavior and the code now executes as one (or at least me) might expect :

```python
import obspy

cat1 = obspy.read_events()
# The resource_id attached to the first event should point to the first event
cat1[0] is cat1[0].resource_id.get_referred_object()  # True
cat2 = cat1.copy()
cat3 = obspy.read_events()
# the resource_id on the new catalogs now point to their attached objects
cat1[0] is cat1[0].resource_id.get_referred_object()  # True
cat2[0] is cat2[0].resource_id.get_referred_object()  # True
cat3[0] is cat3[0].resource_id.get_referred_object()  # True
# now what happens if the original catalog goes out of scope? Nothing really...
del cat1
cat2[0].resource_id.get_referred_object()  # Event (the one you would expect)
cat3[0].resource_id.get_referred_object()  # Event
# now if we create a resource_id with the same id, the last defined object
# with the same resource id (that is still in scope) is returned
new_id = cat2[0].resource_id.id
rid = obspy.core.event.ResourceIdentifier(new_id)
rid.get_referred_object() is cat3[0]  # True
# if cat3 went out of scope then the object from cat2 would be returned
del cat3
rid.get_referred_object() is cat2[0]  # True
# if all objects with the same resource_id get gc’ed then None is returned
del cat2
rid.get_referred_object() is None  # True
```


### PR Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.  (one fails but it failed on fresh fork)
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .