### PR TITLE
obspy-runtests -v also triggers verbose run of flake8

### DIFF
--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -736,6 +736,11 @@ def run(argv=None, interactive=True):
         os.environ['OBSPY_KEEP_ONLY_FAILED_IMAGES'] = ""
     if args.no_flake8:
         os.environ['OBSPY_NO_FLAKE8'] = ""
+
+    # All arguments are used by the test runner and should not interfere
+    # with any other module that might also parse them, e.g. flake8.
+    sys.argv = sys.argv[:1]
+
     return run_tests(verbosity, args.tests, report, args.log, args.server,
                      args.all, args.timeit, interactive, args.n,
                      exclude=args.exclude, tutorial=args.tutorial,


### PR DESCRIPTION
```
(Python35) D:\Python\...\Scripts>python runtests.py -v obspy.core.tests.test_code_formatting -d
Running D:\Workspace\obspy\obspy\scripts\runtests.py, ObsPy version '1.0.3rc1'
test_flake8 (obspy.core.tests.test_code_formatting.CodeFormattingTestCase) ... flake8.plugins.manager    MainProcess   1390 INFO     Loading entry-points for "flake8.extension".
flake8.plugins.manager    MainProcess   1391 INFO     Loading entry-points for "flake8.listen".
flake8.plugins.manager    MainProcess   1401 INFO     Loading entry-points for "flake8.report".
flake8.plugins.manager    MainProcess   1413 INFO     Loading plugin "N8" from entry-point.
flake8.plugins.manager    MainProcess   1425 INFO     Loading plugin "C90" from entry-point.
flake8.plugins.manager    MainProcess   1426 INFO     Loading plugin "pycodestyle.explicit_line_join" from entry-point.
flake8.plugins.manager    MainProcess   1443 INFO     Loading plugin "pycodestyle.trailing_whitespace" from entry-point.
flake8.plugins.manager    MainProcess   1446 INFO     Loading plugin "pycodestyle.whitespace_around_operator" from entry-point.
flake8.plugins.manager    MainProcess   1447 INFO     Loading plugin "pycodestyle.indentation" from entry-point.
flake8.plugins.manager    MainProcess   1458 INFO     Loading plugin "pycodestyle.compound_statements" from entry-point.
flake8.plugins.manager    MainProcess   1469 INFO     Loading plugin "pycodestyle.python_3000_raise_comma" from entry-point.
flake8.plugins.manager    MainProcess   1469 INFO     Loading plugin "F" from entry-point.
flake8.plugins.manager    MainProcess   1489 INFO     Loading plugin "pycodestyle.maximum_line_length" from entry-point.
flake8.plugins.manager    MainProcess   1494 INFO     Loading plugin "pycodestyle.whitespace_before_comment" from entry-point.
flake8.plugins.manager    MainProcess   1506 INFO     Loading plugin "pycodestyle.missing_whitespace_after_import_keyword" from entry-point.
flake8.plugins.manager    MainProcess   1517 INFO     Loading plugin "pycodestyle.extraneous_whitespace" from entry-point.
flake8.plugins.manager    MainProcess   1518 INFO     Loading plugin "pycodestyle.whitespace_around_named_parameter_equals" from entry-point.
flake8.plugins.manager    MainProcess   1529 INFO     Loading plugin "pycodestyle.missing_whitespace_around_operator" from entry-point.
flake8.plugins.manager    MainProcess   1539 INFO     Loading plugin "pycodestyle.module_imports_on_top_of_file" from entry-point.
flake8.plugins.manager    MainProcess   1540 INFO     Loading plugin "pycodestyle.tabs_obsolete" from entry-point.
flake8.plugins.manager    MainProcess   1552 INFO     Loading plugin "pycodestyle.imports_on_separate_lines" from entry-point.
flake8.plugins.manager    MainProcess   1563 INFO     Loading plugin "pycodestyle.tabs_or_spaces" from entry-point.
flake8.plugins.manager    MainProcess   1563 INFO     Loading plugin "pycodestyle.comparison_type" from entry-point.
flake8.plugins.manager    MainProcess   1575 INFO     Loading plugin "pycodestyle.whitespace_around_keywords" from entry-point.
flake8.plugins.manager    MainProcess   1585 INFO     Loading plugin "pycodestyle.blank_lines" from entry-point.
flake8.plugins.manager    MainProcess   1586 INFO     Loading plugin "pycodestyle.python_3000_has_key" from entry-point.
flake8.plugins.manager    MainProcess   1599 INFO     Loading plugin "pycodestyle.continued_indentation" from entry-point.
flake8.plugins.manager    MainProcess   1609 INFO     Loading plugin "pycodestyle.comparison_negative" from entry-point.
flake8.plugins.manager    MainProcess   1610 INFO     Loading plugin "pycodestyle.python_3000_not_equal" from entry-point.
flake8.plugins.manager    MainProcess   1622 INFO     Loading plugin "pycodestyle.trailing_blank_lines" from entry-point.
flake8.plugins.manager    MainProcess   1633 INFO     Loading plugin "pycodestyle.whitespace_around_comma" from entry-point.
flake8.plugins.manager    MainProcess   1634 INFO     Loading plugin "pycodestyle.missing_whitespace" from entry-point.
flake8.plugins.manager    MainProcess   1645 INFO     Loading plugin "pycodestyle.whitespace_before_parameters" from entry-point.
flake8.plugins.manager    MainProcess   1656 INFO     Loading plugin "pycodestyle.comparison_to_singleton" from entry-point.
flake8.plugins.manager    MainProcess   1657 INFO     Loading plugin "pycodestyle.break_around_binary_operator" from entry-point.
flake8.plugins.manager    MainProcess   1668 INFO     Loading plugin "pycodestyle.python_3000_backticks" from entry-point.
flake8.plugins.manager    MainProcess   1679 INFO     Loading plugin "pylint" from entry-point.
flake8.plugins.manager    MainProcess   1680 INFO     Loading plugin "quiet-nothing" from entry-point.
flake8.plugins.manager    MainProcess   1691 INFO     Loading plugin "default" from entry-point.
flake8.plugins.manager    MainProcess   1701 INFO     Loading plugin "quiet-filename" from entry-point.
flake8.checker            MainProcess   1704 WARNING  The --jobs option is not available on Windows due to a bug (https://bugs.python.org/issue27649) in Python 2.7.11+ and 3.3+. We have detected that you are running an unsupported version of Python on Windows. Ignoring --jobs arguments.
flake8.checker            MainProcess   1764 INFO     Making checkers
flake8.checker            MainProcess   2501 INFO     Checking 339 files
flake8.main.application   MainProcess  43784 INFO     Finished running
flake8.main.application   MainProcess  43785 INFO     Reporting errors
flake8.main.application   MainProcess  43807 INFO     Found a total of 1100 violations and reported 0
ok
test_use_obspy_deprecation_warning (obspy.core.tests.test_code_formatting.CodeFormattingTestCase) ... ok
test_future_imports_in_every_file (obspy.core.tests.test_code_formatting.FutureUsageTestCase) ... ok

----------------------------------------------------------------------
Ran 3 tests in 42.709s

OK
```

also very interesting is ```Found a total of 1100 violations and reported 0``` ^^

