### PR TITLE
Seedlink client broken by libmseed updates

### DIFF
--- a/obspy/clients/seedlink/slpacket.py
+++ b/obspy/clients/seedlink/slpacket.py
@@ -113,10 +113,9 @@ class SLPacket(object):
     def get_ms_record(self):
         # following from obspy.io.mseed.tests.test_libmseed.py -> test_msrParse
         msr = clibmseed.msr_init(None)
-        pyobj = from_buffer(self.msrecord, dtype=np.uint8)
+        pyobj = from_buffer(self.msrecord, dtype=np.int8)
         errcode = \
-            clibmseed.msr_parse(pyobj.ctypes.data_as(C.POINTER(C.c_char)),
-                                len(pyobj), C.pointer(msr), -1, 1, 1)
+            clibmseed.msr_parse(pyobj, len(pyobj), C.pointer(msr), -1, 1, 1)
         if errcode != 0:
             msg = "failed to decode mini-seed record: msr_parse errcode: %s"
             raise SeedLinkException(msg % (errcode))


### PR DESCRIPTION
```python
from obspy import UTCDateTime
from obspy.clients.seedlink.basic_client import Client

t = UTCDateTime() - 10 * 60
client = Client("rtserve.iris.washington.edu", debug=True)
request = ["IU", "ANMO", "00", "LHZ", t, t + 20]
print(client.get_waveforms(*request))
```
On 1.0.3
```
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:parsed 1 streams from stream list
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 0
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:network socket opened
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: HELLO
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:connected to: 'SeedLink v3.1 (2017.052 RingServer) :: SLPROTO:3.1 CAP EXTREPLY NSWILDCARD BATCH WS:13'
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: STATION  ANMO IU
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: station is OK (selected)
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: SELECT 00LHZ
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: selector 00LHZ is OK
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: 1 selector(s) accepted
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:requesting specified time window
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: TIME 2017,3,28,13,5,23 2017,3,28,13,5,43
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: DATA/FETCH/TIME command is OK
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:1 station(s) accepted
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: END
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 2
1000
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 2
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 2
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:end of buffer or selected time window
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:network socket closed
1 Trace(s) in Stream:
IU.ANMO.00.LHZ | 2017-03-28T13:05:23.069538Z - 2017-03-28T13:05:43.069538Z | 1.0 Hz, 21 samples
```
On master:
```
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:parsed 1 streams from stream list
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 0
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:network socket opened
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: HELLO
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:connected to: 'SeedLink v3.1 (2017.052 RingServer) :: SLPROTO:3.1 CAP EXTREPLY NSWILDCARD BATCH WS:13'
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: STATION  ANMO IU
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: station is OK (selected)
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: SELECT 00LHZ
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: selector 00LHZ is OK
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: 1 selector(s) accepted
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:requesting specified time window
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: TIME 2017,3,28,13,5,17 2017,3,28,13,5,37
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:response: DATA/FETCH/TIME command is OK
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:1 station(s) accepted
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:sending: END
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 2
ERROR: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:bad packet: u"blockette not 1000 (Data Only SEED Blockette) or other error reading miniseed data: argument 1: <type 'exceptions.TypeError'>: argument must be an ndarray"
DEBUG: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:primary loop pass 0, state 2
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:end of buffer or selected time window
INFO: obspy.clients.seedlink [rtserve.iris.washington.edu:18000]:network socket closed
0 Trace(s) in Stream:

```

Note the problems in usage of libmseed that are caught and handled badly.

Changes need to be done here: https://github.com/obspy/obspy/blob/master/obspy/clients/seedlink/slpacket.py#L113-L129