### PR TITLE
zerophase filter breaks C_CONTIGUOUS array layout

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ master: (doi: 10.5281/zenodo.165135)
      obspy.io.reftek (see #1433)
    * Add Nordic format (s-file) read/write (see #1517)
  - obspy.core:
+   * Ensure that Trace.data is always C-contiguous in memory (see #1732)
    * Event/ResourceIdentifier is now object aware, meaning even if two
      objects share a resource_id the distinct objects will be returned with
      the get_referred_object method provided both are still in scope. If one


### PR DESCRIPTION
I discovered the following issue when I wanted to interpolate data after a zerophase lowpass filter.
A non-zero phase filter maintains the C_CONTIGUOUS layout of the data array.
Since I know very little about these details on memory layouts I'm pretty uncertain how relevant that problem actually is.

Best
Christian

```python
> In [582]: import obspy
> 
> In [583]: obspy.__version__
> Out[583]: '1.0.3'
> 
> In [584]: tr = obspy.read()[0]
> 
> In [585]: tr.data.flags
> Out[585]: 
>   C_CONTIGUOUS : True
>   F_CONTIGUOUS : True
>   OWNDATA : True
>   WRITEABLE : True
>   ALIGNED : True
>   UPDATEIFCOPY : False
> 
> In [586]: tr.filter('lowpass', freq=10., zerophase=True)
> Out[586]: BW.RJOB..EHZ | 2009-08-24T00:20:03.000000Z - 2009-08-24T00:20:32.990000Z | 100.0 Hz, 3000 samples
> 
> In [587]: tr.data.flags
> Out[587]: 
>   C_CONTIGUOUS : False
>   F_CONTIGUOUS : False
>   OWNDATA : False
>   WRITEABLE : True
>   ALIGNED : True
>   UPDATEIFCOPY : False
> 
> In [588]: tr.interpolate(10.)
> ---------------------------------------------------------------------------
> ArgumentError                             Traceback (most recent call last)
> <ipython-input-588-e3a8747f6e59> in <module>()
> ----> 1 tr.interpolate(10.)
> 
> /usr/lib/python2.7/dist-packages/obspy/core/trace.py in interpolate(self, sampling_rate, method, starttime, npts, time_shift, *args, **kwargs)
> 
> /usr/lib/python2.7/dist-packages/obspy/core/util/decorator.py in skip_if_no_data(func, *args, **kwargs)
>     241     if not args[0]:
>     242         return
> --> 243     return func(*args, **kwargs)
>     244 
>     245 
> 
> /usr/lib/python2.7/dist-packages/obspy/core/trace.py in interpolate(self, sampling_rate, method, starttime, npts, time_shift, *args, **kwargs)
> 
> /usr/lib/python2.7/dist-packages/obspy/core/util/decorator.py in raise_if_masked(func, *args, **kwargs)
>     230                   "unmasked Traces."
>     231             raise NotImplementedError(msg)
> --> 232     return func(*args, **kwargs)
>     233 
>     234 
> 
> /usr/lib/python2.7/dist-packages/obspy/core/trace.py in interpolate(self, sampling_rate, method, starttime, npts, time_shift, *args, **kwargs)
> 
> /usr/lib/python2.7/dist-packages/obspy/core/trace.py in _add_processing_info(func, *args, **kwargs)
>     230     info = info % "::".join(arguments)
>     231     self = args[0]
> --> 232     result = func(*args, **kwargs)
>     233     # Attach after executing the function to avoid having it attached
>     234     # while the operation failed.
> 
> /usr/lib/python2.7/dist-packages/obspy/core/trace.py in interpolate(self, sampling_rate, method, starttime, npts, time_shift, *args, **kwargs)
>    2361             self.data = np.atleast_1d(func(
>    2362                 np.require(self.data, dtype=np.float64), old_start, old_dt,
> -> 2363                 starttime, dt, npts, type=method, *args, **kwargs))
>    2364             self.stats.starttime = UTCDateTime(starttime)
>    2365             self.stats.delta = dt
> 
> /usr/lib/python2.7/dist-packages/obspy/signal/interpolation.py in weighted_average_slopes(data, old_start, old_dt, new_start, new_dt, new_npts, *args, **kwargs)
>     169     clibsignal.hermite_interpolation(data, slope, new_time_array, return_data,
>     170                                      len(data), len(return_data), old_dt,
> --> 171                                      old_start)
>     172     return return_data
>     173 
> 
> ArgumentError: argument 1: <type 'exceptions.TypeError'>: array must have flags ['C_CONTIGUOUS']
```