### PR TITLE
Update to Libmseed 2.19.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -101,7 +101,7 @@ master: (doi: 10.5281/zenodo.165135)
      function is also much faster. (see #1141)
    * Always hook up the libmseed logging to its Python counterpart to avoid
      some rare segfaults. (see #1658)
-   * Update to libmseed v2.19.2 (see #1703).
+   * Update to libmseed v2.19.4 (see #1703, #1780).
    * Correctly read MiniSEED files with a data offset of 48 bytes (see #1540).
    * InternalMSEEDReadingError now called InternalMSEEDError and
      InternalMSEEDReadingWarning now called InternalMSEEDWarning as both

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -28,7 +28,7 @@ for _c in [C.c_long, C.c_longlong, C.c_int]:
     if C.sizeof(_c) == sizeoff_off_t:
         off_t_type = _c
         break
-else:
+else:  # pragma: no cover
     raise InternalMSEEDError("Could not determine corresponding ctypes "
                              "datatype for off_t.")
 

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -16,6 +16,23 @@ from . import InternalMSEEDError, InternalMSEEDWarning
 from obspy.core.util.libnames import _load_cdll
 
 
+# Load the shared library. Later on it is wrapped into another object that
+# correctly set's up error and warning handles - but information from the
+# library is already required at an earlier point.
+__clibmseed = _load_cdll("mseed")
+
+
+# Size of the off_t type.
+sizeoff_off_t = C.c_int.in_dll(__clibmseed, "LM_SIZEOF_OFF_T").value
+for _c in [C.c_long, C.c_longlong, C.c_int]:
+    if C.sizeof(_c) == sizeoff_off_t:
+        off_t_type = _c
+        break
+else:
+    raise InternalMSEEDError("Could not determine corresponding ctypes "
+                             "datatype for off_t.")
+
+
 HPTERROR = -2145916800000000
 
 ENDIAN = {0: '<', 1: '>'}
@@ -462,9 +479,9 @@ MsfileparamS._fields_ = [
     ('readlen', C.c_int),
     ('readoffset', C.c_int),
     ('packtype', C.c_int),
-    ('packhdroffset', C.c_long),
-    ('filepos', C.c_long),
-    ('filesize', C.c_long),
+    ('packhdroffset', off_t_type),
+    ('filepos', off_t_type),
+    ('filesize', off_t_type),
     ('recordcount', C.c_int),
 ]
 MSFileParam = MsfileparamS  # noqa
@@ -619,8 +636,6 @@ LinkedIDList._fields_ = [
 # Define the argument and return types of all the used libmseed functions.
 ##########################################################################
 
-__clibmseed = _load_cdll("mseed")
-
 # Declare function of libmseed library, argument parsing
 __clibmseed.mst_init.argtypes = [C.POINTER(MSTrace)]
 __clibmseed.mst_init.restype = C.POINTER(MSTrace)
@@ -639,7 +654,7 @@ __clibmseed.msr_init.restype = C.POINTER(MSRecord)
 
 __clibmseed.ms_readmsr_r.argtypes = [
     C.POINTER(C.POINTER(MSFileParam)), C.POINTER(C.POINTER(MSRecord)),
-    C.c_char_p, C.c_int, C.POINTER(Py_ssize_t), C.POINTER(C.c_int), C.c_short,
+    C.c_char_p, C.c_int, C.POINTER(off_t_type), C.POINTER(C.c_int), C.c_short,
     C.c_short, C.c_short]
 __clibmseed.ms_readmsr_r.restypes = C.c_int
 

--- a/obspy/io/mseed/src/libmseed/ChangeLog
+++ b/obspy/io/mseed/src/libmseed/ChangeLog
@@ -1,3 +1,11 @@
+2017.118: 2.19.4
+	- Add global LM_SIZEOF_OFF_T variable that is set to the size of
+	the off_t data type as determined at compile time.
+
+2017.075: 2.19.3
+	- Add missing public, global symbols to libmseed.map, thanks
+	to Elliott Sales de Andrade.
+
 2017.061: 2.19.2
 	- Provide install target in Makefile thanks to by Pierre Duperray.
 	- Deprecate dynamic build target, the shared target will now build

--- a/obspy/io/mseed/src/libmseed/README.md
+++ b/obspy/io/mseed/src/libmseed/README.md
@@ -16,7 +16,7 @@ Solaris and Win32 environments.
 
 ## Documentation
 
-The [Wiki](https://github.com/iris-edu/libmseed/Wiki) provides an
+The [Wiki](https://github.com/iris-edu/libmseed/wiki) provides an
 overview of using the library. For function level documentation,
 man pages are included in the [doc](doc) directory.
 

--- a/obspy/io/mseed/src/libmseed/libmseed.def
+++ b/obspy/io/mseed/src/libmseed/libmseed.def
@@ -102,3 +102,4 @@ EXPORTS
    ms_gswap2a
    ms_gswap4a
    ms_gswap8a
+   LM_SIZEOF_OFF_T

--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBMSEED_VERSION "2.19.2"
-#define LIBMSEED_RELEASE "2017.061"
+#define LIBMSEED_VERSION "2.19.4"
+#define LIBMSEED_RELEASE "2017.118"
 
 /* C99 standard headers */
 #include <stdlib.h>
@@ -117,6 +117,8 @@ extern "C" {
 #else
   #include <inttypes.h>
 #endif
+
+extern int LM_SIZEOF_OFF_T;  /* Size of off_t data type determined at build time */
 
 #define MINRECLEN   128      /* Minimum Mini-SEED record length, 2^7 bytes */
                              /* Note: the SEED specification minimum is 256 */

--- a/obspy/io/mseed/src/libmseed/libmseed.map
+++ b/obspy/io/mseed/src/libmseed/libmseed.map
@@ -4,7 +4,13 @@
       msr_*;
       mst_*;
       mstl_*;
+      packheaderbyteorder;
+      packdatabyteorder;
+      unpackheaderbyteorder;
+      unpackdatabyteorder;
       unpackencodingformat;
+      unpackencodingfallback;
+      LM_SIZEOF_OFF_T;
 
   local:
       *;

--- a/obspy/io/mseed/src/libmseed/lmplatform.c
+++ b/obspy/io/mseed/src/libmseed/lmplatform.c
@@ -3,13 +3,16 @@
  *
  * Platform portability routines.
  *
- * modified: 2010.304
+ * modified: 2017.118
  ***************************************************************************/
 
 /* Define _LARGEFILE_SOURCE to get ftello/fseeko on some systems (Linux) */
 #define _LARGEFILE_SOURCE 1
 
 #include "libmseed.h"
+
+/* Size of off_t data type as determined at build time */
+int LM_SIZEOF_OFF_T = sizeof(off_t);
 
 /***************************************************************************
  * lmp_ftello:


### PR DESCRIPTION
Continuation of  #1769 as I currently don't really trust the issue to PR conversion of Github.

The corresponding `ctypes` datatype for `off_t` is now derived by testing the size of a couple of candidates and chosing one that is equal to the size in `libmseed` indicated by the new global `LM_SIZEOF_OFF_T` variable.