### PR TITLE
earthworm client: slow stream cleanup

### DIFF
--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -123,7 +123,7 @@ class Client(object):
         if cleanup:
             st._cleanup()
 
-        # only traces from the first and last tracebug need to be trimmed
+        # only traces from the first and last tracebuf need to be trimmed
         st[0].trim(starttime, endtime)
         st[len(st)-1].trim(starttime, endtime)
 

--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -122,7 +122,11 @@ class Client(object):
             st.append(tb.get_obspy_trace())
         if cleanup:
             st._cleanup()
-        st.trim(starttime, endtime)
+
+        # only traces from the first and last tracebug need to be trimmed
+        st[0].trim(starttime, endtime)
+        st[len(st)-1].trim(starttime, endtime)
+
         return st
 
     @deprecated("'saveWaveform' has been renamed to 'save_waveforms'. Use "


### PR DESCRIPTION
Earthworm's waveserverV returns data in an ordered set of small chucks. The first chuck returned may start before the requested start time, and the last chuck returned may end after the requested end time. The time required to trim the data using Stream.trim() grows linearly with the number of data chunks returned by the server.

This change replaces the call to Stream.trim() with individual calls to trim only the first and the last trace in the Stream.
