### PR TITLE
CatchOutput manager makes tests crash on Windows Python 3.6

### DIFF
--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -26,7 +26,7 @@ from matplotlib import rcParams
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
     _pitick2latex, PolesZerosResponseStage)
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import CCatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy.signal.invsim import evalresp
@@ -167,7 +167,7 @@ class ResponseTestCase(unittest.TestCase):
         t_samp = 0.05
         nfft = 256
 
-        with CatchOutput():
+        with CCatchOutput():
             self.assertRaises(ValueError,
                               inv[0][0][0].response.get_evalresp_response,
                               t_samp, nfft, output="DISP")

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -26,7 +26,7 @@ from matplotlib import rcParams
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
     _pitick2latex, PolesZerosResponseStage)
-from obspy.core.util.capture import CCatchOutput
+from obspy.core.util.capture import SuppressOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
 from obspy.core.util.testing import ImageComparison, get_matplotlib_version
 from obspy.signal.invsim import evalresp
@@ -167,7 +167,7 @@ class ResponseTestCase(unittest.TestCase):
         t_samp = 0.05
         nfft = 256
 
-        with CCatchOutput():
+        with SuppressOutput():
             self.assertRaises(ValueError,
                               inv[0][0][0].response.get_evalresp_response,
                               t_samp, nfft, output="DISP")

--- a/obspy/core/tests/test_util_capture.py
+++ b/obspy/core/tests/test_util_capture.py
@@ -17,7 +17,7 @@ class UtilCaptureTestCase(unittest.TestCase):
     """
     Test suite for obspy.core.util.capture
     """
-    def test_CCatchOutput(self):
+    def test_c_catch_output(self):
         """
         Tests for CatchOutput context manager.
         """
@@ -46,7 +46,7 @@ class UtilCaptureTestCase(unittest.TestCase):
         self.assertEqual(out.stdout, b'ghi\njkl\n')
         self.assertEqual(out.stderr, b'456\n')
 
-    def test_PyCatchOutput(self):
+    def test_py_catch_output(self):
         """
         Tests that PyCatchOutput context manager does not break I/O.
         """
@@ -61,7 +61,7 @@ class UtilCaptureTestCase(unittest.TestCase):
         except OSError as e:
             self.fail('PyCatchOutput has broken file I/O!\n' + str(e))
 
-    def test_SuppressOutput(self):
+    def test_suppress_output(self):
         """
         Tests for SuppressOutput context manager.
         """

--- a/obspy/core/tests/test_util_capture.py
+++ b/obspy/core/tests/test_util_capture.py
@@ -75,9 +75,11 @@ class UtilCaptureTestCase(unittest.TestCase):
             os.system('echo "test_SuppressOutput #1 failed"')
             libc.printf(b"test_SuppressOutput #2 failed")
             os.system('echo "test_SuppressOutput #3 failed" 1>&2')
-            print("test_SuppressOutput #4 failed")
-            print("test_SuppressOutput #5 failed", file=sys.__stdout__)
-            print("test_SuppressOutput #6 failed", file=sys.__stderr__)
+            sys.stderr.write("test_SuppressOutput #4 failed")
+            sys.stdout.write("test_SuppressOutput #5 failed")
+            print("test_SuppressOutput #6 failed")
+            print("test_SuppressOutput #7 failed", file=sys.__stdout__)
+            print("test_SuppressOutput #8 failed", file=sys.__stderr__)
 
 
 def suite():

