### PR TITLE
Added FDSNNoDataException

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,8 @@ master: (doi: 10.5281/zenodo.165135)
    * The mass downloader can now download stations that are part of a given
      inventory object.
    * The mass downloader now also works with restricted data. (See #1350)
+   * No data (HTTP 204) responses now raise `FDSNNoDataException` rather than
+     the more general `FDSNException`.
  - obspy.imaging:
    * The functionality behind the `obspy-scan` command line script has been
      refactored into a `Scanner` class so that it can be reused in custom

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -12,6 +12,7 @@ Beyreuther, Moritz
 Bonaimé, Sébastien
 Carothers, Lloyd
 Chamberlain, Calum
+Clark, Adam
 Danecek, Peter
 van Driel, Martin
 Egdorf, Sven

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -45,7 +45,7 @@ from obspy import UTCDateTime, read_inventory
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES, URL_MAPPINGS,
                      WADL_PARAMETERS_NOT_TO_BE_PARSED, FDSNException,
-                     FDSNRedirectException)
+                     FDSNRedirectException, FDSNNoDataException)
 from .wadl_parser import WADLParser
 
 
@@ -1312,7 +1312,7 @@ class Client(object):
                 server_info = None
         # No data.
         if code == 204:
-            raise FDSNException("No data available for request.", server_info)
+            raise FDSNNoDataException("No data available for request.", server_info)
         elif code == 400:
             msg = ("Bad request. If you think your request was valid "
                    "please contact the developers.")

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1312,7 +1312,8 @@ class Client(object):
                 server_info = None
         # No data.
         if code == 204:
-            raise FDSNNoDataException("No data available for request.", server_info)
+            raise FDSNNoDataException("No data available for request.",
+                                      server_info)
         elif code == 400:
             msg = ("Bad request. If you think your request was valid "
                    "please contact the developers.")

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -31,6 +31,10 @@ class FDSNRedirectException(FDSNException):
     pass
 
 
+class FDSNNoDataException(FDSNException):
+    pass
+
+
 # A curated list collecting some implementations:
 # https://www.fdsn.org/webservices/datacenters/
 # http://www.orfeus-eu.org/eida/eida_odc.html

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1179,8 +1179,8 @@ class ClientTestCase(unittest.TestCase):
         Verify that a request returning no data raises an identifiable exception
         """
         self.assertRaises(FDSNNoDataException, self.client.get_events,
-            starttime=UTCDateTime("2001-01-07T01:00:00"),
-            endtime=UTCDateTime("2001-01-07T01:01:00"), minmagnitude=8)
+                          starttime=UTCDateTime("2001-01-07T01:00:00"),
+                          endtime=UTCDateTime("2001-01-07T01:01:00"), minmagnitude=8)
 
 
 def suite():

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1176,11 +1176,13 @@ class ClientTestCase(unittest.TestCase):
 
     def test_no_data(self):
         """
-        Verify that a request returning no data raises an identifiable exception
+        Verify that a request returning no data raises an identifiable
+        exception
         """
         self.assertRaises(FDSNNoDataException, self.client.get_events,
                           starttime=UTCDateTime("2001-01-07T01:00:00"),
-                          endtime=UTCDateTime("2001-01-07T01:01:00"), minmagnitude=8)
+                          endtime=UTCDateTime("2001-01-07T01:01:00"),
+                          minmagnitude=8)
 
 
 def suite():

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -30,7 +30,8 @@ from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn import Client
 from obspy.clients.fdsn.client import build_url, parse_simple_xml
 from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
-                                       FDSNException, FDSNRedirectException)
+                                       FDSNException, FDSNRedirectException,
+                                       FDSNNoDataException)
 from obspy.core.inventory import Response
 from obspy.geodetics import locations2degrees
 
@@ -1172,6 +1173,14 @@ class ClientTestCase(unittest.TestCase):
                 url = m.call_args[0][0]
             url_parts = url.replace(url_base, '').split("&")
             self.assertIn('{}='.format(key), url_parts)
+
+    def test_no_data(self):
+        """
+        Verify that a request returning no data raises an identifiable exception
+        """
+        self.assertRaises(FDSNNoDataException, self.client.get_events,
+            starttime=UTCDateTime("2001-01-07T01:00:00"),
+            endtime=UTCDateTime("2001-01-07T01:01:00"), minmagnitude=8)
 
 
 def suite():


### PR DESCRIPTION
### What does this PR do?

Adds a new exception FDSNNoDataException to be raised by the FDSN client when the server returns a 204 (No Data) status.

### Why was it initiated?  Any relevant Issues?

This allows the caller to distinguish a successful but empty response from other types of error. See issue #1656.

### PR Checklist
- [ x] This PR is not directly related to an existing issue (which has no PR yet).
- [ x] All tests still pass.
- [ x] Any new features or fixed regressions are be covered via new tests.
- [ x] Any new or changed features have are fully documented.
- [ x] Significant changes have been added to `CHANGELOG.txt` .
- [ x] First time contributors have added your name to `CONTRIBUTORS.txt` .
