### PR TITLE
'unicode' does not have the buffer interface

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -111,7 +111,8 @@ master: (doi: 10.5281/zenodo.165135)
  - obspy.io.win:
    * see obspy.io.datamark.
  - obspy.io.xseed:
-   * Added azimuth and dip to the get_coordinates() function.  (see #1315)
+   * Added azimuth and dip to the get_coordinates() function. (see #1315)
+   * Fixing some issues with the get_resp() output on Python 3 (see #1748).
  - obspy.scripts:
    * obspy-scan command line script now also plots and prints overlaps
      alongside gaps (see #1366)

--- a/obspy/io/xseed/blockette/blockette041.py
+++ b/obspy/io/xseed/blockette/blockette041.py
@@ -142,4 +142,4 @@ class Blockette041(Blockette):
             string += 'B041F09    %4s %13s\n' \
                 % (0, format_resp(self.FIR_coefficient, 6))
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette043.py
+++ b/obspy/io/xseed/blockette/blockette043.py
@@ -124,4 +124,4 @@ class Blockette043(Blockette):
                     format_resp(self.real_pole_error, 6),
                     format_resp(self.imaginary_pole_error, 6))
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette044.py
+++ b/obspy/io/xseed/blockette/blockette044.py
@@ -101,4 +101,4 @@ class Blockette044(Blockette):
                     format_resp(self.denominator_coefficient, 6),
                     format_resp(self.denominator_error, 6))
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette047.py
+++ b/obspy/io/xseed/blockette/blockette047.py
@@ -52,4 +52,4 @@ class Blockette047(Blockette):
             'B047F09     Response correction:                   %s\n' \
             % format_resp(self.correction_applied, 6) + \
             '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette048.py
+++ b/obspy/io/xseed/blockette/blockette048.py
@@ -72,4 +72,4 @@ class Blockette048(Blockette):
                     format_resp(self.frequency_of_calibration_sensitivity, 6),
                     self.time_of_above_calibration.format_seed())
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette055.py
+++ b/obspy/io/xseed/blockette/blockette055.py
@@ -62,11 +62,11 @@ class Blockette055(Blockette):
 
             'B055F05     Response out units lookup:             %s\n'
 
-            'B055F06     Number of responses:                   %s\n') % \
-                (station, channel, self.stage_sequence_number,
-                 blockette_34_lookup(abbreviations, self.stage_input_units),
-                 blockette_34_lookup(abbreviations, self.stage_output_units),
-                 self.number_of_responses_listed)
+            'B055F06     Number of responses:                   %s\n') % (
+                station, channel, self.stage_sequence_number,
+                blockette_34_lookup(abbreviations, self.stage_input_units),
+                blockette_34_lookup(abbreviations, self.stage_output_units),
+                self.number_of_responses_listed)
 
         if self.number_of_responses_listed:
             string += \

--- a/obspy/io/xseed/blockette/blockette055.py
+++ b/obspy/io/xseed/blockette/blockette055.py
@@ -48,22 +48,26 @@ class Blockette055(Blockette):
         """
         Returns RESP string.
         """
-        string = \
-            '#\t\t+                     +---------------------------------+' +\
-            '                     +\n' + \
-            '#\t\t+                     |   Response List,%6s ch %s   |' + \
-            '                     +\n' % (station, channel) + \
-            '#\t\t+                     +---------------------------------+' +\
-            '                     +\n' + \
-            '#\t\t\n' + \
-            'B055F03     Stage sequence number:                 %s\n' \
-            % self.stage_sequence_number + \
-            'B055F04     Response in units lookup:              %s\n' \
-            % blockette_34_lookup(abbreviations, self.stage_input_units) + \
-            'B055F05     Response out units lookup:             %s\n' \
-            % blockette_34_lookup(abbreviations, self.stage_output_units) + \
-            'B055F06     Number of responses:                   %s\n' \
-            % self.number_of_responses_listed
+        string = (
+            '#\t\t+                     +---------------------------------+'
+            '                     +\n'
+            '#\t\t+                     |   Response List,%6s ch %s   |'
+            '                     +\n'
+            '#\t\t+                     +---------------------------------+'
+            '                     +\n'
+            '#\t\t\n'
+            'B055F03     Stage sequence number:                 %s\n'
+
+            'B055F04     Response in units lookup:              %s\n'
+
+            'B055F05     Response out units lookup:             %s\n'
+
+            'B055F06     Number of responses:                   %s\n') % \
+                (station, channel, self.stage_sequence_number,
+                 blockette_34_lookup(abbreviations, self.stage_input_units),
+                 blockette_34_lookup(abbreviations, self.stage_output_units),
+                 self.number_of_responses_listed)
+
         if self.number_of_responses_listed:
             string += \
                 '#\t\tResponses:\n' + \