--- a/obspy/core/tests/test_util_capture.py
+++ b/obspy/core/tests/test_util_capture.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import ctypes
+import os
+import platform
+import sys
+import tempfile
+import unittest
+
+from obspy.core.util.capture import PyCatchOutput, CCatchOutput, SuppressOutput
+
+
+class UtilCaptureTestCase(unittest.TestCase):
+    """
+    Test suite for obspy.core.util.capture
+    """
+    def test_CCatchOutput(self):
+        """
+        Tests for CatchOutput context manager.
+        """
+        if sys.platform == 'win32':
+            libc = ctypes.CDLL('msvcrt')
+        else:
+            libc = ctypes.CDLL(ctypes.util.find_library("c"))
+
+        with CCatchOutput() as out:
+            os.system('echo "abc"')
+            libc.printf(b"def\n")
+            os.system('echo "123" 1>&2')
+
+        if platform.system() == "Windows":
+            self.assertEqual(out.stdout, b'"abc"\ndef\n')
+            self.assertEqual(out.stderr, b'"123" \n')
+        else:
+            self.assertEqual(out.stdout, b"abc\ndef\n")
+            self.assertEqual(out.stderr, b"123\n")
+
+        with CCatchOutput() as out:
+            print("ghi")
+            print("jkl", file=sys.stdout)
+            print("456", file=sys.stderr)
+
+        self.assertEqual(out.stdout, b'ghi\njkl\n')
+        self.assertEqual(out.stderr, b'456\n')
+
+    def test_PyCatchOutput(self):
+        """
+        Tests that PyCatchOutput context manager does not break I/O.
+        """
+        with PyCatchOutput():
+            fn = tempfile.TemporaryFile(prefix='obspy')
+
+        try:
+            fn.write(b'abc')
+            fn.seek(0)
+            fn.read(3)
+            fn.close()
+        except OSError as e:
+            self.fail('PyCatchOutput has broken file I/O!\n' + str(e))
+
+    def test_SuppressOutput(self):
+        """
+        Tests for SuppressOutput context manager.
+        """
+        if sys.platform == 'win32':
+            libc = ctypes.CDLL('msvcrt')
+        else:
+            libc = ctypes.CDLL(ctypes.util.find_library("c"))
+
+        # this should write nothing to console
+        with SuppressOutput():
+            os.system('echo "test_SuppressOutput #1 failed"')
+            libc.printf(b"test_SuppressOutput #2 failed")
+            os.system('echo "test_SuppressOutput #3 failed" 1>&2')
+            print("test_SuppressOutput #4 failed")
+            print("test_SuppressOutput #5 failed", file=sys.__stdout__)
+            print("test_SuppressOutput #6 failed", file=sys.__stderr__)
+
+
+def suite():
+    return unittest.makeSuite(UtilCaptureTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -12,7 +12,8 @@ from ctypes import CDLL
 from ctypes.util import find_library
 
 from obspy import UTCDateTime
-from obspy.core.util.misc import CatchOutput, get_window_times
+from obspy.core.util.misc import get_window_times
+from obspy.core.util.capture import PyCatchOutput, CCatchOutput
 
 
 class UtilMiscTestCase(unittest.TestCase):
@@ -23,13 +24,13 @@ class UtilMiscTestCase(unittest.TestCase):
                      platform.python_version_tuple()[0] == "3",
                      "Does not work with Python 3 for some Windows and OSX "
                      "versions")
-    def test_catch_output(self):
+    def test_c_catch_output(self):
         """
         Tests for CatchOutput context manager.
         """
         libc = CDLL(find_library("c"))
 
-        with CatchOutput() as out:
+        with CCatchOutput() as out:
             os.system('echo "abc"')
             libc.printf(b"def\n")
             # This flush is necessary for Python 3, which uses different
@@ -52,11 +53,11 @@ class UtilMiscTestCase(unittest.TestCase):
             self.assertEqual(out.stdout, b"abc\ndef\nghi\njkl\n")
             self.assertEqual(out.stderr, b"123\n456\n")
 
-    def test_catch_output_io(self):
+    def test_py_catch_output_io(self):
         """
-        Tests that CatchOutput context manager does not break I/O.
+        Tests that PyCatchOutput context manager does not break I/O.
         """
-        with CatchOutput():
+        with PyCatchOutput():
             fn = tempfile.TemporaryFile(prefix='obspy')
 
         try:
@@ -65,7 +66,7 @@ class UtilMiscTestCase(unittest.TestCase):
             fn.read(3)
             fn.close()
         except OSError as e:
