### PR TITLE
Proof of concept: Using scipy instead evalresp

### DIFF
--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -149,25 +149,25 @@ class ResponseTestCase(unittest.TestCase):
                 np.unwrap(np.angle(new_resp))[:800],
                 rtol=1E-2, atol=2E-2)
 
-        # import matplotlib.pyplot as plt
-        # plt.subplot(411)
-        # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
-        # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
-        # plt.legend(loc=3)
-        # plt.subplot(412)
-        # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
-        # plt.subplot(413)
-        #
-        # new_phase = np.angle(new_resp)
-        # xml_phase = np.angle(xml_resp)
-        #
-        # plt.semilogx(freqs, xml_phase, label="evalresp")
-        # plt.semilogx(freqs, new_phase, label="scipy")
-        # plt.legend(loc=3)
-        # plt.xlim(1E-2, 20.0)
-        # plt.subplot(414)
-        # plt.semilogx(freqs,xml_phase - new_phase)
-        # plt.show()
+            # import matplotlib.pyplot as plt
+            # plt.subplot(411)
+            # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
+            # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
+            # plt.legend(loc=3)
+            # plt.subplot(412)
+            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
+            # plt.subplot(413)
+            #
+            # new_phase = np.angle(new_resp)
+            # xml_phase = np.angle(xml_resp)
+            #
+            # plt.semilogx(freqs, xml_phase, label="evalresp")
+            # plt.semilogx(freqs, new_phase, label="scipy")
+            # plt.legend(loc=3)
+            # plt.xlim(1E-2, 20.0)
+            # plt.subplot(414)
+            # plt.semilogx(freqs,xml_phase - new_phase)
+            # plt.show()
 
     def test_evalresp_with_output_from_seed(self):
         """

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -52,99 +52,95 @@ class ResponseTestCase(unittest.TestCase):
         np.seterr(**self.nperr)
 
     def test_get_response(self):
-        units = ["DISP", "VEL", "ACC"]
-        units = ["VEL"]
-        filenames = ["IRIS_single_channel_with_response"]
+        unit = "VEL"
+        filename = "IRIS_single_channel_with_response"
 
-        for filename in filenames:
-            xml_filename = os.path.join(self.data_dir,
-                                        filename + os.path.extsep + "xml")
-            inv = read_inventory(xml_filename)
-            resp = inv[0][0][0].response
+        xml_filename = os.path.join(self.data_dir,
+                                    filename + os.path.extsep + "xml")
+        inv = read_inventory(xml_filename)
+        resp = inv[0][0][0].response
 
-            freqs = np.logspace(-2, 2, 1000)
+        freqs = np.logspace(-2, 2, 1000)
 
-            # PAZ stage.
-            xml_resp = resp.get_evalresp_response_for_frequencies(
-                frequencies=freqs, output=units[0],
-                start_stage=1,
-                end_stage=1)
-            new_resp = resp.get_response(
-                frequencies=freqs, output=units[0],
-                start_stage=1,
-                end_stage=1)
-            np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
-            np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+        # PAZ stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=1,
+            end_stage=1)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=1,
+            end_stage=1)
+        np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+        np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
 
-            # Decimation stage.
-            xml_resp = resp.get_evalresp_response_for_frequencies(
-                frequencies=freqs, output=units[0],
-                start_stage=2,
-                end_stage=2)
-            new_resp = resp.get_response(
-                frequencies=freqs, output=units[0],
-                start_stage=2,
-                end_stage=2)
-            np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
-            np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+        # Decimation stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=2,
+            end_stage=2)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=2,
+            end_stage=2)
+        np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+        np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
 
-            # Coefficients stage.
-            xml_resp = resp.get_evalresp_response_for_frequencies(
-                frequencies=freqs, output=units[0],
-                start_stage=3,
-                end_stage=3)
-            new_resp = resp.get_response(
-                frequencies=freqs, output=units[0],
-                start_stage=3,
-                end_stage=3)
-            # Amplitude if fully identical everywhere.
-            np.testing.assert_allclose(np.abs(xml_resp), np.abs(new_resp))
-            # Phase starts to differ slightly before Nyquist and quite a bit
-            # after. Evalresp appears to have some Gibb's artifacts and
-            # scipy's solution does look better.
-            np.testing.assert_allclose(
-                np.unwrap(np.angle(xml_resp))[:800],
-                np.unwrap(np.angle(new_resp))[:800],
-                rtol=1E-2, atol=2E-2)
+        # Coefficients stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=3,
+            end_stage=3)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=3,
+            end_stage=3)
+        # Amplitude if fully identical everywhere.
+        np.testing.assert_allclose(np.abs(xml_resp), np.abs(new_resp))
+        # Phase starts to differ slightly before Nyquist and quite a bit
+        # after. Evalresp appears to have some Gibb's artifacts and
+        # scipy's solution does look better.
+        np.testing.assert_allclose(
+            np.unwrap(np.angle(xml_resp))[:800],
+            np.unwrap(np.angle(new_resp))[:800],
+            rtol=1E-2, atol=2E-2)
 
-            # Full response.
-            xml_resp = resp.get_evalresp_response_for_frequencies(
-                frequencies=freqs, output=units[0])
-            new_resp = resp.get_response(
-                frequencies=freqs, output=units[0])
+        # Full response.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit)
 
-            print(np.abs(xml_resp).max() / np.abs(new_resp).max())
+        #np.abs(new_resp), rtol=1E-6)
+        np.testing.assert_allclose(np.abs(xml_resp),
+                                   np.abs(new_resp), rtol=1E-5)
+        # Phase starts to differ slightly before Nyquist and quite a bit
+        # after. Evalresp appears to have some Gibb's artifacts and
+        # scipy's solution does look better.
+        np.testing.assert_allclose(
+            np.unwrap(np.angle(xml_resp))[:800],
+            np.unwrap(np.angle(new_resp))[:800],
+            rtol=1E-2, atol=2E-2)
 
-            #np.abs(new_resp), rtol=1E-6)
-            np.testing.assert_allclose(np.abs(xml_resp),
-                                       np.abs(new_resp), rtol=1E-5)
-            # Phase starts to differ slightly before Nyquist and quite a bit
-            # after. Evalresp appears to have some Gibb's artifacts and
-            # scipy's solution does look better.
-            np.testing.assert_allclose(
-                np.unwrap(np.angle(xml_resp))[:800],
-                np.unwrap(np.angle(new_resp))[:800],
-                rtol=1E-2, atol=2E-2)
-
-            # import matplotlib.pyplot as plt
-            # plt.subplot(411)
-            # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
-            # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
-            # plt.legend(loc=3)
-            # plt.subplot(412)
-            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
-            # plt.subplot(413)
-            #
-            # new_phase = np.angle(new_resp)
-            # xml_phase = np.angle(xml_resp)
-            #
-            # plt.semilogx(freqs, xml_phase, label="evalresp")
-            # plt.semilogx(freqs, new_phase, label="scipy")
-            # plt.legend(loc=3)
-            # plt.xlim(1E-2, 20.0)
-            # plt.subplot(414)
-            # plt.semilogx(freqs,xml_phase - new_phase)
-            # plt.show()
+        # import matplotlib.pyplot as plt
+        # plt.subplot(411)
+        # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
+        # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
+        # plt.legend(loc=3)
+        # plt.subplot(412)
+        # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
+        # plt.subplot(413)
+        #
+        # new_phase = np.angle(new_resp)
+        # xml_phase = np.angle(xml_resp)
+        #
+        # plt.semilogx(freqs, xml_phase, label="evalresp")
+        # plt.semilogx(freqs, new_phase, label="scipy")
+        # plt.legend(loc=3)
+        # plt.xlim(1E-2, 20.0)
+        # plt.subplot(414)
+        # plt.semilogx(freqs,xml_phase - new_phase)
+        # plt.show()
 
     def test_evalresp_with_output_from_seed(self):
         """

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -51,6 +51,101 @@ class ResponseTestCase(unittest.TestCase):
     def tearDown(self):
         np.seterr(**self.nperr)
 
