### PR TITLE
Attempting to polyfill the decorate() function

### DIFF
--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -300,18 +300,39 @@ def map_example_filename(arg_kwarg_name):
     return _map_example_filename
 
 
-@decorator
-def rlock(func, *args, **kwargs):
+def _decorate_polyfill(func, caller):
+    """
+    decorate(func, caller) decorates a function using a caller.
+    """
+    try:
+        from decorator import decorate
+        return decorate(func, caller)
+    except ImportError:
+        from decorator import FunctionMaker
+        evaldict = dict(_call_=caller, _func_=func)
+        fun = FunctionMaker.create(
+            func, "return _call_(_func_, %(shortsignature)s)",
+            evaldict, __wrapped__=func)
+        if hasattr(func, '__qualname__'):
+            fun.__qualname__ = func.__qualname__
+        return fun
+
+
+def rlock(func):
     """
     Place a threading recursive lock (Rlock) on the wrapped function
+    This decorator has to be called as a function!
     """
     # This lock will be instantiated at function creation time, i.e. at the
     # time the Python interpreter sees the decorated function the very
     # first time - this lock thus exists once for each decorated function.
     _rlock = threading.RLock()
 
-    with _rlock:
-        return func(*args, **kwargs)
+    def _locked_f(f, *args, **kwargs):
+        with _rlock:
+            return func(*args, **kwargs)
+
+    return _decorate_polyfill(func, _locked_f)
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -321,7 +321,6 @@ def _decorate_polyfill(func, caller):
 def rlock(func):
     """
     Place a threading recursive lock (Rlock) on the wrapped function
-    This decorator has to be called as a function!
     """
     # This lock will be instantiated at function creation time, i.e. at the
     # time the Python interpreter sees the decorated function the very


### PR DESCRIPTION
See #1644.

#1671 did fix the test failures but the decorator in this case did not actually do anything as the lock was recreated for each function call and thus there was no lock.

This is an attempt to polyfill the `decorate()` function to older decorator modules as that functionality is crucial for a lot of things that don't really work with normal decorators like our documentation.

I honestly have no idea how to actually test this - one would need to get access to the local variables of the decorated function but `__closure__` appears to be empty. A found a solution online but that seems a bit too much hassle to actually do it: http://stackoverflow.com/questions/9186395/python-is-there-a-way-to-get-a-local-function-variable-from-within-a-decorator

I tested this with print statements and it appears to work as intended.