-            self.fail('CatchOutput has broken file I/O!\n' + str(e))
+            self.fail('PyCatchOutput has broken file I/O!\n' + str(e))
 
     def test_no_obspy_imports(self):
         """

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -44,12 +44,6 @@ class UtilMiscTestCase(unittest.TestCase):
             os.system('echo "123" 1>&2')
             print("456", file=sys.stderr)
 
-        if platform.system() == "Windows":
-            self.assertEqual(out.stdout.splitlines(),
-                             ['"abc"', 'def', 'ghi', 'jkl'])
-            self.assertEqual(out.stderr.splitlines(),
-                             ['"123" ', '456'])
-        else:
             self.assertEqual(out.stdout, b"abc\ndef\nghi\njkl\n")
             self.assertEqual(out.stderr, b"123\n456\n")
 

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -29,10 +29,10 @@ from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
                                   NamedTemporaryFile, _read_from_plugin,
                                   create_empty_data_chunk, get_example_file,
                                   get_matplotlib_version, get_script_dir_name)
-from obspy.core.util.misc import (BAND_CODE, CatchOutput, complexify_string,
-                                  guess_delta, loadtxt, score_at_percentile,
-                                  to_int_or_zero)
+from obspy.core.util.misc import (BAND_CODE, complexify_string, guess_delta,
+                                  loadtxt, score_at_percentile, to_int_or_zero)
 from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)
 from obspy.core.util.testing import add_doctests, add_unittests
 from obspy.core.util.version import get_git_version as _get_version_string
+from obspy.core.util.capture import PyCatchOutput, CCatchOutput

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -35,4 +35,4 @@ from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)
 from obspy.core.util.testing import add_doctests, add_unittests
 from obspy.core.util.version import get_git_version as _get_version_string
-from obspy.core.util.capture import PyCatchOutput, CCatchOutput
+from obspy.core.util.capture import PyCatchOutput, CCatchOutput, SuppressOutput

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -11,7 +11,7 @@ Context managers to catch output to stdout/stderr streams.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2
+from future.utils import PY2, native_str
 
 import contextlib
 import ctypes
@@ -36,9 +36,9 @@ else:
 
 
 if sys.platform == 'win32':
-    libc = ctypes.CDLL('msvcrt')
+    libc = ctypes.CDLL(native_str("msvcrt"))
 else:
-    libc = ctypes.CDLL(ctypes.util.find_library("c"))
+    libc = ctypes.CDLL(ctypes.util.find_library(native_str("c")))
 
 
 def flush():

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -28,10 +28,8 @@ if PY2:
 else:
     class CaptureIO(io.TextIOWrapper):
         def __init__(self):
-            super(CaptureIO, self).__init__(
-                io.BytesIO(),
-                encoding='UTF-8', newline='', write_through=True,
-            )
+            super(CaptureIO, self).__init__(io.BytesIO(), encoding='UTF-8',
+                                            newline='', write_through=True)
 
         def getvalue(self):
             return self.buffer.getvalue()
@@ -47,6 +45,9 @@ def flush():
     try:
         sys.stdout.flush()
         sys.stderr.flush()
+    except:
+        pass
+    try:
         libc.fflush(None)
     except:
         pass
@@ -201,15 +202,15 @@ def SuppressOutput():  # noqa
     stderr_fd = sys.stderr.fileno()
     with os.fdopen(os.dup(stdout_fd), 'wb') as tmp_stdout:
         with os.fdopen(os.dup(stderr_fd), 'wb') as tmp_stderr:
-            flush()
             with open(os.devnull, 'wb') as to_file:
+                flush()
                 os.dup2(to_file.fileno(), stdout_fd)
                 os.dup2(to_file.fileno(), stderr_fd)
-            try:
-                yield
-            finally:
-                flush()
-                os.dup2(tmp_stdout.fileno(), stdout_fd)
-                os.dup2(tmp_stderr.fileno(), stderr_fd)
+                try:
+                    yield
+                finally:
+                    flush()
+                    os.dup2(tmp_stdout.fileno(), stdout_fd)
+                    os.dup2(tmp_stderr.fileno(), stderr_fd)
     sys.stdout = sys.__stdout__
     sys.stderr = sys.__stderr__

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 
 
 if PY2:
-    CaptureIO = io.StringIO
+    CaptureIO = io.BytesIO
 else:
     class CaptureIO(io.TextIOWrapper):
         def __init__(self):

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""
+Context managers to catch output to stdout/stderr streams.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+from future.utils import PY2
+
+import io
+import os
+import platform
+import sys
+import tempfile
+from contextlib import contextmanager
+
+
+if PY2:
+    CaptureIO = io.StringIO
+else:
+    class CaptureIO(io.TextIOWrapper):
+        def __init__(self):
+            super(CaptureIO, self).__init__(
+                io.BytesIO(),
+                encoding='UTF-8', newline='', write_through=True,
+            )
+
+        def getvalue(self):
+            return self.buffer.getvalue()
+
+
+@contextmanager
+def PyCatchOutput():  # noqa
+    """
+    A context manager that catches stdout/stderr/exit() for its scope.
+
+    Always use with "with" statement. Does nothing otherwise.
+
+    >>> with PyCatchOutput() as out:  # doctest: +SKIP
+    ...    os.system('echo "mystdout"')
+    ...    os.system('echo "mystderr" >&2')
+    >>> print(out.stdout)  # doctest: +SKIP
+    mystdout
+    >>> print(out.stderr)  # doctest: +SKIP
+    mystderr
+    """
+
+    # Dummy class to transport the output.
+    class Output():
+        pass
+    out = Output()
+    out.stdout = ''
+    out.stderr = ''
+
+    sys.stdout = temp_out = CaptureIO()
+    sys.stderr = temp_err = CaptureIO()
+
+    yield out
+
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+
+    out.stdout = temp_out.getvalue()
+    out.stderr = temp_err.getvalue()
+
+    if platform.system() == "Windows":
+        out.stdout = out.stdout.replace(b'\r', b'')
+        out.stderr = out.stderr.replace(b'\r', b'')
+
+
+@contextmanager
+def CCatchOutput():  # noqa
+    """
+    A context manager that catches stdout/stderr/exit() for its scope.
+
+    Always use with "with" statement. Does nothing otherwise.
+
+    Based on: https://bugs.python.org/msg184312
+
+    >>> with CCatchOutput() as out:  # doctest: +SKIP
+    ...    os.system('echo "mystdout"')
+    ...    os.system('echo "mystderr" >&2')
+    >>> print(out.stdout)  # doctest: +SKIP
+    mystdout
+    >>> print(out.stderr)  # doctest: +SKIP
+    mystderr
+    """
+
+    # Dummy class to transport the output.
+    class Output():
+        pass
+    out = Output()
+    out.stdout = ''
+    out.stderr = ''
+
+    stdout_fd = sys.stdout.fileno()
+    stderr_fd = sys.stderr.fileno()
+    with tempfile.TemporaryFile(prefix='obspy-') as tmp_stdout:
+        with tempfile.TemporaryFile(prefix='obspy-') as tmp_stderr:
+            stdout_copy = os.dup(stdout_fd)
+            stderr_copy = os.dup(stderr_fd)
+
+            try:
+                sys.stdout.flush()
+                os.dup2(tmp_stdout.fileno(), stdout_fd)
+
+                sys.stderr.flush()
+                os.dup2(tmp_stderr.fileno(), stderr_fd)
+
+                raised = False
+                yield out
+
+            except SystemExit:
+                raised = True
+
+            finally:
+                sys.stdout.flush()
+                os.dup2(stdout_copy, stdout_fd)
+                os.close(stdout_copy)
+                tmp_stdout.seek(0)
+                out.stdout = tmp_stdout.read()
+
+                sys.stderr.flush()
+                os.dup2(stderr_copy, stderr_fd)
+                os.close(stderr_copy)
+                tmp_stderr.seek(0)
+                out.stderr = tmp_stderr.read()
+
+                if platform.system() == "Windows":
+                    out.stdout = out.stdout.replace(b'\r', b'')
+                    out.stderr = out.stderr.replace(b'\r', b'')
+
+                if raised:
+                    raise SystemExit(out.stderr)

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 
 
 if PY2:
-    CaptureIO = io.BytesIO
+    CaptureIO = io.StringIO
 else:
     class CaptureIO(io.TextIOWrapper):
         def __init__(self):

--- a/obspy/core/util/capture.py
+++ b/obspy/core/util/capture.py
@@ -22,7 +22,8 @@ from contextlib import contextmanager
 
 
 if PY2:
-    CaptureIO = io.StringIO
+    from cStringIO import StringIO
+    CaptureIO = StringIO
 else:
     class CaptureIO(io.TextIOWrapper):
         def __init__(self):
@@ -143,7 +144,7 @@ def CCatchOutput():  # noqa
 @contextmanager
 def SuppressOutput():  # noqa
     """
