### PR TITLE
Update SC3ML version to 0.9 in seiscomp event module

### DIFF
--- a/obspy/io/seiscomp/data/quakeml_1.2__sc3ml_0.9.xsl
+++ b/obspy/io/seiscomp/data/quakeml_1.2__sc3ml_0.9.xsl
@@ -2,7 +2,7 @@
 <!--
     ***************************************************************************
 
-QuakeML 1.2 to SC3ML 0.8 stylesheet converter
+QuakeML 1.2 to SC3ML 0.9 stylesheet converter
 
 Author:
     EOST (École et Observatoire des Sciences de la Terre)
@@ -18,8 +18,8 @@ Usage
 This stylesheet converts a QuakeML to a SC3ML document. It may be invoked using
 xalan or xsltproc:
 
-    xalan -in quakeml.xml -xsl quakeml_1.2__sc3ml_0.8.xsl -out sc3ml.xml
-    xsltproc quakeml_1.2__sc3ml_0.8.xsl quakeml.xml -o sc3ml.xml
+    xalan -in quakeml.xml -xsl quakeml_1.2__sc3ml_0.9.xsl -out sc3ml.xml
+    xsltproc quakeml_1.2__sc3ml_0.9.xsl quakeml.xml -o sc3ml.xml
 
 Transformation
 ==============
@@ -119,8 +119,8 @@ SC3ML. Unnecessary attributes must also be removed.
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
         xmlns:ext="http://exslt.org/common"
-        xmlns:sc="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8"
-        xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8"
+        xmlns:sc="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"
+        xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"
         xmlns:qml="http://quakeml.org/xmlns/bed/1.2"
         xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
         exclude-result-prefixes="q qml xsl">
@@ -128,8 +128,8 @@ SC3ML. Unnecessary attributes must also be removed.
     <xsl:strip-space elements="*"/>
 
     <!-- Define some global variables -->
-    <xsl:variable name="version" select="0.8"/>
-    <xsl:variable name="schema" select="document('sc3ml_0.8.xsd')"/>
+    <xsl:variable name="version" select="0.9"/>
+    <xsl:variable name="schema" select="document('sc3ml_0.9.xsd')"/>
 
     <!-- Define key to remove duplicates-->
     <xsl:key name="pick_key" match="qml:pick" use="@publicID"/>

--- a/obspy/io/seiscomp/data/sc3ml_0.9.xsd
+++ b/obspy/io/seiscomp/data/sc3ml_0.9.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated from Seiscomp Schema, do not edit -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:import namespace="http://quakeml.org/xmlns/quakeml/1.0" schemaLocation="quakeml_types.xsd"/>
   <xs:simpleType name="OriginUncertaintyDescription">
     <xs:restriction base="xs:string">
@@ -589,6 +589,7 @@
   </xs:complexType>
   <xs:complexType name="ConfigStation">
     <xs:sequence>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
       <xs:element name="setup" type="scs:Setup" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>

--- a/obspy/io/seiscomp/event.py
+++ b/obspy/io/seiscomp/event.py
@@ -25,7 +25,7 @@ from obspy.io.quakeml.core import Pickler
 
 def _validate_sc3ml(path_or_object, verbose=False):
     """
-    Validates a SC3ML file against the SC3ML 0.8 schema. Returns either True or
+    Validates a SC3ML file against the SC3ML 0.9 schema. Returns either True or
     False.
 
     :param path_or_object: File name or file like object. Can also be an etree
@@ -35,7 +35,7 @@ def _validate_sc3ml(path_or_object, verbose=False):
     """
     # Get the schema location.
     schema_location = os.path.join(os.path.dirname(__file__), 'data',
-                                   'sc3ml_0.8.xsd')
+                                   'sc3ml_0.9.xsd')
     xmlschema = etree.XMLSchema(etree.parse(schema_location))
 
     if isinstance(path_or_object, etree._Element):
@@ -89,7 +89,7 @@ def _write_sc3ml(catalog, filename, validate=False, verbose=False,
     nsmap_ = getattr(catalog, "nsmap", {})
     quakeml_doc = Pickler(nsmap=nsmap_).dumps(catalog)
     xslt_filename = os.path.join(os.path.dirname(__file__), 'data',
-                                 'quakeml_1.2__sc3ml_0.8.xsl')
+                                 'quakeml_1.2__sc3ml_0.9.xsl')
     transform = etree.XSLT(etree.parse(xslt_filename))
     sc3ml_doc = transform(etree.parse(io.BytesIO(quakeml_doc)))
 

--- a/obspy/io/seiscomp/tests/data/iris_events.sc3ml
+++ b/obspy/io/seiscomp/tests/data/iris_events.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:www.iris.edu/ws/event/query">
     <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
       <time>

--- a/obspy/io/seiscomp/tests/data/neries_events.sc3ml
+++ b/obspy/io/seiscomp/tests/data/neries_events.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:local/528a39cd-800a-4a07-9178-4c1255bfeea7">
     <origin publicID="quakeml:eu.emsc/origin/rts/261020/782484">
       <time>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_no_events.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_no_events.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_data_used.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_data_used.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:ISC/bulletin">
     <focalMechanism publicID="smi:ISC/fmid=292310">
       <momentTensor publicID="smi:ISC/mtid=123456">

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_event.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_event.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <event publicID="smi:ch.ethz.sed/event/historical/1165">
       <preferredOriginID>smi:ch.ethz.sed/origin/2054</preferredOriginID>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_focalmechanism.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_focalmechanism.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:ISC/bulletin">
     <focalMechanism publicID="smi:ISC/fmid=292309">
       <triggeringOriginID>smi:local/originId=7680412</triggeringOriginID>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_magnitude.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_magnitude.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <pick publicID="smi:ch.ethz.sed/pick/117634">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitude.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitude.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitudecontributions.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitudecontributions.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
+++ b/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9">
   <EventParameters publicID="quakeml:comcat.cr.usgs.gov/fdsnws/event/1/query">
     <origin publicID="quakeml:earthquake.usgs.gov/product/ci/origin/ci37285320/1415311367340">
       <time>


### PR DESCRIPTION
A new SC3ML schema is out (http://geofon.gfz-potsdam.de/schema/0.9/). There is no change for the event module except the version number. I think it should be better to write sc3ml file in version 0.9 even if it doesn't change anything. A priori, sc3ml 0.9 can be imported into a 0.8 database, so I don't think it can break existing codes.