### PR TITLE
Mseed attributes now per trace

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -111,6 +111,8 @@ master: (doi: 10.5281/zenodo.165135)
    * Should no-longer segfault with arbitrarily truncated files (see #1728).
    * Will now raise an exception when attempting to directly read mini-SEED
      files larger than 2048 MiB (#1746).
+   * `.stats.mseed` attributes are no longer per-file but per-trace where
+     applicable (see #1782).
  - obspy.io.nlloc:
    * Set preferred origin of event (see #1570)
  - obspy.io.nordic:

--- a/obspy/io/mseed/headers.py
+++ b/obspy/io/mseed/headers.py
@@ -598,7 +598,11 @@ ContinuousSegment._fields_ = [
     ('samprate', C.c_double),
     ('sampletype', C.c_char),
     ('hpdelta', C.c_longlong),
+    ('recordcnt', C.c_int64),
     ('samplecnt', C.c_int64),
+    ('encoding', C.c_byte),
+    ('byteorder', C.c_byte),
+    ('reclen', C.c_int),
     ('timing_quality', C.c_uint8),
     ('calibration_type', C.c_int8),
     ('datasamples', C.c_void_p),  # Data samples, 'numsamples' of type

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1499,6 +1499,53 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         # Make sure 23 files have been tested.
         self.assertEqual(count, 24)
 
+    def test_per_trace_mseed_attributes(self):
+        """
+        Tests that most mseed specific attributes like record count, record
+        length and so on are set per trace and not globally.
+        """
+        # Create a concatenated tests file.
+        data_files = ["test.mseed", "two_channels.mseed",
+                      "BW.BGLD.__.EHE.D.2008.001.first_10_records"]
+        data_files = [os.path.join(self.path, "data", _i) for _i in data_files]
+
+        with io.BytesIO() as buf:
+            for d in data_files:
+                with io.open(d, "rb") as fh:
+                    buf.write(fh.read())
+            buf.seek(0, 0)
+            st = read(buf)
+
+        self.assertEqual(len(st), 4)
+        self.assertEqual(st[0].stats.mseed, {
+            'byteorder': '>',
+            'dataquality': 'R',
+            'encoding': 'STEIM2',
+            'filesize': 14336,
+            'number_of_records': 2,
+            'record_length': 4096})
+        self.assertEqual(st[1].stats.mseed, {
+            'byteorder': '>',
+            'dataquality': 'D',
+            'encoding': 'STEIM2',
+            'filesize': 14336,
+            'number_of_records': 1,
+            'record_length': 512})
+        self.assertEqual(st[2].stats.mseed, {
+            'byteorder': '>',
+            'dataquality': 'D',
+            'encoding': 'STEIM2',
+            'filesize': 14336,
+            'number_of_records': 1,
+            'record_length': 512})
+        self.assertEqual(st[3].stats.mseed, {
+            'byteorder': '>',
+            'dataquality': 'D',
+            'encoding': 'STEIM1',
+            'filesize': 14336,
+            'number_of_records': 10,
+            'record_length': 512})
+
 
 def suite():
     return unittest.makeSuite(MSEEDReadingAndWritingTestCase, 'test')


### PR DESCRIPTION
Fixed #1450.

'record_length', 'encoding', 'dataquality', 'number_of_records', and 'byteorder' are now per-trace and no longer global. Includes a test.