-    A context manager that suppresses outout to stdout/stderr.
+    A context manager that suppresses output to stdout/stderr.
 
     Always use with "with" statement. Does nothing otherwise.
 

--- a/obspy/geodetics/tests/test_util_flinnengdahl.py
+++ b/obspy/geodetics/tests/test_util_flinnengdahl.py
@@ -9,7 +9,7 @@ import unittest
 
 from obspy.scripts.flinnengdahl import main as obspy_flinnengdahl
 from obspy.geodetics import FlinnEngdahl
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import PyCatchOutput
 
 
 class UtilFlinnEngdahlTestCase(unittest.TestCase):
@@ -46,7 +46,7 @@ class UtilFlinnEngdahlTestCase(unittest.TestCase):
             line = fh.readline()
             longitude, latitude, checked_region = line.strip().split('\t')
 
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_flinnengdahl([longitude, latitude])
             region = out.stdout.strip()
 

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -48,19 +48,10 @@ Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
 
-        result = out.stdout[:-1]
-        try:
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-        except Exception:
+        result = out.stdout[:-1].decode('utf-8')
+        # depending on system encoding degree character gets replaced in script
+        if '°' not in result:
             expected = expected.replace('°', ' deg')
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-
         self.assertEqual(expected, result)
 
     def test_script_convert_type_tensor(self):
