### PR TITLE
io.wav: unskip test

### DIFF
--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -21,12 +21,10 @@ import warnings
 import numpy as np
 from matplotlib import rcParams
 
-from obspy.core.util.testing import ImageComparison, get_matplotlib_version
+from obspy.core.util import MATPLOTLIB_VERSION
+from obspy.core.util.testing import ImageComparison
 from obspy import read_inventory
 from obspy.core.inventory import Channel, Equipment
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 
 class ChannelTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -19,13 +19,11 @@ from obspy.core.event import (Catalog, Comment, CreationInfo, Event, Origin,
                               read_events, Magnitude, FocalMechanism, Arrival)
 from obspy.core.event.source import farfield
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util.base import get_basemap_version, get_cartopy_version
+from obspy.core.util import BASEMAP_VERSION, CARTOPY_VERSION
 from obspy.core.util.testing import ImageComparison
 from obspy.core.event.base import QuantityError
 
-BASEMAP_VERSION = get_basemap_version()
 
-CARTOPY_VERSION = get_cartopy_version()
 if CARTOPY_VERSION and CARTOPY_VERSION >= [0, 12, 0]:
     HAS_CARTOPY = True
 else:

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -23,16 +23,12 @@ from matplotlib import rcParams
 import obspy
 from obspy import UTCDateTime, read_inventory, read_events
 from obspy.core.compatibility import mock
-from obspy.core.util.base import get_basemap_version, get_cartopy_version
-from obspy.core.util.testing import ImageComparison, get_matplotlib_version
+from obspy.core.util import (
+    BASEMAP_VERSION, CARTOPY_VERSION, MATPLOTLIB_VERSION)
+from obspy.core.util.testing import ImageComparison
 from obspy.core.inventory import (Channel, Inventory, Network, Response,
                                   Station)
 from obspy.core.inventory.util import _unified_content_strings
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
-BASEMAP_VERSION = get_basemap_version()
-CARTOPY_VERSION = get_cartopy_version()
 
 
 class InventoryTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -23,14 +23,10 @@ from matplotlib import rcParams
 import obspy
 from obspy import UTCDateTime, read_inventory
 from obspy.core.compatibility import mock
-from obspy.core.util.base import get_basemap_version, get_cartopy_version
-from obspy.core.util.testing import ImageComparison, get_matplotlib_version
+from obspy.core.util import (
+    BASEMAP_VERSION, CARTOPY_VERSION, MATPLOTLIB_VERSION)
+from obspy.core.util.testing import ImageComparison
 from obspy.core.inventory import Channel, Network, Response, Station
-
-
-BASEMAP_VERSION = get_basemap_version()
-CARTOPY_VERSION = get_cartopy_version()
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 
 class NetworkTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -26,14 +26,12 @@ from matplotlib import rcParams
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
     _pitick2latex, PolesZerosResponseStage)
+from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
-from obspy.core.util.testing import ImageComparison, get_matplotlib_version
+from obspy.core.util.testing import ImageComparison
 from obspy.signal.invsim import evalresp
 from obspy.io.xseed import Parser
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 
 class ResponseTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -21,10 +21,8 @@ import numpy as np
 from matplotlib import rcParams
 
 from obspy import read_inventory, UTCDateTime
-from obspy.core.util.testing import ImageComparison, get_matplotlib_version
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
+from obspy.core.util import MATPLOTLIB_VERSION
+from obspy.core.util.testing import ImageComparison
 
 
 class StationTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -14,12 +14,10 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core.compatibility import mock
 from obspy.core.stream import _is_pickle, _read_pickle, _write_pickle
+from obspy.core.util import SCIPY_VERSION
 from obspy.core.util.attribdict import AttribDict
-from obspy.core.util.base import NamedTemporaryFile, get_scipy_version
+from obspy.core.util.base import NamedTemporaryFile
 from obspy.io.xseed import Parser
-
-
-SCIPY_VERSION = get_scipy_version()
 
 
 class StreamTestCase(unittest.TestCase):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -14,7 +14,6 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core.compatibility import mock
 from obspy.core.stream import _is_pickle, _read_pickle, _write_pickle
-from obspy.core.util import SCIPY_VERSION
 from obspy.core.util.attribdict import AttribDict
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.io.xseed import Parser

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -34,7 +34,10 @@ class UtilBaseTestCase(unittest.TestCase):
                     ("1.2.x", [1, 2, 0]), ("1.3.1rc2", [1, 3, 1]))
 
         for version_string, expected in versions:
