### PR TITLE
seishub: fix `event.get_list()` kwargs `first_pick` and `last_pick`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,9 @@
    * Better end of stream detection. (see #1563)
  - obspy.clients.seedlink:
    * Better end of stream detection. (see #1605)
+ - obspy.clients.seishub:
+   * Fix wrong kwargs `first_pick` and `last_pick` in
+     `Client.event.get_list()`. (see #1661)
  - obspy.io.mseed:
    * ObsPy can now also read (Mini)SEED files with noise records. (see #1495)
    * ObsPy can now read records with a data-offset of zero. (see #1509, #1525)

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -867,10 +867,13 @@ master/seishub/plugins/seismology/event.py
     def getList(self, *args, **kwargs):
         return self.get_list(*args, **kwargs)
 
+    @deprecated_keywords({
+        "first_pick": None, "last_pick": None})
     def get_list(self, limit=50, offset=None, localisation_method=None,
                  author=None, min_datetime=None, max_datetime=None,
-                 first_pick=None, last_pick=None, min_latitude=None,
-                 max_latitude=None, min_longitude=None, max_longitude=None,
+                 min_first_pick=None, max_first_pick=None, min_last_pick=None,
+                 max_last_pick=None, min_latitude=None, max_latitude=None,
+                 min_longitude=None, max_longitude=None,
                  min_magnitude=None, max_magnitude=None, min_depth=None,
                  max_depth=None, used_p=None, min_used_p=None, max_used_p=None,
                  used_s=None, min_used_s=None, max_used_s=None,

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -87,6 +87,10 @@ def deprecated_keywords(keywords):
                 if key in kwargs:
                     new_keyword_appearance_counts[new_key] += 1
             for key_ in keywords.values():
+                # ignore `None` as new value, it means that no mapping is
+                # happening..
+                if key_ is None:
+                    continue
                 if new_keyword_appearance_counts[key_] > 1:
                     conflicting_keys = ", ".join(
                         [old_key for old_key, new_key in keywords.items()


### PR DESCRIPTION
Query parameters `first_pick` and `last_pick` are only used as `min_...`
and `max_...` on server side so these kwargs were just wrong..

Also fixes a minor issue with `deprecated_keywords` decorator.

Should be good to go.