### PR TITLE
Master broken for older distros

### DIFF
--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -25,7 +25,7 @@ import warnings
 import zipfile
 
 import numpy as np
-from decorator import decorator, decorate
+from decorator import decorator
 
 from obspy.core.util import get_example_file
 from obspy.core.util.base import NamedTemporaryFile
@@ -300,20 +300,18 @@ def map_example_filename(arg_kwarg_name):
     return _map_example_filename
 
 
-def rlock(func):
-        """
-        Place a threading recursive lock (Rlock) on the wrapped function
-        """
-        # This lock will be instantiated at function creation time, i.e. at the
-        # time the Python interpreter sees the decorated function the very
-        # first time - this lock thus exists once for each decorated function.
-        _rlock = threading.RLock()
+@decorator
+def rlock(func, *args, **kwargs):
+    """
+    Place a threading recursive lock (Rlock) on the wrapped function
+    """
+    # This lock will be instantiated at function creation time, i.e. at the
+    # time the Python interpreter sees the decorated function the very
+    # first time - this lock thus exists once for each decorated function.
+    _rlock = threading.RLock()
 
-        def _locked_f(f, *args, **kwargs):
-            with _rlock:
-                return func(*args, **kwargs)
-
-        return decorate(func, _locked_f)
+    with _rlock:
+        return func(*args, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit dbf73680b3e3a631f99f0c3cc88100a2394eff4d on master breaks obspy on older distros. It was discovered because for some PRs (e.g. #1670) not all docker testbot containers are able to send test reports which leads to the confusing situation that docker testbot commit status is "red" while the corresponding link to test reports at tests.obspy.org shows only "green" reports (but way fewer than the docker testbot runs containers). Please fix @krischer and next time check out docker testbot status before merging.. ;-)