-            with mock.patch('matplotlib.__version__', new=version_string):
+            with mock.patch('pkg_resources.get_distribution') as p:
+                class _D(object):
+                    version = version_string
+                p.return_value = _D()
                 got = get_dependency_version('matplotlib')
             self.assertEqual(expected, got)
 

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -8,15 +8,8 @@ import shutil
 import unittest
 
 from obspy.core.compatibility import mock
-from obspy.core.util.base import NamedTemporaryFile, get_matplotlib_version
+from obspy.core.util.base import NamedTemporaryFile, get_dependency_version
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
-
-# checking for matplotlib
-try:
-    import matplotlib  # @UnusedImport
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
 
 
 def image_comparison_in_function(path, img_basename, img_to_compare):
@@ -31,39 +24,19 @@ class UtilBaseTestCase(unittest.TestCase):
     """
     Test suite for obspy.core.util.base
     """
-    @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib is not installed')
     def test_get_matplotlib_version(self):
         """
         Tests for the get_matplotlib_version() function as it continues to
         cause problems.
         """
-        original_version = matplotlib.__version__
+        versions = (("1.2.3", [1, 2, 3]), ("0.9.11", [0, 9, 11]),
+                    ("0.9.svn", [0, 9, 0]), ("1.1.1~rc1-1", [1, 1, 1]),
+                    ("1.2.x", [1, 2, 0]), ("1.3.1rc2", [1, 3, 1]))
 
-        matplotlib.__version__ = "1.2.3"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [1, 2, 3])
-        matplotlib.__version__ = "0.9.11"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [0, 9, 11])
-
-        matplotlib.__version__ = "0.9.svn"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [0, 9, 0])
-
-        matplotlib.__version__ = "1.1.1~rc1-1"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [1, 1, 1])
-
-        matplotlib.__version__ = "1.2.x"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [1, 2, 0])
-
-        matplotlib.__version__ = "1.3.1rc2"
-        version = get_matplotlib_version()
-        self.assertEqual(version, [1, 3, 1])
-
-        # Set it to the original version str just in case.
-        matplotlib.__version__ = original_version
+        for version_string, expected in versions:
+            with mock.patch('matplotlib.__version__', new=version_string):
+                got = get_dependency_version('matplotlib')
+            self.assertEqual(expected, got)
 
     def test_named_temporay_file__context_manager(self):
         """

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -28,7 +28,9 @@ from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
                                   NATIVE_BYTEORDER, NETWORK_MODULES,
                                   NamedTemporaryFile, _read_from_plugin,
                                   create_empty_data_chunk, get_example_file,
-                                  get_matplotlib_version, get_script_dir_name)
+                                  get_script_dir_name, MATPLOTLIB_VERSION,
+                                  SCIPY_VERSION, NUMPY_VERSION,
+                                  BASEMAP_VERSION, CARTOPY_VERSION)
 from obspy.core.util.misc import (BAND_CODE, CatchOutput, complexify_string,
                                   guess_delta, loadtxt, score_at_percentile,
                                   to_int_or_zero)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -14,6 +14,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 from future.utils import native_str
 
 import doctest
+import importlib
 import inspect
 import io
 import os
@@ -323,77 +324,13 @@ def _get_function_from_entry_point(group, type):
     return func
 
 
-def get_matplotlib_version():
+def get_dependency_version(package_name):
     """
-    Get matplotlib version information.
+    Get version information of a dependency package.
 
-    :returns: Matplotlib version as a list of three integers or ``None`` if
-        matplotlib import fails.
-        The last version number can indicate different things like it being a
-        version from the old svn trunk, the latest git repo, some release
-        candidate version, ...
-        If the last number cannot be converted to an integer it will be set to
-        0.
-    """
-    try:
-        import matplotlib
-        version = matplotlib.__version__
-        version = version.split("rc")[0].strip("~")
-        version = list(map(to_int_or_zero, version.split(".")))
-    except ImportError:
-        version = None
-    return version
-
-
-def get_basemap_version():
-    """
-    Get basemap version information.
-
-    :returns: basemap version as a list of three integers or ``None`` if
-        basemap import fails.
-        The last version number can indicate different things like it being a
-        version from the old svn trunk, the latest git repo, some release
-        candidate version, ...
-        If the last number cannot be converted to an integer it will be set to
-        0.
-    """
-    try:
-        from mpl_toolkits import basemap
-        version = basemap.__version__
-        version = version.split("rc")[0].strip("~")
-        version = list(map(to_int_or_zero, version.split(".")))
-    except ImportError:
-        version = None
-    return version
-
-
-def get_cartopy_version():
-    """
-    Get cartopy version information.
-
-    :returns: Cartopy version as a list of three integers or ``None`` if
-        cartopy import fails.
-        The last version number can indicate different things like it being a
-        version from the old svn trunk, the latest git repo, some release
-        candidate version, ...
-        If the last number cannot be converted to an integer it will be set to
-        0.
-    """
-    try:
-        import cartopy
-        version = cartopy.__version__
-        version = version.split("rc")[0].strip("~")
-        version = list(map(to_int_or_zero, version.split(".")))
-    except ImportError:
-        version = None
-    return version
-
-
-def get_scipy_version():
-    """
-    Get SciPy version information.
-
-    :returns: SciPy version as a list of three integers or ``None`` if scipy
+    :type package_name: str
+    :param package_name: Name of package to return version info for
+    :returns: Package version as a list of three integers or ``None`` if
         import fails.
         The last version number can indicate different things like it being a
         version from the old svn trunk, the latest git repo, some release
