### PR TITLE
io.xseed: don't raise Userwarning if station comment end time is unset

### DIFF
--- a/obspy/io/xseed/blockette/blockette051.py
+++ b/obspy/io/xseed/blockette/blockette051.py
@@ -19,7 +19,7 @@ class Blockette051(Blockette):
     name = "Station Comment"
     fields = [
         VariableString(3, "Beginning effective time", 1, 22, 'T'),
-        VariableString(4, "End effective time", 1, 22, 'T', optional=True),
+        VariableString(4, "End effective time", 0, 22, 'T', optional=True),
         Integer(5, "Comment code key", 4, xpath=31),
         Integer(6, "Comment level", 6, ignore=True)
     ]

--- a/obspy/io/xseed/tests/blockette-tests/blockette051.txt
+++ b/obspy/io/xseed/tests/blockette-tests/blockette051.txt
@@ -9,3 +9,15 @@
   <end_effective_time>2000-07-05T07:03:20.000000Z</end_effective_time>
   <comment_code_key>/xseed/abbreviation_dictionary_control_header/comment_description/comment_code_key[text()="1"]/parent::*</comment_code_key>
 </station_comment>
+
+
+# empty optional endtime
+
+--02-SEED
+05100412000,187,06:36:04.0000~~0001000000
+
+--02-XSEED
+<station_comment blockette="051">
+  <beginning_effective_time>2000-07-05T06:36:04.000000Z</beginning_effective_time>
+  <comment_code_key>/xseed/abbreviation_dictionary_control_header/comment_description/comment_code_key[text()="1"]/parent::*</comment_code_key>
+</station_comment>

--- a/obspy/io/xseed/tests/test_parser.py
+++ b/obspy/io/xseed/tests/test_parser.py
@@ -41,29 +41,18 @@ class ParserTestCase(unittest.TestCase):
          - an unsupported response information somewhere in the metadata should
            not automatically raise an Error, if the desired information can
            still be retrieved
-
-        This test also tests if a warning is raised if no startime is given.
         """
-        parser = Parser()
+        parser = Parser(strict=True)
         file = os.path.join(self.path, "bug165.dataless")
         t = UTCDateTime("2010-01-01T00:00:00")
-        # raises UserWarning
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            parser.read(file)
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertTrue('date' and 'required' in
-                            str(w[-1].message).lower())
-            # Triggers a warning.
-            paz = parser.get_paz("NZ.DCZ.20.HNZ", t)
-            result = {'digitizer_gain': 419430.0, 'gain': 24595700000000.0,
-                      'poles': [(-981 + 1009j), (-981 - 1009j),
-                                (-3290 + 1263j), (-3290 - 1263j)],
-                      'seismometer_gain': 1.01885, 'sensitivity': 427336.0,
-                      'zeros': []}
-            self.assertEqual(paz, result)
+        parser.read(file)
+        paz = parser.get_paz("NZ.DCZ.20.HNZ", t)
+        result = {'digitizer_gain': 419430.0, 'gain': 24595700000000.0,
+                  'poles': [(-981 + 1009j), (-981 - 1009j),
+                            (-3290 + 1263j), (-3290 - 1263j)],
+                  'seismometer_gain': 1.01885, 'sensitivity': 427336.0,
+                  'zeros': []}
+        self.assertEqual(paz, result)
 
     def test_invalid_start_header(self):
         """


### PR DESCRIPTION
also corrected a wrong part of a test case claiming it raises on missing starttime - it raised because endtime was missing ...

fixes #1564
