### PR TITLE
Fix Trace splitting with empty masked array

### DIFF
--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1455,6 +1455,22 @@ class TraceTestCase(unittest.TestCase):
         self.assertFalse(isinstance(st[0].data, np.ma.masked_array))
         self.assertFalse(isinstance(st[1].data, np.ma.masked_array))
 
+    def test_split_empty_masked_array(self):
+        """
+        Test split method with a masked array without any data.
+        """
+        tr1 = Trace(data=np.arange(1000))
+        tr2 = Trace(data=np.arange(1000, 2000))
+        trace = tr1 + tr2
+
+        self.assertTrue(isinstance(trace.data, np.ma.masked_array))
+        self.assertTrue(isinstance(trace, Trace))
+
+        st = trace.split()
+
+        self.assertTrue(isinstance(st, Stream))
+        self.assertEqual(len(st), 0)
+
     def test_simulate_evalresp(self):
         """
         Tests that trace.simulate calls evalresp with the correct network,

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1459,14 +1459,12 @@ class TraceTestCase(unittest.TestCase):
         """
         Test split method with a masked array without any data.
         """
-        tr1 = Trace(data=np.arange(1000))
-        tr2 = Trace(data=np.arange(1000, 2000))
-        trace = tr1 + tr2
+        tr = Trace(data=np.ma.masked_all(100))
 
-        self.assertTrue(isinstance(trace.data, np.ma.masked_array))
-        self.assertTrue(isinstance(trace, Trace))
+        self.assertTrue(isinstance(tr.data, np.ma.masked_array))
+        self.assertTrue(isinstance(tr, Trace))
 
-        st = trace.split()
+        st = tr.split()
 
         self.assertTrue(isinstance(st, Stream))
         self.assertEqual(len(st), 0)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -153,7 +153,7 @@ def flat_not_masked_contiguous(a):
         if not k:
             result.append(slice(i, i + n))
         i += n
-    return result or None
+    return result
 
 
 def complexify_string(line):


### PR DESCRIPTION
This is a little PR to fix the Trace splitting when there is no data in the masked array.

```
Traceback (most recent call last):
  File "/home/toto/.virtualenvs/obspy/lib/python3.5/site-packages/obspy/core/tests/test_trace.py", line 1499, in test_split_empty_masked_array
    st = trace.split()
  File "<decorator-gen-24>", line 2, in split
  File "/home/toto/.virtualenvs/obspy/lib/python3.5/site-packages/obspy/core/trace.py", line 231, in _add_processing_info
    result = func(*args, **kwargs)
  File "/home/toto/.virtualenvs/obspy/lib/python3.5/site-packages/obspy/core/trace.py", line 2227, in split
    for slice in slices:
TypeError: 'NoneType' object is not iterable
```

The function `obspy.core.util.misc.flat_not_masked_contiguous` returns `None` instead of an empty list when there is no data, raising a `TypeError` in  `obspy.core.trace.Trace.split`.

I added a unit test to cover this case.