### PR TITLE
Raise better error message if failing to create ResourceIdentifier

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ master: (doi: 10.5281/zenodo.165135)
      the get_referred_object method provided both are still in scope. If one
      of the objects gets garbage collected, however, a warning will be issued
      and the behavior will be the same as before (see #1644).
+   * Better error message when attempting to write invalid QuakeML resource
+     ids (see #1699).
    * Stream/Trace.write() can now autodetect file format from file extension
      (see #1321).
    * New convenience property `.matplotlib_date` for `UTCDateTime` objects to

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -788,7 +788,14 @@ class ResourceIdentifier(object):
         # ID.
         result = re.match(regex, id)
         if result is None:
-            msg = "Failed to create a valid QuakeML ResourceIdentifier."
+            msg = (
+                "The id '%s' is not a valid QuakeML resource "
+                "identifier. ObsPy tried modifying it to '%s' but it is still "
+                "not valid. Please make sure all resource ids are either "
+                "valid or can be made valid by prefixing it with "
+                "'smi:<authority_id>/'. Valid ids are specified in the "
+                "QuakeML manual section 3.1 and in particular exclude colons "
+                "for the final part." % (self.id, id))
             raise ValueError(msg)
         return id
 

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -975,6 +975,25 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         self.assertEqual(rid, rid2)
         self.assertEqual(rid, rid3)
 
+    def test_error_message_for_failing_quakeml_id_conversion(self):
+        """
+        Converting an id to a QuakeML compatible id might fail. Test the
+        error message.
+        """
+        invalid_id = "http://example.org"
+        rid = ResourceIdentifier(invalid_id)
+        with self.assertRaises(ValueError) as e:
+            rid.get_quakeml_uri()
+        self.assertEqual(
+            e.exception.args[0],
+            "The id 'http://example.org' is not a valid QuakeML resource "
+            "identifier. ObsPy tried modifying it to "
+            "'smi:local/http://example.org' but it is still not valid. Please "
+            "make sure all resource ids are either valid or can be made valid "
+            "by prefixing it with 'smi:<authority_id>/'. Valid ids are "
+            "specified in the QuakeML manual section 3.1 and in particular "
+            "exclude colons for the final part.")
+
 
 class ResourceIDEventScopeTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
http://lists.swapbytes.de/archives/obspy-users/2017-March/002313.html

We should raise a message that is more descriptive and tells people how to fix it.