### PR TITLE
Cleaning up the renaming of io.datamark -> io.win

### DIFF
--- a/misc/docs/source/packages/index.rst
+++ b/misc/docs/source/packages/index.rst
@@ -38,7 +38,6 @@ The functionality is provided through the following packages:
    obspy.io.ah
    obspy.io.ascii
    obspy.io.css
-   obspy.io.datamark
    obspy.io.gcf
    obspy.io.gse2
    obspy.io.kinemetrics
@@ -52,6 +51,7 @@ The functionality is provided through the following packages:
    obspy.io.segy
    obspy.io.sh
    obspy.io.wav
+   obspy.io.win
    obspy.io.y
 
 .. rubric:: Event Data Import/Export Plug-ins

--- a/misc/docs/source/packages/obspy.io.win.rst
+++ b/misc/docs/source/packages/obspy.io.win.rst
@@ -1,5 +1,5 @@
-.. currentmodule:: obspy.io.datamark
-.. automodule:: obspy.io.datamark
+.. currentmodule:: obspy.io.win
+.. automodule:: obspy.io.win
 
     .. comment to end block
 

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -48,7 +48,7 @@ ALL_MODULES = DEFAULT_MODULES + NETWORK_MODULES
 # default order of automatic format detection
 WAVEFORM_PREFERRED_ORDER = ['MSEED', 'SAC', 'GSE2', 'SEISAN', 'SACXY', 'GSE1',
                             'Q', 'SH_ASC', 'SLIST', 'TSPAIR', 'Y', 'PICKLE',
-                            'SEGY', 'SU', 'SEG2', 'WAV', 'DATAMARK', 'CSS',
+                            'SEGY', 'SU', 'SEG2', 'WAV', 'WIN', 'CSS',
                             'NNSA_KB_CORE', 'AH', 'PDAS', 'KINEMETRICS_EVT',
                             'GCF']
 EVENT_PREFERRED_ORDER = ['QUAKEML', 'NLLOC_HYP']

--- a/obspy/io/win/core.py
+++ b/obspy/io/win/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-DATAMARK bindings to ObsPy core module.
+WIN/DATAMARK format bindings to ObsPy.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -24,7 +24,7 @@ def _is_win(filename, century="20"):  # @UnusedVariable
     :return: ``True`` if a WIN file.
     """
     # as long we don't have full format description we just try to read the
-    # file like _read_datamark and check for errors
+    # file like _read_win and check for errors
     century = "20"  # hardcoded ;(
     try:
         with open(filename, "rb") as fpin:

--- a/obspy/io/win/tests/test_core.py
+++ b/obspy/io/win/tests/test_core.py
@@ -45,7 +45,7 @@ class CoreTestCase(unittest.TestCase):
 
     def test_read_via_module(self):
         """
-        Read files via obspy.io.win.core._read_datamark function.
+        Read files via obspy.io.win.core._read_win function.
         """
         filename = os.path.join(self.path, '10030302.00')
         # 1


### PR DESCRIPTION
Removes a couple of stray leftovers in the code base and most importantly it should now render the new `io.win` docs.

+DOCS