### PR TITLE
Document local alternatives to the IRIS web services

### DIFF
--- a/obspy/clients/iris/__init__.py
+++ b/obspy/clients/iris/__init__.py
@@ -11,6 +11,22 @@ provided by IRIS (https://service.iris.edu/irisws/).
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 
+Local Alternatives
+------------------
+
+ObsPy contains local alternatives to some of the calculation tools offered by
+the IRIS web services. Consider using them when working within ObsPy:
+
++---------------------------------------------------------+--------------------------------------------------------------+
+| IRIS Web Service                                        | Equivalent ObsPy Function/Module                             |
++=========================================================+==============================================================+
+| :meth:`obspy.clients.iris.client.Client.traveltime()`   | :mod:`obspy.taup`                                            |
++---------------------------------------------------------+--------------------------------------------------------------+
+| :meth:`obspy.clients.iris.client.Client.distaz()`       | :mod:`obspy.geodetics`                                       |
++---------------------------------------------------------+--------------------------------------------------------------+
+| :meth:`obspy.clients.iris.client.Client.flinnengdahl()` | :class:`obspy.geodetics.flinnengdahl.FlinnEngdahl`           |
++---------------------------------------------------------+--------------------------------------------------------------+
+
 Web service Interfaces
 ----------------------
 


### PR DESCRIPTION
They were previously documented here: http://docs.obspy.org/tutorial/code_snippets/retrieving_data_from_datacenters.html#iris-web-services

But that is hard to discover so now they are also on the module page of the IRIS client.

+DOCS