+    def test_get_response(self):
+        units = ["DISP", "VEL", "ACC"]
+        units = ["VEL"]
+        filenames = ["IRIS_single_channel_with_response"]
+
+        for filename in filenames:
+            xml_filename = os.path.join(self.data_dir,
+                                        filename + os.path.extsep + "xml")
+            inv = read_inventory(xml_filename)
+            resp = inv[0][0][0].response
+
+            freqs = np.logspace(-2, 2, 1000)
+
+            # PAZ stage.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=units[0],
+                start_stage=1,
+                end_stage=1)
+            new_resp = resp.get_response(
+                frequencies=freqs, output=units[0],
+                start_stage=1,
+                end_stage=1)
+            np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+            np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+
+            # Decimation stage.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=units[0],
+                start_stage=2,
+                end_stage=2)
+            new_resp = resp.get_response(
+                frequencies=freqs, output=units[0],
+                start_stage=2,
+                end_stage=2)
+            np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+            np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+
+            # Coefficients stage.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=units[0],
+                start_stage=3,
+                end_stage=3)
+            new_resp = resp.get_response(
+                frequencies=freqs, output=units[0],
+                start_stage=3,
+                end_stage=3)
+            # Amplitude if fully identical everywhere.
+            np.testing.assert_allclose(np.abs(xml_resp), np.abs(new_resp))
+            # Phase starts to differ slightly before Nyquist and quite a bit
+            # after. Evalresp appears to have some Gibb's artifacts and
+            # scipy's solution does look better.
+            np.testing.assert_allclose(
+                np.unwrap(np.angle(xml_resp))[:800],
+                np.unwrap(np.angle(new_resp))[:800],
+                rtol=1E-2, atol=2E-2)
+
+            # Full response.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=units[0])
+            new_resp = resp.get_response(
+                frequencies=freqs, output=units[0])
+
+            print(np.abs(xml_resp).max() / np.abs(new_resp).max())
+
+            #np.abs(new_resp), rtol=1E-6)
+            np.testing.assert_allclose(np.abs(xml_resp),
+                                       np.abs(new_resp), rtol=1E-5)
+            # Phase starts to differ slightly before Nyquist and quite a bit
+            # after. Evalresp appears to have some Gibb's artifacts and
+            # scipy's solution does look better.
+            np.testing.assert_allclose(
+                np.unwrap(np.angle(xml_resp))[:800],
+                np.unwrap(np.angle(new_resp))[:800],
+                rtol=1E-2, atol=2E-2)
+
+            # import matplotlib.pyplot as plt
+            # plt.subplot(411)
+            # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
+            # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
+            # plt.legend(loc=3)
+            # plt.subplot(412)
+            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
+            # plt.subplot(413)
+            #
+            # new_phase = np.angle(new_resp)
+            # xml_phase = np.angle(xml_resp)
+            #
+            # plt.semilogx(freqs, xml_phase, label="evalresp")
+            # plt.semilogx(freqs, new_phase, label="scipy")
+            # plt.legend(loc=3)
+            # plt.xlim(1E-2, 20.0)
+            # plt.subplot(414)
+            # plt.semilogx(freqs,xml_phase - new_phase)
+            # plt.show()
+
     def test_evalresp_with_output_from_seed(self):
         """
         The StationXML file has been converted to SEED with the help of a tool

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -111,7 +111,6 @@ class ResponseTestCase(unittest.TestCase):
         new_resp = resp.get_response(
             frequencies=freqs, output=unit)
 
-        #np.abs(new_resp), rtol=1E-6)
         np.testing.assert_allclose(np.abs(xml_resp),
                                    np.abs(new_resp), rtol=1E-5)
         # Phase starts to differ slightly before Nyquist and quite a bit
@@ -121,6 +120,34 @@ class ResponseTestCase(unittest.TestCase):
             np.unwrap(np.angle(xml_resp))[:800],
             np.unwrap(np.angle(new_resp))[:800],
             rtol=1E-2, atol=2E-2)
+
+    def test_get_response_disp_vel_acc(self):
+        units = ["DISP", "VEL", "ACC"]
+        filename = "IRIS_single_channel_with_response"
+
+        xml_filename = os.path.join(self.data_dir,
+                                    filename + os.path.extsep + "xml")
+        inv = read_inventory(xml_filename)
+        resp = inv[0][0][0].response
+
+        freqs = np.logspace(-2, 2, 1000)
+
+        for unit in units:
+            # Full response.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=unit)
+            new_resp = resp.get_response(
+                frequencies=freqs, output=unit)
+
+            np.testing.assert_allclose(np.abs(xml_resp),
+                                       np.abs(new_resp), rtol=1E-5)
+            # Phase starts to differ slightly before Nyquist and quite a bit
+            # after. Evalresp appears to have some Gibb's artifacts and
+            # scipy's solution does look better.
+            np.testing.assert_allclose(
+                np.unwrap(np.angle(xml_resp))[:800],
+                np.unwrap(np.angle(new_resp))[:800],
+                rtol=1E-2, atol=2E-2)
 
         # import matplotlib.pyplot as plt
         # plt.subplot(411)

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -350,7 +350,8 @@ def corn_freq_2_paz(fc, damp=0.707):
     return {'poles': poles, 'zeros': [0j, 0j], 'gain': 1, 'sensitivity': 1.0}
 
 
-def paz_to_freq_resp(poles, zeros, scale_fac, t_samp, nfft, freq=False):
+def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
+                     frequencies=None, freq=False):
     """
     Convert Poles and Zeros (PAZ) to frequency response. The output
     contains the frequency zero which is the offset of the trace.
