### PR TITLE
Run test suite for obspy/scripts and fix test cases

### DIFF
--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -40,7 +40,8 @@ DEFAULT_MODULES = ['clients.filesystem', 'core', 'db', 'geodetics', 'imaging',
                    'io.pdas', 'io.pde', 'io.quakeml', 'io.sac', 'io.seg2',
                    'io.segy', 'io.seisan', 'io.sh', 'io.shapefile',
                    'io.seiscomp', 'io.stationtxt', 'io.stationxml', 'io.wav',
-                   'io.xseed', 'io.y', 'io.zmap', 'realtime', 'signal', 'taup']
+                   'io.xseed', 'io.y', 'io.zmap', 'realtime', 'scripts',
+                   'signal', 'taup']
 NETWORK_MODULES = ['clients.arclink', 'clients.earthworm', 'clients.fdsn',
                    'clients.iris', 'clients.neic', 'clients.seedlink',
                    'clients.seishub', 'clients.syngine']

--- a/obspy/scripts/tests/test_print.py
+++ b/obspy/scripts/tests/test_print.py
@@ -7,13 +7,15 @@ from future.builtins import *  # NOQA
 import os
 import unittest
 
-from obspy.core.scripts.print import main as obspy_print
+from obspy.scripts.print import main as obspy_print
 from obspy.core.util.misc import CatchOutput
 
 
 class PrintTestCase(unittest.TestCase):
     def setUp(self):
-        self.all_files = [os.path.join(os.path.dirname(__file__), 'data', x)
+        self.all_files = [os.path.join(os.path.dirname(__file__), os.pardir,
+                                       os.pardir, 'io', 'ascii', 'tests',
+                                       'data', x)
                           for x in ['slist.ascii', 'tspair.ascii']]
 
     def test_print(self):


### PR DESCRIPTION
In some cases I get problems with `obspy-print` command line script, seemingly because of the filename `print.py`.

One case is that `py.test` is complaining and can't execute the tests:
```
$ py.test $OBSPY/scripts/tests/test_print.py
============================================================================= test session starts ==============================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/megies/git/obspy-maintenance_1.0.x, inifile: 
collected 0 items / 1 errors 

==================================================================================== ERRORS ====================================================================================
______________________________________________________________ ERROR collecting obspy/scripts/tests/test_print.py ______________________________________________________________
ImportError while importing test module '/home/megies/git/obspy-maintenance_1.0.x/obspy/scripts/tests/test_print.py'.
Original error message:
'No module named scripts.print'
Make sure your test modules/packages have valid Python names.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=========================================================================== 1 error in 0.86 seconds ============================================================================
```

Another case when installing obspy and running `obspy-print` on command line didn't work because `pkg_resources` was complaining during lookup of the fail from the entry point (with a similar error as pytest shows above), but I can't reproduce it anymore right now..


So.. I think we should rename `print.py`, maybe to `print_script.py` or something else, should not be a problem as I don't think anybody is doing an import like `from obspy.scripts.print import ..` because there's really not much interesting in there..