### PR TITLE
SDS client: ignore <128 bytes MSEED files

### DIFF
--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -43,10 +43,13 @@ from obspy.core.trace import Trace  # NOQA
 from obspy.core.stream import Stream, read
 from obspy.core.event import read_events, Catalog
 from obspy.core.inventory import read_inventory, Inventory  # NOQA
+from obspy.core.util.obspy_types import (
+    ObsPyException, ObsPyReadingError)  # NOQA
 
 
 __all__ = ["UTCDateTime", "Trace", "__version__", "Stream", "read",
-           "read_events", "Catalog", "read_inventory"]
+           "read_events", "Catalog", "read_inventory", "ObsPyException",
+           "ObsPyReadingError"]
 __all__ = [native_str(i) for i in __all__]
 
 

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -50,7 +50,7 @@ import numpy as np
 from obspy import Stream, read, UTCDateTime
 from obspy.core.stream import _headonly_warning_msg
 from obspy.core.util.misc import BAND_CODE
-from obspy.io.mseed.headers import FILESIZE_TOO_SMALL_MSG
+from obspy.io.mseed import ObsPyMSEEDFilesizeTooSmallError
 
 
 SDS_FMTSTR = os.path.join(
@@ -174,15 +174,12 @@ class Client(object):
             try:
                 st += read(full_path, format=self.format, starttime=starttime,
                            endtime=endtime, sourcename=seed_pattern, **kwargs)
-            except Exception as e:
+            except ObsPyMSEEDFilesizeTooSmallError:
                 # just ignore small MSEED files, in use cases working with
                 # near-realtime data these are usually just being created right
                 # at request time, e.g. when fetching current data right after
                 # midnight
-                if (self.format in ('MSEED', None) and
-                        str(e).startswith(FILESIZE_TOO_SMALL_MSG)):
-                    continue
-                raise
+                continue
 
         # make sure we only have the desired data, just in case the file
         # contents do not match the expected SEED id
@@ -403,15 +400,12 @@ class Client(object):
                 try:
                     st = read(filename, format=self.format, headonly=True,
                               sourcename=seed_pattern)
-                except Exception as e:
+                except ObsPyMSEEDFilesizeTooSmallError:
                     # just ignore small MSEED files, in use cases working with
                     # near-realtime data these are usually just being created
                     # right at request time, e.g. when fetching current data
                     # right after midnight
-                    if (self.format in ('MSEED', None) and
-                            str(e).startswith(FILESIZE_TOO_SMALL_MSG)):
-                        st = None
-                    raise
+                    st = None
                 else:
                     st = st.select(network=network, station=station,
                                    location=location, channel=channel)

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -50,6 +50,7 @@ import numpy as np
 from obspy import Stream, read, UTCDateTime
 from obspy.core.stream import _headonly_warning_msg
 from obspy.core.util.misc import BAND_CODE
+from obspy.io.mseed.headers import FILESIZE_TOO_SMALL_MSG
 
 
 SDS_FMTSTR = os.path.join(
@@ -111,7 +112,7 @@ class Client(object):
             raise IOError(msg)
         self.sds_root = sds_root
         self.sds_type = sds_type
-        self.format = format
+        self.format = format and format.upper()
         self.fileborder_seconds = fileborder_seconds
         self.fileborder_samples = fileborder_samples
 
@@ -170,8 +171,18 @@ class Client(object):
             channel=channel, starttime=starttime, endtime=endtime,
             sds_type=sds_type)
         for full_path in full_paths:
-            st += read(full_path, format=self.format, starttime=starttime,
-                       endtime=endtime, sourcename=seed_pattern, **kwargs)
+            try:
+                st += read(full_path, format=self.format, starttime=starttime,
+                           endtime=endtime, sourcename=seed_pattern, **kwargs)
+            except Exception as e:
+                # just ignore small MSEED files, in use cases working with
+                # near-realtime data these are usually just being created right
+                # at request time, e.g. when fetching current data right after
+                # midnight
+                if (self.format in ('MSEED', None) and
+                        str(e).startswith(FILESIZE_TOO_SMALL_MSG)):
+                    continue
+                raise
 
         # make sure we only have the desired data, just in case the file
         # contents do not match the expected SEED id
@@ -389,10 +400,21 @@ class Client(object):
                 network=network, station=station, location=location,
                 channel=channel, time=time, sds_type=sds_type)
             if os.path.isfile(filename):
-                st = read(filename, format=self.format, headonly=True,
-                          sourcename=seed_pattern)
-                st = st.select(network=network, station=station,
-                               location=location, channel=channel)
+                try:
+                    st = read(filename, format=self.format, headonly=True,
+                              sourcename=seed_pattern)
+                except Exception as e:
+                    # just ignore small MSEED files, in use cases working with
+                    # near-realtime data these are usually just being created
+                    # right at request time, e.g. when fetching current data
+                    # right after midnight
+                    if (self.format in ('MSEED', None) and
+                            str(e).startswith(FILESIZE_TOO_SMALL_MSG)):
+                        st = None
+                    raise
+                else:
+                    st = st.select(network=network, station=station,
+                                   location=location, channel=channel)
                 if st:
                     break
             time -= 24 * 3600

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -455,6 +455,10 @@ class ObsPyException(Exception):
     pass
 
 
+class ObsPyReadingError(ObsPyException):
+    pass
+
+
 class ZeroSamplingRate(ObsPyException):
     pass
 

--- a/obspy/io/mseed/__init__.py
+++ b/obspy/io/mseed/__init__.py
@@ -145,13 +145,31 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+from obspy import ObsPyException, ObsPyReadingError
 
