### PR TITLE
Appveyor improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,13 +39,13 @@ environment:
     #   PYTHON_VERSION: "3.5"
     #   PYTHON_ARCH: "64"
 
-    # - PYTHON: "C:\\Miniconda36"
-    #   PYTHON_VERSION: "3.6"
-    #   PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda36"
       PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
+      PYTHON_ARCH: "32"
+
+    # - PYTHON: "C:\\Miniconda36-x64"
+    #   PYTHON_VERSION: "3.6"
+    #   PYTHON_ARCH: "64"
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\misc\\appveyor\\run_with_env.cmd"
     CI_URL: "--ci-url https://ci.appveyor.com/project/%APPVEYOR_REPO_NAME%/build/1.0.%APPVEYOR_BUILD_NUMBER%-%APPVEYOR_REPO_BRANCH%"
     PR_URL: "--pr-url https://github.com/%APPVEYOR_REPO_NAME%/pull/%APPVEYOR_PULL_REQUEST_NUMBER%"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,21 +23,21 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Miniconda3"
+    #   PYTHON_VERSION: "3.4"
+    #   PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Miniconda3-x64"
+    #   PYTHON_VERSION: "3.4"
+    #   PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda35"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Miniconda35"
+    #   PYTHON_VERSION: "3.5"
+    #   PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Miniconda35-x64"
+    #   PYTHON_VERSION: "3.5"
+    #   PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda36"
       PYTHON_VERSION: "3.6"
@@ -84,7 +84,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema basemap-data-hires"
+  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema basemap-data-hires"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy matplotlib=1.3.1 lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
+  - "conda install -q --yes pip numpy scipy matplotlib<2 lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ environment:
     PR_URL: "--pr-url https://github.com/%APPVEYOR_REPO_NAME%/pull/%APPVEYOR_PULL_REQUEST_NUMBER%"
 
   matrix:
-    # enable fast fail strategy
-    fast_finish: true
-
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
@@ -100,3 +97,7 @@ build: false
 test_script:
   - "%CMD_IN_ENV% python setup.py develop"
   - "python -m obspy.scripts.runtests --no-flake8 -n appveyor-ci -r %CI_URL% %PR_URL%"
+
+matrix:
+  # enable fast fail strategy
+  fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   # Add miniconda path.
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   # Check that we have the expected version and architecture for Python
-  - "%CMD_IN_ENV% python --version"
+  - "%CMD_IN_ENV% python -c 'import sys; print(sys.version)'"
   # Install the build and runtime dependencies of the project.
   - "conda update -q --yes conda"
   # add conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
     PR_URL: "--pr-url https://github.com/%APPVEYOR_REPO_NAME%/pull/%APPVEYOR_PULL_REQUEST_NUMBER%"
 
   matrix:
+    # enable fast fail strategy
+    fast_finish: true
+
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy matplotlib<2 lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
+  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,43 +1,84 @@
 # AppVeyor.com is a Continuous Integration service to build and run tests under Windows
+# see https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
 
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: https://stackoverflow.com/a/13751649
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\misc\\appveyor\\run_with_env.cmd"
-    PYTHON: "C:\\Miniconda-x64"
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
     CI_URL: "--ci-url https://ci.appveyor.com/project/%APPVEYOR_REPO_NAME%/build/1.0.%APPVEYOR_BUILD_NUMBER%-%APPVEYOR_REPO_BRANCH%"
     PR_URL: "--pr-url https://github.com/%APPVEYOR_REPO_NAME%/pull/%APPVEYOR_PULL_REQUEST_NUMBER%"
 
   matrix:
-    - PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      platform: x64
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+    # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      platform: x64
-
-    - PYTHON_VERSION: "2.7"
+    - PYTHON: "C:\\Miniconda" 
+      PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
-      platform: x32
 
-    - PYTHON_VERSION: "3.5"
+    - PYTHON: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda3"
+      PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
-      platform: x32
 
-platform:
-  - Any CPU
+    - PYTHON: "C:\\Miniconda3-x64"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Miniconda35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Miniconda36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+
 
 install:
-  # Add miniconda path.
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+  # Prepend Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
   # Check that we have the expected version and architecture for Python
