### PR TITLE
avoid using basemap hires data in tests, could lead to faster installation during CI

### DIFF
--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -589,7 +589,7 @@ class CatalogBasemapTestCase(unittest.TestCase):
                              reltol=reltol) as ic:
             rcParams['savefig.dpi'] = 72
             cat.plot(method='basemap', outfile=ic.name, projection='local',
-                     resolution='i', continent_fill_color='0.3',
+                     resolution='l', continent_fill_color='0.3',
                      color='date', colormap='gist_heat')
 
 

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -462,7 +462,7 @@ class InventoryBasemapTestCase(unittest.TestCase):
         with ImageComparison(self.image_dir, 'inventory_location-basemap3.png',
                              reltol=reltol) as ic:
             rcParams['savefig.dpi'] = 72
-            inv.plot(method='basemap', projection='local', resolution='i',
+            inv.plot(method='basemap', projection='local', resolution='l',
                      size=20**2, color_per_network={'GR': 'b', 'BW': 'green'},
                      outfile=ic.name)
 

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -309,7 +309,7 @@ class NetworkBasemapTestCase(unittest.TestCase):
         with ImageComparison(self.image_dir, 'network_location-basemap3.png',
                              reltol=reltol) as ic:
             rcParams['savefig.dpi'] = 72
-            net.plot(method='basemap', projection='local', resolution='i',
+            net.plot(method='basemap', projection='local', resolution='l',
                      size=13**2, outfile=ic.name)
 
 


### PR DESCRIPTION
..because basemap-hires conda packages don't have to be installed.

Basemap standard build on conda-forge comes with resolution "c" and "l"
only.

If we're lucky image diffs are even still within tolerance..