### PR TITLE
Adding short period 'SH' instruments to the default channel priorities

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -199,7 +199,8 @@ class Restrictions(object):
                                      "MH[ZNE12]", "EH[ZNE12]",
                                      "LH[ZNE12]", "HL[ZNE12]",
                                      "BL[ZNE12]", "ML[ZNE12]",
-                                     "EL[ZNE12]", "LL[ZNE12]"),
+                                     "EL[ZNE12]", "LL[ZNE12]",
+                                     "SH[ZNE12]"),
                  location_priorities=("", "00", "10")):
         self.starttime = obspy.UTCDateTime(starttime)
         self.endtime = obspy.UTCDateTime(endtime)


### PR DESCRIPTION
As requested in [this](https://github.com/obspy/obspy/pull/1373#issuecomment-282975477) comment.