### PR TITLE
io.nordic: Settings "Time_Residual_RMS"

### DIFF
--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -32,7 +32,7 @@ import io
 from obspy import UTCDateTime, read
 from obspy.geodetics import kilometers2degrees, degrees2kilometers
 from obspy.core.event import Event, Origin, Magnitude, Comment, Catalog
-from obspy.core.event import EventDescription, CreationInfo
+from obspy.core.event import EventDescription, CreationInfo, OriginQuality
 from obspy.core.event import Pick, WaveformStreamID, Arrival, Amplitude
 
 
@@ -287,12 +287,8 @@ def _readheader(f):
     ksta = Comment(text='Number of stations=' + topline[49:51].strip())
     new_event.origins[0].comments.append(ksta)
     if _float_conv(topline[51:55]) is not None:
-        # raises "UserWarning: Setting attribute "Time_Residual_RMS" which is
-        # not a default attribute"
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            new_event.origins[0].time_errors['Time_Residual_RMS'] = \
-                _float_conv(topline[51:55])
+        new_event.origins[0].quality = OriginQuality(
+            standard_error=_float_conv(topline[51:55]))
     # Read in magnitudes if they are there.
     for index in [59, 67, 75]:
         if not topline[index].isspace():
@@ -896,12 +892,8 @@ def _write_nordic(event, filename, userid='OBSP', evtype='L', outdir='.',
     if len(agency) > 3:
         agency = agency[0:3]
     # Cope with differences in event uncertainty naming
-    if event.origins[0].time_errors:
-        try:
-            timerms = '{0:.1f}'.format(event.origins[0].
-                                       time_errors.Time_Residual_RMS)
-        except AttributeError:
-            timerms = '0.0'
+    if event.origins[0].quality and event.origins[0].quality['standard_error']:
+        timerms = '{0:.1f}'.format(event.origins[0].quality['standard_error'])
     else:
         timerms = '0.0'
     conv_mags = []

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -15,7 +15,7 @@ import warnings
 
 from obspy import read_events, Catalog, UTCDateTime, read
 from obspy.core.event import Pick, WaveformStreamID, Arrival, Amplitude
-from obspy.core.event import Event, Origin, Magnitude
+from obspy.core.event import Event, Origin, Magnitude, OriginQuality
 from obspy.core.event import EventDescription, CreationInfo
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.io.nordic.core import _is_sfile, read_spectral_info, read_nordic
@@ -168,11 +168,7 @@ class TestNordicMethods(unittest.TestCase):
                           evtype='L', outdir='albatross',
                           wavefiles='test', explosion=True,
                           overwrite=True)
-        # raises "UserWarning: Setting attribute "Time_Residual_RMS" which is
-        # not a default attribute"
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            invalid_origin = test_ev.copy()
+        invalid_origin = test_ev.copy()
 
         invalid_origin.origins = []
         with self.assertRaises(NordicParsingError):
@@ -180,11 +176,7 @@ class TestNordicMethods(unittest.TestCase):
                           evtype='L', outdir='.',
                           wavefiles='test', explosion=True,
                           overwrite=True)
-        # raises "UserWarning: Setting attribute "Time_Residual_RMS" which is
-        # not a default attribute"
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            invalid_origin = test_ev.copy()
+        invalid_origin = test_ev.copy()
         invalid_origin.origins[0].time = None
         with self.assertRaises(NordicParsingError):
             _write_nordic(invalid_origin, filename=None, userid='TEST',
@@ -192,11 +184,7 @@ class TestNordicMethods(unittest.TestCase):
                           wavefiles='test', explosion=True,
                           overwrite=True)
         # Write a near empty origin
-        # raises "UserWarning: Setting attribute "Time_Residual_RMS" which is
-        # not a default attribute"
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
-            valid_origin = test_ev.copy()
+        valid_origin = test_ev.copy()
         valid_origin.origins[0].latitude = None
         valid_origin.origins[0].longitude = None
         valid_origin.origins[0].depth = None
@@ -683,11 +671,7 @@ def full_test_event():
     test_event.origins[0].longitude = 25.0
     test_event.origins[0].depth = 15000
     test_event.creation_info = CreationInfo(agency_id='TES')
-    # raises "UserWarning: Setting attribute "Time_Residual_RMS" which is not
-    # a default attribute"
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', UserWarning)
-        test_event.origins[0].time_errors['Time_Residual_RMS'] = 0.01
+    test_event.origins[0].quality = OriginQuality(standard_error=0.01)
     test_event.magnitudes.append(Magnitude())
     test_event.magnitudes[0].mag = 0.1
     test_event.magnitudes[0].magnitude_type = 'ML'


### PR DESCRIPTION
https://github.com/obspy/obspy/pull/1695/commits/4363cb6bf2fc6d61a5886e69c03a6ab4629a37a6 hides a warning that is set when `Time_Residual_RMS` timing errors are set. Our event data model cannot represent that and it should potentially be changed to something else? Support error quantifications include `uncertainty`, `lower_uncertainty`, `upper_uncertainty`, and `confidence_level`.

@calum-chamberlain: Any opinion/preference?


