### PR TITLE
fix flake8 false positives: "closing bracket does not match indentation of opening bracket's line"

### DIFF
--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -64,7 +64,12 @@ class CodeFormattingTestCase(unittest.TestCase):
         # Import the legacy API as flake8 3.0 currently has not official
         # public API - this has to be changed at some point.
         from flake8.api import legacy as flake8
-        style_guide = flake8.get_style_guide(ignore=FLAKE8_IGNORE_CODES)
+        # not sure if there's a better way to get a hold of default ignore
+        # codes..
+        default_ignore_codes = \
+            flake8.get_style_guide().options.__dict__['ignore']
+        ignore_codes = list(set(default_ignore_codes + FLAKE8_IGNORE_CODES))
+        style_guide = flake8.get_style_guide(ignore=ignore_codes)
 
         untracked_files = get_untracked_files_from_git() or []
         files = []


### PR DESCRIPTION
We currently get **false positives** from our code formatting checks:

```
test_code_formatting.py:194:13: E123 closing bracket does not match indentation of opening bracket's line
```

This is valid python syntax according to PEP8 and needs to be fixed upstream or by using proper versions of flake8/pep8/whatever8.

 - see #1672 
 - see c3120f234392909121f3694b5a12d6262c25c9f9 in #1647
 - supposedly fixed in 2014, see PyCQA/pycodestyle/issues/103

CC @krischer 