@@ -85,4 +89,4 @@ class Blockette055(Blockette):
                      format_resp(self.phase_angle, 6),
                      format_resp(self.phase_error, 6))
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -164,25 +164,24 @@ class Blockette060(Blockette):
         """
         Returns RESP string.
         """
-        string = ''
+        string = b''
         # Possible dictionary blockettes.
         dict_blockettes = [41, 43, 44, 45, 46, 47, 48]
         for _i in range(len(self.stages)):
-            string += \
-                '#\t\t+            +----------------------------------' + \
-                '----------------+             +\n' + \
-                '#\t\t+            |   Response Reference Information,' + \
-                '%6s ch %s   |             +\n' % (station, channel) + \
-                '#\t\t+            +----------------------------------' + \
-                '----------------+             +\n' + \
-                '#\t\t\n' + \
-                'B060F03     Number of Stages:                      %s\n' \
-                % len(self.stages) + \
-                'B060F04     Stage number:                          %s\n' \
-                % (_i + 1) + \
-                'B060F05     Number of Responses:                   %s\n' \
-                % len(self.stages[_i]) + \
+            string += (
+                '#\t\t+            +----------------------------------'
+                '----------------+             +\n' 
+                '#\t\t+            |   Response Reference Information,'
+                '%6s ch %s   |             +\n' % (station, channel) +
+                '#\t\t+            +----------------------------------'
+                '----------------+             +\n'
                 '#\t\t\n'
+                'B060F03     Number of Stages:                      %s\n'
+                % len(self.stages) +
+                'B060F04     Stage number:                          %s\n'
+                % (_i + 1) +
+                'B060F05     Number of Responses:                   %s\n'
+                % len(self.stages[_i]) + '#\t\t\n').encode()
             # Loop over all keys and print the information in order.
             for response_key in self.stages[_i]:
                 # Find the corresponding key in the abbreviations.
@@ -190,18 +189,16 @@ class Blockette060(Blockette):
                 for blockette in abbreviations:
                     if blockette.id in dict_blockettes and \
                             blockette.response_lookup_key == response_key:
-                        try:
-                            string += \
-                                blockette.get_resp(station, channel,
-                                                   abbreviations)
-                            found_abbrev = True
-                        except AttributeError:
+                        if not hasattr(blockette, "get_resp"):
                             msg = 'RESP output not implemented for ' + \
                                   'blockette %d.' % blockette.id
                             raise AttributeError(msg)
+                        string += blockette.get_resp(station, channel,
+                                                     abbreviations)
+                        found_abbrev = True
                 if not found_abbrev:
                     msg = 'The reference blockette for response key ' + \
                           '%d could not be found.' % response_key
                     raise Exception(msg)
-        string += '#\t\t\n'
-        return string.encode()
+        string += b'#\t\t\n'
+        return string

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -97,24 +97,25 @@ class Blockette060(Blockette):
         """
         Writes Blockette 60.
         """
-        data = ''
+        data = b''
         # Write number of stages.
-        data += '%2d' % len(self.stages)
+        data += b'%2d' % len(self.stages)
         # Loop over all items in self.stages.
         stage_number = 1
         for stage in self.stages:
             # Write stage sequence number.
-            data += '%2d' % stage_number
+            data += b'%2d' % stage_number
             stage_number += 1
             # Write number of items.
-            data += '%2d' % len(stage)
+            data += b'%2d' % len(stage)
             for number in stage:
-                data += '%4d' % number
+                data += b'%4d' % number
         # Add header.
         length = len(data) + 7
-        header = '060%4d' % length
+        header = b'060%4d' % length
         data = header + data
         return data
+
 
     def get_xml(self, xseed_version, *args, **kwargs):  # @UnusedVariable
         """

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -116,7 +116,6 @@ class Blockette060(Blockette):
         data = header + data
         return data
 
-
     def get_xml(self, xseed_version, *args, **kwargs):  # @UnusedVariable
         """
         Write XML.
