### PR TITLE
Travis: fast fail builds if newer builds for the branch/PR are already queued

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ matrix:
     - os: osx
       env: PYTHON_VERSION=3.5
 
+# mimick travis fast fail and rolling build setup from:
+# https://github.com/JuliaLang/julia/blob/master/.travis.yml
+before_install:
+  - if [ `uname` = "Darwin" ]; then brew update; brew install -v jq; fi
+  - curl "https://raw.githubusercontent.com/JuliaLang/julia/master/contrib/travis_fastfail.sh" -o "/tmp/fastfail.sh" || echo "Failed to fetch travis_fastfail.sh"
+  - if [ -f /tmp/fastfail.sh ]; then chmod u+x /tmp/fastfail.sh; /tmp/fastfail.sh || exit 1; fi
+
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";


### PR DESCRIPTION
This PR enables a strategy to reduce number of redundant Travis builds by reusing `travis_fastfail.sh` implemented by Julia developers.