### PR TITLE
Run dedicated code formatting check in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,9 +192,9 @@ script:
   - export IFS=" "
   # if not on a PR, i.e. running on a push to master or maintenance_XXX: test *all* modules
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --all -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}";
+      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 --all -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}";
     else
-      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --pr-url="https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}" $MODULELISTSPACES;
+      coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n travis-ci -r --ci-url="https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}" --pr-url="https://github.com/obspy/obspy/pull/${TRAVIS_PULL_REQUEST}" $MODULELISTSPACES;
     fi;
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,10 +136,7 @@ install:
   - pip install geographiclib
   # current pyimgur stable release has a py3 incompatibility
   - pip install https://github.com/megies/PyImgur/archive/py3.zip
-  # Always install the latest flake8 to get up-to-date formatting checks.
-  - pip install flake8
   - pip freeze
-  - pip install pep8-naming
   - pip install https://github.com/obspy/obspy_github_api/archive/0.7.0.zip
   - conda list
   # done installing dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,4 +41,4 @@ build: false
 
 test_script:
   - "%CMD_IN_ENV% python setup.py develop"
-  - "python -m obspy.scripts.runtests -n appveyor-ci -r %CI_URL% %PR_URL%"
+  - "python -m obspy.scripts.runtests --no-flake8 -n appveyor-ci -r %CI_URL% %PR_URL%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,6 @@ install:
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
   - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
   # additional dependecies
-  - "pip install flake8"
   - "pip install pyimgur"
   - "pip install -U future"
   # list package versions

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,5 @@ compile:
     - pwd
 test:
   override:
-    - flake8 --ignore=E402,$(python -c 'import pycodestyle; print(pycodestyle.DEFAULT_IGNORE)') --exclude=__init__.py obspy
+    - flake8 --version
+    - flake8 --verbose --ignore=E402,$(python -c 'import pycodestyle; print(pycodestyle.DEFAULT_IGNORE)') --exclude=__init__.py obspy

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,8 @@ machine:
     version: 3.6
 dependencies:
   override:
-    - pip install -U flake8
+   # Install latest versions of flake8 and pep8-naming.
+    - pip install -U flake8 pep8-naming
 compile:
   override:
     - pwd

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 # Thus ObsPy does not even have to be installed.
 machine:
   python:
-    version: 3.6
+    version: 3.6.0
 dependencies:
   override:
    # Install latest versions of flake8 and pep8-naming.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+# CircleCI is used exclusively to test code formatting.
+# Thus ObsPy does not even have to be installed.
+dependencies:
+  override:
+    - pip install -U flake8
+compile:
+  override:
+    - pwd
+test:
+  override:
+    - flake8 --ignore=E402 --exclude=__init__.py obspy

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,8 @@
 # CircleCI is used exclusively to test code formatting.
 # Thus ObsPy does not even have to be installed.
+machine:
+  python:
+    version: 3.6
 dependencies:
   override:
     - pip install -U flake8

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,4 @@ compile:
     - pwd
 test:
   override:
-    - flake8 --ignore=E402 --exclude=__init__.py obspy
+    - flake8 --ignore=E402,$(python -c 'import pycodestyle; print(pycodestyle.DEFAULT_IGNORE)') --exclude=__init__.py obspy


### PR DESCRIPTION
Should ease discovery of code formatting changes. Code formatting checks should of course be disabled in all other runners.

See discussion here: https://github.com/obspy/obspy/commit/c3120f234392909121f3694b5a12d6262c25c9f9#commitcomment-21103422

Maybe we could even run this on a different CI service? Then it would be very easy to tell if a failure is code formatting related. Maybe on CircleCI?