@@ -160,19 +151,10 @@ Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
 
-        result = out.stdout[:-1]
-        try:
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-        except Exception:
+        result = out.stdout[:-1].decode('utf-8')
+        # depending on system encoding degree character gets replaced in script
+        if '°' not in result:
             expected = expected.replace('°', ' deg')
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-
         self.assertEqual(expected, result)
 
     #

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -19,7 +19,7 @@ else:
 
 import numpy as np
 
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import PyCatchOutput
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 from obspy.imaging.scripts.mopad import main as obspy_mopad
 
@@ -39,7 +39,7 @@ class MopadTestCase(unittest.TestCase):
     #
 
     def test_script_convert_type_sdr(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 'sdr',
                          ','.join(str(x) for x in self.mt)])
 
@@ -64,7 +64,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         self.assertEqual(expected, result)
 
     def test_script_convert_type_tensor(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 't',
                          ','.join(str(x) for x in self.mt)])
 
@@ -81,7 +81,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
                          out.stdout)
 
     def test_script_convert_type_tensor_large(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 't',
                          ','.join(str(x * 100) for x in self.mt)])
 
@@ -121,7 +121,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
                                         product(['NED', 'USE', 'XYZ', 'NWU'],
                                                 repeat=2)):
 
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_mopad(['convert', '-b', insys, outsys,
                              ','.join(str(x) for x in self.mt)])
 
@@ -133,7 +133,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
                 self.assertAlmostEqual(e, a, msg=msg)
 
     def test_script_convert_vector(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['convert', '-v', 'NED', 'NED',
                          ','.join(str(x) for x in self.mt)])
 
