### PR TITLE
fdsn mass downloader: skip some known failures on ancient scipy

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -513,12 +513,28 @@ Further functionality of this module is documented at a couple of other places:
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import native_str
 
+import warnings
+
+import scipy
+
+from obspy.core.util.base import get_scipy_version
 # Convenience imports.
 from .mass_downloader import MassDownloader  # NOQA
 from .restrictions import Restrictions  # NOQA
 from .domain import (Domain, RectangularDomain,  # NOQA
                      CircularDomain, GlobalDomain)  # NOQA
+
+
+__all__ = [native_str(i) for i in (
+    'MassDownloader', 'Restrictions', 'Domain', 'RectangularDomain',
+    'CircularDomain', 'GlobalDomain')]
+
+if get_scipy_version() < [0, 12]:
+    msg = ('At least some parts of FDSN Mass downloader might not '
+           'work with old scipy versions <0.12.0 (installed: {})')
+    warnings.warn(msg.format(scipy.__version__))
 
 
 if __name__ == '__main__':

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -27,7 +27,7 @@ import numpy as np
 
 import obspy
 from obspy.core.compatibility import mock
-from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.base import NamedTemporaryFile, get_scipy_version
 from obspy.clients.fdsn import Client
 from obspy.clients.fdsn.mass_downloader import (domain, Restrictions,
                                                 MassDownloader)
@@ -37,6 +37,9 @@ from obspy.clients.fdsn.mass_downloader.utils import (
     download_stationxml, download_and_split_mseed_bulk)
 from obspy.clients.fdsn.mass_downloader.download_helpers import (
     Channel, TimeInterval, Station, STATUS, ClientDownloadHelper)
+
+
+SCIPY_VERSION = get_scipy_version()
 
 
 class DomainTestCase(unittest.TestCase):
@@ -414,6 +417,8 @@ class DownloadHelpersUtilTestCase(unittest.TestCase):
             channels, key="location", priorities=None)
         self.assertEqual(filtered_channels, channels)
 
+    @unittest.skipIf(SCIPY_VERSION < [0, 12],
+                     'scipy version 0.12 or higher needed.')
     def test_spherical_nearest_neighbour(self):
         """
         Tests the spherical kd-tree.
@@ -1812,6 +1817,8 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
             "Station "
         ))
 
+    @unittest.skipIf(SCIPY_VERSION < [0, 12],
+                     'scipy version 0.12 or higher needed.')
     def test_station_list_nearest_neighbour_filter(self):
         """
         Test the filtering based on geographical distance.
@@ -2573,6 +2580,8 @@ class DownloadHelperTestCase(unittest.TestCase):
     @mock.patch("os.makedirs")
     @mock.patch("logging.Logger.info")
     @mock.patch("logging.Logger.warning")
+    @unittest.skipIf(SCIPY_VERSION < [0, 12],
+                     'scipy version 0.12 or higher needed.')
     def test_download_method(self, _log_w, _log_p, _patch_makedirs,
                              patch_dl_mseed, patch_dl_stationxml,
                              patch_get_avail, patch_discover):


### PR DESCRIPTION
Skip some known failures on ancient scipy < 0.12, see e.g. http://tests.obspy.org/74905/