### PR TITLE
Debian stretch / Ubuntu Zesty 17.04

### DIFF
--- a/debian/pybuild/control
+++ b/debian/pybuild/control
@@ -6,7 +6,7 @@ X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.2
 Build-Depends: debhelper (>= 5),
  python (>= 2.7), python-dev (>= 2.7), python3-all-dev,
- python-support (>= 0.7.1), dh-python, python-numpy, python3-numpy,
+ dh-python, python-numpy, python3-numpy,
  python-setuptools (>=0.6.21), python3-setuptools, gcc, help2man,
  quilt, python-future (>= 0.12.4), python3-future (>= 0.12.4)
 Standards-Version: 3.9.3

--- a/debian/pybuild/control
+++ b/debian/pybuild/control
@@ -40,7 +40,8 @@ Replaces: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-wav, python-obspy-xseed
 Recommends: python-obspy-dbg (= ${binary:Version}),
  python-mpltoolkits.basemap, python-geographiclib, python-imaging,
- python-nose, python-flake8, python-mock, python-gdal
+ python-nose, python-flake8, python-mock, python-gdal,
+ python-cryptography, python-m2crypto
 Suggests: python-mlpy, python-pyproj, ipython
 Description: ObsPy: A Python Toolbox for seismology
  ObsPy is an open-source project dedicated to provide a Python framework for
@@ -64,7 +65,8 @@ Depends: python3 (>= 3.2),
  python3-future (>= 0.12.4), python3-decorator, python3-requests
 Recommends: python-obspy-dbg (= ${binary:Version}),
  python3-mpltoolkits.basemap, python3-geographiclib,
- python3-imaging, python3-nose, python3-flake8, python3-mock, python3-gdal
+ python3-imaging, python3-nose, python3-flake8, python3-mock, python3-gdal,
+ python3-cryptography
 Suggests: python3-pyproj, ipython3, ipython3-notebook
 Description: ObsPy: A Python Toolbox for seismology
  ObsPy is an open-source project dedicated to provide a Python framework for

--- a/debian/python_distutils/control
+++ b/debian/python_distutils/control
@@ -38,7 +38,7 @@ Replaces: python-obspy-arclink, python-obspy-core, python-obspy-datamark,
  python-obspy-wav, python-obspy-xseed
 Recommends: python-obspy-dbg (= ${binary:Version}),
  python-geographiclib, python-nose, python-flake8, python-imaging, python-mock,
- python-mpltoolkits.basemap, python-gdal
+ python-mpltoolkits.basemap, python-gdal, python-m2crypto
 Suggests: python-mlpy, python-pyproj, ipython
 Description: ObsPy: A Python Toolbox for seismology seismological observatories
  ObsPy is an open-source project dedicated to provide a Python framework for

--- a/misc/debian/deb__build_debs.sh
+++ b/misc/debian/deb__build_debs.sh
@@ -59,7 +59,7 @@ git clean -fxd
 # first of all selectively use debian build instructions for either
 # buildsystem=python_distutils (older Debuntu releases) or buildsystem=pybuild
 # (newer Debuntu releases)
