### PR TITLE
Comparing UTCDateTime with other objects (float, int, UTCDateTime, datetime.datetime)

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1104,6 +1104,23 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(str(UTCDateTime("9999-12-31T23:59:59.999999")),
                          "9999-12-31T23:59:59.999999Z")
 
+    def test_1652(self):
+        """
+        Comparing UTCDateTime and datetime.datetime objects - see #1652
+        """
+        a = datetime.datetime(1990, 1, 1, 0, 0)
+        e = UTCDateTime(2000, 1, 2, 1, 39, 37)
+        self.assertTrue(a < e)
+        self.assertFalse(a > e)
+        self.assertTrue(a <= e)
+        self.assertFalse(e <= a)
+        self.assertFalse(a > e)
+        self.assertTrue(e > a)
+        self.assertFalse(a >= e)
+        self.assertTrue(e >= a)
+        self.assertFalse(a == e)
+        self.assertFalse(e == a)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -941,7 +941,7 @@ class UTCDateTime(object):
             dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
             ns[2:self.precision + 2])
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p, cycle):  # @UnusedVariable
         p.text(str(self))
 
     def __unicode__(self):
@@ -983,10 +983,13 @@ class UTCDateTime(object):
         >>> t1 == t2
         False
         """
-        try:
+        if isinstance(other, UTCDateTime):
+            return round((self._ns - other._ns) / 1e9, self.__precision) == 0
+        elif isinstance(other, float) or isinstance(other, int):
             return round(self.timestamp - float(other), self.__precision) == 0
-        except (TypeError, ValueError):
-            return False
+        elif isinstance(other, datetime.datetime):
+            return self.datetime == other
+        return False
 
     def __ne__(self, other):
         """
@@ -1040,10 +1043,13 @@ class UTCDateTime(object):
         >>> t1 < t2
         True
         """
-        try:
+        if isinstance(other, UTCDateTime):
+            return round((self._ns - other._ns) / 1e9, self.__precision) < 0
+        elif isinstance(other, float) or isinstance(other, int):
             return round(self.timestamp - float(other), self.__precision) < 0
-        except (TypeError, ValueError):
-            return False
+        elif isinstance(other, datetime.datetime):
+            return self.datetime < other
+        return False
 
     def __le__(self, other):
         """
@@ -1070,10 +1076,13 @@ class UTCDateTime(object):
         >>> t1 <= t2
         False
         """
-        try:
+        if isinstance(other, UTCDateTime):
+            return round((self._ns - other._ns) / 1e9, self.__precision) <= 0
+        elif isinstance(other, float) or isinstance(other, int):
             return round(self.timestamp - float(other), self.__precision) <= 0
-        except (TypeError, ValueError):
-            return False
+        elif isinstance(other, datetime.datetime):
+            return self.datetime <= other
+        return False
 
     def __gt__(self, other):
         """
@@ -1100,10 +1109,13 @@ class UTCDateTime(object):
         >>> t1 > t2
         True
         """
-        try:
+        if isinstance(other, UTCDateTime):
+            return round((self._ns - other._ns) / 1e9, self.__precision) > 0
+        elif isinstance(other, float) or isinstance(other, int):
             return round(self.timestamp - float(other), self.__precision) > 0
-        except (TypeError, ValueError):
-            return False
+        elif isinstance(other, datetime.datetime):
+            return self.datetime > other
+        return False
 
     def __ge__(self, other):
         """
@@ -1130,10 +1142,13 @@ class UTCDateTime(object):
         >>> t1 >= t2
         False
         """
-        try:
+        if isinstance(other, UTCDateTime):
+            return round((self._ns - other._ns) / 1e9, self.__precision) >= 0
+        elif isinstance(other, float) or isinstance(other, int):
             return round(self.timestamp - float(other), self.__precision) >= 0
-        except (TypeError, ValueError):
-            return False
+        elif isinstance(other, datetime.datetime):
+            return self.datetime >= other
+        return False
 
     def __repr__(self):
         """

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -134,6 +134,15 @@ class MSEEDUtilTestCase(unittest.TestCase):
         self.assertEqual(timestring, util._convert_datetime_to_mstime(
             util._convert_mstime_to_datetime(timestring)))
 
+    def test_convert_datetime2(self):
+        """
+        Currently failing test in #1670
+        """
+        dt = UTCDateTime(ns=1487021451935737333)
+        self.assertEqual(str(dt), "2017-02-13T21:30:51.935737Z")
+        self.assertEqual(dt, util._convert_mstime_to_datetime(
+            util._convert_datetime_to_mstime(dt)))
+
     def test_get_record_information(self):
         """
         Tests the util._get_ms_file_info method with known values.

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -136,10 +136,27 @@ class MSEEDUtilTestCase(unittest.TestCase):
 
     def test_convert_datetime2(self):
         """
-        Currently failing test in #1670
+        Some failing test discovered in #1670
         """
+        # 1
         dt = UTCDateTime(ns=1487021451935737333)
         self.assertEqual(str(dt), "2017-02-13T21:30:51.935737Z")
+        self.assertEqual(util._convert_datetime_to_mstime(dt),
+                         1487021451935737)
+        self.assertEqual(dt, util._convert_mstime_to_datetime(
+            util._convert_datetime_to_mstime(dt)))
+        # 2
+        dt = UTCDateTime(ns=1487021451935736449)
+        self.assertEqual(str(dt), "2017-02-13T21:30:51.935736Z")
+        self.assertEqual(util._convert_datetime_to_mstime(dt),
+                         1487021451935736)
+        self.assertEqual(dt, util._convert_mstime_to_datetime(
+            util._convert_datetime_to_mstime(dt)))
+        # 3
+        dt = UTCDateTime(ns=1487021451935736501)
+        self.assertEqual(str(dt), "2017-02-13T21:30:51.935737Z")
+        self.assertEqual(util._convert_datetime_to_mstime(dt),
+                         1487021451935737)
         self.assertEqual(dt, util._convert_mstime_to_datetime(
             util._convert_datetime_to_mstime(dt)))
 

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -9,7 +9,6 @@ from future.utils import native_str
 
 import collections
 import ctypes as C
-import math
 import os
 import sys
 import warnings
@@ -815,8 +814,8 @@ def _convert_datetime_to_mstime(dt):
 
     :param dt: obspy.util.UTCDateTime object.
     """
-    _fsec, _sec = math.modf(dt.timestamp)
-    return int(round(_fsec * HPTMODULUS)) + int(_sec * HPTMODULUS)
+    rest = (dt._ns % 10**3) >= 500 and 1 or 0
+    return dt._ns // 10**3 + rest
 
 
 def _convert_mstime_to_datetime(timestring):
@@ -825,7 +824,7 @@ def _convert_mstime_to_datetime(timestring):
 
     :param timestamp: MiniSEED timestring (Epoch time string in ms).
     """
-    return UTCDateTime(timestring / HPTMODULUS)
+    return UTCDateTime(ns=int(round(timestring * 10**3)))
 
 
 def _unpack_steim_1(data, npts, swapflag=0, verbose=0):


### PR DESCRIPTION
see #1652 - those isinstance checks seem to influence performance not very much - no change in execution time for all core tests ...
