### PR TITLE
Change nlloc signature format

### DIFF
--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -169,11 +169,15 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks):
 
     lines = dict([line.split(None, 1) for line in lines[:-1]])
     line = lines["SIGNATURE"]
-
     line = line.rstrip().split('"')[1]
-    signature, version, date, time = line.rsplit(" ", 3)
+    if "NLLoc:v6" in line:
+        signature=line.rsplit("obs:",1)[0].strip()
+        version=line.rsplit("NLLoc:",1)[1].split(" ")[0].strip()
+        date,time=line.rsplit("run:",1)[1].split(" ")
+    else:
+        signature, version, date, time = line.rsplit(" ", 3)
     creation_time = UTCDateTime().strptime(date + time, str("%d%b%Y%Hh%Mm%S"))
-
+    
     if coordinate_converter:
         # maximum likelihood origin location in km info line
         line = lines["HYPOCENTER"]


### PR DESCRIPTION
### What does this PR do?

fix the problem to read the "signature" in nlloc phase-hyp file line. It allows to recognize between old version (<6) and new nlloc version 

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
