### PR TITLE
more verbose TypeErrors in trace.__add__

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,7 @@ install:
   - "activate test"
   # Install default dependencies
   #   for now fix requests version, can be changed when a new requests is released (see #1599)
-  - "conda install -q --yes pip numpy scipy \"matplotlib<2\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema"
+  - "conda install -q --yes pip numpy scipy \"matplotlib<1.9\" lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema"
   # additional dependencies
   - "pip install pyimgur"
   - "pip install -U future"

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -667,16 +667,21 @@ class Trace(object):
                 raise TypeError
             #  check id
             if self.get_id() != trace.get_id():
-                raise TypeError("Trace ID differs")
+                raise TypeError("Trace ID differs: %s vs %s" %
+                                (self.get_id(), trace.get_id()))
             #  check sample rate
             if self.stats.sampling_rate != trace.stats.sampling_rate:
-                raise TypeError("Sampling rate differs")
+                raise TypeError("Sampling rate differs: %s vs %s" %
+                                (self.stats.sampling_rate,
+                                 trace.stats.sampling_rate))
             #  check calibration factor
             if self.stats.calib != trace.stats.calib:
-                raise TypeError("Calibration factor differs")
+                raise TypeError("Calibration factor differs: %s vs %s" %
+                                (self.stats.calib, trace.stats.calib))
             # check data type
             if self.data.dtype != trace.data.dtype:
-                raise TypeError("Data type differs")
+                raise TypeError("Data type differs: %s vs %s" %
+                                (self.data.dtype, trace.data.dtype))
         # check times
         if self.stats.starttime <= trace.stats.starttime:
             lt = self


### PR DESCRIPTION
### What does this PR do?
Just adds some verbosity in the sanity checks done in the __add__ method of traces.

### Why was it initiated?  Any relevant Issues?
It's soooooo frustrating to debug 
```TypeError("Data type differs") ```

### PR Checklist
- [x] All tests still pass.
- [X] Significant changes have been added to `CHANGELOG.txt`  (is this significant? don't think so)

