### PR TITLE
SDS client: add option to fetch available seed ids for specific net/sta only

### DIFF
--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -486,7 +486,8 @@ class Client(object):
         else:
             return False
 
-    def get_all_nslc(self, sds_type=None, datetime=None):
+    def get_all_nslc(self, sds_type=None, datetime=None, network=None,
+                     station=None):
         """
         Return information on what streams are included in archive.
 
@@ -502,6 +503,10 @@ class Client(object):
             time (checks if file exists that should have the data, i.e. streams
             might be returned that have data on the same day but not at exactly
             this point in time).
+        :type network: str
+        :param network: Restrict query to given network code.
+        :type station: str
+        :param station: Restrict query to given station code.
         :rtype: list
         :returns: List of (network, station, location, channel) 4-tuples of all
             available streams in archive.
@@ -510,13 +515,26 @@ class Client(object):
         result = set()
         # wildcarded pattern to match all files of interest
         if datetime is None:
+            no_wildcard = {'sds_type': sds_type}
+            if network is not None:
+                no_wildcard['network'] = network
+            if station is not None:
+                no_wildcard['station'] = station
             pattern = re.sub(
                 FORMAT_STR_PLACEHOLDER_REGEX,
-                _wildcarded_except(["sds_type"]),
-                self.FMTSTR).format(sds_type=sds_type)
+                _wildcarded_except(no_wildcard.keys()),
+                self.FMTSTR)
+            pattern = pattern.format(**no_wildcard)
             pattern = os.path.join(self.sds_root, pattern)
         else:
-            pattern = self._get_filename("*", "*", "*", "*", datetime)
+            network_ = network
+            if network_ is None:
+                network_ = '*'
+            station_ = station
+            if station_ is None:
+                station_ = '*'
+            pattern = self._get_filename(
+                network_, station_, "*", "*", datetime)
         all_files = glob.glob(pattern)
         # set up inverse regex to extract kwargs/values from full paths
         pattern_ = os.path.join(self.sds_root, self.FMTSTR)


### PR DESCRIPTION
This PR enables fetching available SEED IDs in the SDS archive for specific network/station codes. Getting a list of *all* available SEED IDs might take a very long time on slow file systems because a huge amount folders/files need to be checked. This speeds up requests when only SEED IDs of specific stations are of interest.

Not yet ready.. needs test etc. just posting it here so I don't forget later.