### PR TITLE
Non-verbose error message using invalid FDSN request for PY3

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1298,10 +1298,14 @@ class Client(object):
         # get detailed server response message
         if code != 200:
             try:
-                server_info = "\n".join([
-                    line for line in data.read().splitlines() if line])
+                server_info = data.read()
             except Exception:
                 server_info = None
+            else:
+                server_info = server_info.decode('ASCII', errors='ignore')
+            if server_info:
+                server_info = "\n".join(
+                    line for line in server_info.splitlines() if line)
         # No data.
         if code == 204:
             raise FDSNNoDataException("No data available for request.",


### PR DESCRIPTION
Anaconda installation of ObsPy 1.0.3 on Linux

Script:
```
from obspy.core import UTCDateTime as UTC
from obspy.clients.fdsn import Client as FSDNClient

kw = {'starttime': UTC('2005-04-01'), 'endtime': UTC('2005-05-01'),
      'minmagnitude': 1.5, 'maxmagnitude': 3.5,
      'minlatitude': 25, 'maxlatitude': 49.5,
      'minlongitude': -124, 'maxlongitude': -67,
      'maxdepth': 40,
      'catalog': 'ANF'}
client = FSDNClient()
events = client.get_events(**kw)
```

Output of `python2`:
```
  File "bug_client.py", line 16, in <module>
    events = client.get_events(**kw)
  File "/home/eule/anaconda/envs/dev2/lib/python2.7/site-packages/obspy/clients/fdsn/client.py", line 419, in get_events
    data_stream = self._download(url)
  File "/home/eule/anaconda/envs/dev2/lib/python2.7/site-packages/obspy/clients/fdsn/client.py", line 1363, in _download
    server_info)
obspy.clients.fdsn.header.FDSNException: Service responds: Internal server error
Detailed response of server:

Error 500: ERROR: invalid input value for enum catalog_: "ANF"
Request:
http://service.iris.edu/fdsnws/event/1/query?endtime=2015-09-01T00%3A00%3A00.000000&maxlongitude=-67.0&includearrivals=false&minlongitude=-124.0&maxlatitude=49.5&catalog=ANF&maxmagnitude=3.5&maxdepth=40.0&starttime=2005-04-01T00%3A00%3A00.000000&minmagnitude=1.5&minlatitude=25.0
Request Submitted:
2017/04/12 11:24:33 UTC
Service version:
Service: fdsnws-event  version: 1.1.7
```

Output using `python3`:

```
Traceback (most recent call last):
  File "bug_client.py", line 16, in <module>
    events = client.get_events(**kw)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/site-packages/obspy/clients/fdsn/client.py", line 415, in get_events
    data_stream = self._download(url)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/site-packages/obspy/clients/fdsn/client.py", line 1359, in _download
    server_info)
obspy.clients.fdsn.header.FDSNException: Service responds: Internal server error
```
(No detailed response displayed)

By the way: Does anybody know where I can download the ANF event catalog (via FDSN webservice) wich was formerly available via IRIS?