-  - "%CMD_IN_ENV% python -c 'import sys; print(sys.version)'"
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
   # Install the build and runtime dependencies of the project.
   - "conda update -q --yes conda"
-  # add conda-forge
   - "conda config --add channels conda-forge"
   # Create a conda environment using the required ObsPy packages.
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema basemap-data-hires"
+  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,3 +101,6 @@ test_script:
 matrix:
   # enable fast fail strategy
   fast_finish: true
+
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,22 @@ environment:
   matrix:
     - PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
+      platform: x64
+
+    - PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      platform: x64
+
+    - PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      platform: x32
+
+    - PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+      platform: x32
 
 platform:
-  - x64
+  - Any CPU
 
 install:
   # Add miniconda path.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema"
+  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator \"requests<2.12\" basemap jsonschema basemap-data-hires"
   # additional dependecies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,9 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Miniconda" 
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Miniconda" 
+    #   PYTHON_VERSION: "2.7"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
@@ -39,9 +39,9 @@ environment:
     #   PYTHON_VERSION: "3.5"
     #   PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda36"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Miniconda36"
+    #   PYTHON_VERSION: "3.6"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,8 @@ install:
   - "%CMD_IN_ENV% python --version"
   # Install the build and runtime dependencies of the project.
   - "conda update -q --yes conda"
+  # add conda-forge
+  - "conda config --add channels conda-forge"
   # Create a conda environment using the required ObsPy packages.
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,8 +70,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - "python -c \"import sys; print(sys.version)\""
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,11 +58,11 @@ install:
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
-  - ECHO "Filesystem root:"
-  - ps: "ls \"C:/\""
+  # - ECHO "Filesystem root:"
+  # - ps: "ls \"C:/\""
 
-  - ECHO "Installed SDKs:"
-  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+  # - ECHO "Installed SDKs:"
+  # - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
 
   # Prepend Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart

--- a/misc/appveyor/run_with_env.cmd
+++ b/misc/appveyor/run_with_env.cmd
@@ -6,46 +6,83 @@
 :: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
 :: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
 ::
-:: 32 bit builds do not require specific environment configurations.
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
 ::
 :: Note: this script needs to be run with the /E:ON and /V:ON flags for the
 :: cmd interpreter, at least for (SDK v7.0)
 ::
 :: More details at:
 :: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
-:: https://stackoverflow.com/a/13751649
+:: http://stackoverflow.com/a/13751649/163740
 ::
 :: Author: Olivier Grisel
-:: License: CC0 1.0 Universal: https://creativecommons.org/publicdomain/zero/1.0/
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
 @ECHO OFF
 
 SET COMMAND_TO_RUN=%*
 SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
 
-SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
-IF %MAJOR_PYTHON_VERSION% == "2" (
-    SET WINDOWS_SDK_VERSION="v7.0"
-) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
-    SET WINDOWS_SDK_VERSION="v7.1"
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
 ) ELSE (
-    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
-    EXIT 1
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
 )
 
-IF "%PYTHON_ARCH%"=="64" (
-    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
-    SET DISTUTILS_USE_SDK=1
-    SET MSSdk=1
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
-    ECHO Executing: %COMMAND_TO_RUN%
-    call %COMMAND_TO_RUN% || EXIT 1
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
 ) ELSE (
-    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 32 bit architecture
-    SET DISTUTILS_USE_SDK=1
-    SET MSSdk=1
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x86 /release
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
     ECHO Executing: %COMMAND_TO_RUN%
     call %COMMAND_TO_RUN% || EXIT 1
 )


### PR DESCRIPTION
- now building Py2.7/64 bit and Py3.6/32bit
- enabled rolling builds: whenever you do a new commit to the same branch OR pull request all current queued/running builds for that branch or PR are cancelled and the new one is queued. 
- enabled fast finish:  if first job has failed the entire build is marked as failed and no further jobs will start
- do not build feature branch with open Pull Requests

todo in future: add +TESTS magic to enable building the full matrix (py2.7 - py3.6, 32 and 64bit)

IMHO ready to merge see: https://ci.appveyor.com/project/obspy/obspy/build/1.0.4368-appveyor
