### PR TITLE
Fix wildcard exceptions handling

### DIFF
--- a/misc/docs/make_pep8.py
+++ b/misc/docs/make_pep8.py
@@ -19,7 +19,7 @@ path = obspy.__path__[0]
 
 try:
     os.makedirs(os.path.join('source', 'pep8'))
-except:
+except Exception:
     pass
 
 report, message = check_flake8()
@@ -85,7 +85,7 @@ with open(os.path.join('source', 'pep8', 'index.rst'), 'wt') as fh:
 # remove any old image
 try:
     os.remove(PEP8_IMAGE)
-except:
+except Exception:
     pass
 # copy correct pep8 image
 if error_count > 0:

--- a/misc/docs/source/_ext/obspydoc.py
+++ b/misc/docs/source/_ext/obspydoc.py
@@ -8,7 +8,7 @@ def post_process_html(app, pagename, templatename, context, doctree):
     try:
         context['body'] = \
             context['body'].replace("&#8211;", '<span class="dash" />')
-    except:
+    except Exception:
         pass
 
     if not doctree or not doctree.has_name('citations'):

--- a/misc/docs/source/tutorial/advanced_exercise/advanced_exercise_solution_4c.py
+++ b/misc/docs/source/tutorial/advanced_exercise/advanced_exercise_solution_4c.py
@@ -24,7 +24,7 @@ for station in stations:
         st = client.get_waveforms("CH", station, "", "[EH]H[ZNE]", t - 300,
                                   t + 300, metadata=True)
         assert(len(st) == 3)
-    except:
+    except Exception:
         print(station, "---")
         continue
 

--- a/misc/docs/source/tutorial/advanced_exercise/advanced_exercise_solution_5.py
+++ b/misc/docs/source/tutorial/advanced_exercise/advanced_exercise_solution_5.py
@@ -22,7 +22,7 @@ for station in stations:
     try:
         tmp = client.get_waveforms("CH", station, "", "[EH]HZ", t, t2,
                                    metadata=True)
-    except:
+    except Exception:
         print(station, "---")
         continue
     st += tmp
@@ -55,7 +55,7 @@ for trig in triglist:
             st = client.get_waveforms("CH", station, "", "[EH]H[ZNE]", t - 300,
                                       t + 300, metadata=True)
             assert(len(st) == 3)
-        except:
+        except Exception:
             print(station, "---")
             continue
 

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -141,7 +141,7 @@ class Client(object):
         try:
             with open(dcid_key_file, 'rt') as fp:
                 lines = fp.readlines()
-        except:
+        except Exception:
             pass
         else:
             for line in lines:
@@ -167,7 +167,7 @@ class Client(object):
             self._client.open(native_str(self._client.host),
                               self._client.port,
                               self._client.timeout)
