### PR TITLE
is_segy() now explicitly checks the version number

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,8 @@ master: (doi: 10.5281/zenodo.165135)
       `obspy.io.segy.segy.iread_segy` and `obspy.io.segy.segy.iread_su`.
       (see #1400).
     * Write correct revision number (see #1737).
+    * The SEG-Y format detection now also checks the format version number
+      (see #1781).
  - obspy.io.css:
    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.io.mseed:

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -110,7 +110,7 @@ def _is_segy(filename):
     # Test the version number. The only really support version number of
     # ObsPy is 1.0 which is encoded has 0100_16. Many file have version
     # number zero which is used to indicate "traditional SEG-Y" conforming
-    # to the1975 standard.
+    # to the 1975 standard.
     # Also allow 0010_16 and 0001_16 as the definition is honestly awkward
     # and I image many writers get it wrong.
     if _format_number not in (0x0000, 0x0100, 0x0010, 0x0001):

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -105,15 +105,23 @@ def _is_segy(filename):
     _number_of_data_traces = unpack(fmt, _number_of_data_traces)[0]
     _number_of_auxiliary_traces = unpack(fmt,
                                          _number_of_auxiliary_traces)[0]
+
     _format_number = unpack(fmt, _format_number)[0]
+    # Test the version number. The only really support version number of
+    # ObsPy is 1.0 which is encoded has 0100_16. Many file have version
+    # number zero which is used to indicate "traditional SEG-Y" conforming
+    # to the1975 standard.
+    # Also allow 0010_16 and 0001_16 as the definition is honestly awkward
+    # and I image many writers get it wrong.
+    if _format_number not in (0x0000, 0x0100, 0x0010, 0x0001):
+        return False
+
     _fixed_length = unpack(fmt, _fixed_length)[0]
     _extended_number = unpack(fmt, _extended_number)[0]
     # Make some sanity checks and return False if they fail.
-    # Unfortunately the format number is 0 in many files so it cannot be truly
-    # tested.
     if _sample_interval <= 0 or _samples_per_trace <= 0 \
-       or _number_of_data_traces < 0 or _number_of_auxiliary_traces < 0 \
-       or _format_number < 0 or _fixed_length < 0 or _extended_number < 0:
+            or _number_of_data_traces < 0 or _number_of_auxiliary_traces < 0 \
+            or _fixed_length < 0 or _extended_number < 0:
         return False
     return True
 

--- a/obspy/io/segy/core.py
+++ b/obspy/io/segy/core.py
@@ -107,8 +107,8 @@ def _is_segy(filename):
                                          _number_of_auxiliary_traces)[0]
 
     _format_number = unpack(fmt, _format_number)[0]
-    # Test the version number. The only really support version number of
-    # ObsPy is 1.0 which is encoded has 0100_16. Many file have version
+    # Test the version number. The only really supported version number in
+    # ObsPy is 1.0 which is encoded as 0100_16. Many file have version
     # number zero which is used to indicate "traditional SEG-Y" conforming
     # to the 1975 standard.
     # Also allow 0010_16 and 0001_16 as the definition is honestly awkward

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -221,7 +221,7 @@ class SEGYFile(object):
         # If bytes 3506-3506 are not zero, an extended textual header follows
         # which is not supported so far.
         if bfh.number_of_3200_byte_ext_file_header_records_following != 0:
-            msg = 'Extended textual headers are supported yet. ' + \
+            msg = 'Extended textual headers are not yet supported. ' + \
                 'Please contact the developers.'
             raise NotImplementedError(msg)
 


### PR DESCRIPTION
Fixes a bug noticed on the mailing list where a GCF files was format-detected as a SEG-Y file: http://lists.swapbytes.de/archives/obspy-users/2017-May/002419.html

This PR fixes it by asserting the SEG-Y version number. I don't think an extra test is necessary for this as it would be very constructed and it is already tested by the other tests cases.