### PR TITLE
Konno-Ohmachi: function to apply smoothing matrix

### DIFF
--- a/obspy/signal/konnoohmachismoothing.py
+++ b/obspy/signal/konnoohmachismoothing.py
@@ -82,8 +82,8 @@ def konno_ohmachi_smoothing_window(frequencies, center_frequency,
         # Calculate the bandwidth*log10(f/f_c)
         smoothing_window = bandwidth * np.log10(frequencies / center_frequency)
         # Just the Konno-Ohmachi formulae.
-        smoothing_window[...] =\
-            (np.sin(smoothing_window) / smoothing_window) ** 4
+        smoothing_window[:] = (
+            np.sin(smoothing_window) / smoothing_window) ** 4
     # Check if the center frequency is exactly part of the provided
     # frequencies. This will result in a division by 0. The limit of f->f_c is
     # one.
@@ -227,14 +227,10 @@ def konno_ohmachi_smoothing(spectra, frequencies, bandwidth=40, count=1,
     # matrix and apply to each spectrum. Also only use when more then one
     # spectrum is to be smoothed.
     if enforce_no_matrix is False and (len(spectra.shape) > 1 or count > 1) \
-       and approx_mem_usage < max_memory_usage:
+            and approx_mem_usage < max_memory_usage:
         smoothing_matrix = calculate_smoothing_matrix(
             frequencies, bandwidth, normalize=normalize)
-        new_spec = np.dot(spectra, smoothing_matrix)
-        # Eventually apply more than once.
-        for _i in range(count - 1):
-            new_spec = np.dot(new_spec, smoothing_matrix)
-        return new_spec
+        return apply_smoothing_matrix(spectra, smoothing_matrix, count=count)
     # Otherwise just calculate the smoothing window every time and apply it.
     else:
         new_spec = np.empty(spectra.shape, spectra.dtype)

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 
 from obspy.signal.konnoohmachismoothing import (calculate_smoothing_matrix,
+                                                apply_smoothing_matrix,
                                                 konno_ohmachi_smoothing_window,
                                                 konno_ohmachi_smoothing)
 
@@ -130,19 +131,23 @@ class KonnoOhmachiTestCase(unittest.TestCase):
                                              max_memory_usage=0)
         # XXX: Why are the numerical inaccuracies quite large?
         np.testing.assert_almost_equal(smoothed_1, smoothed_2, 3)
+        # Test using a pre-computed smoothing matrix
+        smoothing_matrix = calculate_smoothing_matrix(frequencies)
+        smoothed_3 = apply_smoothing_matrix(spectra, smoothing_matrix, count=3)
+        np.testing.assert_almost_equal(smoothed_1, smoothed_3, 3)
         # Test the non-matrix mode for single spectra.
-        smoothed_3 = konno_ohmachi_smoothing(
+        smoothed_4 = konno_ohmachi_smoothing(
             np.require(spectra[0], dtype=np.float64),
             np.require(frequencies, dtype=np.float64))
-        smoothed_4 = konno_ohmachi_smoothing(
+        smoothed_5 = konno_ohmachi_smoothing(
             np.require(spectra[0], dtype=np.float64),
             np.require(frequencies, dtype=np.float64),
             normalize=True)
         # The normalized and not normalized should not be the same. That the
         # normalizing works has been tested before.
-        self.assertFalse(np.all(smoothed_3 == smoothed_4))
+        self.assertFalse(np.all(smoothed_4 == smoothed_5))
         # Input dtype should be output dtype.
-        self.assertEqual(smoothed_3.dtype, np.float64)
+        self.assertEqual(smoothed_4.dtype, np.float64)
 
 
 def suite():

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -31,81 +31,77 @@ class KonnoOhmachiTestCase(unittest.TestCase):
         """
         Tests the creation of the smoothing window.
         """
-        # Disable div by zero errors.
-        with np.errstate(all='ignore'):
-            # Frequency of zero results in a delta peak at zero (there usually
-            # should be just one zero in the frequency array.
-            window = konno_ohmachi_smoothing_window(
-                np.array([0, 1, 0, 3], dtype=np.float32), 0)
-            np.testing.assert_array_equal(window, np.array([1, 0, 1, 0],
-                                                           dtype=np.float32))
-            # Wrong dtypes raises.
-            self.assertRaises(ValueError, konno_ohmachi_smoothing_window,
-                              np.arange(10, dtype=np.int32), 10)
-            # If frequency=center frequency, log results in infinity. Limit of
-            # whole formulae is 1.
-            window = konno_ohmachi_smoothing_window(
-                np.array([5.0, 1.0, 5.0, 2.0], dtype=np.float32), 5)
-            np.testing.assert_array_equal(
-                window[[0, 2]], np.array([1.0, 1.0], dtype=np.float32))
-            # Output dtype should be the dtype of frequencies.
-            self.assertEqual(konno_ohmachi_smoothing_window(
-                np.array([1, 6, 12], dtype=np.float32), 5).dtype, np.float32)
-            self.assertEqual(konno_ohmachi_smoothing_window(
-                np.array([1, 6, 12], dtype=np.float64), 5).dtype, np.float64)
-            # Check if normalizing works.
-            window = konno_ohmachi_smoothing_window(self.frequencies, 20)
-            self.assertGreater(window.sum(), 1.0)
-            window = konno_ohmachi_smoothing_window(self.frequencies, 20,
-                                                    normalize=True)
-            self.assertAlmostEqual(window.sum(), 1.0, 5)
-            # Just one more to test if there are no invalid values and the
-            # range if ok.
-            window = konno_ohmachi_smoothing_window(self.frequencies, 20)
-            self.assertEqual(np.any(np.isnan(window)), False)
-            self.assertEqual(np.any(np.isinf(window)), False)
-            self.assertTrue(np.all(window <= 1.0))
-            self.assertTrue(np.all(window >= 0.0))
+        # Frequency of zero results in a delta peak at zero (there usually
+        # should be just one zero in the frequency array.
+        window = konno_ohmachi_smoothing_window(
+            np.array([0, 1, 0, 3], dtype=np.float32), 0)
+        np.testing.assert_array_equal(window, np.array([1, 0, 1, 0],
+                                                       dtype=np.float32))
+        # Wrong dtypes raises.
+        self.assertRaises(ValueError, konno_ohmachi_smoothing_window,
+                          np.arange(10, dtype=np.int32), 10)
+        # If frequency=center frequency, log results in infinity. Limit of
+        # whole formulae is 1.
+        window = konno_ohmachi_smoothing_window(
+            np.array([5.0, 1.0, 5.0, 2.0], dtype=np.float32), 5)
+        np.testing.assert_array_equal(
+            window[[0, 2]], np.array([1.0, 1.0], dtype=np.float32))
+        # Output dtype should be the dtype of frequencies.
+        self.assertEqual(konno_ohmachi_smoothing_window(
+            np.array([1, 6, 12], dtype=np.float32), 5).dtype, np.float32)
+        self.assertEqual(konno_ohmachi_smoothing_window(
+            np.array([1, 6, 12], dtype=np.float64), 5).dtype, np.float64)
+        # Check if normalizing works.
+        window = konno_ohmachi_smoothing_window(self.frequencies, 20)
+        self.assertGreater(window.sum(), 1.0)
+        window = konno_ohmachi_smoothing_window(self.frequencies, 20,
+                                                normalize=True)
+        self.assertAlmostEqual(window.sum(), 1.0, 5)
+        # Just one more to test if there are no invalid values and the
+        # range if ok.
+        window = konno_ohmachi_smoothing_window(self.frequencies, 20)
+        self.assertEqual(np.any(np.isnan(window)), False)
+        self.assertEqual(np.any(np.isinf(window)), False)
+        self.assertTrue(np.all(window <= 1.0))
+        self.assertTrue(np.all(window >= 0.0))
 
     def test_smoothing_matrix(self):
         """
         Tests some aspects of the matrix.
         """
-        # Disable div by zero errors.
-        with np.errstate(all='ignore'):
-            frequencies = np.array([0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
-                                   dtype=np.float32)
-            matrix = calculate_smoothing_matrix(frequencies, 20.0)
-            self.assertEqual(matrix.dtype, np.float32)
-            for _i, freq in enumerate(frequencies):
-                np.testing.assert_array_equal(
-                    matrix[_i],
-                    konno_ohmachi_smoothing_window(frequencies, freq, 20.0))
-                # Should not be normalized. Test only for larger frequencies
-                # because smaller ones have a smaller window.
-                if freq >= 10.0:
-                    self.assertGreater(matrix[_i].sum(), 1.0)
-            # Input should be output dtype.
-            frequencies = np.array(
-                [0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
-                dtype=np.float64)
-            matrix = calculate_smoothing_matrix(frequencies, 20.0)
-            self.assertEqual(matrix.dtype, np.float64)
-            # Check normalization.
-            frequencies = np.array(
-                [0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
-                dtype=np.float32)
-            matrix = calculate_smoothing_matrix(frequencies, 20.0,
-                                                normalize=True)
-            self.assertEqual(matrix.dtype, np.float32)
-            for _i, freq in enumerate(frequencies):
-                np.testing.assert_array_equal(
-                    matrix[_i],
-                    konno_ohmachi_smoothing_window(
-                        frequencies, freq, 20.0, normalize=True))
-                # Should not be normalized. Test only for larger frequencies
-                # because smaller ones have a smaller window.
-                self.assertAlmostEqual(matrix[_i].sum(), 1.0, 5)
+        frequencies = np.array([0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
+                               dtype=np.float32)
+        matrix = calculate_smoothing_matrix(frequencies, 20.0)
+        self.assertEqual(matrix.dtype, np.float32)
+        for _i, freq in enumerate(frequencies):
+            np.testing.assert_array_equal(
+                matrix[_i],
+                konno_ohmachi_smoothing_window(frequencies, freq, 20.0))
+            # Should not be normalized. Test only for larger frequencies
+            # because smaller ones have a smaller window.
+            if freq >= 10.0:
+                self.assertGreater(matrix[_i].sum(), 1.0)
+        # Input should be output dtype.
+        frequencies = np.array(
+            [0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
+            dtype=np.float64)
+        matrix = calculate_smoothing_matrix(frequencies, 20.0)
+        self.assertEqual(matrix.dtype, np.float64)
+        # Check normalization.
+        frequencies = np.array(
+            [0.0, 1.0, 2.0, 10.0, 25.0, 50.0, 100.0],
+            dtype=np.float32)
+        matrix = calculate_smoothing_matrix(frequencies, 20.0,
+                                            normalize=True)
+        self.assertEqual(matrix.dtype, np.float32)
+        for _i, freq in enumerate(frequencies):
+            np.testing.assert_array_equal(
+                matrix[_i],
+                konno_ohmachi_smoothing_window(
+                    frequencies, freq, 20.0, normalize=True))
+            # Should not be normalized. Test only for larger frequencies
+            # because smaller ones have a smaller window.
+            self.assertAlmostEqual(matrix[_i].sum(), 1.0, 5)
 
     def test_konno_ohmachi_smoothing(self):
         """


### PR DESCRIPTION
A new function (`apply_smoothing_matrix()`) to smooth spectra through a pre-computed smoothing matrix.
This is useful to speed-up calculation on the same type of spectra across different function calls.