-        except:
+        except Exception:
             # old Python 2.7: port needs to be native int or string -> not long
             self._client.open(native_str(self._client.host),
                               native_str(self._client.port),
@@ -281,7 +281,7 @@ class Client(object):
             status = self._read_ln()
             try:
                 req_id = int(status)
-            except:
+            except Exception:
                 if 'ERROR' in status:
                     self._bye()
                     raise ArcLinkException('Error requesting status id')
@@ -543,7 +543,7 @@ class Client(object):
         if compressed:
             try:
                 import bz2
-            except:
+            except Exception:
                 compressed = False
             else:
                 rtype += " compression=bzip2"
@@ -633,7 +633,7 @@ class Client(object):
                 temp = {}
                 try:
                     temp['priority'] = int(node.get('priority'))
-                except:
+                except Exception:
                     temp['priority'] = -1
                 temp['start'] = UTCDateTime(node.get('start'))
                 if node.get('end'):
@@ -816,7 +816,7 @@ class Client(object):
         # Response type: A=Laplace(rad/s), B=Analog(Hz), C, D
         try:
             paz['response_type'] = xml_doc.get('type')
-        except:
+        except Exception:
             paz['response_type'] = None
 
         # normalization factor
@@ -826,7 +826,7 @@ class Client(object):
                     float(xml_doc.get('normalizationFactor'))
             else:
                 paz['normalization_factor'] = float(xml_doc.get('norm_fac'))
-        except:
+        except Exception:
             paz['normalization_factor'] = None
 
         try:
@@ -836,7 +836,7 @@ class Client(object):
             else:
                 paz['normalization_frequency'] = \
                     float(xml_doc.get('norm_freq'))
-        except:
+        except Exception:
             paz['normalization_frequency'] = None
 
         # for backwards compatibility (but this is wrong naming!)
@@ -854,7 +854,7 @@ class Client(object):
             temp = zeros.strip().replace(' ', '').replace(')(', ') (')
             for zeros in temp.split():
                 paz['zeros'].append(complexify_string(zeros))
-        except:
+        except Exception:
             pass
         # check number of zeros
         if len(paz['zeros']) != nzeros:
@@ -871,7 +871,7 @@ class Client(object):
             temp = poles.strip().replace(' ', '').replace(')(', ') (')
             for poles in temp.split():
                 paz['poles'].append(complexify_string(poles))
-        except:
+        except Exception:
             pass
         # check number of poles
         if len(paz['poles']) != npoles:
@@ -944,7 +944,7 @@ class Client(object):
             else:
                 # new schema
                 return result[id][0].paz
-        except:
+        except Exception:
             msg = 'Could not find PAZ for channel %s' % id
             raise ArcLinkException(msg)
 
@@ -1144,17 +1144,17 @@ class Client(object):
             # date / times
             try:
                 net.start = UTCDateTime(network.get('start'))
-            except:
+            except Exception:
                 net.start = None
             try:
                 net.end = UTCDateTime(network.get('end'))
-            except:
+            except Exception:
                 net.end = None
             # remark
             try:
                 net.remark = network.xpath(
                     'ns:remark', namespaces={'ns': xml_ns})[0].text or ''
-            except:
+            except Exception:
                 net.remark = ''
             # write network entries
             data[net.code] = net
@@ -1170,7 +1170,7 @@ class Client(object):
                 for key in ['elevation', 'longitude', 'depth', 'latitude']:
                     try:
                         sta[key] = float(station.get(key))
-                    except:
+                    except Exception:
                         sta[key] = None
                 # restricted
                 if station.get('restricted', '') == 'false':
@@ -1180,17 +1180,17 @@ class Client(object):
                 # date / times
                 try:
                     sta.start = UTCDateTime(station.get('start'))
-                except:
+                except Exception:
                     sta.start = None
                 try:
                     sta.end = UTCDateTime(station.get('end'))
-                except:
+                except Exception:
                     sta.end = None
                 # remark
                 try:
                     sta.remark = station.xpath(
                         'ns:remark', namespaces={'ns': xml_ns})[0].text or ''
-                except:
+                except Exception:
                     sta.remark = ''
                 # write station entry
                 data[net.code + '.' + sta.code] = sta
@@ -1203,11 +1203,11 @@ class Client(object):
                         # date / times
                         try:
                             start = UTCDateTime(comp.get('start'))
-                        except:
+                        except Exception:
                             start = None
                         try:
                             end = UTCDateTime(comp.get('end'))
-                        except:
+                        except Exception:
                             end = None
                         # check date/time boundaries
                         if start > endtime:
@@ -1238,28 +1238,28 @@ class Client(object):
                         # fetch sensitivity etc
                         try:
                             temp['sensitivity'] = float(comp.get('gain'))
-                        except:
+                        except Exception:
                             temp['sensitivity'] = None
                         # again keep it backwards compatible
                         temp['gain'] = temp['sensitivity']
                         try:
                             temp['sensitivity_frequency'] = \
                                 float(comp.get('gainFrequency'))
-                        except:
+                        except Exception:
                             temp['sensitivity_frequency'] = None
                         try:
                             temp['sensitivity_unit'] = comp.get('gainUnit')
-                        except:
+                        except Exception:
                             temp['sensitivity_unit'] = None
 
                         # date / times
                         try:
                             temp['starttime'] = UTCDateTime(comp.get('start'))
-                        except:
+                        except Exception:
                             temp['starttime'] = None
                         try:
                             temp['endtime'] = UTCDateTime(comp.get('end'))
-                        except:
+                        except Exception:
                             temp['endtime'] = None
                         if not instruments or not seismometer_id:
                             continue
@@ -1309,7 +1309,7 @@ class Client(object):
                             paz['sensor_manufacturer'] = \
                                 sensors[public_id]['manufacturer']
                             paz['sensor_model'] = sensors[public_id]['model']
-                        except:
+                        except Exception:
                             paz['sensor_manufacturer'] = None
                             paz['sensor_model'] = None
 

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1145,7 +1145,7 @@ class Client(object):
 
             try:
                 value = this_type(value)
-            except:
+            except Exception:
                 msg = "'%s' could not be converted to type '%s'." % (
                     str(value), this_type.__name__)
                 raise TypeError(msg)
@@ -1308,7 +1308,7 @@ class Client(object):
             try:
                 server_info = "\n".join([
                     line for line in data.read().splitlines() if line])
-            except:
+            except Exception:
                 server_info = None
         # No data.
         if code == 204:
@@ -1618,7 +1618,7 @@ def build_url(base_url, service, major_version, resource_type,
         for key, value in parameters.items():
             try:
                 parameters[key] = value.strip()
-            except:
+            except Exception:
                 pass
         url = "?".join((url, urllib.parse.urlencode(parameters)))
     return url

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -251,7 +251,7 @@ def download_and_split_mseed_bulk(client, client_name, chunks, logger):
                 for f in open_files.values():
                     try:
                         f.close()
-                    except:
+                    except Exception:
                         pass
     logger.info("Client '%s' - Successfully downloaded %i channels (of %i)" % (
         client_name, len(open_files), original_bulk_length))

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -249,14 +249,14 @@ class ClientTestCase(unittest.TestCase):
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
                 try:
                     self.client.get_stations(0, 0, location=loc)
-                except:
+                except Exception:
                     pass
             self.assertEqual(p.call_count, 1)
             self.assertIn("location=--", p.call_args[0][0])
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
                 try:
                     self.client.get_waveforms(1, 2, loc, 4, 0, 0)
-                except:
+                except Exception:
                     pass
             self.assertEqual(p.call_count, 1)
             self.assertIn("location=--", p.call_args[0][0])
@@ -983,7 +983,7 @@ class ClientTestCase(unittest.TestCase):
         try:
             c.get_waveforms("A", "B", "C", "D", UTCDateTime() - 100,
                             UTCDateTime())
-        except:
+        except Exception:
             pass
         self.assertTrue(
             base_url_ds in download_url_mock.call_args_list[0][0][0])
@@ -994,7 +994,7 @@ class ClientTestCase(unittest.TestCase):
         download_url_mock.return_value = 404, None
         try:
             c.get_stations()
-        except:
+        except Exception:
             pass
         self.assertTrue(
             base_url_station in download_url_mock.call_args_list[0][0][0])
@@ -1005,7 +1005,7 @@ class ClientTestCase(unittest.TestCase):
         download_url_mock.return_value = 404, None
         try:
             c.get_events()
-        except:
+        except Exception:
             pass
         self.assertTrue(
             base_url_event in download_url_mock.call_args_list[0][0][0])

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -212,7 +212,7 @@ class WADLParser(object):
                 return True
             else:
                 return None
-        except:
+        except Exception:
             return None
 
     def _xpath(self, doc, expr):

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -349,7 +349,7 @@ class Client(object):
             tf.seek(0)
             try:
                 stream = read(tf.name, 'MSEED')
-            except:
+            except Exception:
                 stream = Stream()
         return stream
 
@@ -425,18 +425,18 @@ class Client(object):
             try:
                 kwargs['starttime'] = \
                     UTCDateTime(starttime).format_iris_web_service()
-            except:
+            except Exception:
                 kwargs['starttime'] = starttime
             try:
                 kwargs['endtime'] = \
                     UTCDateTime(endtime).format_iris_web_service()
-            except:
+            except Exception:
                 kwargs['endtime'] = endtime
         elif 'time' in kwargs:
             try:
                 kwargs['time'] = \
                     UTCDateTime(kwargs['time']).format_iris_web_service()
-            except:
+            except Exception:
                 pass
         # build up query
         try:
@@ -539,18 +539,18 @@ class Client(object):
             try:
                 kwargs['starttime'] = \
                     UTCDateTime(starttime).format_iris_web_service()
-            except:
+            except Exception:
                 kwargs['starttime'] = starttime
             try:
                 kwargs['endtime'] = \
                     UTCDateTime(endtime).format_iris_web_service()
-            except:
+            except Exception:
                 kwargs['endtime'] = endtime
         elif starttime:
             try:
                 kwargs['time'] = \
                     UTCDateTime(starttime).format_iris_web_service()
-            except:
+            except Exception:
                 kwargs['time'] = starttime
         data = self._fetch("sacpz", **kwargs)
         return self._to_file_or_data(filename, data)
@@ -962,7 +962,7 @@ class Client(object):
         kwargs['channel'] = str(channel)
         try:
             kwargs['time'] = UTCDateTime(time).format_iris_web_service()
-        except:
+        except Exception:
             kwargs['time'] = time
         kwargs['minfreq'] = float(minfreq)
         if maxfreq:

--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -1249,7 +1249,7 @@ class SeedLinkConnection(object):
                 # print("DEBUG: tmpstr:", tmpstr)
                 # print("DEBUG: tmpstr[0:endndx]:", tmpstr[0:endndx])
                 self.server_version = float(tmpstr[0:endndx])
-        except:
+        except Exception:
             msg = "bad server ID/version string: '%s'"
             raise SeedLinkException(msg % (servstr))
 
@@ -1476,7 +1476,7 @@ class SeedLinkConnection(object):
         curstream = None
         try:
             curstream = self.streams[0]
-        except:
+        except Exception:
             msg = "cannot negotiate uni-station, stream list does not " + \
                 "have exactly one element"
             raise SeedLinkException(msg)
@@ -1589,7 +1589,7 @@ class SeedLinkConnection(object):
             curstream = None
             try:
                 curstream = self.streams[0]
-            except:
+            except Exception:
                 msg = "cannot update uni-station stream, stream list does " + \
                     "not have exactly one element"
                 raise SeedLinkException(msg)

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -156,7 +156,7 @@ class Client(object):
             t1 = time.time()
             urllib.request.urlopen(self.base_url, timeout=self.timeout).read()
             return (time.time() - t1) * 1000.0
-        except:
+        except Exception:
             pass
 
     def test_auth(self):
@@ -733,7 +733,7 @@ master/seishub/plugins/seismology/waveform.py
                 paz = parser.get_paz(seed_id=seed_id,
                                      datetime=UTCDateTime(datetime))
                 return paz
-            except:
+            except Exception:
                 continue
         network, station, location, channel = seed_id.split(".")
         # request station information

--- a/obspy/clients/seishub/tests/test_client.py
+++ b/obspy/clients/seishub/tests/test_client.py
@@ -29,7 +29,7 @@ def _check_server_availability():
     try:
         code = urllib.request.urlopen(TESTSERVER, timeout=3).getcode()
         assert(code == 200)
-    except:
+    except Exception:
         return TESTSERVER_UNREACHABLE_MSG
     return ""
 

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -37,7 +37,7 @@ def get_json(r):
     c = r.content
     try:
         c = c.decode()
-    except:
+    except Exception:
         pass
     return json.loads(c)
 
@@ -49,7 +49,7 @@ def get_text(r):
     c = r.content
     try:
         c = c.decode()
-    except:
+    except Exception:
         pass
     return c
 
@@ -183,7 +183,7 @@ class Client(WaveformClient, HTTPClient):
             elif isinstance(value, (str, native_str)):
                 try:
                     value = obspy.UTCDateTime(value)
-                except:
+                except Exception:
                     pass
             # Last but not least just try to pass it to the datetime
             # constructor without catching the error.
@@ -213,7 +213,7 @@ class Client(WaveformClient, HTTPClient):
             # it's a saczip file.
             try:
                 st = obspy.read(buf)
-            except:
+            except Exception:
                 st = obspy.Stream()
                 # Seek as some bytes might have been already read.
                 buf.seek(0, 0)

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -14,7 +14,7 @@ try:
         import mock  # NOQA
     else:
         from unittest import mock  # NOQA
-except:
+except ImportError:
     pass
 
 if PY2:

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -322,7 +322,7 @@ class Inventory(ComparingObject):
                 continue
             try:
                 responses.append(net.get_response(seed_id, datetime))
-            except:
+            except Exception:
                 pass
         if len(responses) > 1:
             msg = "Found more than one matching response. Returning first."
@@ -352,7 +352,7 @@ class Inventory(ComparingObject):
                 continue
             try:
                 coordinates.append(net.get_coordinates(seed_id, datetime))
-            except:
+            except Exception:
                 pass
         if len(coordinates) > 1:
             msg = "Found more than one matching coordinates. Returning first."

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -784,7 +784,7 @@ class Response(ComparingObject):
         def get_unit_mapping(key):
             try:
                 key = key.upper()
-            except:
+            except Exception:
                 pass
             units_mapping = {
                 "M": ew.ENUM_UNITS["DIS"],

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2611,13 +2611,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if back_azimuth is None:
             try:
                 back_azimuth = self[0].stats.back_azimuth
-            except:
+            except Exception:
                 msg = "No back-azimuth specified."
                 raise TypeError(msg)
         if len(input_components) == 3 and inclination is None:
             try:
                 inclination = self[0].stats.inclination
-            except:
+            except Exception:
                 msg = "No inclination specified."
                 raise TypeError(msg)
         # Do one of the two-component rotations.
@@ -3120,12 +3120,12 @@ def _is_pickle(filename):  # @UnusedVariable
         try:
             with open(filename, 'rb') as fp:
                 st = pickle.load(fp)
-        except:
+        except Exception:
             return False
     else:
         try:
             st = pickle.load(filename)
-        except:
+        except Exception:
             return False
     return isinstance(st, Stream)
 

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1499,7 +1499,7 @@ class TraceTestCase(unittest.TestCase):
                 tr.simulate(seedresp={"filename": "RESP.dummy",
                                       "units": "VEL",
                                       "date": tr.stats.starttime})
-        except:
+        except Exception:
             pass
 
         self.assertEqual(patch.call_count, 1)

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -221,7 +221,7 @@ class WaveformPluginsTestCase(unittest.TestCase):
         # Use try except to produce a meaningful error message.
         try:
             self.assertEqual(len(false_positives), 0)
-        except:  # pragma: no cover
+        except Exception:  # pragma: no cover
             msg = 'False positives for isFormat:\n'
             msg += '\n'.join(['\tFormat %s: %s' % (_i[0], _i[1]) for _i in
                               false_positives])

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -709,7 +709,7 @@ class Trace(object):
             elif method == 1 and interpolation_samples >= -1:
                 try:
                     ls = lt.data[-delta - 1]
-                except:
+                except Exception:
                     ls = lt.data[0]
                 if interpolation_samples == -1:
                     interpolation_samples = delta
@@ -2344,7 +2344,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         try:
             method = method.lower()
-        except:
+        except Exception:
             pass
 
         dt = float(sampling_rate)
@@ -2511,7 +2511,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             try:
                 responses.append(inv.get_response(self.id,
                                                   self.stats.starttime))
-            except:
+            except Exception:
                 pass
         if len(responses) > 1:
             msg = "Found more than one matching response. Using first."

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -235,7 +235,7 @@ class UTCDateTime(object):
                 # got a timestamp
                 self._from_timestamp(value.__float__())
                 return
-            except:
+            except Exception:
                 pass
             if isinstance(value, datetime.datetime):
                 # got a Python datetime.datetime object
@@ -256,7 +256,7 @@ class UTCDateTime(object):
                     try:
                         self._from_iso8601_string(value)
                         return
-                    except:
+                    except Exception:
                         if iso8601:
                             raise
                 # try to apply some standard patterns
@@ -296,7 +296,7 @@ class UTCDateTime(object):
                     value = parts[0].strip()
                     try:
                         ms = float('.' + parts[1].strip())
-                    except:
+                    except Exception:
                         pass
                 # all parts should be digits now - here we filter unknown
                 # patterns and pass it directly to Python's  datetime.datetime
@@ -320,7 +320,7 @@ class UTCDateTime(object):
                 temp = "%4d%03d" % (int(year),
                                     int(kwargs['julday']))
                 dt = datetime.datetime.strptime(temp, '%Y%j')
-            except:
+            except Exception:
                 pass
             else:
                 kwargs['month'] = dt.month
@@ -399,7 +399,7 @@ class UTCDateTime(object):
         # split between date and time
         try:
             (date, time) = value.split("T")
-        except:
+        except Exception:
             date = value
             time = ""
         # remove all hyphens in date

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -253,7 +253,7 @@ def _get_ordered_entry_points(group, subgroup=None, order_list=[]):
     for name in order_list:
         try:
             entry_points[name] = ep_dict.pop(name)
-        except:
+        except Exception:
             # skip plug-ins which are not installed
             continue
     # extend entry points with any left over waveform plug-ins

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -162,13 +162,13 @@ def uncompress_file(func, filename, *args, **kwargs):
                     if not data:
                         continue
                     obj_list.append(data)
-        except:
+        except Exception:
             pass
     elif zipfile.is_zipfile(filename):
         try:
             zip = zipfile.ZipFile(filename)
             obj_list = [zip.read(name) for name in zip.namelist()]
-        except:
+        except Exception:
             pass
     elif filename.endswith('.bz2'):
         # bz2 module
@@ -176,7 +176,7 @@ def uncompress_file(func, filename, *args, **kwargs):
             import bz2
             with open(filename, 'rb') as fp:
                 obj_list.append(bz2.decompress(fp.read()))
-        except:
+        except Exception:
             pass
     elif filename.endswith('.gz'):
         # gzip module
@@ -184,7 +184,7 @@ def uncompress_file(func, filename, *args, **kwargs):
             import gzip
             with gzip.open(filename, 'rb') as fp:
                 obj_list.append(fp.read())
-        except:
+        except Exception:
             pass
     # handle results
     if obj_list:

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -74,7 +74,7 @@ def guess_delta(channel):
     """
     try:
         return 1. / BAND_CODE[channel[0]]
-    except:
+    except Exception:
         msg = "No or unknown channel id provided. Specifying a channel id " + \
               "could lead to better selection of first/last samples of " + \
               "fetched traces."
@@ -519,7 +519,7 @@ def limit_numpy_fft_cache(max_size_in_mb_per_cache=100):
         # try/except to guard against future numpy changes.
         try:
             total_size = sum([_j.nbytes for _i in cache.values() for _j in _i])
-        except:
+        except Exception:
             continue
         if total_size > max_size_in_mb_per_cache * 1024 * 1024:
             cache.clear()

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -89,7 +89,7 @@ class Enum(object):
     def __call__(self, enum):
         try:
             return self.get(enum)
-        except:
+        except Exception:
             return None
 
     def get(self, key):

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -338,11 +338,11 @@ class ImageComparison(NamedTemporaryFile):
 
         try:
             locale.setlocale(locale.LC_ALL, native_str('en_US.UTF-8'))
-        except:
+        except Exception:
             try:
                 locale.setlocale(locale.LC_ALL,
                                  native_str('English_United States.1252'))
-            except:
+            except Exception:
                 msg = "Could not set locale to English/United States. " + \
                       "Some date-related tests may fail"
                 warnings.warn(msg)
@@ -369,7 +369,7 @@ class ImageComparison(NamedTemporaryFile):
             import matplotlib.pyplot as plt
             try:
                 plt.close("all")
-            except:
+            except Exception:
                 pass
         return self
 
@@ -462,7 +462,7 @@ class ImageComparison(NamedTemporaryFile):
                 import matplotlib.pyplot as plt
                 try:
                     plt.close("all")
-                except:
+                except Exception:
                     pass
             if self.keep_output:
                 if failed or not self.keep_only_failed:
@@ -564,7 +564,7 @@ def compare_xml_strings(doc1, doc2):
     try:
         doc1 = doc1.encode()
         doc2 = doc2.encode()
-    except:
+    except Exception:
         pass
     obj1 = etree.fromstring(doc1).getroottree()
     obj2 = etree.fromstring(doc2).getroottree()

--- a/obspy/db/client.py
+++ b/obspy/db/client.py
@@ -198,13 +198,13 @@ class Client(object):
         # start and end time
         try:
             starttime = UTCDateTime(starttime)
-        except:
+        except Exception:
             starttime = UTCDateTime() - 60 * 20
         finally:
             query = query.filter(WaveformChannel.endtime > starttime.datetime)
         try:
             endtime = UTCDateTime(endtime)
-        except:
+        except Exception:
             # 10 minutes
             endtime = UTCDateTime()
         finally:
@@ -231,13 +231,13 @@ class Client(object):
         # start and end time
         try:
             starttime = UTCDateTime(starttime)
-        except:
+        except Exception:
             starttime = UTCDateTime() - 60 * 20
         finally:
             query = query.filter(WaveformChannel.endtime > starttime.datetime)
         try:
             endtime = UTCDateTime(endtime)
-        except:
+        except Exception:
             # 10 minutes
             endtime = UTCDateTime()
         finally:

--- a/obspy/db/db.py
+++ b/obspy/db/db.py
@@ -125,7 +125,7 @@ class WaveformChannel(Base):
     def get_preview(self, apply_calibration=False):
         try:
             data = np.loads(self.preview)
-        except:
+        except Exception:
             data = np.array([])
         if apply_calibration:
             data = data * self.calib

--- a/obspy/db/indexer.py
+++ b/obspy/db/indexer.py
@@ -63,7 +63,7 @@ class WaveformFileCrawler(object):
             # search for existing path
             query = session.query(WaveformPath)
             path = query.filter_by(path=data['path']).one()
-        except:
+        except Exception:
             # create new path entry
             path = WaveformPath(data)
             session.add(path)
@@ -181,7 +181,7 @@ class WaveformFileCrawler(object):
     def _process_output_queue(self):
         try:
             dataset = self.output_queue.pop(0)
-        except:
+        except Exception:
             pass
         else:
             self._update_or_insert(dataset)
@@ -189,7 +189,7 @@ class WaveformFileCrawler(object):
     def _process_log_queue(self):
         try:
             msg = self.log_queue.pop(0)
-        except:
+        except Exception:
             pass
         else:
             if msg.startswith('['):
@@ -367,7 +367,7 @@ class WaveformFileCrawler(object):
             if time.time() - mtime > 60 * 60 * self.options.recent:
                 try:
                     db_file_mtime = self._db_files.pop(file)
-                except:
+                except Exception:
                     pass
                 return
         # option force-reindex set -> process file regardless if already in
@@ -384,7 +384,7 @@ class WaveformFileCrawler(object):
         # -> remove from file list so it won't be deleted on database cleanup
         try:
             db_file_mtime = self._db_files.pop(file)
-        except:
+        except Exception:
             return
         # -> compare modification times of current file with database entry
         if mtime == db_file_mtime:
@@ -411,14 +411,14 @@ def worker(_i, input_queue, work_queue, output_queue, log_queue, mappings={}):
             all_features[key]['run'] = func
             try:
                 all_features[key]['indexer_kwargs'] = cls['indexer_kwargs']
-            except:
+            except Exception:
                 all_features[key]['indexer_kwargs'] = {}
         # loop through input queue
         while True:
             # fetch a unprocessed item
             try:
                 filepath, (path, file, features) = input_queue.popitem()
-            except:
+            except Exception:
                 continue
             # skip item if already in work queue
             if filepath in work_queue:
@@ -446,7 +446,7 @@ def worker(_i, input_queue, work_queue, output_queue, log_queue, mappings={}):
                 log_queue.append(msg % (filepath, e))
                 try:
                     work_queue.remove(filepath)
-                except:
+                except Exception:
                     pass
                 continue
             # build up dictionary of gaps and overlaps for easier lookup
@@ -534,11 +534,11 @@ def worker(_i, input_queue, work_queue, output_queue, log_queue, mappings={}):
             # return results to main loop
             try:
                 output_queue.append(dataset)
-            except:
+            except Exception:
                 pass
             try:
                 work_queue.remove(filepath)
-            except:
+            except Exception:
                 pass
     except KeyboardInterrupt:
         return

--- a/obspy/db/util.py
+++ b/obspy/db/util.py
@@ -54,7 +54,7 @@ def parse_mapping_data(lines):
         if len(data) > 2:
             try:
                 temp['starttime'] = UTCDateTime(data[2])
-            except:
+            except Exception:
                 msg += "starttime '%s' is not a time format"
                 raise Exception(msg % data[2])
         else:
@@ -62,7 +62,7 @@ def parse_mapping_data(lines):
         if len(data) > 3:
             try:
                 temp['endtime'] = UTCDateTime(data[3])
-            except:
+            except Exception:
                 msg += "endtime '%s' is not a time format"
                 raise Exception(msg % data[3])
             if temp['endtime'] < temp['starttime']:

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -222,7 +222,7 @@ class MomentTensor:
         if len(mech) == 3 or len(mech) == 4:
             try:
                 [float(val) for val in mech]
-            except:
+            except Exception:
                 msg = "angles must be given as floats, separated by commas"
                 sys.exit('\n  ERROR -  %s\n  ' % msg)
 
@@ -1810,7 +1810,7 @@ def fancy_matrix(m_in):
                 out += "  \\ %5.2F %5.2F %5.2F /\n" % \
                     (m[2, 0], m[2, 1], m[2, 2])
                 return out
-    except:
+    except Exception:
         pass
 
     return "\n  / %5.2F %5.2F %5.2F \\\n" % (m[0, 0], m[0, 1], m[0, 2]) + \
@@ -1891,30 +1891,30 @@ class BeachBall:
         if self._plot_outfile_format == 'svg':
             try:
                 matplotlib.use('SVG')
-            except:
+            except Exception:
                 matplotlib.use('Agg')
         elif self._plot_outfile_format == 'pdf':
             try:
                 matplotlib.use('PDF')
-            except:
+            except Exception:
                 matplotlib.use('Agg')
                 pass
         elif self._plot_outfile_format == 'ps':
             try:
                 matplotlib.use('PS')
-            except:
+            except Exception:
                 matplotlib.use('Agg')
                 pass
         elif self._plot_outfile_format == 'eps':
             try:
                 matplotlib.use('Agg')
-            except:
+            except Exception:
                 matplotlib.use('PS')
                 pass
         elif self._plot_outfile_format == 'png':
             try:
                 matplotlib.use('AGG')
-            except:
+            except Exception:
                 mp_out = matplotlib.use('GTKCairo')
                 if mp_out:
                     mp_out2 = matplotlib.use('Cairo')
@@ -1935,7 +1935,7 @@ class BeachBall:
             plotfig.savefig(outfile_abs_name, dpi=self._plot_dpi,
                             transparent=True, facecolor='k',
                             format=outfile_format)
-        except:
+        except Exception:
             print('ERROR!! -- Saving of plot not possible')
             return
         plt.close(667)
@@ -2346,7 +2346,7 @@ class BeachBall:
                                 self._plot_outfile_format, dpi=self._plot_dpi,
                                 transparent=True,
                                 format=self._plot_outfile_format)
-            except:
+            except Exception:
                 print('saving of plot not possible')
 
         plt.show()
@@ -2402,7 +2402,7 @@ class BeachBall:
                             self._plot_outfile_format, dpi=self._plot_dpi,
                             transparent=True,
                             format=self._plot_outfile_format)
-            except:
+            except Exception:
                 print('saving of plot not possible')
         plt.show()
 
@@ -3669,7 +3669,7 @@ class BeachBall:
                                 self._plot_outfile_format, dpi=self._plot_dpi,
                                 transparent=True,
                                 format=self._plot_outfile_format)
-            except:
+            except Exception:
                 print('saving of plot not possible')
         plt.show()
         plt.close('all')
@@ -4089,7 +4089,7 @@ def main(argv=None):
                 decomp = MT.get_full_decomposition()
                 try:
                     print(decomp)
-                except:
+                except Exception:
                     print(decomp.replace('°', ' deg'))
                 return
             else:
@@ -4200,7 +4200,7 @@ def main(argv=None):
                     raise
                 consistent_kwargs_dict['plot_viewpoint'] = \
                     [float(vp[0]), float(vp[1]), float(vp[2])]
-            except:
+            except Exception:
                 pass
 
         if args.GMT_projection:
@@ -4216,7 +4216,7 @@ def main(argv=None):
                         do_allowed_projections[gmtp]
                 else:
                     consistent_kwargs_dict['plot_projection'] = 'stereo'
-            except:
+            except Exception:
                 pass
 
         consistent_kwargs_dict['_GMT_scaling'] = args.GMT_scaling
@@ -4392,7 +4392,7 @@ def main(argv=None):
                     consistent_kwargs_dict['plot_outfile_format'] = \
                         lo_possible_formats[0]
 
-            except:
+            except Exception:
                 msg = 'please provide valid filename: <name>.<format>  !!\n'
                 msg += ' <format> must be svg, png, eps, pdf, or ps '
                 exit(msg)
@@ -4421,7 +4421,7 @@ def main(argv=None):
                     raise
                 consistent_kwargs_dict['plot_viewpoint'] = \
                     [float(vp[0]), float(vp[1]), float(vp[2])]
-            except:
+            except Exception:
                 pass
 
         if args.plot_projection:
@@ -4437,7 +4437,7 @@ def main(argv=None):
                         do_allowed_projections[ppl]
                 else:
                     consistent_kwargs_dict['plot_projection'] = 'stereo'
-            except:
+            except Exception:
                 pass
 
         if args.plot_show_upper_hemis:
@@ -4458,7 +4458,7 @@ def main(argv=None):
                     consistent_kwargs_dict['plot_size'] = 5
                 consistent_kwargs_dict['plot_aux_plot_size'] = \
                     consistent_kwargs_dict['plot_size']
-            except:
+            except Exception:
                 pass
 
         if args.plot_pressure_colour:
@@ -4480,7 +4480,7 @@ def main(argv=None):
                          float(sec_colour_raw[2]) / 255.)
                 else:
                     raise
-            except:
+            except Exception:
                 pass
 
         if args.plot_tension_colour:
@@ -4502,7 +4502,7 @@ def main(argv=None):
                          float(sec_colour_raw[2]) / 255.)
                 else:
                     raise
-            except:
+            except Exception:
                 pass
 
         if args.plot_total_alpha:
@@ -4547,16 +4547,16 @@ def main(argv=None):
                              float(sec_colour_raw[2]) / 255.)
                     else:
                         raise
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_faultplane_colour'] = 'k'
 
                 try:
                     if 0 <= float(fp_args[3]) <= 1:
                         consistent_kwargs_dict['plot_faultplane_alpha'] = \
                             float(fp_args[3])
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_faultplane_alpha'] = 1
-            except:
+            except Exception:
                 pass
 
         if args.plot_show_faultplanes:
@@ -4597,16 +4597,16 @@ def main(argv=None):
                              float(sec_colour_raw[2]) / 255.)
                     else:
                         raise
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_outerline_colour'] = 'k'
 
                 try:
                     if 0 <= float(fp_args[2]) <= 1:
                         consistent_kwargs_dict['plot_outerline_alpha'] = \
                             float(fp_args[2])
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_outerline_alpha'] = 1
-            except:
+            except Exception:
                 pass
 
         if args.plot_nodalline:
@@ -4637,15 +4637,15 @@ def main(argv=None):
                              float(sec_colour_raw[2]) / 255.)
                     else:
                         raise
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_nodalline_colour'] = 'k'
                 try:
                     if 0 <= float(fp_args[2]) <= 1:
                         consistent_kwargs_dict['plot_nodalline_alpha'] = \
                             float(fp_args[2])
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_nodalline_alpha'] = 1
-            except:
+            except Exception:
                 pass
 
         if args.plot_show_princ_axes:
@@ -4668,9 +4668,9 @@ def main(argv=None):
                     if 0 <= float(fp_args[2]) <= 1:
                         consistent_kwargs_dict['plot_princ_axes_alpha'] = \
                             float(fp_args[2])
-                except:
+                except Exception:
                     consistent_kwargs_dict['plot_princ_axes_alpha'] = 1
-            except:
+            except Exception:
                 pass
 
         if args.plot_show_basis_axes:
@@ -5091,7 +5091,7 @@ The 'source mechanism' as a comma-separated list of length:
 
     try:
         M_raw = [float(xx) for xx in args.mechanism.split(',')]
-    except:
+    except Exception:
         parser.error('invalid source mechanism')
 
     if not len(M_raw) in [3, 4, 6, 7, 9]:
@@ -5103,7 +5103,7 @@ The 'source mechanism' as a comma-separated list of length:
     if aa is not None:
         try:
             print(aa)
-        except:
+        except Exception:
             print(aa.replace('°', ' deg'))
 
 

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -118,7 +118,7 @@ def parse_file_to_dict(data_dict, samp_int_dict, file, counter, format=None,
         return counter
     try:
         stream = read(file, format=format, headonly=True)
-    except:
+    except Exception:
         if verbose or not quiet:
             print("Can not read %s" % (file))
         return counter

--- a/obspy/imaging/tests/test_beachball.py
+++ b/obspy/imaging/tests/test_beachball.py
@@ -228,7 +228,7 @@ class BeachballTestCase(unittest.TestCase):
         # Initialize figure
         try:
             plt.close("all")
-        except:
+        except Exception:
             pass
         fig = plt.figure(figsize=(6, 6), dpi=300)
         ax = fig.add_subplot(111, aspect='equal')
@@ -263,7 +263,7 @@ class BeachballTestCase(unittest.TestCase):
         # Initialize figure
         try:
             plt.close("all")
-        except:
+        except Exception:
             pass
         fig = plt.figure()
         ax = fig.add_subplot(111)

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -52,7 +52,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
                 expected = expected.encode(sys.stdout.encoding)
             else:
                 expected = expected.encode()
-        except:
+        except Exception:
             expected = expected.replace('°', ' deg')
             if sys.stdout.encoding is not None:
                 expected = expected.encode(sys.stdout.encoding)
@@ -164,7 +164,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
                 expected = expected.encode(sys.stdout.encoding)
             else:
                 expected = expected.encode()
-        except:
+        except Exception:
             expected = expected.replace('°', ' deg')
             if sys.stdout.encoding is not None:
                 expected = expected.encode(sys.stdout.encoding)

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -325,7 +325,7 @@ class WaveformPlotting(object):
                     if not self.fig_obj and self.show:
                         try:
                             plt.show(block=self.block)
-                        except:
+                        except Exception:
                             plt.show()
 
     def plot(self, *args, **kwargs):
@@ -1168,7 +1168,7 @@ class WaveformPlotting(object):
             try:
                 for _i, tr in enumerate(self.stream):
                     self._tr_offsets[_i] = tr.stats.distance
-            except:
+            except Exception:
                 msg = 'trace.stats.distance undefined ' +\
                       '(set before plotting [in m], ' +\
                       'or use the ev_coords argument)'
@@ -1181,7 +1181,7 @@ class WaveformPlotting(object):
                         tr.stats.coordinates.latitude,
                         tr.stats.coordinates.longitude,
                         self.ev_coord[0], self.ev_coord[1])
-            except:
+            except Exception:
                 msg = 'Define latitude/longitude in trace.stats.' + \
                     'coordinates and ev_coord. See documentation.'
                 raise ValueError(msg)

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -76,7 +76,7 @@ def _get_ah_version(filename):
             data = xdrlib.Unpacker(fh.read(8))
             # check for magic version number
             magic = data.unpack_int()
-        except:
+        except Exception:
             return False
         if magic == 1100:
             try:
@@ -84,7 +84,7 @@ def _get_ah_version(filename):
                 length = data.unpack_uint()
                 # read first record
                 fh.read(length)
-            except:
+            except Exception:
                 return False
             # seems to be AH v2
             return '2.0'
@@ -104,7 +104,7 @@ def _get_ah_version(filename):
                 fh.seek(784)
                 if xdrlib.Unpacker(fh.read(4)).unpack_int() != 202:
                     return False
-            except:
+            except Exception:
                 return False
             return '1.0'
         else:
@@ -170,7 +170,7 @@ def _read_ah1(filename):
         ot_sec = data.unpack_float()
         try:
             ot = UTCDateTime(ot_year, ot_mon, ot_day, ot_hour, ot_min, ot_sec)
-        except:
+        except Exception:
             ot = None
         ah_stats.event.origin_time = ot
         ah_stats.event.comment = _unpack_string(data)
@@ -291,7 +291,7 @@ def _read_ah2(filename):
         ot_sec = data.unpack_float()
         try:
             ot = UTCDateTime(ot_year, ot_mon, ot_day, ot_hour, ot_min, ot_sec)
-        except:
+        except Exception:
             ot = None
         ah_stats.event.origin_time = ot
         data.unpack_int()  # and again?

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -78,7 +78,7 @@ def _is_slist(filename):
     try:
         with open(filename, 'rt') as f:
             temp = f.readline()
-    except:
+    except Exception:
         return False
     if not temp.startswith('TIMESERIES'):
         return False
@@ -104,7 +104,7 @@ def _is_tspair(filename):
     try:
         with open(filename, 'rt') as f:
             temp = f.readline()
-    except:
+    except Exception:
         return False
     if not temp.startswith('TIMESERIES'):
         return False
@@ -317,7 +317,7 @@ def _write_slist(stream, filename, **kwargs):  # @UnusedVariable
             # quality code
             try:
                 dataquality = stats.mseed.dataquality
-            except:
+            except Exception:
                 dataquality = ''
             # sample type
             if trace.data.dtype.name.startswith('int'):
@@ -331,7 +331,7 @@ def _write_slist(stream, filename, **kwargs):  # @UnusedVariable
             # unit
             try:
                 unit = stats.ascii.unit
-            except:
+            except Exception:
                 unit = ''
             # write trace header
             header = _format_header(stats, 'SLIST', dataquality, dtype, unit)
@@ -425,7 +425,7 @@ def _write_tspair(stream, filename, **kwargs):  # @UnusedVariable
             # quality code
             try:
                 dataquality = stats.mseed.dataquality
-            except:
+            except Exception:
                 dataquality = ''
             # sample type
             if trace.data.dtype.name.startswith('int'):
@@ -439,7 +439,7 @@ def _write_tspair(stream, filename, **kwargs):  # @UnusedVariable
             # unit
             try:
                 unit = stats.ascii.unit
-            except:
+            except Exception:
                 unit = ''
             # write trace header
             header = _format_header(stats, 'TSPAIR', dataquality, dtype, unit)

--- a/obspy/io/cmtsolution/core.py
+++ b/obspy/io/cmtsolution/core.py
@@ -97,7 +97,7 @@ def _internal_is_cmtsolution(buf):
     try:
         _internal_read_single_cmtsolution(buf)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/obspy/io/cmtsolution/tests/test_core.py
+++ b/obspy/io/cmtsolution/tests/test_core.py
@@ -47,7 +47,7 @@ class CmtsolutionTestCase(unittest.TestCase):
         finally:
             try:
                 os.remove(temp_filename)
-            except:
+            except Exception:
                 pass
 
         self.assertEqual(data.decode().splitlines(),
@@ -75,7 +75,7 @@ class CmtsolutionTestCase(unittest.TestCase):
         finally:
             try:
                 os.remove(temp_filename)
-            except:
+            except Exception:
                 pass
 
         self.assertEqual(data.decode().splitlines(),
@@ -191,7 +191,7 @@ class CmtsolutionTestCase(unittest.TestCase):
         finally:
             try:
                 os.remove(temp_filename)
-            except:
+            except Exception:
                 pass
 
         self.assertEqual(data.decode().splitlines(),

--- a/obspy/io/css/contrib/css28fix.py
+++ b/obspy/io/css/contrib/css28fix.py
@@ -22,7 +22,7 @@ from datetime import datetime
 try:
     # only process first line
     head = list(map(str.strip, open(sys.argv[1]).readlines()[0].split()))
-except:
+except Exception:
     sys.exit("cannot read wfdisc file (arg)")
 
 input = head[15]  # input file name
@@ -62,5 +62,5 @@ try:
     pylab.plot([x * SH["DELTA"] for x in range(SH["LENGTH"])],
                [d * SH["CALIB"] for d in data])
     pylab.show()
-except:
+except Exception:
     sys.exit("cannot show plot!")

--- a/obspy/io/css/contrib/css2asc.py
+++ b/obspy/io/css/contrib/css2asc.py
@@ -71,7 +71,7 @@ def convert(parts):
     try:
         datafile.seek(parts[17])
         values = struct.unpack(fmt, datafile.read(size))
-    except:
+    except Exception:
         print("error reading binary packed data from \"%s\"" %
               os.path.split(parts[16])[1])
         return False
@@ -137,5 +137,5 @@ if __name__ == '__main__':
     # close file
     try:
         wfdisc.close()
-    except:
+    except Exception:
         pass

--- a/obspy/io/css/core.py
+++ b/obspy/io/css/core.py
@@ -67,7 +67,7 @@ def _is_css(filename):
                 assert(line[71:72] == b".")
                 UTCDateTime(float(line[61:78]))
                 assert(line[143:145] in DTYPE)
-    except:
+    except Exception:
         return False
     return True
 
@@ -101,7 +101,7 @@ def _is_nnsa_kb_core(filename):
                 assert(line[73:74] == b".")
                 UTCDateTime(float(line[62:79]))
                 assert(line[144:146] in DTYPE)
-    except:
+    except Exception:
         return False
     return True
 

--- a/obspy/io/datamark/core.py
+++ b/obspy/io/datamark/core.py
@@ -47,7 +47,7 @@ def _is_datamark(filename, century="20"):  # @UnusedVariable
             ord(buff[3:4])
             idata00 = fpin.read(4)
             np.fromstring(idata00, native_str('>i'))[0]
-    except:
+    except Exception:
         return False
     return True
 

--- a/obspy/io/gcf/core.py
+++ b/obspy/io/gcf/core.py
@@ -52,7 +52,7 @@ def _is_gcf(filename):
     try:
         with open(filename, 'rb') as f:
             libgcf.is_gcf(f)
-    except:
+    except Exception:
         return False
     return True
 

--- a/obspy/io/gse2/bulletin.py
+++ b/obspy/io/gse2/bulletin.py
@@ -115,7 +115,7 @@ def _is_gse2(filename):
     try:
         with open(filename, 'rb') as fh:
             temp = fh.read(12)
-    except:
+    except Exception:
         return False
     if temp != b'BEGIN GSE2.0':
         return False
@@ -965,7 +965,7 @@ class Unpickler(object):
         except StopIteration:
             message = self._add_line_nb('Unexpected EOF while parsing')
             raise GSE2BulletinSyntaxError(message)
-        except:
+        except Exception:
             self._warn('Unexpected error')
             raise
 

--- a/obspy/io/gse2/core.py
+++ b/obspy/io/gse2/core.py
@@ -25,7 +25,7 @@ def _is_gse2(filename):
     try:
         with open(filename, 'rb') as f:
             libgse2.is_gse2(f)
-    except:
+    except Exception:
         return False
     return True
 
@@ -124,7 +124,7 @@ def _is_gse1(filename):
     with open(filename, 'rb') as f:
         try:
             data = f.readline()
-        except:
+        except Exception:
             return False
     if data.startswith(b'WID1') or data.startswith(b'XW01'):
         return True

--- a/obspy/io/gse2/libgse2.py
+++ b/obspy/io/gse2/libgse2.py
@@ -227,7 +227,7 @@ def write_header(f, headdict):
             )
     try:
         sta2_line = compile_sta2(headdict)
-    except:
+    except Exception:
         msg = "GSE2: Error while compiling the STA2 header line, omitting it."
         warnings.warn(msg)
     else:
@@ -526,7 +526,7 @@ def parse_sta2(line):
         header['coordsys'] = line[36:48].strip()
         header['elev'] = elev
         header['edepth'] = edepth
-    except:
+    except Exception:
         msg = 'GSE2: Invalid STA2 header, ignoring.'
         warnings.warn(msg)
         return {}

--- a/obspy/io/kml/core.py
+++ b/obspy/io/kml/core.py
@@ -308,7 +308,7 @@ def _rgba_tuple_to_kml_color_code(rgba):
     """
     try:
         r, g, b, a = rgba
-    except:
+    except Exception:
         r, g, b = rgba
         a = 1.0
     return "".join(["%02x" % int(x * 255) for x in (a, b, g, r)])

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -54,7 +54,7 @@ def _is_mseed(filename):
                 file_size = filename.getbuffer().nbytes
             try:
                 file_size = os.fstat(filename.fileno()).st_size
-            except:
+            except Exception:
                 _p = filename.tell()
                 filename.seek(0, 2)
                 file_size = filename.tell()
@@ -81,7 +81,7 @@ def __is_mseed(fp, file_size):  # NOQA
         fp.seek(-7, 1)
         try:
             _t = fp.read(128).decode().strip()
-        except:
+        except Exception:
             return False
         if not _t:
             return __is_mseed(fp=fp, file_size=file_size)
@@ -94,7 +94,7 @@ def __is_mseed(fp, file_size):  # NOQA
         # (min record size) and try again.
         try:
             _t = fp.read(128 - 7).decode().strip()
-        except:
+        except Exception:
             return False
         if not _t:
             return __is_mseed(fp=fp, file_size=file_size)
@@ -115,7 +115,7 @@ def __is_mseed(fp, file_size):  # NOQA
         # to the appropriate position
         try:
             fp.seek(int(fp.read(4)) - 7, 1)
-        except:
+        except Exception:
             return False
         _i += 1
         # break after 3 cycles
@@ -126,7 +126,7 @@ def __is_mseed(fp, file_size):  # NOQA
     fp.seek(8, 1)
     try:
         record_length = pow(2, int(fp.read(2)))
-    except:
+    except Exception:
         return False
 
     # Jump to the second record.
@@ -399,7 +399,7 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
 
     try:
         verbose = int(verbose)
-    except:
+    except Exception:
         verbose = 0
 
     lil = clibmseed.readMSEEDBuffer(
@@ -663,7 +663,7 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
         try:
             trace_attr['dataquality'] = \
                 trace.stats['mseed']['dataquality'].upper()
-        except:
+        except Exception:
             trace_attr['dataquality'] = 'D'
         # Sanity check for the dataquality to get a nice Python exception
         # instead of a C error.

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -33,7 +33,7 @@ from obspy.io.mseed.msstruct import _MSStruct
 NO_NEGATIVE_TIMESTAMPS = False
 try:
     UTCDateTime(-50000)
-except:
+except Exception:
     NO_NEGATIVE_TIMESTAMPS = True
 
 

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -587,7 +587,7 @@ def _get_record_information(file_object, offset=0, endian=None):
     elif _code == b' ':
         try:
             _t = file_object.read(120).decode().strip()
-        except:
+        except Exception:
             raise ValueError("Invalid MiniSEED file.")
         if not _t:
             info = _get_record_information(file_object=file_object,
@@ -663,7 +663,7 @@ def _get_record_information(file_object, offset=0, endian=None):
             endian = ">"
             values = unpack(fmt(endian), data)
             starttime = _parse_time(values)
-        except:
+        except Exception:
             endian = "<"
             values = unpack(fmt(endian), data)
             starttime = _parse_time(values)
@@ -671,7 +671,7 @@ def _get_record_information(file_object, offset=0, endian=None):
         values = unpack(fmt(endian), data)
         try:
             starttime = _parse_time(values)
-        except:
+        except Exception:
             msg = ("Invalid starttime found. The passed byte order is likely "
                    "wrong.")
             raise ValueError(msg)
@@ -1640,7 +1640,7 @@ def _convert_and_check_encoding_for_writing(encoding):
 
     try:
         encoding = int(encoding)
-    except:
+    except Exception:
         pass
 
     if isinstance(encoding, int):

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -97,10 +97,10 @@ def _is_ndk(filename):
         try:
             with open(filename, "rt") as fh:
                 first_line = fh.readline()
-        except:
+        except Exception:
             try:
                 filename = filename.decode()
-            except:
+            except Exception:
                 filename = str(filename)
             filename = filename.strip()
             line_ending = filename.find("\n")
@@ -155,10 +155,10 @@ def _read_ndk(filename, *args, **kwargs):  # @UnusedVariable
         try:
             with open(filename, "rt") as fh:
                 data = fh.read()
-        except:
+        except Exception:
             try:
                 data = filename.decode()
-            except:
+            except Exception:
                 data = str(filename)
             data = data.strip()
     else:

--- a/obspy/io/nied/fnetmt.py
+++ b/obspy/io/nied/fnetmt.py
@@ -113,7 +113,7 @@ def _internal_is_fnetmt_catalog(buf):
                         return False
                     return True
             cnt += 1
-    except:
+    except Exception:
         return False
     else:
         return True

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -38,7 +38,7 @@ def is_nlloc_hyp(filename):
     try:
         with open(filename, 'rb') as fh:
             temp = fh.read(6)
-    except:
+    except Exception:
         return False
     if temp != b'NLLOC ':
         return False
@@ -86,10 +86,10 @@ def read_nlloc_hyp(filename, coordinate_converter=None, picks=None, **kwargs):
             with open(filename, "rb") as fh:
                 data = fh.read()
             data = data.decode("UTF-8")
-        except:
+        except Exception:
             try:
                 data = filename.decode("UTF-8")
-            except:
+            except Exception:
                 data = str(filename)
             data = data.strip()
     else:
@@ -145,7 +145,7 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks):
         for line in lines[1:-1]:
             assert not line.startswith("NLLOC ")
             assert not line.startswith("END_NLLOC")
-    except:
+    except Exception:
         msg = ("This should not have happened, please report this as a bug at "
                "https://github.com/obspy/obspy/issues.")
         raise Exception(msg)
@@ -403,7 +403,7 @@ def write_nlloc_obs(catalog, filename, **kwargs):
             try:
                 time_error = (pick.time_errors.upper_uncertainty +
                               pick.time_errors.lower_uncertainty) / 2.0
-            except:
+            except Exception:
                 pass
         info_ = fmt % (station.ljust(6), "?".ljust(4), component.ljust(4),
                        onset.ljust(1), phase_type.ljust(6), polarity.ljust(1),

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -64,7 +64,7 @@ def _is_sfile(sfile):
         try:
             with open(sfile, 'r') as f:
                 head_line = _get_headline(f)
-        except:
+        except Exception:
             return False
     else:
         head_line = _get_headline(sfile)
@@ -81,7 +81,7 @@ def _is_sfile(sfile):
                         int(head_line[13:15]), sfile_seconds,
                         int(head_line[19:20]) * 100000)
             return True
-        except:
+        except Exception:
             return False
     else:
         return False
@@ -110,7 +110,7 @@ def _int_conv(string):
     """
     try:
         intstring = int(string)
-    except:
+    except Exception:
         intstring = None
     return intstring
 
@@ -129,7 +129,7 @@ def _float_conv(string):
     """
     try:
         floatstring = float(string)
-    except:
+    except Exception:
         floatstring = None
     return floatstring
 
@@ -266,7 +266,7 @@ def _readheader(f):
                                                 int(topline[19:20]) *
                                                 100000)\
             + add_seconds
-    except:
+    except Exception:
         NordicParsingError("Couldn't read a date from sfile")
     # new_event.loc_mod_ind=topline[20]
     new_event.event_descriptions.append(EventDescription())
@@ -444,10 +444,10 @@ def read_nordic(select_file, return_wavnames=False):
     if not hasattr(select_file, "readline"):
         try:
             f = open(select_file, 'r')
-        except:
+        except Exception:
             try:
                 f = select_file.decode()
-            except:
+            except Exception:
                 f = str(select_file)
     else:
         f = select_file
@@ -676,7 +676,7 @@ def blanksfile(wavefile, evtype, userid, overwrite=False, evtime=None):
         try:
             st = read(wavefile)
             evtime = st[0].stats.starttime
-        except:
+        except Exception:
             raise NordicParsingError('Wavefile: ' + wavefile +
                                      ' is invalid, try again with real data.')
     # Check that user ID is the correct length

--- a/obspy/io/pdas/core.py
+++ b/obspy/io/pdas/core.py
@@ -37,7 +37,7 @@ def _is_pdas(filename):
             return True
         else:
             return False
-    except:
+    except Exception:
         return False
 
 

--- a/obspy/io/pde/tests/test_mchedr.py
+++ b/obspy/io/pde/tests/test_mchedr.py
@@ -20,7 +20,7 @@ try:
     version = float(__version__.rsplit('.', 1)[0])
     if version >= 2.3:
         IS_RECENT_LXML = True
-except:
+except Exception:
     pass
 
 

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -70,13 +70,13 @@ def _xml_doc_from_anything(source):
     """
     try:
         xml_doc = etree.parse(source)
-    except:
+    except Exception:
         try:
             xml_doc = etree.fromstring(source)
-        except:
+        except Exception:
             try:
                 xml_doc = etree.fromstring(source.encode())
-            except:
+            except Exception:
                 raise ValueError("Could not parse '%s' to an etree element." %
                                  source)
     return xml_doc
@@ -105,7 +105,7 @@ def _is_quakeml(filename):
 
     try:
         xml_doc = _xml_doc_from_anything(filename)
-    except:
+    except Exception:
         return False
     finally:
         if file_like_object:
@@ -118,7 +118,7 @@ def _is_quakeml(filename):
         else:
             namespace = _get_first_child_namespace(xml_doc)
         xml_doc.xpath('q:eventParameters', namespaces={"q": namespace})[0]
-    except:
+    except Exception:
         return False
     return True
 
@@ -176,7 +176,7 @@ class Unpickler(object):
             return None
         try:
             return convert_to(text)
-        except:
+        except Exception:
             msg = "Could not convert %s to type %s. Returning None."
             warnings.warn(msg % (text, convert_to))
         return None
@@ -726,7 +726,7 @@ class Unpickler(object):
         # optional attribute
         try:
             obj.preferred_plane = int(sub_el.get('preferredPlane'))
-        except:
+        except Exception:
             obj.preferred_plane = None
         self._extra(sub_el, obj)
         return obj
@@ -1081,7 +1081,7 @@ class Pickler(object):
     def _id(self, obj):
         try:
             return obj.get_quakeml_uri()
-        except:
+        except Exception:
             return ResourceIdentifier().get_quakeml_uri()
 
     def _str(self, value, root, tag, always_create=False, attrib=None):

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -413,7 +413,7 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
             np.savetxt(f, np.reshape(data[0:5 * rows], (rows, 5)),
                        fmt=native_str("%#15.7g"), delimiter='')
             np.savetxt(f, data[5 * rows:], delimiter=b'\t')
-        except:
+        except Exception:
             f.close()
             raise SacIOError("Cannot write trace values: " + f.name)
 

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -107,7 +107,7 @@ def _internal_is_sac(buf):
             return False
         if lcalda != 0 and lcalda != 1 and lcalda != -12345:
             return False
-    except:
+    except Exception:
         return False
     finally:
         # Reset buffer head position after reading.
@@ -160,7 +160,7 @@ def _internal_is_sac_xy(buf):
             npts = int(hdcards[15].split()[-1])
             # read in the seismogram
             seis = buf.read(-1).split()
-        except:
+        except Exception:
             return False
         # check that npts header value and seismogram length are consistent
         if npts != len(seis):

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -328,7 +328,7 @@ def _is_seg2(filename):
             endian = b'>'
         else:
             return False
-    except:
+    except Exception:
         return False
     # Check the revision number.
     revision_number = unpack(endian + b'H',

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -80,12 +80,12 @@ def _is_segy(filename):
             _format_number = fp.read(2)
             _fixed_length = fp.read(2)
             _extended_number = fp.read(2)
-    except:
+    except Exception:
         return False
     # Unpack using big endian first and check if it is valid.
     try:
         format = unpack(b'>h', data_format_code)[0]
-    except:
+    except Exception:
         return False
     if format in VALID_FORMATS:
         _endian = '>'

--- a/obspy/io/seisan/core.py
+++ b/obspy/io/seisan/core.py
@@ -38,7 +38,7 @@ def _is_seisan(filename):
     try:
         with open(filename, 'rb') as f:
             data = f.read(12 * 80)
-    except:
+    except Exception:
         return False
     # read some data - contains at least 12 lines a 80 characters
     if _get_version(data):

--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -69,7 +69,7 @@ def _is_sc3ml(path_or_file_object):
                 r'{http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/[-+]?'
                 '[0-9]*\.?[0-9]+}', root.tag)
             assert match is not None
-        except:
+        except Exception:
             return False
         # Convert schema number to a float to have positive comparisons
         # between, e.g "1" and "1.0".
@@ -82,7 +82,7 @@ def _is_sc3ml(path_or_file_object):
         # Make sure to reset file pointer position.
         try:
             path_or_file_object.seek(current_position, 0)
-        except:
+        except Exception:
             pass
 
 
@@ -178,7 +178,7 @@ def _tag2obj(element, tag, convert):
         if element.find(tag).text is None:
             return None
         return convert(element.find(tag).text)
-    except:
+    except Exception:
         None
 
 
@@ -891,7 +891,7 @@ def _read_float_var(elem, cls, unit=False, datum=False, additional_mapping={}):
 
     try:
         convert = float(elem)
-    except:
+    except Exception:
         warnings.warn(
             "Encountered a value '%s' which could not be converted to a "
             "float. Will be skipped. Please contact to report this "

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -85,7 +85,7 @@ def _is_asc(filename):
     try:
         with open(filename, 'rb') as f:
             temp = f.read(6)
-    except:
+    except Exception:
         return False
     if temp != b'DELTA:':
         return False
@@ -315,7 +315,7 @@ def _is_q(filename):
     try:
         with open(filename, 'rb') as f:
             temp = f.read(5)
-    except:
+    except Exception:
         return False
     if temp != b'43981':
         return False
@@ -512,7 +512,7 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
             trcs = _read_q(filename_header, headonly=True)
             mode = 'ab'
             count_offset = len(trcs)
-        except:
+        except Exception:
             raise Exception("Target filename '%s' not readable!" % filename)
     else:
         append = False
@@ -570,7 +570,7 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
             try:
                 line = "%02d|%s\n" % ((i + 1 + count_offset) % 100, temp[j])
                 fh.write(line.encode('ascii', 'strict'))
-            except:
+            except Exception:
                 line = "%02d|\n" % ((i + 1 + count_offset) % 100)
                 fh.write(line.encode('ascii', 'strict'))
         # write data in given byte order

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -65,7 +65,7 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
     for row in csv_reader:
         try:
             yield [str(cell, "utf8") for cell in row]
-        except:
+        except Exception:
             yield [str(cell) for cell in row]
 
 
@@ -91,13 +91,13 @@ def is_fdsn_station_text_file(path_or_file_object):
         else:
             with open(path_or_file_object, "rt", encoding="utf8") as fh:
                 first_line = fh.readline()
-    except:
+    except Exception:
         return False
 
     # Attempt to move the file pointer to the old position.
     try:
         path_or_file_object.seek(cur_pos, 0)
-    except:
+    except Exception:
         pass
 
     first_line = first_line.strip()
@@ -105,7 +105,7 @@ def is_fdsn_station_text_file(path_or_file_object):
     # Attempt to decode.
     try:
         first_line = first_line.decode("utf-8")
-    except:
+    except Exception:
         pass
 
     if not first_line.startswith("#"):

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -74,7 +74,7 @@ def _is_stationxml(path_or_file_object):
                 r'{http://www.fdsn.org/xml/station/[0-9]+}FDSNStationXML',
                 root.tag)
             assert match is not None
-        except:
+        except Exception:
             return False
         # Convert schema number to a float to have positive comparisons
         # between, e.g "1" and "1.0".
@@ -87,7 +87,7 @@ def _is_stationxml(path_or_file_object):
         # Make sure to reset file pointer position.
         try:
             path_or_file_object.seek(current_position, 0)
-        except:
+        except Exception:
             pass
 
 
@@ -249,7 +249,7 @@ def _read_floattype(parent, tag, cls, unit=False, datum=False,
     # Catch non convertible numbers.
     try:
         convert = float(elem.text)
-    except:
+    except Exception:
         warnings.warn(
             "'%s' could not be converted to a float. Will be skipped. Please "
             "contact to report this issue." % etree.tostring(elem),
@@ -1384,7 +1384,7 @@ def _tag2obj(element, tag, convert):
     # we use future.builtins.str and are sure we have unicode here
     try:
         return convert(element.find(tag).text)
-    except:
+    except Exception:
         None
 
 
@@ -1401,7 +1401,7 @@ def _attr2obj(element, attr, convert):
         return None
     try:
         return convert(attribute)
-    except:
+    except Exception:
         None
 
 

--- a/obspy/io/wav/core.py
+++ b/obspy/io/wav/core.py
@@ -59,7 +59,7 @@ def _is_wav(filename):
                 fh.getparams()
         finally:
             fh.close()
-    except:
+    except Exception:
         return False
     if width in [1, 2, 4]:
         return True

--- a/obspy/io/xseed/fields.py
+++ b/obspy/io/xseed/fields.py
@@ -136,7 +136,7 @@ class Field(object):
         self.compact = blockette.compact
         try:
             result = getattr(blockette, self.attribute_name)
-        except:
+        except Exception:
             if blockette.strict:
                 msg = "Missing attribute %s in Blockette %s"
                 raise Exception(msg % (self.name, blockette))
@@ -159,7 +159,7 @@ class Field(object):
             return []
         try:
             result = getattr(blockette, self.attribute_name)
-        except:
+        except Exception:
             if blockette.strict:
                 msg = "Missing attribute %s in Blockette %s"
                 raise Exception(msg % (self.name, blockette))
@@ -171,7 +171,7 @@ class Field(object):
         if self.optional:
             try:
                 result = result.strip()
-            except:
+            except Exception:
                 pass
             if not result:
                 # debug
@@ -200,7 +200,7 @@ class Field(object):
         """
         try:
             text = xml_doc.xpath(self.field_name + "/text()")[pos]
-        except:
+        except Exception:
             setattr(blockette, self.attribute_name, self.default_value)
             # debug
             if blockette.debug:
@@ -239,7 +239,7 @@ class Integer(Field):
                 return [int(_i) for _i in value]
             else:
                 return int(value)
-        except:
+        except Exception:
             if not self.strict:
                 return self.default_value
             msg = "No integer value found for %s." % self.attribute_name
@@ -253,7 +253,7 @@ class Integer(Field):
         format_str = "%%0%dd" % self.length
         try:
             temp = int(data)
-        except:
+        except Exception:
             msg = "No integer value found for %s." % self.attribute_name
             raise SEEDTypeException(msg)
         result = format_str % temp
@@ -282,7 +282,7 @@ class Float(Field):
                 return [float(_i) for _i in value]
             else:
                 return float(value)
-        except:
+        except Exception:
             if not self.strict:
                 return self.default_value
             msg = "No float value found for %s." % self.attribute_name
@@ -296,7 +296,7 @@ class Float(Field):
         format_str = "%%0%ds" % self.length
         try:
             temp = float(data)
-        except:
+        except Exception:
             msg = "No float value found for %s." % self.attribute_name
             raise SEEDTypeException(msg)
         # special format for exponential output
@@ -448,7 +448,7 @@ class Loop(Field):
         """
         try:
             self.length = int(getattr(blockette, self.index_field))
-        except:
+        except Exception:
             msg = "Missing attribute %s in Blockette %s"
             raise Exception(msg % (self.index_field, blockette))
         # loop over number of entries
@@ -474,7 +474,7 @@ class Loop(Field):
         """
         try:
             self.length = int(getattr(blockette, self.index_field))
-        except:
+        except Exception:
             msg = "Missing attribute %s in Blockette %s"
             raise Exception(msg % (self.index_field, blockette))
         # loop over number of entries
@@ -492,7 +492,7 @@ class Loop(Field):
             return []
         try:
             self.length = int(getattr(blockette, self.index_field))
-        except:
+        except Exception:
             msg = "Missing attribute %s in Blockette %s"
             raise Exception(msg % (self.index_field, blockette))
         if self.length == 0 and self.optional:
@@ -535,7 +535,7 @@ class Loop(Field):
         """
         try:
             self.length = int(getattr(blockette, self.index_field))
-        except:
+        except Exception:
             msg = "Missing attribute %s in Blockette %s"
             raise Exception(msg % (self.index_field, blockette))
         if self.length == 0:

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -111,7 +111,7 @@ class Parser(object):
         try:
             if len(self.stations) == 0:
                 return 'No data'
-        except:
+        except Exception:
             return 'No data'
         ret_str = ""
         inv = self.get_inventory()
@@ -170,11 +170,11 @@ class Parser(object):
             else:
                 try:
                     data = data.encode()
-                except:
+                except Exception:
                     pass
                 try:
                     data = io.BytesIO(data)
-                except:
+                except Exception:
                     raise IOError("data is neither filename nor valid URL")
         # but could also be a big string with data
         elif isinstance(data, bytes):
@@ -1050,7 +1050,7 @@ class Parser(object):
             for blkt in station:
                 try:
                     fields = blockettes[blkt.blockette_type]
-                except:
+                except Exception:
                     continue
                 for field in fields:
                     setattr(blkt, blkt.get_fields()[field - 2].field_name,
@@ -1099,7 +1099,7 @@ class Parser(object):
             try:
                 blockette_id = int(data.read(3))
                 blockette_length = int(data.read(4))
-            except:
+            except Exception:
                 break
             data.seek(data.tell() - 7)
             if blockette_id in HEADER_INFO[record_type].get('blockettes', []):
@@ -1277,12 +1277,12 @@ def is_xseed(path_or_file_object):
             return False
     try:
         root = xmldoc.getroot()
-    except:
+    except Exception:
         return False
     # check tag of root element
     try:
         assert root.tag == "xseed"
-    except:
+    except Exception:
         return False
     return True
 

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -180,7 +180,7 @@ class BlocketteTestCase(unittest.TestCase):
             # Check whether the blockette class can be loaded.
             try:
                 __import__('obspy.io.xseed.blockette.blockette' + blkt_number)
-            except:
+            except Exception:
                 msg = 'Failed to import blockette', blkt_number
                 raise ImportError(msg)
             # Parse the file.

--- a/obspy/io/xseed/utils.py
+++ b/obspy/io/xseed/utils.py
@@ -61,7 +61,7 @@ def datetime_2_string(dt, compact=False):
     try:
         dt = UTCDateTime(dt)
         return dt.format_seed(compact)
-    except:
+    except Exception:
         raise Exception("Invalid datetime %s: %s" % (type(dt), str(dt)))
 
 
@@ -165,7 +165,7 @@ def blockette_34_lookup(abbr, lookup):
         l2 = lookup_code(abbr, 34, 'unit_description', 'unit_lookup_code',
                          lookup)
         return l1 + ' - ' + l2
-    except:
+    except Exception:
         msg = '\nWarning: Abbreviation reference not found.'
         sys.stdout.write(msg)
         return 'No Abbreviation Referenced'
@@ -177,7 +177,7 @@ def set_xpath(blockette, identifier):
     """
     try:
         identifier = int(identifier)
-    except:
+    except Exception:
         msg = 'X-Path identifier needs to be an integer.'
         raise TypeError(msg)
     abbr_path = '/xseed/abbreviation_dictionary_control_header/'

--- a/obspy/io/y/core.py
+++ b/obspy/io/y/core.py
@@ -123,7 +123,7 @@ def _is_y(filename):
         # get first tag (16 bytes)
         with open(filename, 'rb') as fh:
             _, tag_type, _, _ = _parse_tag(fh)
-    except:
+    except Exception:
         return False
     # The first tag in a Y-file must be the TAG_Y_FILE tag (tag type 0)
     if tag_type != 0:

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -328,7 +328,7 @@ def _read_zmap(filename, **kwargs):
         try:
             with open(filename):
                 pass
-        except:
+        except Exception:
             # we assume it's a string now
             return Unpickler().loads(filename)
     return Unpickler().load(filename)
@@ -366,10 +366,10 @@ def _is_zmap(filename):
         try:
             with open(filename, 'rb') as f:
                 first_line = f.readline().decode()
-        except:
+        except Exception:
             try:
                 first_line = filename.decode()
-            except:
+            except Exception:
                 first_line = str(filename)
             line_ending = first_line.find("\n")
             if line_ending == -1:

--- a/obspy/scripts/reftekrescue.py
+++ b/obspy/scripts/reftekrescue.py
@@ -104,7 +104,7 @@ def reftek_rescue(input_file, output_folder, reftek_id, year,
                     # at least for packet types 'DT', 'EH' and 'ET'
                     try:
                         event_no = int(b2a_hex(m[(ind + 16):(ind + 18)]))
-                    except:
+                    except Exception:
                         msg = "Could not decode event number. Dropping " + \
                               "possibly corrupted packet at byte position" + \
                               " %d in input file."

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -221,7 +221,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
         try:
             data = codecs.open(log, 'r', encoding='UTF-8').read()
             result['install_log'] = escape(data)
-        except:
+        except Exception:
             print("Cannot open log file %s" % log)
     # get ObsPy module versions
     result['obspy'] = {}
@@ -231,7 +231,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     skipped = 0
     try:
         installed = get_git_version()
-    except:
+    except Exception:
         installed = ''
     result['obspy']['installed'] = installed
     for module in sorted(ALL_MODULES):
@@ -313,14 +313,14 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
             if isinstance(temp, tuple):
                 temp = temp[0]
             result['platform'][func] = temp
-        except:
+        except Exception:
             result['platform'][func] = ''
     # set node name to hostname if set
     result['platform']['node'] = hostname
     # post only the first part of the node name (only applies to MacOS X)
     try:
         result['platform']['node'] = result['platform']['node'].split('.')[0]
-    except:
+    except Exception:
         pass
     # test results
     result['tests'] = tests
@@ -337,7 +337,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
                         (module, skipped_test.__module__,
                          skipped_test.__class__.__name__,
                          skipped_test._testMethodName, skip_message))
-    except:
+    except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()
         print("\n".join(traceback.format_exception(exc_type, exc_value,
                                                    exc_tb)))
@@ -498,7 +498,7 @@ class _TextTestRunner:
                 num = test.countTestCases()
                 try:
                     avg = float(total) / num
-                except:
+                except Exception:
                     avg = 0
                 msg = '%d tests in %.3fs (average of %.4fs per test)'
                 self.stream.writeln(msg % (num, total, avg))
@@ -586,7 +586,7 @@ def run_tests(verbosity=1, tests=None, report=False, log=None,
                 filesuite = doctest.DocFileSuite(file, module_relative=False)
                 tut_suite.addTest(filesuite)
             suites['tutorial'] = tut_suite
-        except:
+        except Exception:
             msg = "Could not add tutorial files to tests."
             warnings.warn(msg)
     # run test suites

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -89,7 +89,7 @@ def recursive_sta_lta_py(a, nsta, nlta):
     """
     try:
         a = a.tolist()
-    except:
+    except Exception:
         pass
     ndat = len(a)
     # compute the short time average (STA) and long time average (LTA)

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -386,7 +386,7 @@ class TauPyModelTestCase(unittest.TestCase):
                 line = line.split()
                 try:
                     float(line[0])
-                except:
+                except Exception:
                     continue
                 expected[(float(line[0]), float(line[1]))].append({
                     "distance": float(line[0]),

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ For more information visit https://www.obspy.org.
 # setuptools.
 try:
     import setuptools  # @UnusedImport # NOQA
-except:
+except ImportError:
     pass
 
 try:
     import numpy  # @UnusedImport # NOQA
-except:
+except ImportError:
     msg = ("No module named numpy. "
            "Please install numpy first, it is needed before installing ObsPy.")
     raise ImportError(msg)
@@ -93,10 +93,10 @@ KEYWORDS = [
     'NERIES', 'NonLinLoc', 'NLLOC', 'Nordic', 'observatory', 'ORFEUS', 'PDAS',
     'picker', 'processing', 'PQLX', 'Q', 'real time', 'realtime', 'REFTEK',
     'REFTEK130', 'RT-130', 'RESP', 'response file', 'RT', 'SAC', 'sc3ml',
-    'SDS', 'SEED', 'SeedLink', 'SEG-2', 'SEG Y', 'SEISAN', 'SeisHub', 
-    'Seismic Handler', 'seismology', 'seismogram', 'seismograms', 
+    'SDS', 'SEED', 'SeedLink', 'SEG-2', 'SEG Y', 'SEISAN', 'SeisHub',
+    'Seismic Handler', 'seismology', 'seismogram', 'seismograms',
     'shapefile', 'signal', 'slink', 'spectrogram', 'StationXML', 'taper',
-    'taup', 'travel time', 'trigger', 'VERCE', 'WAV', 'waveform', 
+    'taup', 'travel time', 'trigger', 'VERCE', 'WAV', 'waveform',
     'WaveServer', 'WaveServerV', 'WebDC', 'web service', 'Winston',
     'XML-SEED', 'XSEED']
 
@@ -758,24 +758,24 @@ if __name__ == '__main__':
         path = os.path.join(SETUP_DIRECTORY, 'build')
         try:
             shutil.rmtree(path)
-        except:
+        except Exception:
             pass
         # delete all shared libs from lib directory
         path = os.path.join(SETUP_DIRECTORY, 'obspy', 'lib')
         for filename in glob.glob(path + os.sep + '*.pyd'):
             try:
                 os.remove(filename)
-            except:
+            except Exception:
                 pass
         for filename in glob.glob(path + os.sep + '*.so'):
             try:
                 os.remove(filename)
-            except:
+            except Exception:
                 pass
         path = os.path.join(SETUP_DIRECTORY, 'obspy', 'taup', 'data', 'models')
         try:
             shutil.rmtree(path)
-        except:
+        except Exception:
             pass
     else:
         setupPackage()


### PR DESCRIPTION
There is a lot of 

```
try:
    …
except:
    …
```

in obspy (nearly 300) and this can lead to not correctly catch exceptions like `KeyboardInterrupt` or `SystemExit`. I didn't have faith to fix each of them perfectly by catching only the expected exceptions so I did this little PR to replace the wildcard excepts by:

```
try:
    …
except Exception:
    …
```

At least, system-exiting exceptions won't be caught.