### PR TITLE
Docstring rendering problem for `plot_radiation_pattern()` and `Event.plot()`

### DIFF
--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -173,17 +173,19 @@ class Event(__Event):
         :param kind: A list of strings (for a 1-row plot) or a nested list of
             strings (one list of strings per row), with the following keywords
             to generate a matplotlib figure:
-                * 'ortho' (Orthographic plot of event location,
-                  see :meth:`~obspy.core.event.catalog.Catalog.plot`),
-                * 'global' (Global plot of event location,
-                  see :meth:`~obspy.core.event.catalog.Catalog.plot`),
-                * 'local' (Local plot of event location,
-                  see :meth:`~obspy.core.event.catalog.Catalog.plot`),
-                * 'beachball' (Beachball of preferred focal mechanism),
-                * 'p_quiver' (quiver plot of p wave farfield),
-                * 's_quiver' (quiver plot of s wave farfield),
-                * 'p_sphere' (surface plot of p wave farfield),
-                * 's_sphere' (surface plot of s wave farfield).
+
+            * ``'ortho'`` (Orthographic plot of event location
+              see :meth:`~obspy.core.event.catalog.Catalog.plot`)
+            * ``'global'`` (Global plot of event location
+              see :meth:`~obspy.core.event.catalog.Catalog.plot`)
+            * ``'local'`` (Local plot of event location
+              see :meth:`~obspy.core.event.catalog.Catalog.plot`)
+            * ``'beachball'`` (Beachball of preferred focal mechanism)
+            * ``'p_quiver'`` (quiver plot of p wave farfield)
+            * ``'s_quiver'`` (quiver plot of s wave farfield)
+            * ``'p_sphere'`` (surface plot of p wave farfield)
+            * ``'s_sphere'`` (surface plot of s wave farfield)
+
         :type subplot_size: float
         :param subplot_size: Width/height of one single subplot cell in inches.
         :type show: bool

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -81,27 +81,24 @@ def plot_radiation_pattern(
         Harvard/Global CMT convention). The relation to [Aki1980]_
         x,y,z equals North,East,Down convention is as follows: Mrr=Mzz,
         Mtt=Mxx, Mpp=Myy, Mrt=Mxz, Mrp=-Myz, Mtp=-Mxy.
+    :param kind: One of:
 
-    :param kind: One of the following three options:
-        * A list of strings or nested list of strings for a matplotlib plot
-          (for details see :meth:`obspy.core.event.event.Event.plot`)
-        * 'mayavi': uses the mayavi library (not yet available under Python 3
-          and problematic with anaconda)
-        * 'vtk': This vtk option writes two vtk files to the current working
-          directory. rpattern.vtk contains the p and s wave farfield vector
-          field. beachlines.vtk contains the nodal lines of the radiation
-          pattern. A vtk glyph filter should be applied to the vector field
-          (e.g. in ParaView) to visualize it.
+        * **(A)** A list of strings or nested list of strings for a matplotlib
+          plot (for details see :meth:`obspy.core.event.event.Event.plot`).
+        * **(B)** ``"mayavi"``: uses the mayavi library.
+        * **(C)** ``"vtk"``: This vtk option writes two vtk files to the
+          current working directory. ``rpattern.vtk`` contains the p and s
+          wave farfield vector field. ``beachlines.vtk`` contains the nodal
+          lines of the radiation pattern. A vtk glyph filter should be applied
+          to the vector field (e.g. in ParaView) to visualize it.
 
-    :param coordinate_system: the only implemented option so far is 'RTP' (also
-        called 'USE'). Should be extended to support NED, DSE, NED in the
-        future.
     :type fig: :class:`matplotlib.figure.Figure`
     :param fig: Figure instance to use.
     :type show: bool
     :param show: Whether to show the figure after plotting or not. Can be
         used to do further customization of the plot before showing it.
-    :returns: Matplotlib figure or None (if `kind` is "mayavi" or "vtk")
+    :returns: Matplotlib figure or ``None`` (if ``kind`` is ``"mayavi"`` or
+        ``"vtk"``)
     """
     import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Docstrings for [plot_radiation_pattern()](http://docs.obspy.org/master/packages/autogen/obspy.imaging.source.plot_radiation_pattern.html#obspy.imaging.source.plot_radiation_pattern) and [Event.plot()](http://docs.obspy.org/master/packages/autogen/obspy.core.event.event.Event.plot.html#obspy.core.event.event.Event.plot) currently render very large fonts in some parts. 

Furthermore, it looks that, for `plot_radiation_pattern()` there should be a list for the `kind` parameter, which is not rendered properly.