@@ -402,13 +339,21 @@ def get_scipy_version():
         0.
     """
     try:
-        import scipy
-        version = scipy.__version__
-        version = version.split("~rc")[0]
-        version = list(map(to_int_or_zero, version.split(".")))
+        module = importlib.import_module(package_name)
     except ImportError:
         version = None
+    else:
+        version = module.__version__
+        version = version.split("rc")[0].strip("~")
+        version = list(map(to_int_or_zero, version.split(".")))
     return version
+
+
+NUMPY_VERSION = get_dependency_version('numpy')
+SCIPY_VERSION = get_dependency_version('scipy')
+MATPLOTLIB_VERSION = get_dependency_version('matplotlib')
+BASEMAP_VERSION = get_dependency_version('mpl_toolkits.basemap')
+CARTOPY_VERSION = get_dependency_version('cartopy')
 
 
 def _read_from_plugin(plugin_type, filename, format=None, **kwargs):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -14,10 +14,10 @@ from future.builtins import *  # NOQA @UnusedWildImport
 from future.utils import native_str
 
 import doctest
-import importlib
 import inspect
 import io
 import os
+import pkg_resources
 import sys
 import tempfile
 from collections import OrderedDict
@@ -339,20 +339,18 @@ def get_dependency_version(package_name):
         0.
     """
     try:
-        module = importlib.import_module(package_name)
-    except ImportError:
-        version = None
-    else:
-        version = module.__version__
-        version = version.split("rc")[0].strip("~")
-        version = list(map(to_int_or_zero, version.split(".")))
+        version = pkg_resources.get_distribution(package_name).version
+    except pkg_resources.DistributionNotFound:
+        return None
+    version = version.split("rc")[0].strip("~")
+    version = list(map(to_int_or_zero, version.split(".")))
     return version
 
 
 NUMPY_VERSION = get_dependency_version('numpy')
 SCIPY_VERSION = get_dependency_version('scipy')
 MATPLOTLIB_VERSION = get_dependency_version('matplotlib')
-BASEMAP_VERSION = get_dependency_version('mpl_toolkits.basemap')
+BASEMAP_VERSION = get_dependency_version('basemap')
 CARTOPY_VERSION = get_dependency_version('cartopy')
 
 

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -27,11 +27,10 @@ import warnings
 from lxml import etree
 import numpy as np
 
-from obspy.core.util.base import NamedTemporaryFile, get_matplotlib_version
+from obspy.core.util.base import NamedTemporaryFile, MATPLOTLIB_VERSION
 from obspy.core.util.misc import MatplotlibBackend
 
 
-MATPLOTLIB_VERSION = get_matplotlib_version()
 # this dictionary contains the locations of checker routines that determine
 # whether the module's tests can be executed or not (e.g. because test server
 # is unreachable, necessary ports are blocked, etc.).

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -26,10 +26,9 @@ from matplotlib.ticker import (FormatStrFormatter, Formatter, FuncFormatter,
                                MaxNLocator)
 
 from obspy import UTCDateTime
-from obspy.core.util.base import get_basemap_version, get_cartopy_version
+from obspy.core.util import BASEMAP_VERSION, CARTOPY_VERSION
 from obspy.geodetics.base import mean_longitude
 
-BASEMAP_VERSION = get_basemap_version()
 if BASEMAP_VERSION:
     from mpl_toolkits.basemap import Basemap
     HAS_BASEMAP = True
@@ -41,7 +40,6 @@ if BASEMAP_VERSION:
 else:
     HAS_BASEMAP = False
 
