### PR TITLE
Exception raised while comparing stream objects read from big and little endian SEG-Y files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,6 +81,8 @@ master: (doi: 10.5281/zenodo.165135)
     * No longer add the (unused) time zone field to StationXML datetimes to
       follow the example of big data centers. (see #1572)
  - obspy.io.segy:
+    * Fixing an issue when comparing two still packed SEG-Y trace headers
+      (see #1735).
     * Iterative reading of large SEG-Y and SU files with
       `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.
       (see #1400).

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -656,7 +656,7 @@ class LazyTraceHeaderAttribDict(AttribDict):
 
     This version is used for the SEGY/SU trace headers.
     """
-    readonly = ["unpacked_data", "endian"]
+    readonly = ["unpacked_header", "endian"]
 
     def __init__(self, unpacked_header, unpacked_header_endian, data={}):
         dict.__init__(data)
@@ -692,7 +692,7 @@ class LazyTraceHeaderAttribDict(AttribDict):
             unpacked_header=deepcopy(self.__dict__['unpacked_header']),
             unpacked_header_endian=deepcopy(self.__dict__['endian']),
             data=dict((k, deepcopy(v)) for k, v in self.__dict__.items()
-                      if k not in ('unpacked_data', 'endian')))
+                      if k not in self.readonly))
         return ad
 
 

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -656,7 +656,7 @@ class LazyTraceHeaderAttribDict(AttribDict):
 
     This version is used for the SEGY/SU trace headers.
     """
-    readonly = []
+    readonly = ["unpacked_data", "endian"]
 
     def __init__(self, unpacked_header, unpacked_header_endian, data={}):
         dict.__init__(data)
@@ -667,9 +667,7 @@ class LazyTraceHeaderAttribDict(AttribDict):
     def __getitem__(self, name):
         # Return if already set.
         if name in self.__dict__:
-            if name in self.readonly:
-                return self.__dict__[name]
-            return super(AttribDict, self).__getitem__(name)
+            return self.__dict__[name]
         # Otherwise try to unpack them.
         try:
             index = TRACE_HEADER_KEYS.index(name)

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -581,6 +581,19 @@ class SEGYCoreTestCase(unittest.TestCase):
             outfile = tf.name
             st.write(outfile, format='SEGY')
 
+    def test_comparing_still_packed_trace_headers(self):
+        """
+        Regression test to guard against an issue that caused an exception
+        to be raised when attempting to compare two still packed trace headers.
+
+        The exception only occured when reading the `obspy.read()`.
+        """
+        file = os.path.join(self.path, '1.sgy_first_trace')
+        # The exception was
+        header_a = read(file)[0].stats.segy.trace_header
+        header_b = read(file)[0].stats.segy.trace_header
+        self.assertEqual(header_a, header_b)
+
 
 def suite():
     return unittest.makeSuite(SEGYCoreTestCase, 'test')


### PR DESCRIPTION
Linux, Obspy 1.0.2 installed via pip

Hi trying to compare the stream objects read from two SEGY files (both were created using obspy), which only differ by endianess I get the following exception: 

    Python 2.7.12 (default, Jul 01 2016, 15:36:53) [GCC] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from obspy import read
    >>> sl = read("littleEndian.sgy")
    >>> s = read("bigEndian.sgy")   
    >>> s == sl
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib64/python2.7/site-packages/obspy/core/stream.py", line 595, in __eq__
        if self_sorted.traces != other_sorted.traces:
      File "/usr/lib64/python2.7/site-packages/obspy/core/trace.py", line 298, in __eq__
        if not self.stats == other.stats:
      File "/usr/lib64/python2.7/_abcoll.py", line 426, in __eq__
        return dict(self.items()) == dict(other.items())
      File "/usr/lib64/python2.7/_abcoll.py", line 426, in __eq__
        return dict(self.items()) == dict(other.items())
      File "/usr/lib64/python2.7/_abcoll.py", line 426, in __eq__
        return dict(self.items()) == dict(other.items())
      File "/usr/lib64/python2.7/_abcoll.py", line 414, in items
        return [(key, self[key]) for key in self]
      File "/usr/lib64/python2.7/site-packages/obspy/io/segy/core.py", line 721, in __getitem__
        return super(AttribDict, self).__getitem__(name)
      File "/usr/lib64/python2.7/_abcoll.py", line 377, in __getitem__
        raise KeyError
    KeyError

Indicating that not all attributes are properly set in reading one of the files. The files read can be found in attached zip file [segy_files.zip](https://github.com/obspy/obspy/files/878843/segy_files.zip)
 