-class InternalMSEEDError(Exception):
+
+class ObsPyMSEEDError(ObsPyException):
+    pass
+
+
+class ObsPyMSEEDReadingError(ObsPyMSEEDError, ObsPyReadingError):
+    pass
+
+
+class InternalMSEEDError(ObsPyMSEEDError):
     pass
 
 
 class InternalMSEEDWarning(UserWarning):
     pass
+
+
+class ObsPyMSEEDFilesizeTooSmallError(ObsPyMSEEDReadingError):
+    pass
+
+
+__all__ = ['InternalMSEEDError', 'InternalMSEEDWarning', 'ObsPyMSEEDError',
+           'ObsPyMSEEDFilesizeTooSmallError']
 
 
 if __name__ == '__main__':

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -17,12 +17,11 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.util import NATIVE_BYTEORDER
-from . import util, InternalMSEEDError
+from . import util, InternalMSEEDError, ObsPyMSEEDFilesizeTooSmallError
 from .headers import (DATATYPES, ENCODINGS, HPTERROR, HPTMODULUS, SAMPLETYPE,
                       SEED_CONTROL_HEADERS, UNSUPPORTED_ENCODINGS,
                       VALID_CONTROL_HEADERS, VALID_RECORD_LENGTHS, Selections,
-                      SelectTime, Blkt100S, Blkt1001S, clibmseed,
-                      FILESIZE_TOO_SMALL_MSG)
+                      SelectTime, Blkt100S, Blkt1001S, clibmseed)
 
 
 def _is_mseed(filename):
@@ -269,9 +268,9 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
         length = os.path.getsize(mseed_object)
 
     if length < 128:
-        msg = '{} The passed buffer or file contains only {:d} bytes.'.format(
-            FILESIZE_TOO_SMALL_MSG, length)
-        raise ValueError(msg)
+        msg = "The smallest possible mini-SEED record is made up of 128 " \
+              "bytes. The passed buffer or file contains only %i." % length
+        raise ObsPyMSEEDFilesizeTooSmallError(msg)
 
     info = util.get_record_information(mseed_object, endian=bo)
 

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -21,7 +21,8 @@ from . import util, InternalMSEEDError
 from .headers import (DATATYPES, ENCODINGS, HPTERROR, HPTMODULUS, SAMPLETYPE,
                       SEED_CONTROL_HEADERS, UNSUPPORTED_ENCODINGS,
                       VALID_CONTROL_HEADERS, VALID_RECORD_LENGTHS, Selections,
-                      SelectTime, Blkt100S, Blkt1001S, clibmseed)
+                      SelectTime, Blkt100S, Blkt1001S, clibmseed,
+                      FILESIZE_TOO_SMALL_MSG)
 
 
 def _is_mseed(filename):
@@ -268,8 +269,8 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
         length = os.path.getsize(mseed_object)
 
     if length < 128:
-        msg = "The smallest possible mini-SEED record is made up of 128 " \
-              "bytes. The passed buffer or file contains only %i." % length
+        msg = '{} The passed buffer or file contains only {:d} bytes.'.format(
+            FILESIZE_TOO_SMALL_MSG, length)
         raise ValueError(msg)
 
     info = util.get_record_information(mseed_object, endian=bo)

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -53,6 +53,9 @@ SAMPLESIZES = {'a': 1, 'i': 4, 'f': 4, 'd': 8}
 VALID_RECORD_LENGTHS = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
                         131072, 262144, 524288, 1048576]
 
+FILESIZE_TOO_SMALL_MSG = (
+    'The smallest possible mini-SEED record is made up of 128 bytes.')
+
 # allowed encodings:
 # id: (name, sampletype a/i/f/d, default NumPy type, write support)
 ENCODINGS = {0: ("ASCII", "a", np.dtype(native_str("|S1")).type, True),

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -53,9 +53,6 @@ SAMPLESIZES = {'a': 1, 'i': 4, 'f': 4, 'd': 8}
 VALID_RECORD_LENGTHS = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
                         131072, 262144, 524288, 1048576]
 
-FILESIZE_TOO_SMALL_MSG = (
-    'The smallest possible mini-SEED record is made up of 128 bytes.')
-
 # allowed encodings:
 # id: (name, sampletype a/i/f/d, default NumPy type, write support)
 ENCODINGS = {0: ("ASCII", "a", np.dtype(native_str("|S1")).type, True),

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1141,7 +1141,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
         self.assertEqual(
             e.exception.args[0],
             "The smallest possible mini-SEED record is made up of 128 bytes. "
-            "The passed buffer or file contains only 127.")
+            "The passed buffer or file contains only 127 bytes.")
 
 
 def suite():

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -22,7 +22,7 @@ from obspy.core.compatibility import from_buffer
 from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.attribdict import AttribDict
 from obspy.io.mseed import InternalMSEEDError, \
-    InternalMSEEDWarning
+    InternalMSEEDWarning, ObsPyMSEEDFilesizeTooSmallError
 from obspy.io.mseed import util
 from obspy.io.mseed.core import _read_mseed, _write_mseed
 from obspy.io.mseed.headers import clibmseed
@@ -1135,13 +1135,13 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                          "the file will not be read.", w[-1].message.args[0])
 
         # Reading anything less result in an exception.
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(ObsPyMSEEDFilesizeTooSmallError) as e:
             with io.BytesIO(data[:127]) as buf:
                 _read_mseed(buf)
         self.assertEqual(
             e.exception.args[0],
             "The smallest possible mini-SEED record is made up of 128 bytes. "
-            "The passed buffer or file contains only 127 bytes.")
+            "The passed buffer or file contains only 127.")
 
 
 def suite():


### PR DESCRIPTION
Just ignore small MSEED files, in use cases working with near-realtime data these are usually just being created right at request time, e.g. when fetching current data or checking latency right after midnight when first samples are currently being written to a new file.