### PR TITLE
Upping tolerance for a few test images

### DIFF
--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -554,7 +554,8 @@ class CatalogBasemapTestCase(unittest.TestCase):
         parameters, using Basemap.
         """
         cat = read_events()
-        with ImageComparison(self.image_dir, 'catalog-basemap2.png') as ic:
+        with ImageComparison(self.image_dir, 'catalog-basemap2.png',
+                             reltol=1.3) as ic:
             rcParams['savefig.dpi'] = 72
             cat.plot(method='basemap', outfile=ic.name, projection='ortho',
                      resolution='c', water_fill_color='#98b7e2', label=None,
@@ -567,8 +568,8 @@ class CatalogBasemapTestCase(unittest.TestCase):
         computed in a circular fashion.
         """
         cat = read_events('/path/to/events_longitude_wrap.zmap', format='ZMAP')
-        with ImageComparison(self.image_dir,
-                             'catalog-basemap_long-wrap.png') as ic:
+        with ImageComparison(self.image_dir, 'catalog-basemap_long-wrap.png',
+                             reltol=1.1) as ic:
             rcParams['savefig.dpi'] = 40
             cat.plot(method='basemap', outfile=ic.name, projection='ortho',
                      resolution='c', label=None, title='', colorbar=False,

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -419,7 +419,7 @@ class InventoryBasemapTestCase(unittest.TestCase):
         Basemap.
         """
         inv = read_inventory()
-        reltol = 1.0
+        reltol = 1.3
         # Coordinate lines might be slightly off, depending on the basemap
         # version.
         if BASEMAP_VERSION < [1, 0, 7]:
@@ -469,7 +469,7 @@ class InventoryBasemapTestCase(unittest.TestCase):
         """
         inv = read_inventory()
         cat = read_events()
-        reltol = 1.0
+        reltol = 1.1
         # Coordinate lines might be slightly off, depending on the basemap
         # version.
         if BASEMAP_VERSION < [1, 0, 7]:

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -266,7 +266,7 @@ class NetworkBasemapTestCase(unittest.TestCase):
         Basemap.
         """
         net = read_inventory()[0]
-        reltol = 1.0
+        reltol = 1.3
         # Coordinate lines might be slightly off, depending on the basemap
         # version.
         if BASEMAP_VERSION < [1, 0, 7]:


### PR DESCRIPTION
This is to deal with some last minute changes (?) to matplotlib 2.0.1 as noticed in #1773. Just ups the tolerances a tiny bit so there are really no downsides to this.