### PR TITLE
Fix bytes to str compare with bytes.decode()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,8 @@
    * ObsPy can now read MiniSEED files with no blockette 1000. (see #1544)
    * ObsPy now always writes Blockette 100 if sampling rate accuracy is
      otherwise lost. (see #1550)
+   * obspy.io.mseed.util.set_flags_in_fixed_header() now works with Python 3
+     and also for files with Blockette 100.
  - obspy.io.quakeml:
    * write StationMagnitude.residual even when it is zero (see #1625)
    * read & write Event.region

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -808,10 +808,10 @@ class MSEEDUtilTestCase(unittest.TestCase):
         while file_bfr.tell() < filesize:
             file_bfr.seek(8, os.SEEK_CUR)
             # Read trace id
-            sta = file_bfr.read(5)
-            loc = file_bfr.read(2)
-            cha = file_bfr.read(3)
-            net = file_bfr.read(2)
+            sta = file_bfr.read(5).decode()
+            loc = file_bfr.read(2).decode()
+            cha = file_bfr.read(3).decode()
+            net = file_bfr.read(2).decode()
 
             # Check whether we want to check this trace
             expectedtrace = trace_id.split(".")

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -8,6 +8,7 @@ import copy
 import io
 import os
 import random
+import shutil
 import sys
 import unittest
 import warnings
@@ -770,6 +771,29 @@ class MSEEDUtilTestCase(unittest.TestCase):
             wrong_trace = {'not_three_points': copy.deepcopy(classic_flags)}
             self.assertRaises(ValueError, set_flags_in_fixed_headers,
                               file_name, wrong_trace)
+
+    def test_set_flags_in_fixed_header_with_blockette_100(self):
+        """
+        Test the set_flags_in_fixed_header function for a file with
+        blockette 100.
+        """
+        with NamedTemporaryFile() as tf:
+            tf.close()
+            shutil.copy(os.path.join(self.path, 'data', 'test.mseed'),
+                        tf.name)
+            # No flags set.
+            flags = util.get_timing_and_data_quality(tf.name)
+            self.assertEqual(flags["data_quality_flags"], [0] * 8)
+            # Set flags.
+            util.set_flags_in_fixed_headers(tf.name, {
+                "NL.HGN.00.BHZ": {"data_qual_flags": {
+                    'glitches_detected': True,
+                    'time_tag_questionable': True}}})
+            # Flags are set now.
+            flags = util.get_timing_and_data_quality(tf.name)
+            # 2 because file contains two records.
+            self.assertEqual(flags["data_quality_flags"],
+                             [0, 0, 0, 2, 0, 0, 0, 2])
 
     def _check_values(self, file_bfr, trace_id, record_numbers, expected_bytes,
                       reclen):

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -804,10 +804,10 @@ def set_flags_in_fixed_headers(filename, flags):
             # Ignore sequence number and data header
             mseed_file.seek(8, os.SEEK_CUR)
             # Read identifier
-            sta = mseed_file.read(5).strip()
-            loc = mseed_file.read(2).strip()
-            chan = mseed_file.read(3).strip()
-            net = mseed_file.read(2).strip()
+            sta = mseed_file.read(5).strip().decode()
+            loc = mseed_file.read(2).strip().decode()
+            chan = mseed_file.read(3).strip().decode()
+            net = mseed_file.read(2).strip().decode()
 
             # Search the nested dict for the network identifier
             if net in flags_bytes:

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -866,7 +866,7 @@ def set_flags_in_fixed_headers(filename, flags):
                 # Search for blockette 100's "Actual sample rate" field
                 samp_rate = _search_flag_in_blockette(mseed_file, 4, 100, 4, 1)
                 if samp_rate is not None:
-                    samp_rate = unpack(native_str(">b"), samp_rate)
+                    samp_rate = unpack(native_str(">b"), samp_rate)[0]
                 # Search for blockette 1001's "microsec" field
                 microsec = _search_flag_in_blockette(mseed_file, 4, 1001, 5, 1)
                 if microsec is not None:


### PR DESCRIPTION
This PR fixes a problem setting the miniseed fixed header flags when using Python 3. They are not getting set due to the fact that the Trace ID matching logic is comparing bytes with str, which will fail  in Python 3.

This PR also fixes the test that failed to detect this problem due to a similar problem in the testing code. No miniseed records were actually getting tested (python 3 only) because the requested Trace IDs were not matching those in the test file due to bytes to str comparisons.

I did not see an existing issue that seemed related, so I don't believe this affects any open issues.

I first fixed the broken test to confirm that it would fail, which it did.

```
----------------------------------------------------------------------
FAIL: test_set_flags_in_fixed_header (obspy.io.mseed.tests.test_mseed_util.MSEEDUtilTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dauerbach/anaconda3/envs/idadcc/lib/python3.5/site-packages/obspy/io/mseed/tests/test_mseed_util.py", line 681, in test_set_flags_in_fixed_header
    512)
  File "/Users/dauerbach/anaconda3/envs/idadcc/lib/python3.5/site-packages/obspy/io/mseed/tests/test_mseed_util.py", line 832, in _check_values
    "Expected bytes")
AssertionError: b'\x15(\x88' != b'\x05(\x88' : Expected bytes

----------------------------------------------------------------------
Ran 1359 tests in 208.915s

FAILED (failures=1)
```

After fixing `_check_values()` all tests passed and the header flags were getting set.

I do not have a Python 2 env set up and have only tested in Python 3.5 (Conda installed, OS X 10.12).

Hopefully I haven't missed anything... :)

Cheers,
Dan