### PR TITLE
Skip test if jsonschema version is too old

### DIFF
--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -325,14 +325,15 @@ def _get_function_from_entry_point(group, type):
     return func
 
 
-def get_dependency_version(package_name):
+def get_dependency_version(package_name, raw_string=False):
     """
     Get version information of a dependency package.
 
     :type package_name: str
     :param package_name: Name of package to return version info for
     :returns: Package version as a list of three integers or ``None`` if
-        import fails.
+        import fails. With option ``raw_string=True`` returns raw version
+        string instead (or ``None`` if import fails).
         The last version number can indicate different things like it being a
         version from the old svn trunk, the latest git repo, some release
         candidate version, ...
@@ -340,12 +341,14 @@ def get_dependency_version(package_name):
         0.
     """
     try:
-        version = pkg_resources.get_distribution(package_name).version
+        version_string = pkg_resources.get_distribution(package_name).version
     except pkg_resources.DistributionNotFound:
         return None
-    version = version.split("rc")[0].strip("~")
-    version = list(map(to_int_or_zero, version.split(".")))
-    return version
+    if raw_string:
+        return version_string
+    version_list = version_string.split("rc")[0].strip("~")
+    version_list = list(map(to_int_or_zero, version_list.split(".")))
+    return version_list
 
 
 NUMPY_VERSION = get_dependency_version('numpy')

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -604,7 +604,7 @@ class MSEEDMetadata(object):
         if _v < [1, 0, 0]:  # pragma: no cover
             msg = ("Validating the QC metrics requires jsonschema >= 1.0.0 "
                    "You have %s. Please update." %
-                   ".".join(str(_i) for _i in _v))
+                   get_dependency_version("jsonschema", raw_string=True))
             raise ValueError(msg)
 
         schema_path = os.path.join(os.path.dirname(__file__), "data",

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -31,6 +31,7 @@ from uuid import uuid4
 import numpy as np
 
 from obspy import Stream, UTCDateTime, read, __version__
+from obspy.core.util.base import get_dependency_version
 from obspy.io.mseed.util import get_flags
 
 
@@ -596,6 +597,15 @@ class MSEEDMetadata(object):
         :type qc_metrics: dict, str, or file-like object
         """
         import jsonschema
+
+        # Judging from the changelog 1.0.0 appears to be the first version
+        # to have fully working support for references.
+        _v = get_dependency_version("jsonschema")
+        if _v < [1, 0, 0]:  # pragma: no cover
+            msg = ("Validating the QC metrics requires jsonschema >= 1.0.0 "
+                   "You have %s. Please update." %
+                   ".".join(str(_i) for _i in _v))
+            raise ValueError(msg)
 
         schema_path = os.path.join(os.path.dirname(__file__), "data",
                                    "wf_metadata_schema.json")

--- a/obspy/signal/tests/test_quality_control.py
+++ b/obspy/signal/tests/test_quality_control.py
@@ -12,14 +12,18 @@ import unittest
 import numpy as np
 
 import obspy
-from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.base import NamedTemporaryFile, get_dependency_version
 # A bit wild to import a utility function from another test suite ...
 from obspy.io.mseed.tests.test_mseed_util import _create_mseed_file
 from obspy.signal.quality_control import MSEEDMetadata
 
 try:
     import jsonschema  # NOQA
-    HAS_JSONSCHEMA = True
+    # 1.0.0 is the first version with full $ref support.
+    if get_dependency_version("jsonschema") < [1, 0, 0]:
+        HAS_JSONSCHEMA = False
+    else:
+        HAS_JSONSCHEMA = True
 except ImportError:
     HAS_JSONSCHEMA = False
 


### PR DESCRIPTION
Also raise a warning message if that is encountered during run time. Fixes the issue mentioned in https://github.com/obspy/obspy/pull/1141#issuecomment-301049970