### PR TITLE
missing mandatory items in SEGYFile._write_textual_header(...)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,8 @@ master: (doi: 10.5281/zenodo.165135)
       `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.
       (see #1400).
     * Write correct revision number (see #1737).
+    * Textual headers will now always contain the file revision number and the
+      end header mark if nothing else exists at these positions (see #1738).
     * The SEG-Y format detection now also checks the format version number
       (see #1781).
  - obspy.io.css:

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -195,8 +195,12 @@ class SEGYFile(object):
         # character always is mostly 'C' and therefore used to check the
         # encoding. Sometimes is it not C but also cannot be decoded from
         # EBCDIC so it is treated as ASCII and all empty symbols are removed.
+        #
+        # Also check the revision number and textual header end markers for
+        # the "C" as they might be set when the first byte is not.
         if not self.textual_header_encoding:
-            if textual_header[0:1] != b'C':
+            if not (b'C' in (textual_header[0:1], textual_header[3040:3041],
+                             textual_header[3120:3120])):
                 try:
                     textual_header = \
                         textual_header.decode('EBCDIC-CP-BE').encode('ascii')

--- a/obspy/io/segy/tests/__init__.py
+++ b/obspy/io/segy/tests/__init__.py
@@ -11,6 +11,27 @@ from obspy.core.util import add_doctests, add_unittests
 MODULE_NAME = "obspy.io.segy"
 
 
+def _patch_header(header, ebcdic=False):
+    """
+    Helper function to patch a textual header to include the revision
+    number and the end header mark.
+    """
+    revnum = "C39 SEG Y REV1"
+    end_header = "C40 END TEXTUAL HEADER"
+
+    if ebcdic:
+        revnum = revnum.encode("EBCDIC-CP-BE")
+        end_header = end_header.encode("EBCDIC-CP-BE")
+    else:
+        revnum = revnum.encode("ascii")
+        end_header = end_header.encode("ascii")
+
+    header = header[:3200-160] + revnum + header[3200-146:]
+    header = header[:3200-80] + end_header + header[3200-58:]
+
+    return header
+
+
 def suite():
     suite = unittest.TestSuite()
     add_doctests(suite, MODULE_NAME)

--- a/obspy/io/segy/tests/__init__.py
+++ b/obspy/io/segy/tests/__init__.py
@@ -17,14 +17,13 @@ def _patch_header(header, ebcdic=False):
     number and the end header mark.
     """
     revnum = "C39 SEG Y REV1"
-    end_header = "C40 END TEXTUAL HEADER"
 
     if ebcdic:
         revnum = revnum.encode("EBCDIC-CP-BE")
-        end_header = end_header.encode("EBCDIC-CP-BE")
+        end_header = "C40 END EBCDIC        ".encode("EBCDIC-CP-BE")
     else:
         revnum = revnum.encode("ascii")
-        end_header = end_header.encode("ascii")
+        end_header = "C40 END TEXTUAL HEADER".encode("ascii")
 
     header = header[:3200-160] + revnum + header[3200-146:]
     header = header[:3200-80] + end_header + header[3200-58:]

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -246,7 +246,10 @@ class SEGYCoreTestCase(unittest.TestCase):
             # Compare header.
             with open(out_file, 'rb') as f:
                 new_header = f.read(3200)
-        self.assertEqual(header, new_header)
+        # re-encode both to ASCII to easily compare them.
+        self.assertEqual(
+            header.decode("EBCDIC-CP-BE").encode("ASCII"),
+            new_header.decode("EBCDIC-CP-BE").encode("ASCII"))
         self.assertEqual(st2.stats.textual_file_header_encoding,
                          'EBCDIC')
         # Do once again to enforce EBCDIC.

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -21,6 +21,8 @@ from obspy.io.segy.segy import _read_segy as _read_segy_internal
 from obspy.io.segy.segy import SEGYError
 from obspy.io.segy.tests.header import DTYPES, FILES
 
+from . import _patch_header
+
 
 class SEGYCoreTestCase(unittest.TestCase):
     """
@@ -231,6 +233,11 @@ class SEGYCoreTestCase(unittest.TestCase):
         # Save the header to compare it later on.
         with open(file, 'rb') as f:
             header = f.read(3200)
+
+        # All newly written header will have the file revision number and
+        # the end header mark set - just also set them in the old header.
+        header = _patch_header(header, ebcdic=True)
+
         # First write should remain EBCDIC.
         with NamedTemporaryFile() as tf:
             out_file = tf.name

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -619,6 +619,25 @@ class SEGYTestCase(unittest.TestCase):
             else:
                 self.assertEqual(data[3200:3600][-100:-98], b"\x01\x00")
 
+    def test_textual_header_has_the_right_fields_at_the_end(self):
+        """
+        Needs to have the version number and a magical string at the end.
+        """
+        tr = obspy.read()[0]
+        tr.data = np.float32(tr.data)
+        # Write.
+        with io.BytesIO() as buf:
+            tr.write(buf, format="segy")
+            buf.seek(0, 0)
+            data = buf.read()
+
+        # Make sure the textual header has the required fields.
+        revision_number = data[:3200][-160:-146].decode()
+        end_header_mark = data[:3200][-80:-58].decode()
+
+        self.assertEqual(revision_number, "C39 SEG Y REV1")
+        self.assertEqual(end_header_mark, "C40 END TEXTUAL HEADER")
+
 
 def rms(x, y):
     """

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -664,7 +664,7 @@ class SEGYTestCase(unittest.TestCase):
         with io.BytesIO() as buf:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                st.write(buf, format="segy")
+                st.write(buf, format="segy", textual_header_encoding="EBCDIC")
             self.assertEqual(
                 len([_i for _i in w
                      if _i.category is SEGYInvalidTextualHeaderWarning]), 0)
@@ -672,8 +672,8 @@ class SEGYTestCase(unittest.TestCase):
             data = buf.read()
 
         # Make sure the textual header has the required fields.
-        revision_number = data[:3200][-160:-146].decode()
-        end_header_mark = data[:3200][-80:-58].decode()
+        revision_number = data[:3200][-160:-146].decode("EBCDIC-CP-BE")
+        end_header_mark = data[:3200][-80:-58].decode("EBCDIC-CP-BE")
         self.assertEqual(revision_number, "C39 SEG Y REV1")
         self.assertEqual(end_header_mark, "C40 END EBCDIC        ")
 
@@ -746,7 +746,8 @@ class SEGYTestCase(unittest.TestCase):
             self.assertEqual(
                 w[0].message.args[0],
                 "The end header mark in the textual header should be set as "
-                "'C40 END TEXTUAL HEADER' for a fully valid SEG-Y file. It is "
+                "'C40 END TEXTUAL HEADER' or as 'C40 END EBCDIC        ' for "
+                "a fully valid SEG-Y file. It is "
                 "set to 'ABCDEFGHIJKLMNOPQRSTUV' which will be written to the "
                 "file. Please change it if you want a fully valid file.")
             buf.seek(0, 0)

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -312,7 +312,8 @@ class SEGYTestCase(unittest.TestCase):
                 self.assertEqual(segy.textual_header_encoding, header_enc)
             # The header writes to a file like object.
             new_header = io.BytesIO()
-            segy._write_textual_header(new_header)
+            with warnings.catch_warnings(record=True):
+                segy._write_textual_header(new_header)
             new_header.seek(0, 0)
             new_header = new_header.read()
             # Assert the correct length.
@@ -359,7 +360,8 @@ class SEGYTestCase(unittest.TestCase):
             segy_file = _read_segy(file, headonly=headonly)
             with NamedTemporaryFile() as tf:
                 out_file = tf.name
-                segy_file.write(out_file)
+                with warnings.catch_warnings(record=True):
+                    segy_file.write(out_file)
                 # Read the new file again.
                 with open(out_file, 'rb') as f:
                     new_data = f.read()

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -22,6 +22,8 @@ from obspy.io.segy.segy import (SEGYBinaryFileHeader, SEGYFile,
                                 SEGYInvalidTextualHeaderWarning)
 from obspy.io.segy.tests.header import DTYPES, FILES
 
+from . import _patch_header
+
 
 class SEGYTestCase(unittest.TestCase):
     """
@@ -315,6 +317,10 @@ class SEGYTestCase(unittest.TestCase):
             new_header = new_header.read()
             # Assert the correct length.
             self.assertEqual(len(new_header), 3200)
+            # Patch both headers to not worry about the automatically set
+            # values.
+            org_header = _patch_header(org_header)
+            new_header = _patch_header(new_header)
             # Assert the actual header.
             self.assertEqual(org_header, new_header)
 
@@ -373,6 +379,9 @@ class SEGYTestCase(unittest.TestCase):
                 # Create strings again.
                 org_data = org_data.tostring()
                 new_data = new_data.tostring()
+            # Just patch both headers - this tests something different.
+            org_data = _patch_header(org_data)
+            new_data = _patch_header(new_data)
             # Always write the SEGY File revision number!
             # org_data[3500:3502] = new_data[3500:3502]
             # Test the identity without the SEGY revision number


### PR DESCRIPTION
Linux, Obspy 1.0.2 installed via pip

Hi 

The textual header in a SEGY file have two mandatory entries namely the revision number (same as in bytes 301-302 of the 400 byte binary file header) and the text "C40 END TEXTUAL HEADER" (or alternatively "C40 END EBCDIC") 

It would be neat if this were automatically set by SEGYFile._write_textual_header(...), especially in the case where the textual header is not pre-set but created blank inside the function.

Not sure if the format of the revision number is mandatory, but the documentation in SEG Y rev 1 (table 1 in http://www.seg.org/Portals/0/SEG/News%20and%20Resources/Technical%20Standards/seg_y_rev1.pdf) suggest to set it in record 39 (bytes 3040-3120) on the format "C39 SEG Y REV 1"

Actually the fact that these two pieces of information are mandatory is only mentioned in footnote 6 (see table 1 and page 6 in pdf file linked to above) hence can easily be overlooked

