### PR TITLE
MSEED: Segfault reading truncated file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,8 +93,9 @@ master: (doi: 10.5281/zenodo.165135)
    * Update to libmseed v2.19.2 (see #1703).
    * Correctly read MiniSEED files with a data offset of 48 bytes (see #1540).
    * InternalMSEEDReadingError now called InternalMSEEDError and
-	 InternalMSEEDReadingWarning now called of InternalMSEEDWarning as both
-	 can now also be raised in non-reading contexts (see #1658).
+     InternalMSEEDReadingWarning now called of InternalMSEEDWarning as both
+     can now also be raised in non-reading contexts (see #1658).
+   * Should no-longer segfault with arbitrarily truncated files (see #1728).
  - obspy.io.nlloc:
    * Set preferred origin of event (see #1570)
  - obspy.io.nordic:

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -257,6 +257,21 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
     else:
         bo = None
 
+    # Determine total size. Either its a file-like object.
+    if hasattr(mseed_object, "tell") and hasattr(mseed_object, "seek"):
+        cur_pos = mseed_object.tell()
+        mseed_object.seek(0, 2)
+        length = mseed_object.tell() - cur_pos
+        mseed_object.seek(cur_pos, 0)
+    # Or a file name.
+    else:
+        length = os.path.getsize(mseed_object)
+
+    if length < 128:
+        msg = "The smallest possible mini-SEED record is made up of 128 " \
+              "bytes. The passed buffer or file contains only %i." % length
+        raise ValueError(msg)
+
     info = util.get_record_information(mseed_object, endian=bo)
 
     # Map the encoding to a readable string value.

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -375,12 +375,14 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
             msr_free(&msr);
             break;
         }
-        // msr_parse() returns > 0 if a data record has been detected but the buffer either has not enough
-        // data (this cannot happen with ObsPy's logic) or the last record has no Blockette 1000 and it cannot
-        // determine the record length because there is no next record (this can happen in ObsPy) - handle that
-        // case by just calling msr_parse() with an explicit record length set.
+        // Data missing at the end.
+        else if (retcode > 0 && retcode > (buflen - offset)) {
+            log_error(MS_ENDOFFILE, offset);
+            msr_free(&msr);
+            break;
+        }
+        // Lacking Blockette 1000.
         else if ( retcode > 0 && retcode < (buflen - offset)) {
-
             // Check if the remaining bytes can exactly make up a record length.
             int r_bytes = buflen - offset;
             float exp = log10((float)r_bytes) / log10(2.0);

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -376,7 +376,7 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
             break;
         }
         // Data missing at the end.
-        else if (retcode > 0 && retcode > (buflen - offset)) {
+        else if (retcode > 0 && retcode >= (buflen - offset)) {
             log_error(MS_ENDOFFILE, offset);
             msr_free(&msr);
             break;

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1052,6 +1052,19 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             st[0].data[:6],
             [337, 396, 454, 503, 547, 581])
 
+    def test_reading_truncated_miniseed_files(self):
+        """
+        Regression test to guard against a segfault.
+        """
+        filename = os.path.join(self.path, 'data',
+                                'BW.BGLD.__.EHE.D.2008.001.first_10_records')
+
+        with io.open(filename, 'rb') as fh:
+            data = fh.read()
+
+        with io.BytesIO(data[:-257]) as buf:
+            _read_mseed(buf)
+
 
 def suite():
     return unittest.makeSuite(MSEEDSpecialIssueTestCase, 'test')

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1075,7 +1075,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 st = _read_mseed(buf)
         self.assertEqual(len(st), 1)
         self.assertEqual(len(w), 1)
-        self.assertIs(w[0].category, InternalMSEEDReadingWarning)
+        self.assertIs(w[0].category, InternalMSEEDWarning)
         self.assertEqual("readMSEEDBuffer(): Unexpected end of file when "
                          "parsing record starting at offset 4608. The rest of "
                          "the file will not be read.", w[0].message.args[0])
@@ -1104,7 +1104,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 st = _read_mseed(buf)
         self.assertEqual(len(st), 1)
         self.assertEqual(len(w), 1)
-        self.assertIs(w[0].category, InternalMSEEDReadingWarning)
+        self.assertIs(w[0].category, InternalMSEEDWarning)
         self.assertEqual("readMSEEDBuffer(): Unexpected end of file when "
                          "parsing record starting at offset 4608. The rest of "
                          "the file will not be read.", w[0].message.args[0])
@@ -1129,7 +1129,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 st = _read_mseed(buf)
         self.assertEqual(len(st), 0)  # nothing is read here.
         self.assertGreaterEqual(len(w), 1)
-        self.assertIs(w[-1].category, InternalMSEEDReadingWarning)
+        self.assertIs(w[-1].category, InternalMSEEDWarning)
         self.assertEqual("readMSEEDBuffer(): Unexpected end of file when "
                          "parsing record starting at offset 0. The rest of "
                          "the file will not be read.", w[-1].message.args[0])


### PR DESCRIPTION
While trying to work around a problem when reasding truncated files (in SDS client while reading files that are currently being appended to by a different program), I came across a segfault when reading truncated MiniSEED files:

```python
import copy
from io import BytesIO
from obspy import read
from obspy.core.util import get_example_file

file_ = get_example_file('BW.BGLD.__.EHE.D.2008.001.first_10_records')

with open(file_, 'rb') as fh: 
    data = fh.read()

# for i in range(1, 1000):
for i in [257]:
    print(i)
    bio = BytesIO(copy.deepcopy(data[:-i]))
    read(bio, format='MSEED')
```

```
$ python read_mseed_truncated.py 
257
Segmentation fault
```