@@ -380,15 +381,20 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp, nfft, freq=False):
         negative values in order to get a plot from [0, 2pi]:
         where(phi<0,phi+2*pi,phi); plot(f,phi)
     """
-    n = nfft // 2
     b, a = scipy.signal.ltisys.zpk2tf(zeros, poles, scale_fac)
     # a has to be a list for the scipy.signal.freqs() call later but zpk2tf()
     # strangely returns it as an integer.
     if not isinstance(a, np.ndarray) and a == 1.0:
         a = [1.0]
-    fy = 1 / (t_samp * 2.0)
-    # start at zero to get zero for offset / DC of fft
-    f = np.linspace(0, fy, n + 1)
+
+    if frequencies is None:
+        n = nfft // 2
+        fy = 1 / (t_samp * 2.0)
+        # start at zero to get zero for offset / DC of fft
+        f = np.linspace(0, fy, n + 1)
+    else:
+        f = frequencies
+
     _w, h = scipy.signal.freqs(b, a, f * 2 * np.pi)
     if freq:
         return h, f


### PR DESCRIPTION
Based on the discussion in https://github.com/obspy/obspy/issues/1493 it came to me that it would be almost trivial to replace evalresp completely with scipy. I don't know why I did not think of this before. Much simpler than our current wrapping of evalresp.

This PR does this for the PAZ, decimation, and coefficient response stages which are the most common and it also handles the final assembly and sensitivity calculations so it can already do quite a lot of responses. The rest is quite easy to add.

Of course this needs a lot more testing so I'd personally not include this in the upcoming 1.1 but rather wait a release.

The amplitude response matches the evalresp one to a relative error of 1E-10 - the sensitivity scaling makes this a bit different but I think what's done in this PR is correct. The phase differs a bit more for the FIR stage mainly after nyquist but also a tiny bit before. Again I think here scipy does the correct thing as it for example has no Gibb's artifacts which evalresp has.