### PR TITLE
Docs and tutorial state that output of paz_to_freq_resp should be manipulated to get the phase - really?

### DIFF
--- a/misc/docs/source/tutorial/code_snippets/frequency_response.py
+++ b/misc/docs/source/tutorial/code_snippets/frequency_response.py
@@ -25,6 +25,7 @@ plt.ylabel('Phase [radian]')
 plt.yticks(
     [0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
     ['$0$', r'$\frac{\pi}{2}$', r'$\pi$', r'$\frac{3\pi}{2}$', r'$2\pi$'])
+plt.ylim(-0.2, 2 * np.pi + 0.2)
 # title, centered above both subplots
 plt.suptitle('Frequency Response of LE-3D/1s Seismometer')
 # make more room in between subplots for the ylabel of right plot

--- a/misc/docs/source/tutorial/code_snippets/frequency_response.py
+++ b/misc/docs/source/tutorial/code_snippets/frequency_response.py
@@ -17,8 +17,7 @@ plt.xlabel('Frequency [Hz]')
 plt.ylabel('Amplitude')
 
 plt.subplot(122)
-# take negative of imaginary part
-phase = np.unwrap(np.arctan2(-h.imag, h.real))
+phase = 2 * np.pi + np.unwrap(np.angle(h))
 plt.semilogx(f, phase)
 plt.xlabel('Frequency [Hz]')
 plt.ylabel('Phase [radian]')

--- a/misc/docs/source/tutorial/code_snippets/frequency_response.py
+++ b/misc/docs/source/tutorial/code_snippets/frequency_response.py
@@ -21,6 +21,10 @@ phase = 2 * np.pi + np.unwrap(np.angle(h))
 plt.semilogx(f, phase)
 plt.xlabel('Frequency [Hz]')
 plt.ylabel('Phase [radian]')
+# ticks and tick labels at multiples of pi
+plt.yticks(
+    [0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
+    ['$0$', r'$\frac{\pi}{2}$', r'$\pi$', r'$\frac{3\pi}{2}$', r'$2\pi$'])
 # title, centered above both subplots
 plt.suptitle('Frequency Response of LE-3D/1s Seismometer')
 # make more room in between subplots for the ylabel of right plot

--- a/misc/docs/source/tutorial/code_snippets/frequency_response.rst
+++ b/misc/docs/source/tutorial/code_snippets/frequency_response.rst
@@ -17,13 +17,8 @@ Poles and Zeros, Frequency Response
 
 The following lines show how to calculate and visualize the frequency response
 of a LE-3D/1s seismometer with sampling interval 0.005s and 16384 points of
-fft. Two things have to be taken into account for the phase (actually for the
-imaginary part of the response):
-
-* the fft that is used is defined as exp(-i*phi), but this minus sign is
-  missing for the visualization, so we have to add it again
-* we want the phase to go from 0 to 2*pi, instead of the output from atan2
-  that goes from -pi to pi 
+fft. We want the phase to go from 0 to 2*pi, instead of the output from angle
+that goes from -pi to pi .
 
 .. plot:: tutorial/code_snippets/frequency_response.py
    :include-source:

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -367,18 +367,6 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp, nfft, freq=False):
     :param nfft: Number of FFT points of signal which needs correction
     :rtype: :class:`numpy.ndarray` complex128
     :return: Frequency response of PAZ of length nfft
-
-    .. note::
-        In order to plot/calculate the phase you need to multiply the
-        complex part by -1. This results from the different definition of
-        the Fourier transform and the phase. The numpy.fft is defined as
-        A(jw) = \int_{-\inf}^{+\inf} a(t) e^{-jwt}; where as the analytic
-        signal is defined A(jw) = | A(jw) | e^{j\phi}. That is in order to
-        calculate the phase the complex conjugate of the signal needs to be
-        taken. E.g. phi = angle(f,conj(h),deg=True)
-        As the range of phi is from -pi to pi you could add 2*pi to the
-        negative values in order to get a plot from [0, 2pi]:
-        where(phi<0,phi+2*pi,phi); plot(f,phi)
     """
     n = nfft // 2
     b, a = scipy.signal.ltisys.zpk2tf(zeros, poles, scale_fac)


### PR DESCRIPTION
[Docs](https://docs.obspy.org/master/packages/autogen/obspy.signal.invsim.paz_to_freq_resp.html)
[Tutorial](https://docs.obspy.org/tutorial/code_snippets/frequency_response.html)

The doc states:

Note
In order to plot/calculate the phase you need to multiply the complex part by -1. This results from the different definition of the Fourier transform and the phase. The numpy.fft is defined as A(jw) = int_{-inf}^{+inf} a(t) e^{-jwt}; where as the analytic signal is defined A(jw) = | A(jw) | e^{jphi}. That is in order to calculate the phase the complex conjugate of the signal needs to be taken. E.g. phi = angle(f,conj(h),deg=True) As the range of phi is from -pi to pi you could add 2*pi to the negative values in order to get a plot from [0, 2pi]: where(phi<0,phi+2*pi,phi); plot(f,phi)

But `paz_to_freq_resp` never uses `numpy.fft`, rather `scipy.freqs`. Also the phase in the tutorial plot should go the other way round from `+` to `-`, shouldn't it?