@@ -147,7 +147,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
     #
 
     def test_script_decompose(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['decompose', '-y', ','.join(str(x) for x in self.mt)])
 
         expected = '''
@@ -183,7 +183,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         """
         Helper function that runs GMT and compares results.
         """
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_mopad(['gmt'] + list(args) +
                         [','.join(str(x) for x in self.mt)])
 
@@ -286,7 +286,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         for mt, filename in zip(data, filenames):
             try:
                 with ImageComparison(self.path, filename) as ic:
-                    with CatchOutput() as out:
+                    with PyCatchOutput() as out:
                         obspy_mopad(['plot',
                                      '--output-file', ic.name,
                                      '--input-system', 'USE',

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -13,8 +13,8 @@ from os.path import abspath, dirname, join, pardir
 import warnings
 
 from obspy import read
-from obspy.core.util.base import NamedTemporaryFile
-from obspy.core.util.misc import TemporaryWorkingDirectory, CatchOutput
+from obspy.core.util import NamedTemporaryFile, PyCatchOutput
+from obspy.core.util.misc import TemporaryWorkingDirectory
 from obspy.core.util.testing import ImageComparison
 from obspy.imaging.scripts.scan import main as obspy_scan
 from obspy.imaging.scripts.scan import scan, Scanner
@@ -167,7 +167,7 @@ class ScanTestCase(unittest.TestCase):
                 files.append(fp.name)
             with ImageComparison(self.path, 'scan_mult_sampl.png')\
                     as ic:
-                with CatchOutput() as out:
+                with PyCatchOutput() as out:
                     obspy_scan(files + ['--output', ic.name, '--print-gaps'])
                 self.assertEqual(
                     expected_stdout_lines, out.stdout.decode().splitlines())

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -16,7 +16,7 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime
-from obspy.core.util import CatchOutput, NamedTemporaryFile
+from obspy.core.util import CCatchOutput, NamedTemporaryFile
 from obspy.io.gse2 import libgse2
 from obspy.io.gse2.libgse2 import (ChksumError, GSEUtiError, compile_sta2,
                                    parse_sta2)
@@ -206,9 +206,9 @@ class LibGSE2TestCase(unittest.TestCase):
             fout.write(b"".join(lines))
         fout.seek(0)
         # with CatchOutput() as out:
-        with CatchOutput():
+        with CCatchOutput():
             self.assertRaises(GSEUtiError, libgse2.read, fout)
-        # XXX: CatchOutput does not work on Py3k, skipping for now
+        # XXX: CCatchOutput does not work on Py3k, skipping for now
         # self.assertEqual(out.stdout,
         #                 "decomp_6b: Neither DAT2 or DAT1 found!\n")
 

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -16,7 +16,7 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime
-from obspy.core.util import CCatchOutput, NamedTemporaryFile
+from obspy.core.util import SuppressOutput, NamedTemporaryFile
 from obspy.io.gse2 import libgse2
 from obspy.io.gse2.libgse2 import (ChksumError, GSEUtiError, compile_sta2,
                                    parse_sta2)
@@ -205,12 +205,9 @@ class LibGSE2TestCase(unittest.TestCase):
             lines = (l for l in fin if not l.startswith(b'DAT2'))
             fout.write(b"".join(lines))
         fout.seek(0)
-        # with CatchOutput() as out:
-        with CCatchOutput():
+        # suppress expected warning "decomp_6b: Neither DAT2 or DAT1 found!"
+        with SuppressOutput():
             self.assertRaises(GSEUtiError, libgse2.read, fout)
-        # XXX: CCatchOutput does not work on Py3k, skipping for now
-        # self.assertEqual(out.stdout,
-        #                 "decomp_6b: Neither DAT2 or DAT1 found!\n")
 
     def test_parse_sta2(self):
         """

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core import AttribDict
-from obspy.core.util import CatchOutput, NamedTemporaryFile
+from obspy.core.util import PyCatchOutput, NamedTemporaryFile
 from obspy.io.mseed import (util, InternalMSEEDWarning,
                             InternalMSEEDError)
 from obspy.io.mseed.core import _is_mseed, _read_mseed, _write_mseed
@@ -1142,7 +1142,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         # Catch output. Will raise an internal mseed reading warning.
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 st = read(filename, verbose=2)
 
         self.assertEqual(len(w), 1)

--- a/obspy/io/mseed/tests/test_recordanalyzer.py
+++ b/obspy/io/mseed/tests/test_recordanalyzer.py
@@ -7,7 +7,7 @@ from future.builtins import *  # NOQA
 import os
 import unittest
 
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import PyCatchOutput
 from obspy.io.mseed.scripts.recordanalyzer import main as obspy_recordanalyzer
 
 
@@ -18,7 +18,7 @@ class RecordAnalyserTestCase(unittest.TestCase):
                                       'timingquality.mseed')
 
     def test_default_record(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_recordanalyzer([self.test_file])
 
         expected = '''FILE: %s
