### PR TITLE
Correctly splitting masked arrays with no masked values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@
      dayplot of a trace, see #1566)
    * properly pass through kwargs from Stream.detrend() to Trace.detrend()
      (see #1607)
+   * Correctly splitting masked arrays in Trace objects for a couple of corner
+     cases (see #1650, #1653).
  - obspy.core.event.source:
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
  - obspy.clients.earthworm:

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1469,6 +1469,26 @@ class TraceTestCase(unittest.TestCase):
         self.assertTrue(isinstance(st, Stream))
         self.assertEqual(len(st), 0)
 
+    def test_split_masked_array_without_actually_masked_values(self):
+        """
+        Tests splitting a masked array without actually masked data.
+        """
+        # First non masked.
+        tr = Trace(data=np.arange(100))
+        st = tr.copy().split()
+        self.assertEqual(len(st), 1)
+        self.assertEqual(tr, st[0])
+        self.assertFalse(isinstance(st[0].data, np.ma.masked_array))
+
+        # Now the same thing but with an initially masked array but no
+        # masked values.
+        tr = Trace(data=np.ma.arange(100))
+        self.assertFalse(tr.data.mask)
+        st = tr.copy().split()
+        self.assertEqual(len(st), 1)
+        self.assertEqual(tr, st[0])
+        self.assertFalse(isinstance(st[0].data, np.ma.masked_array))
+
     def test_simulate_evalresp(self):
         """
         Tests that trace.simulate calls evalresp with the correct network,

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2189,9 +2189,18 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             still be returned as Stream with only one entry.
         """
         from obspy import Stream
+
+        # Not a masked array.
         if not isinstance(self.data, np.ma.masked_array):
             # no gaps
-            return Stream([self])
+            return Stream([self.copy()])
+        # Masked array but no actually masked values.
+        elif isinstance(self.data, np.ma.masked_array) and \
+                not np.ma.is_masked(self.data):
+            _tr = self.copy()
+            _tr.data = np.ma.getdata(_tr.data)
+            return Stream([_tr])
+
         slices = flat_not_masked_contiguous(self.data)
         trace_list = []
         for slice in slices:


### PR DESCRIPTION
This is a follow up to #1650 and fixes the mentioned issue with splitting masked arrays without actually masked values.