### PR TITLE
Possible bug on segy: TypeError: Required argument 'month' (pos 2) not found

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -103,6 +103,8 @@ master: (doi: 10.5281/zenodo.165135)
       end header mark if nothing else exists at these positions (see #1738).
     * The SEG-Y format detection now also checks the format version number
       (see #1781).
+    * Enable reading SEG-Y files that have day of year 0 in trace header
+      (see #1722).
  - obspy.io.css:
    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.io.mseed:

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -761,6 +761,14 @@ class SEGYTrace(object):
             hour = tr_header.hour_of_day
             minute = tr_header.minute_of_hour
             second = tr_header.second_of_minute
+            # work around some strange SEGY files that don't store proper
+            # start date/time but only a year (see #1722)
+            if julday == 0 and hour == 0 and minute == 0 and second == 0:
+                msg = ('Trace starttime does not store a proper date (day '
+                       'of year is zero). Using January 1st 00:00 as '
+                       'trace start time.')
+                warnings.warn(msg)
+                julday = 1
             trace.stats.starttime = UTCDateTime(
                 year=year, julday=julday, hour=hour, minute=minute,
                 second=second)


### PR DESCRIPTION
Original issue description by @eusoubrasileiro:

I am using python 3.5 anaconda windows with jupyter notebook

in anaconda installed the following version (using conda-forge channel):

> obspy                     1.0.3                    py35_0    conda-forge

just did:


```
from obspy.io.segy.core import _read_segy
segy = _read_segy('mysegyfile.sgy')
```

I have  no problems on my segy checked against seisee and other interpretation programs. 
I get the following error:


```

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-47f41c963501> in <module>()

C:\Anaconda\envs\py35\lib\site-packages\obspy\io\segy\core.py in _read_segy(filename, headonly, byteorder, textual_header_encoding, unpack_trace_headers, **kwargs)
    246             trace.stats.starttime = UTCDateTime(
    247                 year=year, julday=julday, hour=hour, minute=minute,
--> 248                 second=second)
    249     return stream
    250 

C:\Anaconda\envs\py35\lib\site-packages\obspy\core\utcdatetime.py in __init__(self, *args, **kwargs)
    328             kwargs['second'] = int(_sec)
    329             args = args[0:5]
--> 330         dt = datetime.datetime(*args, **kwargs)
    331         self._from_datetime(dt)
    332 

TypeError: Required argument 'month' (pos 2) not found

```