-if [ "$CODENAME" == "wheezy" ] || [ "$CODENAME" == "precise" ]
+if [ "$CODENAME" == "wheezy" ]
 then
     # old build style, python2 only
     cp -a debian/python_distutils/* debian/
@@ -104,11 +104,6 @@ cat >> debian/changelog << EOF
 
  -- ObsPy Development Team <devs@obspy.org>  $DATE
 EOF
-# adjust dh compatibility for older dh versions
-if [ $CODENAME = "squeeze" ]
-    then
-    echo "8" > ./debian/compat
-fi
 # build the package
 export FFLAGS="$FFLAGS -fPIC"  # needed for gfortran
 export LDFLAGS="$LDFLAGS -shared -z relro -z now"  # needed for gfortran

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -208,6 +208,18 @@ $ docker login  # docker hub user needs write access to "obspy/base-images" of o
 $ docker push obspy/base-images:${DISTRO_FULL}
 ```
 
+To create a Raspbian (Debian ``armhf`` for Raspberry Pi) docker base image (using ``qemu``, https://wiki.debian.org/ArmHardFloatChroot):
+
+```bash
+$ cd /tmp
+$ DISTRO=jessie
+$ DISTRO_FULL=debian_8_jessie_armhf
+$ sudo qemu-debootstrap --arch=armhf ${DISTRO} ${DISTRO_FULL} ftp://ftp.debian.org/debian/ 2>&1 | tee ${DISTRO_FULL}.debootstrap.log
+$ sudo tar -C ${DISTRO_FULL} -c . | docker import - obspy/base-images:${DISTRO_FULL}
+$ docker login  # docker hub user needs write access to "obspy/base-images" of organization "obspy"
+$ docker push obspy/base-images:${DISTRO_FULL}
+```
+
 ### Setting up `docker-testbot` to automatically test PRs and branches and send commit statuses
 
 ##### Install docker

--- a/misc/docker/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy/Dockerfile
@@ -1,33 +1,57 @@
 FROM debian:wheezy
 
-MAINTAINER Lion Krischer
+MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip ttf-bitstream-vera python-decorator python-requests
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-matplotlib \
+    python-m2crypto \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-support \
+    python-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
 RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-RUN echo "backend: agg" > /etc/matplotlibrc
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-m2crypto
-RUN apt-get install -y debhelper python-all devscripts
+RUN echo "backend: agg" > /etc/matplotlibrc
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
 RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb

--- a/misc/docker/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-m2crypto
 RUN apt-get install -y debhelper python-all devscripts
 
 # install fake future packages, so that we can properly install built obspy deb

--- a/misc/docker/base_images/debian_7_wheezy/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     && rm -rf /var/lib/apt/lists/*
 # install some additional packages via pip
 RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -21,8 +21,10 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-gdal \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-matplotlib \
     python-m2crypto \
@@ -32,6 +34,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
@@ -52,6 +55,3 @@ RUN echo "backend: agg" > /etc/matplotlibrc
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
 RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb

--- a/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     && rm -rf /var/lib/apt/lists/*
 # install some additional packages via pip
 RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 RUN echo "backend: agg" > /etc/matplotlibrc

--- a/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy_32bit/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-imaging \
     python-lxml \
     python-matplotlib \
+    python-m2crypto \
     python-mock \
     python-mpltoolkits.basemap \
     python-mpltoolkits.basemap-data \

--- a/misc/docker/base_images/debian_7_wheezy_armhf/Dockerfile
+++ b/misc/docker/base_images/debian_7_wheezy_armhf/Dockerfile
@@ -1,0 +1,57 @@
+FROM obspy/base-images:debian_7_wheezy_armhf
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-matplotlib \
+    python-m2crypto \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-support \
+    python-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+RUN echo "backend: agg" > /etc/matplotlibrc
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb

--- a/misc/docker/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-cryptography
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/debian_8_jessie/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie/Dockerfile
@@ -1,36 +1,77 @@
 FROM debian:jessie
 
-MAINTAINER Lion Krischer
+MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-cryptography \
+    python-decorator \
+    python-dev \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-support \
+    python-tornado \
+    python3 \
+    python3-cryptography \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-cryptography
-RUN apt-get install -y debhelper python-all python3-all devscripts
-RUN pip3 install future
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
-RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-dev \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-m2crypto \
     python-matplotlib \
@@ -33,6 +34,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
@@ -44,12 +46,14 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-decorator \
     python3-dev \
     python3-flake8 \
+    python3-jsonschema \
     python3-lxml \
     python3-matplotlib \
     python3-mock \
     python3-nose \
     python3-numpy \
     python3-pip \
+    python3-pyproj \
     python3-requests \
     python3-scipy \
     python3-sqlalchemy \
@@ -71,7 +75,3 @@ RUN locale-gen en_US.UTF-8
 RUN cd /tmp && \
     (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
     (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
@@ -19,11 +19,13 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-geographiclib \
     python-imaging \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -38,6 +40,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-support \
     python-tornado \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie_32bit/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/debian_8_jessie_armhf/Dockerfile
+++ b/misc/docker/base_images/debian_8_jessie_armhf/Dockerfile
@@ -1,0 +1,77 @@
+FROM obspy/base-images:debian_8_jessie_armhf
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-cryptography \
+    python-decorator \
+    python-dev \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-support \
+    python-tornado \
+    python3 \
+    python3-cryptography \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae27979
 RUN apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
+RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
 RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:stretch
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_PRIORITY critical
+ENV DEBCONF_NOWARNINGS yes
+
+# installation for running tests in docker image
+# Can fail on occasion.
+RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
+RUN pip install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
+
+# additional installation for building deb packages in docker image
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+RUN apt-get install -y python
+RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
+RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
+RUN apt-get install -y ttf-bitstream-vera
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
+RUN apt-get install -y debhelper python-all python3-all devscripts
+RUN pip3 install future
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
+RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
+# debian package for obspy 1.0.2 still have suds listed as dependency
+# for now mock install it, can be removed when 1.0.3 is released
+RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
+RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-pyproj \
     python3-requests \
     python3-scipy \
+    python3-setuptools \
     python3-sqlalchemy \
     python3-tornado \
     python3-wheel \

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -3,33 +3,83 @@ FROM debian:stretch
 MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_PRIORITY=critical
+ENV DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-decorator python-requests
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-flake8 \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
-RUN apt-get install -y debhelper python-all python3-all devscripts
-RUN pip3 install future
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
-RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
 # debian package for obspy 1.0.2 still have suds listed as dependency
 # for now mock install it, can be removed when 1.0.3 is released
 RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -80,7 +80,3 @@ RUN locale-gen en_US.UTF-8
 RUN cd /tmp && \
     (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
     (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-flake8 \
@@ -29,6 +30,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-imaging \
     python-jsonschema \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -44,6 +46,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/debian_9_stretch/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_PRIORITY=critical
 ENV DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-scipy \
     python-setuptools \
     python-sqlalchemy \
-    python-support \
     python-tornado \
     python3 \
     python3-decorator \

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -1,0 +1,74 @@
+FROM obspy/base-images:debian_9_stretch_32bit
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-geographiclib \
+    python-imaging \
+    python-lxml \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-support \
+    python-tornado \
+    python3 \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
+# debian package for obspy 1.0.2 still have suds listed as dependency
+# for now mock install it, can be removed when 1.0.3 is released
+RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
+RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-pyproj \
     python3-requests \
     python3-scipy \
+    python3-setuptools \
     python3-sqlalchemy \
     python3-tornado \
     python3-wheel \

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -80,7 +80,3 @@ RUN locale-gen en_US.UTF-8
 RUN cd /tmp && \
     (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
     (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-flake8 \
@@ -29,6 +30,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-imaging \
     python-jsonschema \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -44,6 +46,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -3,7 +3,9 @@ FROM obspy/base-images:debian_9_stretch_32bit
 MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_PRIORITY=critical
+ENV DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
@@ -21,8 +23,11 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python \
     python-decorator \
     python-dev \
+    python-flake8 \
+    python-gdal \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-matplotlib \
     python-mock \
@@ -31,25 +36,33 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
     python-sqlalchemy \
     python-tornado \
+    python-wheel \
     python3 \
     python3-decorator \
     python3-dev \
     python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
     python3-lxml \
     python3-matplotlib \
     python3-mock \
+    python3-mpltoolkits.basemap \
     python3-nose \
     python3-numpy \
     python3-pip \
+    python3-pyproj \
     python3-requests \
     python3-scipy \
     python3-sqlalchemy \
     python3-tornado \
+    python3-wheel \
     quilt \
     ttf-bitstream-vera \
     vim \

--- a/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_32bit/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_PRIORITY=critical
 ENV DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/debian_9_stretch_armhf/Dockerfile
+++ b/misc/docker/base_images/debian_9_stretch_armhf/Dockerfile
@@ -1,0 +1,86 @@
+FROM obspy/base-images:debian_9_stretch_armhf
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_PRIORITY=critical
+ENV DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-cryptography \
+    python-decorator \
+    python-dev \
+    python-flake8 \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-cryptography \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-setuptools \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -1,36 +1,78 @@
 FROM ubuntu:14.04
 
-MAINTAINER Lion Krischer
+MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera python-requests python-decorator
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-flake8 \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python3 \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-m2crypto
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
-RUN apt-get install -y debhelper python-all python3-all devscripts
-RUN pip3 install future
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
-RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-support python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-m2crypto
 RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future

--- a/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-geographiclib \
     python-imaging \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \

--- a/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_14_04_trusty_32bit/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-decorator \
     python-dev \
     python-flake8 \
+    python-gdal \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-m2crypto \
     python-matplotlib \
@@ -33,6 +35,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
@@ -42,12 +45,16 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-decorator \
     python3-dev \
     python3-flake8 \
+    python3-gdal \
+    python3-jsonschema \
     python3-lxml \
     python3-matplotlib \
     python3-mock \
+    python3-mpltoolkits.basemap \
     python3-nose \
     python3-numpy \
     python3-pip \
+    python3-pyproj \
     python3-requests \
     python3-scipy \
     python3-sqlalchemy \
@@ -69,7 +76,3 @@ RUN locale-gen en_US.UTF-8
 RUN cd /tmp && \
     (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
     (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
@@ -1,36 +1,81 @@
 FROM ubuntu:16.04
 
-MAINTAINER Lion Krischer
+MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-cryptography \
+    python-decorator \
+    python-dev \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-cryptography \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib python3-cryptography
-RUN apt-get install -y debhelper python-all python3-all devscripts
-RUN pip3 install future
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
-RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib python3-cryptography
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-cryptography \
     python-decorator \
     python-dev \
+    python-gdal \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-m2crypto \
     python-matplotlib \
@@ -33,6 +35,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
@@ -44,6 +47,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-decorator \
     python3-dev \
     python3-flake8 \
+    python3-gdal \
+    python3-jsonschema \
     python3-lxml \
     python3-matplotlib \
     python3-mock \
@@ -51,6 +56,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-nose \
     python3-numpy \
     python3-pip \
+    python3-pyproj \
     python3-requests \
     python3-scipy \
     python3-sqlalchemy \
@@ -73,7 +79,3 @@ RUN locale-gen en_US.UTF-8
 RUN cd /tmp && \
     (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
     (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
-# debian package for obspy 1.0.2 still have suds listed as dependency
-# for now mock install it, can be removed when 1.0.3 is released
-RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb
-RUN cd /tmp && echo "Package: python3-suds" > python3-suds.control && equivs-build python3-suds.control && dpkg -i python3-suds_*.deb

--- a/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_04_xenial_32bit/Dockerfile
@@ -19,11 +19,13 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-geographiclib \
     python-imaging \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -38,6 +40,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get install -y python
 RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
 RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
 RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib
+RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
+RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib python3-cryptography
 RUN apt-get install -y debhelper python-all python3-all devscripts
 RUN pip3 install future
 

--- a/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety/Dockerfile
@@ -1,35 +1,86 @@
 FROM ubuntu:16.10
 
-MAINTAINER Lion Krischer
+MAINTAINER Tobias Megies
 
 # Set the env variables to non-interactive
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
-ENV DEBCONF_NOWARNINGS yes
+ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
-# installation for running tests in docker image
-# Can fail on occasion.
+# install packages to install obspy and build deb packages
 RUN apt-get update && apt-get upgrade -y || true
-RUN apt-get -y install python-numpy python-scipy python-matplotlib python-sqlalchemy python-lxml python-mock python-mpltoolkits.basemap python-mpltoolkits.basemap-data python-pip python-tornado ttf-bitstream-vera
-RUN pip install future
-RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
-
-# additional installation for building deb packages in docker image
-RUN apt-get install -y locales
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-cryptography \
+    python-decorator \
+    python-dev \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-m2crypto \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-cryptography \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-setuptools \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
-RUN apt-get install -y python
-RUN apt-get install -y python python-dev python-setuptools python-numpy lsb-release gcc
-RUN apt-get install -y vim git fakeroot equivs lintian help2man quilt git
-RUN apt-get install -y ttf-bitstream-vera
-RUN apt-get install -y python-matplotlib python-numpy python-scipy python-lxml python-sqlalchemy python-nose python-flake8 python-setuptools python-imaging python-mock python-decorator python-requests python-tornado python-geographiclib python-cryptography python-m2crypto
-RUN apt-get install -y python3 python3-dev python3-numpy python3-scipy python3-lxml python3-matplotlib python3-sqlalchemy python3-tornado python3-nose python3-mock python3-flake8 python3-decorator python3-requests python3-tornado python3-pip python3-geographiclib python3-cryptography
-RUN apt-get install -y debhelper python-all python3-all devscripts
-RUN pip3 install future
 
 # install fake future packages, so that we can properly install built obspy deb
 # packages to test them (we install future via pip)
-RUN cd /tmp && echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb
-RUN cd /tmp && echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)
 # debian package for obspy 1.0.2 still have suds listed as dependency
 # for now mock install it, can be removed when 1.0.3 is released
 RUN cd /tmp && echo "Package: python-suds" > python-suds.control && equivs-build python-suds.control && dpkg -i python-suds_*.deb

--- a/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-cryptography \
     python-decorator \
     python-dev \
+    python-gdal \
     python-geographiclib \
     python-imaging \
+    python-jsonschema \
     python-lxml \
     python-m2crypto \
     python-matplotlib \
@@ -33,6 +35,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-nose \
     python-numpy \
     python-pip \
+    python-pyproj \
     python-requests \
     python-scipy \
     python-setuptools \
@@ -44,6 +47,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-decorator \
     python3-dev \
     python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
     python3-lxml \
     python3-matplotlib \
     python3-mock \
@@ -51,6 +57,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python3-nose \
     python3-numpy \
     python3-pip \
+    python3-pyproj \
     python3-requests \
     python3-scipy \
     python3-setuptools \

--- a/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tobias Megies
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_16_10_yakkety_32bit/Dockerfile
@@ -19,11 +19,13 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-geographiclib \
     python-imaging \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -38,6 +40,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
@@ -1,0 +1,83 @@
+FROM ubuntu:17.04
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_PRIORITY=critical
+ENV DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-flake8 \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-setuptools \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-flake8 \
@@ -29,6 +30,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-imaging \
     python-jsonschema \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -44,6 +46,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_PRIORITY=critical
 ENV DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     locales \
     lsb-release \
     python \
+    python-cryptography \
     python-decorator \
     python-dev \
     python-flake8 \
@@ -29,6 +30,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-imaging \
     python-jsonschema \
     python-lxml \
+    python-m2crypto \
     python-matplotlib \
     python-mock \
     python-mpltoolkits.basemap \
@@ -44,6 +46,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-tornado \
     python-wheel \
     python3 \
+    python3-cryptography \
     python3-decorator \
     python3-dev \
     python3-flake8 \

--- a/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
@@ -1,0 +1,83 @@
+FROM obspy/base-images:ubuntu_17_04_zesty_32bit
+
+MAINTAINER Tobias Megies
+
+# Set the env variables to non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_PRIORITY=critical
+ENV DEBCONF_NOWARNINGS=yes
+
+# install packages to install obspy and build deb packages
+RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    debhelper \
+    devscripts \
+    equivs \
+    fakeroot \
+    gcc \
+    git \
+    help2man \
+    lintian \
+    locales \
+    lsb-release \
+    python \
+    python-decorator \
+    python-dev \
+    python-flake8 \
+    python-gdal \
+    python-geographiclib \
+    python-imaging \
+    python-jsonschema \
+    python-lxml \
+    python-matplotlib \
+    python-mock \
+    python-mpltoolkits.basemap \
+    python-mpltoolkits.basemap-data \
+    python-nose \
+    python-numpy \
+    python-pip \
+    python-pyproj \
+    python-requests \
+    python-scipy \
+    python-setuptools \
+    python-sqlalchemy \
+    python-tornado \
+    python-wheel \
+    python3 \
+    python3-decorator \
+    python3-dev \
+    python3-flake8 \
+    python3-gdal \
+    python3-geographiclib \
+    python3-jsonschema \
+    python3-lxml \
+    python3-matplotlib \
+    python3-mock \
+    python3-mpltoolkits.basemap \
+    python3-nose \
+    python3-numpy \
+    python3-pip \
+    python3-pyproj \
+    python3-requests \
+    python3-scipy \
+    python3-setuptools \
+    python3-sqlalchemy \
+    python3-tornado \
+    python3-wheel \
+    quilt \
+    ttf-bitstream-vera \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+# install some additional packages via pip
+RUN pip install future; \
+    pip3 install future
+RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+# make sure locale we use in tests is present
+RUN locale-gen en_US.UTF-8
+
+# install fake future packages, so that we can properly install built obspy deb
+# packages to test them (we install future via pip)
+RUN cd /tmp && \
+    (echo "Package: python-future" > python-future.control && equivs-build python-future.control && dpkg -i python-future_*.deb); \
+    (echo "Package: python3-future" > python3-future.control && equivs-build python3-future.control && dpkg -i python3-future_*.deb)

--- a/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
+++ b/misc/docker/base_images/ubuntu_17_04_zesty_32bit/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_PRIORITY=critical
 ENV DEBCONF_NOWARNINGS=yes
 
 # install packages to install obspy and build deb packages
-RUN apt-get update && apt-get upgrade -y || true
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get -y --no-install-recommends install \
     debhelper \
     devscripts \
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN pip install future; \
     pip3 install future
 RUN pip install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip; \
-    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip || true
+    pip3 install https://github.com/Damgaard/PyImgur/archive/9ebd8bed9b3d0ae2797950876f5c1e64a560f7d8.zip
 # make sure locale we use in tests is present
 RUN locale-gen en_US.UTF-8
 

--- a/misc/docker/obspy_images
+++ b/misc/docker/obspy_images
@@ -1,10 +1,12 @@
 centos:centos7
 debian:jessie
+debian:stretch
 debian:wheezy
 fedora:24
 fedora:25
 obspy/base-images:debian_7_wheezy_32bit
 obspy/base-images:debian_8_jessie_32bit
+obspy/base-images:debian_9_stretch_32bit
 obspy/base-images:ubuntu_12_04_precise_32bit
 obspy/base-images:ubuntu_14_04_trusty_32bit
 obspy/base-images:ubuntu_16_04_xenial_32bit
@@ -14,6 +16,8 @@ obspy:debian_7_wheezy
 obspy:debian_7_wheezy_32bit
 obspy:debian_8_jessie
 obspy:debian_8_jessie_32bit
+obspy:debian_9_stretch
+obspy:debian_9_stretch_32bit
 obspy:fedora_24
 obspy:fedora_25
 obspy:opensuse_leap_42_1

--- a/misc/docker/obspy_images
+++ b/misc/docker/obspy_images
@@ -7,7 +7,6 @@ fedora:25
 obspy/base-images:debian_7_wheezy_32bit
 obspy/base-images:debian_8_jessie_32bit
 obspy/base-images:debian_9_stretch_32bit
-obspy/base-images:ubuntu_12_04_precise_32bit
 obspy/base-images:ubuntu_14_04_trusty_32bit
 obspy/base-images:ubuntu_16_04_xenial_32bit
 obspy/base-images:ubuntu_16_10_yakkety_32bit

--- a/misc/docker/obspy_images
+++ b/misc/docker/obspy_images
@@ -10,6 +10,7 @@ obspy/base-images:debian_9_stretch_32bit
 obspy/base-images:ubuntu_14_04_trusty_32bit
 obspy/base-images:ubuntu_16_04_xenial_32bit
 obspy/base-images:ubuntu_16_10_yakkety_32bit
+obspy/base-images:ubuntu_17_04_zesty_32bit
 obspy:centos_7
 obspy:debian_7_wheezy
 obspy:debian_7_wheezy_32bit
@@ -27,6 +28,8 @@ obspy:ubuntu_16_04_xenial
 obspy:ubuntu_16_04_xenial_32bit
 obspy:ubuntu_16_10_yakkety
 obspy:ubuntu_16_10_yakkety_32bit
+obspy:ubuntu_17_04_zesty
+obspy:ubuntu_17_04_zesty_32bit
 opensuse:42.1
 opensuse:42.2
 ubuntu:14.04

--- a/misc/docker/obspy_images
+++ b/misc/docker/obspy_images
@@ -4,8 +4,11 @@ debian:stretch
 debian:wheezy
 fedora:24
 fedora:25
+obspy/base-images:debian_7_wheezy_armhf
 obspy/base-images:debian_7_wheezy_32bit
+obspy/base-images:debian_8_jessie_armhf
 obspy/base-images:debian_8_jessie_32bit
+obspy/base-images:debian_9_stretch_armhf
 obspy/base-images:debian_9_stretch_32bit
 obspy/base-images:ubuntu_14_04_trusty_32bit
 obspy/base-images:ubuntu_16_04_xenial_32bit
@@ -13,10 +16,13 @@ obspy/base-images:ubuntu_16_10_yakkety_32bit
 obspy/base-images:ubuntu_17_04_zesty_32bit
 obspy:centos_7
 obspy:debian_7_wheezy
+obspy:debian_7_wheezy_armhf
 obspy:debian_7_wheezy_32bit
 obspy:debian_8_jessie
+obspy:debian_8_jessie_armhf
 obspy:debian_8_jessie_32bit
 obspy:debian_9_stretch
+obspy:debian_9_stretch_armhf
 obspy:debian_9_stretch_32bit
 obspy:fedora_24
 obspy:fedora_25

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -6,7 +6,7 @@ LOG_DIR_ROOT=logs/package_debs
 LOG_DIR_BASE=$LOG_DIR_ROOT/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit ubuntu_12_04_precise ubuntu_12_04_precise_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit"
+DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_12_04_precise ubuntu_12_04_precise_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit"
 
 # Parse the target for deb package building (e.g. "-tmegies:deb_1.0.2")
 SET_COMMIT_STATUS=false

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -6,7 +6,7 @@ LOG_DIR_ROOT=logs/package_debs
 LOG_DIR_BASE=$LOG_DIR_ROOT/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit ubuntu_17_04_zesty ubuntu_17_04_zesty_32bit"
+DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_7_wheezy_armhf debian_8_jessie debian_8_jessie_32bit debian_8_jessie_armhf debian_9_stretch debian_9_stretch_32bit debian_9_stretch_armhf ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit ubuntu_17_04_zesty ubuntu_17_04_zesty_32bit"
 
 # Parse the target for deb package building (e.g. "-tmegies:deb_1.0.2")
 SET_COMMIT_STATUS=false

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -6,7 +6,7 @@ LOG_DIR_ROOT=logs/package_debs
 LOG_DIR_BASE=$LOG_DIR_ROOT/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_12_04_precise ubuntu_12_04_precise_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit"
+DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit"
 
 # Parse the target for deb package building (e.g. "-tmegies:deb_1.0.2")
 SET_COMMIT_STATUS=false

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -6,7 +6,7 @@ LOG_DIR_ROOT=logs/package_debs
 LOG_DIR_BASE=$LOG_DIR_ROOT/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit"
+DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_8_jessie debian_8_jessie_32bit debian_9_stretch debian_9_stretch_32bit ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_16_10_yakkety ubuntu_16_10_yakkety_32bit ubuntu_17_04_zesty ubuntu_17_04_zesty_32bit"
 
 # Parse the target for deb package building (e.g. "-tmegies:deb_1.0.2")
 SET_COMMIT_STATUS=false


### PR DESCRIPTION
Add new Debian release 9 "stretch" (frozen on Feb 5th) and Ubuntu 17.04 "zesty" in various places..

 - [x] dockerfiles
 - [x] docker deb packaging
 - [x] adaption to deb packaging scripts
 - [x] add [armhf Docker base images](https://hub.docker.com/r/obspy/base-images/tags/) and Dockerfiles for testing/deb packaging

It comes with matplotlib 2.0.0 so lots of (and only) image comparison errors in the first docker test runs on maintenance_1.0.x:

 - http://tests.obspy.org/69674/
 - http://tests.obspy.org/69673

 - [x] ~~Note to self: Debian 9 stretch comes without `python-support`, so at least control files for packaging will need to be adapted..~~

Closes #1753