### PR TITLE
seishub client: avoid auto type casting of 'resource_name' field

### DIFF
--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -56,6 +56,31 @@ def _unpickle(data):
     return obj
 
 
+def _objectify_result_to_dicts(root):
+    """
+    :type root: :class:`lxml.objectify.ObjectifiedElement`
+    :param root: Root node of result set returned by
+        :func:`lxml.objectify.fromstring`.
+    :rtype: list of dict
+    """
+    result = []
+    for node in root.getchildren():
+        result_ = {}
+        for k, v in node.__dict__.items():
+            # resource_name field should never be automatically cast to
+            # potentially matching python type but always remain plain string
+            # type. Otherwise a resource name of e.g. '24330' will be typecast
+            # to an integer which can results in problems later on.
+            if k == 'resource_name':
+                v = v.text
+            # otherwise just rely on autodetection of appropriate python type
+            else:
+                v = v.pyval
+            result_[k] = v
+        result.append(result_)
+    return result
+
+
 class Client(object):
     """
     SeisHub database request Client class.
@@ -467,8 +492,7 @@ master/seishub/plugins/seismology/waveform.py
                 kwargs[key] = value
         url = '/seismology/waveform/getLatency'
         root = self.client._objectify(url, **kwargs)
-        return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                for node in root.getchildren()]
+        return _objectify_result_to_dicts(root)
 
     @deprecated("'getWaveform' has been renamed to 'get_waveforms'. "
                 "Use that instead.")  # noqa
@@ -689,8 +713,7 @@ master/seishub/plugins/seismology/waveform.py
                 kwargs[key] = value
         url = '/seismology/station/getList'
         root = self.client._objectify(url, **kwargs)
-        return [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                for node in root.getchildren()]
+        return _objectify_result_to_dicts(root)
 
     @deprecated("'getCoordinates' has been renamed to 'get_coordinates'. Use "
                 "that instead.")  # noqa
@@ -877,10 +900,7 @@ master/seishub/plugins/seismology/event.py
                 kwargs[key] = value
         url = '/seismology/event/getList'
         root = self.client._objectify(url, **kwargs)
-        results = [dict(((k, v.pyval) for k, v in node.__dict__.items()))
-                   for node in root.getchildren()]
-        for res in results:
-            res['resource_name'] = str(res['resource_name'])
+        results = _objectify_result_to_dicts(root)
         if limit == len(results) or \
            limit is None and len(results) == 50 or \
            len(results) == 2500:


### PR DESCRIPTION
Otherwise this field might end up as numeric types (e.g. integer when server returns xml with `<resource_name>24011</resource_name>` in it) when it should always remain a plain string.
This problem already was fixed in some places with 6db6e7bbd57c07774a1a2773f383c7d54c77c5ef but it still remained in other spots..

Existing seishub tests pass locally (http://tests.obspy.org/67117/; CI can't run them because test server is on our internal network..), should be good to merge.