### PR TITLE
io.shapefile: add support for writing origin uncertainties to shapefile

### DIFF
--- a/obspy/io/shapefile/__init__.py
+++ b/obspy/io/shapefile/__init__.py
@@ -14,6 +14,18 @@ Write support works via the ObsPy plugin structure for
 >>> cat = read_events()  # load example data
 >>> cat.write("my_events.shp", format="SHAPEFILE")  # doctest: +SKIP
 
+For Catalog objects, an additional shapefile with error ellipses representing
+the origin uncertainty can be written using the ``error_ellipses`` kwarg. Since
+origin uncertainties are in meters (as opposed to degrees), an appropriate
+coordinate system has to be specified by EPSG code (the example contains events
+near Vanuatu and correspondingly the EPSG code for 'WGS 84 / UTM zone 58S'):
+
+>>> cat = read_events('/path/to/vanua.sum.grid0.loc.hyp')  # doctest: +SKIP
+>>> cat.write('my_events.shp', format='SHAPEFILE',  # doctest: +SKIP
+...           error_ellipses={'filename': 'my_events_errors.shp',
+...                           'epsg': 32758})
+
+
 .. seealso::
 
     The format definition can be found

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -167,7 +167,11 @@ def _add_catalog_layer(data_source, catalog, epsg=None, geometry='point',
         ["Longitude", ogr.OFTReal, 16, 10],
         ["Latitude", ogr.OFTReal, 16, 10],
         ["Depth", ogr.OFTReal, 8, 3],
-        ["Magnitude", ogr.OFTReal, 8, 3]
+        ["MinHorUncM", ogr.OFTReal, 12, 3],
+        ["MaxHorUncM", ogr.OFTReal, 12, 3],
+        ["MaxHorAzi", ogr.OFTReal, 7, 3],
+        ["OriUncDesc", ogr.OFTString, 40, None],
+        ["Magnitude", ogr.OFTReal, 8, 3],
     ]
 
     layer = _create_layer(data_source, "earthquakes", field_definitions,
@@ -225,6 +229,31 @@ def _add_catalog_layer(data_source, catalog, epsg=None, geometry='point',
             if magnitude.resource_id is not None:
                 feature.SetField(native_str("MagID"),
                                  native_str(magnitude.resource_id))
+            if origin.origin_uncertainty is not None:
+                ou = origin.origin_uncertainty
+                ou_description = ou.preferred_description
+                if ou_description == 'uncertainty ellipse':
+                    feature.SetField(native_str("MinHorUncM"),
+                                     ou.min_horizontal_uncertainty)
+                    feature.SetField(native_str("MaxHorUncM"),
+                                     ou.max_horizontal_uncertainty)
+                    feature.SetField(native_str("MaxHorAzi"),
+                                     ou.azimuth_max_horizontal_uncertainty)
+                    feature.SetField(native_str("OriUncDesc"), ou_description)
+                elif ou_description == 'horizontal uncertainty':
+                    feature.SetField(native_str("MinHorUncM"),
+                                     ou.horizontal_uncertainty)
+                    feature.SetField(native_str("MaxHorUncM"),
+                                     ou.horizontal_uncertainty)
+                    feature.SetField(native_str("MaxHorAzi"), 0.0)
+                    feature.SetField(native_str("OriUncDesc"), ou_description)
+                else:
+                    msg = ('Encountered an event with origin uncertainty '
+                           'description of type "{}". This is not yet '
+                           'implemented for output as shapefile. No origin '
+                           'uncertainty will be added to shapefile for such '
+                           'events.').format(ou_description)
+                    warnings.warn(msg)
 
             if geometry == 'point':
                 if origin.latitude is None or origin.longitude is None:
@@ -310,7 +339,7 @@ def _add_inventory_layer(data_source, inventory):
         ["Elevation", ogr.OFTReal, 9, 3],
         ["StartDate", ogr.OFTDate, None, None],
         ["EndDate", ogr.OFTDate, None, None],
-        ["Channels", ogr.OFTString, 254, None]
+        ["Channels", ogr.OFTString, 254, None],
     ]
 
     layer = _create_layer(data_source, "stations", field_definitions)

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,8 @@ EXTRAS_REQUIRE = {
     'tests': ['flake8>=2', 'pyimgur', 'pyproj', 'pep8-naming'],
     # arclink decryption also works with: pycrypto, cryptography, pycryptodome
     'arclink': ['m2crypto'],
+    # io.shapefile also uses 'pyproj' when writing error ellipses to shapefile
+    # is requested
     'io.shapefile': ['gdal'],
     }
 # PY2


### PR DESCRIPTION
This PR adds functionality to write event origin uncertainties to shapefile format (e.g. to use in GIS applications).

ToDo:
- [x] example / tutorial
- [ ] test
- [x] write uncertainties into shapefile table for reuse in GIS applications
- [ ] other information on the event would be useful to have in the shapefile database table as well, especially origin quality metrics, e.g. number of stations used in location, azimuthal gap, ...

+DOCS


Usage example:
```python
from obspy import read_events
cat = read_events('my_catalog.xml')
cat.write('/tmp/tmp_my_events.shp', format='SHAPEFILE',
          error_ellipses={'filename': '/tmp/tmp_my_events_errors.shp', 'epsg': 31468})
```

Potential improvement:
 - [x] also write origin uncertainties to feature tables (so that filtering by error margins in GIS applications is possible)
 - [ ] automatic lookup of appropriate UTM zone, based on event locations in catalog (or raise exception if catalog is too wide-spread so that a single geocentric zone will not work)