### PR TITLE
earthworm client: Inline tracebuf extraction to minimize copying data.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@
    * Fix `farfield` if input `points` is a 2D array. (see #1499, #1553)
  - obspy.clients.earthworm:
    * Better end of stream detection. (see #1605)
+   * More efficient unpacking of server response. (see #1680)
  - obspy.clients.neic:
    * Better end of stream detection. (see #1563)
  - obspy.clients.seedlink:

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -48,6 +48,7 @@ Bernhard Morgenstern
 Nathaniel C. Miller
 Ran Novitsky Nof
 Mark P. Panning
+Tom Parker
 Giovanni Rapagnani
 Celso Reyes
 Adam Ringler

--- a/obspy/clients/earthworm/waveserver.py
+++ b/obspy/clients/earthworm/waveserver.py
@@ -312,11 +312,21 @@ def read_wave_server_v(server, port, scnl, start, end, timeout=None):
     bytesread = 1
     p = 0
     while bytesread and p < len(dat):
-        bytesread = new.read_tb2(dat[p:])
-        if bytesread:
+        if len(dat) > p + 64:
+            head = dat[p:p + 64]
+            p += 64
+            new.parse_header(head)
+            nbytes = new.ndata * new.inputType.itemsize
+
+            if len(dat) < p + nbytes:
+                break   # not enough array to hold data specified in header
+
+            tbd = dat[p:p + nbytes]
+            p += nbytes
+            new.parse_data(tbd)
+
             tbl.append(new)
             new = TraceBuf2()  # empty..filled on next iteration
-            p += bytesread
     return tbl
 
 


### PR DESCRIPTION
Inline tracebuf extraction. This minimized the amount of data that needs to be copied and greatly speeds extraction of tracebufs from the server response. Fixes #1678.