### PR TITLE
sc3ml reads versions 0.7-0.9; include test

### DIFF
--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -38,7 +38,7 @@ from obspy.io.stationxml.core import _read_floattype
 
 SOFTWARE_MODULE = "ObsPy %s" % obspy.__version__
 SOFTWARE_URI = "http://www.obspy.org"
-SCHEMA_VERSION = "0.7"
+SCHEMA_VERSION = ["0.7", "0.8", "0.9"]
 
 
 def _is_sc3ml(path_or_file_object):
@@ -73,7 +73,7 @@ def _is_sc3ml(path_or_file_object):
             return False
         # Convert schema number to a float to have positive comparisons
         # between, e.g "1" and "1.0".
-        if float(root.attrib["version"]) != float(SCHEMA_VERSION):
+        if root.attrib["version"] not in SCHEMA_VERSION:
             warnings.warn("The sc3ml file has version %s, ObsPy can "
                           "deal with version %s. Proceed with caution." % (
                               root.attrib["version"], SCHEMA_VERSION))
@@ -131,6 +131,14 @@ def _read_sc3ml(path_or_file_object):
     # Fix the namespace as its not always the default namespace. Will need
     # to be adjusted if the sc3ml format gets another revision!
     namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7"
+
+    # Code can be used for version 0.7, 0.8, and 0.9
+    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
+        namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8"
+    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
+        namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"
+    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
+        raise ValueError("Schema version not supported.")
 
     def _ns(tagname):
         return "{%s}%s" % (namespace, tagname)

--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -128,16 +128,13 @@ def _read_sc3ml(path_or_file_object):
     """
     root = etree.parse(path_or_file_object).getroot()
 
-    # Fix the namespace as its not always the default namespace. Will need
-    # to be adjusted if the sc3ml format gets another revision!
-    namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7"
-
     # Code can be used for version 0.7, 0.8, and 0.9
-    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
-        namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8"
-    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
-        namespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"
-    if(root.find("{%s}%s" % (namespace, "Inventory"))) is None:
+    basespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema"
+    for version in SCHEMA_VERSION:
+      namespace = "%s/%s" % (basespace, version)
+      if(root.find("{%s}%s" % (namespace, "Inventory"))) is not None:
+        break
+    else:
         raise ValueError("Schema version not supported.")
 
     def _ns(tagname):

--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -71,11 +71,10 @@ def _is_sc3ml(path_or_file_object):
             assert match is not None
         except Exception:
             return False
-        # Convert schema number to a float to have positive comparisons
-        # between, e.g "1" and "1.0".
+        # Check if schema version is supported
         if root.attrib["version"] not in SCHEMA_VERSION:
             warnings.warn("The sc3ml file has version %s, ObsPy can "
-                          "deal with version %s. Proceed with caution." % (
+                          "deal with versions %s. Proceed with caution." % (
                               root.attrib["version"], SCHEMA_VERSION))
         return True
     finally:
@@ -132,7 +131,7 @@ def _read_sc3ml(path_or_file_object):
     basespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema"
     for version in SCHEMA_VERSION:
         namespace = "%s/%s" % (basespace, version)
-        if(root.find("{%s}%s" % (namespace, "Inventory"))) is not None:
+        if root.find("{%s}%s" % (namespace, "Inventory")) is not None:
             break
     else:
         raise ValueError("Schema version not supported.")

--- a/obspy/io/seiscomp/sc3ml.py
+++ b/obspy/io/seiscomp/sc3ml.py
@@ -131,9 +131,9 @@ def _read_sc3ml(path_or_file_object):
     # Code can be used for version 0.7, 0.8, and 0.9
     basespace = "http://geofon.gfz-potsdam.de/ns/seiscomp3-schema"
     for version in SCHEMA_VERSION:
-      namespace = "%s/%s" % (basespace, version)
-      if(root.find("{%s}%s" % (namespace, "Inventory"))) is not None:
-        break
+        namespace = "%s/%s" % (basespace, version)
+        if(root.find("{%s}%s" % (namespace, "Inventory"))) is not None:
+            break
     else:
         raise ValueError("Schema version not supported.")
 

--- a/obspy/io/seiscomp/tests/data/version0.10
+++ b/obspy/io/seiscomp/tests/data/version0.10
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.7
+++ b/obspy/io/seiscomp/tests/data/version0.7
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7" version="0.7">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.8
+++ b/obspy/io/seiscomp/tests/data/version0.8
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8" version="0.8">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.9
+++ b/obspy/io/seiscomp/tests/data/version0.9
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/test_sc3ml.py
+++ b/obspy/io/seiscomp/tests/test_sc3ml.py
@@ -47,15 +47,15 @@ class SC3MLTestCase(unittest.TestCase):
         """
         Test multiple schema versions
         """
-        inv = read_inventory(os.path.join(self.data_dir, "version0.7"))
-        inv = read_inventory(os.path.join(self.data_dir, "version0.8"))
-        inv = read_inventory(os.path.join(self.data_dir, "version0.9"))
+        read_inventory(os.path.join(self.data_dir, "version0.7"))
+        read_inventory(os.path.join(self.data_dir, "version0.8"))
+        read_inventory(os.path.join(self.data_dir, "version0.9"))
 
         with self.assertRaises(ValueError) as e:
-            with warnings.catch_warnings() as w:
+            with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                inv = read_inventory(os.path.join(self.data_dir,
-                                                  "version0.10"))
+                read_inventory(os.path.join(self.data_dir,
+                                            "version0.10"))
 
         self.assertEqual(e.exception.args[0], "Schema version not supported.")
 

--- a/obspy/io/seiscomp/tests/test_sc3ml.py
+++ b/obspy/io/seiscomp/tests/test_sc3ml.py
@@ -21,6 +21,7 @@ from future.builtins import *  # NOQA
 import inspect
 import io
 import os
+import warnings
 import unittest
 
 from obspy.core.inventory import read_inventory
@@ -41,6 +42,22 @@ class SC3MLTestCase(unittest.TestCase):
         self.stationxml_inventory = read_inventory(stationxml_path,
                                                    format="STATIONXML")
         self.sc3ml_inventory = read_inventory(sc3ml_path, format="SC3ML")
+
+    def test_sc3ml_versions(self):
+        """
+        Test multiple schema versions
+        """
+        inv = read_inventory(os.path.join(self.data_dir, "version0.7"))
+        inv = read_inventory(os.path.join(self.data_dir, "version0.8"))
+        inv = read_inventory(os.path.join(self.data_dir, "version0.9"))
+
+        with self.assertRaises(ValueError) as e:
+            with warnings.catch_warnings() as w:
+                warnings.simplefilter("ignore")
+                inv = read_inventory(os.path.join(self.data_dir,
+                                                  "version0.10"))
+
+        self.assertEqual(e.exception.args[0], "Schema version not supported.")
 
     def test_compare_xml(self):
         """


### PR DESCRIPTION
Pull request so `_read_sc3ml` from `read_inventory` can handle updated SC3ML versions up to 0.9. It would previously throw an error looking for an incorrect namespace if the version numbers did not match.

Includes tests for versions 0.7 (pass), 0.8 (pass), 0.9 (pass), and 0.10 (fail).