### PR TITLE
adjust tolerance for farfield test case

### DIFF
--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -171,7 +171,7 @@ class EventTestCase(unittest.TestCase):
                         -1.13501984, 0.873480164], [0, 0, -0, 0, -0, 0],
                         [2.245, 0.655304008, 0.504304008, -2.245,
                          -0.655304008, -0.504304008]])
-        np.testing.assert_array_almost_equal(result, ref, decimal=5)
+        np.testing.assert_allclose(result, ref, rtol=1e-5, atol=1e-8)
 
 
 class OriginTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -171,7 +171,7 @@ class EventTestCase(unittest.TestCase):
                         -1.13501984, 0.873480164], [0, 0, -0, 0, -0, 0],
                         [2.245, 0.655304008, 0.504304008, -2.245,
                          -0.655304008, -0.504304008]])
-        np.testing.assert_allclose(result, ref)
+        np.testing.assert_allclose(result, ref, rtol=1e-5)
 
 
 class OriginTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -171,7 +171,7 @@ class EventTestCase(unittest.TestCase):
                         -1.13501984, 0.873480164], [0, 0, -0, 0, -0, 0],
                         [2.245, 0.655304008, 0.504304008, -2.245,
                          -0.655304008, -0.504304008]])
-        np.testing.assert_allclose(result, ref, rtol=1e-5)
+        np.testing.assert_array_almost_equal(result, ref, decimal=5)
 
 
 class OriginTestCase(unittest.TestCase):


### PR DESCRIPTION
After merging #1642 there's a test fail in one older debian docker testbox:

 - http://tests.obspy.org/?git=9c357ec4e25ddd95a48d1a1e76829473ecdd6fd8&node=docker-deb-
 - http://tests.obspy.org/67009/
 - http://tests.obspy.org/67004/

Looks like a simple precision issue to me. @seisman maybe you can double-check (once our docker testbot has run through)