### PR TITLE
fix Miniconda installation in Travis for Mac OSX 64bit Py2k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
         export ARCH="_64"
       fi
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
     fi


### PR DESCRIPTION
Seems ContinuumIO changed Miniconda installer filename for Py2: see https://travis-ci.org/obspy/obspy/jobs/207402228#L72

.. or at least removed the alias `Miniconda-...` for Py2k