### PR TITLE
USGS web service endpoint should be updated to https

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ master: (doi: 10.5281/zenodo.165135)
      the more general `FDSNException`.
    * Fixing cross implementation of bulk waveform and station requests (see
      #1685).
+   * Updating some endpoint mappings to use HTTPS. (See #1690, #1048)
  - obspy.imaging:
    * The functionality behind the `obspy-scan` command line script has been
      refactored into a `Scanner` class so that it can be reused in custom

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,7 +47,7 @@ master: (doi: 10.5281/zenodo.165135)
      the more general `FDSNException`.
    * Fixing cross implementation of bulk waveform and station requests (see
      #1685).
-   * Updating some endpoint mappings to use HTTPS. (See #1690, #1048)
+   * Updating some endpoint mappings to use HTTPS. (See #1690, #1665, #1048)
  - obspy.imaging:
    * The functionality behind the `obspy-scan` command line script has been
      refactored into a `Scanner` class so that it can be reused in custom

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -43,7 +43,7 @@ URL_MAPPINGS = {
     "ETH": "http://eida.ethz.ch",
     "EMSC": "http://www.seismicportal.eu",
     "GEONET": "http://service.geonet.org.nz",
-    "GFZ": "http://geofon.gfz-potsdam.de",
+    "GFZ": "https://geofon.gfz-potsdam.de",
     "INGV": "http://webservices.rm.ingv.it",
     "IPGP": "http://eida.ipgp.fr",
     "IRIS": "http://service.iris.edu",
@@ -56,8 +56,8 @@ URL_MAPPINGS = {
     "ODC": "http://www.orfeus-eu.org",
     "ORFEUS": "http://www.orfeus-eu.org",
     "RESIF": "http://ws.resif.fr",
-    "SCEDC": "http://service.scedc.caltech.edu",
-    "USGS": "http://earthquake.usgs.gov",
+    "SCEDC": "https://service.scedc.caltech.edu",
+    "USGS": "https://earthquake.usgs.gov",
     "USP": "http://sismo.iag.usp.br"}
 
 FDSNWS = ("dataselect", "event", "station")


### PR DESCRIPTION
This looks like the same underlying issue as #1048, a query to
http://earthquake.usgs.gov/fdsnws/event/1/query?starttime=2017-03-01T00%3A00%3A00.000000
gets double-encoded in the redirect, pointing to
https://earthquake.usgs.gov/fdsnws/event/1/query?starttime=2017-03-01T00%253A00%253A00.000000

I think that as with the earlier issue this is ultimately a bug on the USGS site, but it can be avoided by updating ObsPy's URL mappings to use the https URL.