@@ -170,7 +169,7 @@ class Blockette060(Blockette):
         for _i in range(len(self.stages)):
             string += (
                 '#\t\t+            +----------------------------------'
-                '----------------+             +\n' 
+                '----------------+             +\n'
                 '#\t\t+            |   Response Reference Information,'
                 '%6s ch %s   |             +\n' % (station, channel) +
                 '#\t\t+            +----------------------------------'

--- a/obspy/io/xseed/blockette/blockette060.py
+++ b/obspy/io/xseed/blockette/blockette060.py
@@ -97,24 +97,24 @@ class Blockette060(Blockette):
         """
         Writes Blockette 60.
         """
-        data = b''
+        data = ''
         # Write number of stages.
-        data += b'%2d' % len(self.stages)
+        data += '%2d' % len(self.stages)
         # Loop over all items in self.stages.
         stage_number = 1
         for stage in self.stages:
             # Write stage sequence number.
-            data += b'%2d' % stage_number
+            data += '%2d' % stage_number
             stage_number += 1
             # Write number of items.
-            data += b'%2d' % len(stage)
+            data += '%2d' % len(stage)
             for number in stage:
-                data += b'%4d' % number
+                data += '%4d' % number
         # Add header.
         length = len(data) + 7
-        header = b'060%4d' % length
+        header = '060%4d' % length
         data = header + data
-        return data
+        return data.encode()
 
     def get_xml(self, xseed_version, *args, **kwargs):  # @UnusedVariable
         """

--- a/obspy/io/xseed/blockette/blockette062.py
+++ b/obspy/io/xseed/blockette/blockette062.py
@@ -125,4 +125,4 @@ class Blockette062(Blockette):
                     % (0, format_resp(self.polynomial_coefficient, 6),
                        format_resp(self.polynomial_coefficient_error, 6))
         string += '#\t\t\n'
-        return string
+        return string.encode()

--- a/obspy/io/xseed/tests/blockette-tests/blockette062.txt
+++ b/obspy/io/xseed/tests/blockette-tests/blockette062.txt
@@ -1,0 +1,26 @@
+### Blockette 062 tests ###
+
+--01-SEED
+0620129P01021001MB+0.00000E+00+0.00000E+00+0.00000E+00+0.00000E+00+0.00000E+00002+2.55000E+01+0.00000E+00-1.44628E+01+0.00000E+00
+
+--01-XSEED
+<response_polynomial blockette="062">
+  <transfer_function_type>P</transfer_function_type>
+  <stage_sequence_number>1</stage_sequence_number>
+  <stage_signal_in_units>/xseed/abbreviation_dictionary_control_header/units_abbreviations/unit_lookup_code[text()="21"]/parent::*</stage_signal_in_units>
+  <stage_signal_out_units>/xseed/abbreviation_dictionary_control_header/units_abbreviations/unit_lookup_code[text()="1"]/parent::*</stage_signal_out_units>
+  <polynomial_approximation_type>M</polynomial_approximation_type>
+  <valid_frequency_units>B</valid_frequency_units>
+  <lower_valid_frequency_bound>+0.00000E+00</lower_valid_frequency_bound>
+  <upper_valid_frequency_bound>+0.00000E+00</upper_valid_frequency_bound>
+  <lower_bound_of_approximation>+0.00000E+00</lower_bound_of_approximation>
+  <upper_bound_of_approximation>+0.00000E+00</upper_bound_of_approximation>
+  <maximum_absolute_error>+0.00000E+00</maximum_absolute_error>
+  <number_of_polynomial_coefficients>2</number_of_polynomial_coefficients>
+  <polynomial_coefficients>
+    <polynomial_coefficient>+2.55000E+01</polynomial_coefficient>
+    <polynomial_coefficient_error>+0.00000E+00</polynomial_coefficient_error>
+    <polynomial_coefficient>-1.44628E+01</polynomial_coefficient>
+    <polynomial_coefficient_error>+0.00000E+00</polynomial_coefficient_error>
+  </polynomial_coefficients>
+</response_polynomial>

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -223,27 +223,32 @@ class BlocketteTestCase(unittest.TestCase):
                 continue
             tested_blockettes += 1
 
-            test_examples = self.parse_file(blkt_file)
-            for ex in test_examples:
-                b = blkt()
-                b.parse_seed(ex["SEED"])
-                if blkt_number != "060":
-                    r = b.get_resp("AA", "BB", [])
-                else:
-                    # Blockette 60 is special as it also needs access to
-                    # other blockettes. Create some dummy data here.
-                    b.stages = [[0]]
-                    blkt41 = Blockette041()
-                    blkt41.response_lookup_key = 0
-                    blkt41.symmetry_code = 0
-                    blkt41.signal_in_units = "m/s"
-                    blkt41.signal_out_units = "m/s"
-                    blkt41.number_of_factors = 0
-                    r = b.get_resp("AA", "BB", [blkt41])
-                # For now only check that it contains something and that it
-                # returns bytes.
-                self.assertGreater(len(r), 0)
-                self.assertTrue(isinstance(r, native_bytes))
+            # Some of the blockettes requires access to other blockettes.
+            # They don't have it for this simplistic test and thus raise
+            # warnings which therefore have to be caught.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                test_examples = self.parse_file(blkt_file)
+                for ex in test_examples:
+                    b = blkt()
+                    b.parse_seed(ex["SEED"])
+                    if blkt_number != "060":
+                        r = b.get_resp("AA", "BB", [])
+                    else:
+                        # Blockette 60 is special as it also needs access to
+                        # other blockettes. Create some dummy data here.
+                        b.stages = [[0]]
+                        blkt41 = Blockette041()
+                        blkt41.response_lookup_key = 0
+                        blkt41.symmetry_code = 0
+                        blkt41.signal_in_units = "m/s"
+                        blkt41.signal_out_units = "m/s"
+                        blkt41.number_of_factors = 0
+                        r = b.get_resp("AA", "BB", [blkt41])
+                    # For now only check that it contains something and that it
+                    # returns bytes.
+                    self.assertGreater(len(r), 0)
+                    self.assertTrue(isinstance(r, native_bytes))
 
         self.assertGreater(tested_blockettes, 0)
 

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -174,6 +174,7 @@ class BlocketteTestCase(unittest.TestCase):
         """
         # Loop over all files in the blockette-tests directory.
         path = os.path.join(self.path, 'blockette-tests', 'blockette*.txt')
+        test_example_count = 0
         for blkt_file in iglob(path):
             # Get blockette number.
             blkt_number = blkt_file[-7:-4]
@@ -185,9 +186,12 @@ class BlocketteTestCase(unittest.TestCase):
                 raise ImportError(msg)
             # Parse the file.
             test_examples = self.parse_file(blkt_file)
+            # Check how many examples were actually tested.
+            test_example_count += len(test_examples)
             # The last step is to actually test the conversions to and from
             # SEED/XSEED for every example in every direction.
             self.seed_and_xseed_conversion(test_examples, blkt_number)
+        self.assertGreater(test_example_count, 0)
 
     def test_blockette60_has_blockette_id(self):
         """

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -15,7 +15,7 @@ from glob import iglob
 from lxml import etree
 
 from obspy.io.xseed.blockette import (
-    Blockette041, Blockette043, Blockette050, Blockette054, Blockette060)
+    Blockette041, Blockette050, Blockette054, Blockette060)
 from obspy.io.xseed.blockette.blockette import BlocketteLengthException
 from obspy.io.xseed.fields import SEEDTypeException
 

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -71,6 +71,12 @@ class BlocketteTestCase(unittest.TestCase):
         file.close()
         # Simplify and Validate the list.
         self.simplify_and_validate_and_create_dictionary(test_examples)
+        # Convert everything to bytes - a lot of the logic in this method
+        # here assumes strings to its easier to work with strings and
+        # convert to bytes after everything is done.
+        for _i in test_examples:
+            for key, value in _i.items():
+                _i[key] = value.encode()
         return test_examples
 
     def simplify_and_validate_and_create_dictionary(self, examples):

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
 
+import io
 import os
 import sys
 import unittest
@@ -40,7 +41,7 @@ class BlocketteTestCase(unittest.TestCase):
         # Create a new empty list to store all information of the test in it.
         test_examples = []
         # Now read the corresponding file and parse it.
-        file = open(blkt_file, 'rb')
+        file = io.open(blkt_file, 'rt')
         # Helper variable to parse the file. Might be a little bit slow but its
         # just for tests.
         cur_stat = None

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -14,7 +14,8 @@ from glob import iglob
 
 from lxml import etree
 
-from obspy.io.xseed.blockette import Blockette050, Blockette054, Blockette060
+from obspy.io.xseed.blockette import (
+    Blockette041, Blockette043, Blockette050, Blockette054, Blockette060)
 from obspy.io.xseed.blockette.blockette import BlocketteLengthException
 from obspy.io.xseed.fields import SEEDTypeException
 
@@ -226,7 +227,19 @@ class BlocketteTestCase(unittest.TestCase):
             for ex in test_examples:
                 b = blkt()
                 b.parse_seed(ex["SEED"])
-                r = b.get_resp("AA", "BB", [])
+                if blkt_number != "060":
+                    r = b.get_resp("AA", "BB", [])
+                else:
+                    # Blockette 60 is special as it also needs access to
+                    # other blockettes. Create some dummy data here.
+                    b.stages = [[0]]
+                    blkt41 = Blockette041()
+                    blkt41.response_lookup_key = 0
+                    blkt41.symmetry_code = 0
+                    blkt41.signal_in_units = "m/s"
+                    blkt41.signal_out_units = "m/s"
+                    blkt41.number_of_factors = 0
+                    r = b.get_resp("AA", "BB", [blkt41])
                 # For now only check that it contains something and that it
                 # returns bytes.
                 self.assertGreater(len(r), 0)

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -170,7 +170,7 @@ class BlocketteTestCase(unittest.TestCase):
                     if key2 == 'SEED':
                         continue
                     xseed = etree.tostring(blkt1['Blkt'].get_xml(
-                        xseed_version=blkt2['version'])).decode()
+                        xseed_version=blkt2['version']))
                     self.assertEqual(xseed, versions[key2]['data'],
                                      errmsg % (blkt_number, 'XSEED', key2,
                                                xseed, blkt2['data']))

--- a/obspy/io/xseed/utils.py
+++ b/obspy/io/xseed/utils.py
@@ -14,7 +14,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 from future.utils import native_str
 
 import re
-import sys
+import warnings
 
 from obspy import UTCDateTime
 
@@ -26,6 +26,10 @@ IGNORE_ATTR = ['blockette_id', 'blockette_name', 'compact', 'debug',
 
 
 class SEEDParserException(Exception):
+    pass
+
+
+class SEEDAbbreviationNotFoundWarning(UserWarning):
     pass
 
 
@@ -166,8 +170,8 @@ def blockette_34_lookup(abbr, lookup):
                          lookup)
         return l1 + ' - ' + l2
     except Exception:
-        msg = '\nWarning: Abbreviation reference not found.'
-        sys.stdout.write(msg)
+        msg = 'Warning: Abbreviation reference for "%i" not found.' % lookup
+        warnings.warn(msg, SEEDAbbreviationNotFoundWarning)
         return 'No Abbreviation Referenced'
 
 


### PR DESCRIPTION

1.0.3.post0+946.g1ab414164e.obspy.master
macos 10.12.4

I want to convert a dataless to RESP.

```code
rdseed -f dataless.G.SSB.seed -R
````
works without problem. But with Obspy I have an error:



```code
from obspy.io.xseed import Parser
p=Parser('http://geoscope.ipgp.fr/metadata/G/dataless.G.SSB.seed')
p.get_resp()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-8-c939779e0345> in <module>()
----> 1 p.get_resp()

/Users/bonaime/git/obspy/obspy/io/xseed/parser.pyc in get_resp(self)
    387                     if _len != 0:
    388                         # Send the blockettes to the parser and append to list.
--> 389                         self._get_resp_string(resp, blockettes, cur_station)
    390                         resp_list.append([filename, resp])
    391                     # Create the file name.

/Users/bonaime/git/obspy/obspy/io/xseed/parser.pyc in _get_resp_string(self, resp, blockettes, station)
    846             try:
    847                 resp.write(blkt.get_resp(
--> 848                     station, channel_info['Channel'], self.abbreviations))
    849             except AttributeError:
    850                 msg = 'RESP output for blockette %s not implemented yet.'

TypeError: 'unicode' does not have the buffer interface
```