-CARTOPY_VERSION = get_cartopy_version()
 if CARTOPY_VERSION and CARTOPY_VERSION >= [0, 12, 0]:
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -21,13 +21,10 @@ import numpy as np
 from mpl_toolkits.mplot3d import Axes3D  # NOQA
 from matplotlib.cm import get_cmap
 
-from obspy.core.util.base import get_matplotlib_version
+from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.event.source import farfield
 from obspy.imaging.scripts.mopad import MomentTensor, BeachBall
 from obspy.imaging.mopad_wrapper import beach
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 
 def _setup_figure_and_axes(kind, fig=None, subplot_size=4.0):

--- a/obspy/imaging/tests/test_source.py
+++ b/obspy/imaging/tests/test_source.py
@@ -10,10 +10,7 @@ import os
 import unittest
 
 from obspy.imaging.source import plot_radiation_pattern
-from obspy.core.util.base import get_matplotlib_version
-
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
+from obspy.core.util.base import MATPLOTLIB_VERSION
 
 
 class RadPatternTestCase(unittest.TestCase):

--- a/obspy/imaging/util.py
+++ b/obspy/imaging/util.py
@@ -19,7 +19,7 @@ from matplotlib.dates import AutoDateFormatter, DateFormatter, num2date
 from matplotlib.ticker import FuncFormatter
 
 from obspy import UTCDateTime
-from obspy.core.util.base import get_matplotlib_version
+from obspy.core.util import MATPLOTLIB_VERSION
 
 
 def _seconds_to_days(sec):
@@ -100,7 +100,7 @@ class ObsPyAutoDateFormatter(AutoDateFormatter):
     def __init__(self, *args, **kwargs):
         # the root class of AutoDateFormatter (TickHelper) is an old style
         # class prior to matplotlib version 1.2
-        if get_matplotlib_version() < [1, 2, 0]:
+        if MATPLOTLIB_VERSION < [1, 2, 0]:
             AutoDateFormatter.__init__(self, *args, **kwargs)
         else:
             super(ObsPyAutoDateFormatter, self).__init__(*args, **kwargs)

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -38,7 +38,7 @@ from matplotlib.ticker import MaxNLocator, ScalarFormatter
 import scipy.signal as signal
 
 from obspy import Stream, Trace, UTCDateTime
-from obspy.core.util import create_empty_data_chunk, get_matplotlib_version
+from obspy.core.util import create_empty_data_chunk, MATPLOTLIB_VERSION
 from obspy.geodetics import FlinnEngdahl, kilometer2degrees, locations2degrees
 from obspy.imaging.util import (ObsPyAutoDateFormatter, _id_key, _timestring)
 
@@ -49,7 +49,6 @@ DATELOCATOR_WARNING_MSG = (
     "AutoDateLocator was unable to pick an appropriate interval for this date "
     "range. It may be necessary to add an interval value to the "
     "AutoDateLocator's intervald dictionary.")
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 
 class WaveformPlotting(object):

--- a/obspy/io/wav/tests/test_core.py
+++ b/obspy/io/wav/tests/test_core.py
@@ -15,11 +15,11 @@ import numpy as np
 
 from obspy import Stream, Trace, read
 from obspy.core.util import NamedTemporaryFile
+from obspy.core.util.base import NUMPY_VERSION
 from obspy.io.wav.core import WIDTH2DTYPE
 
 
-numpy_version = float(".".join(np.version.version.split('.')[:2]))
-if numpy_version <= 1.3:
+if NUMPY_VERSION <= [1, 3]:
     OLD_NUMPY = True
 else:
     OLD_NUMPY = False

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -38,15 +38,14 @@ from obspy import Stream, Trace, UTCDateTime, __version__
 from obspy.core import Stats
 from obspy.imaging.scripts.scan import compress_start_end
 from obspy.core.inventory import Inventory
-from obspy.core.util import get_matplotlib_version, AttribDict
+from obspy.core.util import AttribDict
+from obspy.core.util.base import MATPLOTLIB_VERSION
 from obspy.imaging.cm import obspy_sequential
 from obspy.io.xseed import Parser
 from obspy.signal.invsim import cosine_taper
 from obspy.signal.util import prev_pow_2
 from obspy.signal.invsim import paz_to_freq_resp, evalresp
 
-
-MATPLOTLIB_VERSION = get_matplotlib_version()
 
 dtiny = np.finfo(0.0).tiny
 


### PR DESCRIPTION
Some `io.wav` test was skipped due to a wrong skip condition. Also refactoring getting dependency versions in `core.util`.