@@ -61,7 +61,7 @@ CALCULATED VALUES
                          out.stdout)
 
     def test_second_record(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_recordanalyzer(['-n', '1', self.test_file])
 
         expected = '''FILE: %s
@@ -111,7 +111,7 @@ CALCULATED VALUES
         filename = os.path.join(os.path.dirname(__file__), 'data', 'bizarre',
                                 'mseed_data_offset_0.mseed')
 
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_recordanalyzer(['-n', '1', filename])
 
         expected = '''FILE: %s
@@ -151,7 +151,7 @@ CALCULATED VALUES
         self.assertEqual(expected.encode('utf-8'),  # noqa
                          out.stdout)
 
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_recordanalyzer(['-n', '2', filename])
 
         expected = '''FILE: %s

--- a/obspy/io/xseed/tests/test_scripts.py
+++ b/obspy/io/xseed/tests/test_scripts.py
@@ -9,7 +9,8 @@ import unittest
 import zipfile
 
 from obspy.core.util import NamedTemporaryFile
-from obspy.core.util.misc import CatchOutput, TemporaryWorkingDirectory
+from obspy.core.util.misc import TemporaryWorkingDirectory
+from obspy.core.util.capture import PyCatchOutput
 from obspy.io.xseed.parser import Parser
 from obspy.io.xseed.scripts.dataless2resp import main as obspy_dataless2resp
 from obspy.io.xseed.scripts.dataless2xseed import main as obspy_dataless2xseed
@@ -32,7 +33,7 @@ class ScriptTestCase(unittest.TestCase):
 
     def test_dataless2resp(self):
         with TemporaryWorkingDirectory():
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_dataless2resp([self.dataless_file])
 
             expected = '''Found 1 files.
@@ -49,7 +50,7 @@ Parsing file %s
 
     def test_dataless2resp_zipped(self):
         with TemporaryWorkingDirectory():
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_dataless2resp(['--zipped', self.dataless_file])
 
             expected = '''Found 1 files.
@@ -74,7 +75,7 @@ Parsing file %s
 
     def test_dataless2xseed(self):
         with TemporaryWorkingDirectory():
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_dataless2xseed([self.dataless_file])
 
             expected = '''Found 1 files.
@@ -96,7 +97,7 @@ Parsing file %s
         dataless_multi_file = os.path.join(self.data, 'CL.AIO.dataless')
 
         with TemporaryWorkingDirectory():
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_dataless2xseed(['--split-stations',
                                       dataless_multi_file])
 
@@ -120,7 +121,7 @@ Parsing file %s
 
     def test_xseed2dataless(self):
         with NamedTemporaryFile() as tf:
-            with CatchOutput() as out:
+            with PyCatchOutput() as out:
                 obspy_xseed2dataless(['--output', tf.name, self.xseed_file])
 
             expected = '''Found 1 files.

--- a/obspy/scripts/tests/test_print.py
+++ b/obspy/scripts/tests/test_print.py
@@ -8,7 +8,7 @@ import os
 import unittest
 
 from obspy.scripts.print import main as obspy_print
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import PyCatchOutput
 
 
 class PrintTestCase(unittest.TestCase):
@@ -19,7 +19,7 @@ class PrintTestCase(unittest.TestCase):
                           for x in ['slist.ascii', 'tspair.ascii']]
 
     def test_print(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_print(self.all_files)
 
         self.assertEqual(
@@ -30,7 +30,7 @@ XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 
         )
 
     def test_print_nomerge(self):
-        with CatchOutput() as out:
+        with PyCatchOutput() as out:
             obspy_print(['--no-merge'] + self.all_files)
 
         self.assertEqual(

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from obspy import Trace, UTCDateTime, read, read_inventory
 from obspy.core.util.base import NamedTemporaryFile
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.capture import CCatchOutput
 from obspy.io.sac import attach_paz
 from obspy.signal.headers import clibevresp
 from obspy.signal.invsim import (
@@ -433,7 +433,7 @@ class InvSimTestCase(unittest.TestCase):
         filename = os.path.join(self.path, "segfaulting_RESPs",
                                 "RESP.IE.LLRI..EHZ")
         date = UTCDateTime(2003, 11, 1, 0, 0, 0)
-        with CatchOutput():
+        with CCatchOutput():
             self.assertRaises(ValueError, evalresp, t_samp=10.0, nfft=256,
                               filename=filename, date=date, station="LLRI",
                               channel="EHZ", network="IE", locid="*",
@@ -465,7 +465,7 @@ class InvSimTestCase(unittest.TestCase):
 
         # The RESP file only contains two channels.
         kwargs["channel"] = "BHZ"
-        with CatchOutput() as out:
+        with CCatchOutput() as out:
             self.assertRaises(ValueError, evalresp, **kwargs)
         self.assertIn(b"no response found for", out.stderr.lower())
 

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from obspy import Trace, UTCDateTime, read, read_inventory
 from obspy.core.util.base import NamedTemporaryFile
-from obspy.core.util.capture import CCatchOutput
+from obspy.core.util.capture import CCatchOutput, SuppressOutput
 from obspy.io.sac import attach_paz
 from obspy.signal.headers import clibevresp
 from obspy.signal.invsim import (
@@ -433,7 +433,7 @@ class InvSimTestCase(unittest.TestCase):
         filename = os.path.join(self.path, "segfaulting_RESPs",
                                 "RESP.IE.LLRI..EHZ")
         date = UTCDateTime(2003, 11, 1, 0, 0, 0)
-        with CCatchOutput():
+        with SuppressOutput():
             self.assertRaises(ValueError, evalresp, t_samp=10.0, nfft=256,
                               filename=filename, date=date, station="LLRI",
                               channel="EHZ", network="IE", locid="*",


### PR DESCRIPTION
See https://github.com/obspy/obspy/issues/1561#issuecomment-282266027

```
py3.6 on Windows crashes on our CatchOutput implementation
```