### PR TITLE
Wrong segy revision number in SEGYFile._write

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -84,6 +84,7 @@ master: (doi: 10.5281/zenodo.165135)
     * Iterative reading of large SEG-Y and SU files with
       `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.
       (see #1400).
+    * Write correct revision number (see #1737).
  - obspy.io.css:
    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.io.mseed:

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -261,7 +261,7 @@ class SEGYFile(object):
                 len(self.traces[0].data)
 
         # Always set the SEGY Revision number to 1.0 (hex-coded).
-        self.binary_file_header.seg_y_format_revision_number = 16
+        self.binary_file_header.seg_y_format_revision_number = 256
         # Set the fixed length flag to zero if all traces have NOT the same
         # length. Leave unchanged otherwise.
         if len(set([len(tr.data) for tr in self.traces])) != 1:


### PR DESCRIPTION
Linux, Obspy 1.0.2 installed via pip

Hi 

In SEGYFile._write `self.binary_file_header.seg_y_format_revision_number` is currently hard coded to 16 (0x0010) this should be changed to 256 (0x0100) to yield the intended revision number 1.0