### PR TITLE
Implementing Encoding Flag for Reading/writing SAC files.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -200,6 +200,7 @@ master: (doi: 10.5281/zenodo.165135)
      (see #1575)
    * Reinforce ASCII encoding in reading non-ASCII SAC files regardless of
       default encoding setting. (see #1768)
+   * Implementing encoding flag for reading/writing SAC files.
 - obspy.io.sh:
    * Fix writing of long headers for Python 3 (see #1526)
    * Whitespace in header fields is not ignored anymore (see #1552)

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -425,7 +425,7 @@ def write_sac_ascii(dest, hf, hi, hs, data=None):
 # TODO: this functionality is basically the same as the getters and setters in
 #    sac.sactrace. find a way to avoid duplication?
 # TODO: put these in sac.util?
-def header_arrays_to_dict(hf, hi, hs, nulls=False):
+def header_arrays_to_dict(hf, hi, hs, nulls=False, encoding='ASCII'):
     """
     Convert SAC header arrays to a more user-friendly dict.
 
@@ -438,6 +438,9 @@ def header_arrays_to_dict(hf, hi, hs, nulls=False):
     :param nulls: If True, return all header values, including nulls, else
         omit them.
     :type nulls: bool
+    :param encoding: Encoding string that passes the user specified 
+        encoding scheme.
+    :type nulls: str
 
     :return: SAC header dictionary
     :rtype: dict
@@ -453,8 +456,8 @@ def header_arrays_to_dict(hf, hi, hs, nulls=False):
                  if val != HD.FNULL] + \
                 [(key, val) for (key, val) in zip(HD.INTHDRS, hi)
                  if val != HD.INULL] + \
-                [(key, val.decode()) for (key, val) in zip(HD.STRHDRS, hs)
-                 if val.decode() != HD.SNULL]
+                [(key, val.decode(encoding)) for (key, val)
+                 in zip(HD.STRHDRS,hs) if val.decode(encoding) != HD.SNULL]
 
     header = dict(items)
 

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -438,7 +438,7 @@ def header_arrays_to_dict(hf, hi, hs, nulls=False, encoding='ASCII'):
     :param nulls: If True, return all header values, including nulls, else
         omit them.
     :type nulls: bool
-    :param encoding: Encoding string that passes the user specified 
+    :param encoding: Encoding string that passes the user specified
         encoding scheme.
     :type nulls: str
 
@@ -457,7 +457,7 @@ def header_arrays_to_dict(hf, hi, hs, nulls=False, encoding='ASCII'):
                 [(key, val) for (key, val) in zip(HD.INTHDRS, hi)
                  if val != HD.INULL] + \
                 [(key, val.decode(encoding)) for (key, val)
-                 in zip(HD.STRHDRS,hs) if val.decode(encoding) != HD.SNULL]
+                 in zip(HD.STRHDRS, hs) if val.decode(encoding) != HD.SNULL]
 
     header = dict(items)
 

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -385,10 +385,10 @@ def _internal_read_sac(buf, headonly=False, debug_headers=False, fsize=True,
     encoding_str = kwargs.get('encoding', 'ascii')
 
     # read SAC file
-    sac = SACTrace.read(buf, encoding=encoding_str, headonly=headonly,
-                        ascii=False, checksize=fsize)
+    sac = SACTrace.read(buf, headonly=headonly, ascii=False,
+                        checksize=fsize, encoding=encoding_str)
     # assign all header entries to a new dictionary compatible with an ObsPy
-    tr = sac.to_obspy_trace(encoding=encoding_str, debug_headers=debug_headers)
+    tr = sac.to_obspy_trace(debug_headers=debug_headers, encoding=encoding_str)
 
     return Stream([tr])
 

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -380,10 +380,15 @@ def _internal_read_sac(buf, headonly=False, debug_headers=False, fsize=True,
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
     """
+
+    # Extract encoding flag (default to ascii)
+    encoding_str = kwargs.get('encoding', 'ascii')
+
     # read SAC file
-    sac = SACTrace.read(buf, headonly=headonly, ascii=False, checksize=fsize)
+    sac = SACTrace.read(buf, encoding=encoding_str, headonly=headonly,
+                        ascii=False, checksize=fsize)
     # assign all header entries to a new dictionary compatible with an ObsPy
-    tr = sac.to_obspy_trace(debug_headers=debug_headers)
+    tr = sac.to_obspy_trace(encoding=encoding_str, debug_headers=debug_headers)
 
     return Stream([tr])
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1030,17 +1030,14 @@ class SACTrace(object):
 
     # --------------------------- I/O METHODS ---------------------------------
     @classmethod
-    def read(cls, source, encoding='ASCII', headonly=False, ascii=False,
-             byteorder=None, checksize=False, debug_strings=False):
+    def read(cls, source, headonly=False, ascii=False, byteorder=None,
+             checksize=False, debug_strings=False, encoding='ASCII'):
         """
         Construct an instance from a binary or ASCII file on disk.
 
         :param source: Full path string for File-like object from a SAC binary
             file on disk.  If it is an open File object, open 'rb'.
         :type source: str or file
-        :param encoding: Encoding string that passes the user specified
-        encoding scheme.
-        :type encoding: str
         :param headonly: If headonly is True, only read the header arrays not
             the data array.
         :type headonly: bool
@@ -1059,6 +1056,9 @@ class SACTrace(object):
             beginning with '-12345' are considered unset. If True, they
             are instead passed without modification.  Good for debugging.
         :type debug_strings: bool
+        :param encoding: Encoding string that passes the user specified
+        encoding scheme.
+        :type encoding: str
 
         :raises: :class:`SacIOError` if checksize failed, byteorder was wrong,
             or header arrays are wrong size.
@@ -1247,7 +1247,7 @@ class SACTrace(object):
 
         return sac
 
-    def to_obspy_trace(self, encoding='ASCII', debug_headers=False):
+    def to_obspy_trace(self, debug_headers=False, encoding='ASCII'):
         """
         Return an ObsPy Trace instance.
 
@@ -1257,6 +1257,9 @@ class SACTrace(object):
         :param debug_headers: Include _all_ SAC headers into the
             Trace.stats.sac dictionary.
         :type debug_headers: bool
+        :param encoding: Encoding string that passes the user specified
+        encoding scheme.
+        :type encoding: str        
 
         .. rubric:: Example
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1038,7 +1038,7 @@ class SACTrace(object):
         :param source: Full path string for File-like object from a SAC binary
             file on disk.  If it is an open File object, open 'rb'.
         :type source: str or file
-        :param encoding: Encoding string that passes the user specified 
+        :param encoding: Encoding string that passes the user specified
         encoding scheme.
         :type encoding: str
         :param headonly: If headonly is True, only read the header arrays not

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1259,7 +1259,7 @@ class SACTrace(object):
         :type debug_headers: bool
         :param encoding: Encoding string that passes the user specified
         encoding scheme.
-        :type encoding: str        
+        :type encoding: str
 
         .. rubric:: Example
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -1030,14 +1030,17 @@ class SACTrace(object):
 
     # --------------------------- I/O METHODS ---------------------------------
     @classmethod
-    def read(cls, source, headonly=False, ascii=False, byteorder=None,
-             checksize=False, debug_strings=False):
+    def read(cls, source, encoding='ASCII', headonly=False, ascii=False,
+             byteorder=None, checksize=False, debug_strings=False):
         """
         Construct an instance from a binary or ASCII file on disk.
 
         :param source: Full path string for File-like object from a SAC binary
             file on disk.  If it is an open File object, open 'rb'.
         :type source: str or file
+        :param encoding: Encoding string that passes the user specified 
+        encoding scheme.
+        :type encoding: str
         :param headonly: If headonly is True, only read the header arrays not
             the data array.
         :type headonly: bool
@@ -1089,10 +1092,11 @@ class SACTrace(object):
                                             checksize=checksize)
         if not debug_strings:
             for i, val in enumerate(hs):
-                val = _ut._clean_str(val, strip_whitespace=False)
+                val = _ut._clean_str(val.decode(encoding, 'replace'),
+                                     strip_whitespace=False)
                 if val.startswith(native_str('-12345')):
                     val = HD.SNULL
-                hs[i] = val.encode('ASCII', 'replace')
+                hs[i] = val.encode(encoding, 'replace')
 
         sac = cls._from_arrays(hf, hi, hs, data)
         if sac.dist is None:
@@ -1243,7 +1247,7 @@ class SACTrace(object):
 
         return sac
 
-    def to_obspy_trace(self, debug_headers=False):
+    def to_obspy_trace(self, encoding='ASCII', debug_headers=False):
         """
         Return an ObsPy Trace instance.
 
@@ -1285,7 +1289,8 @@ class SACTrace(object):
             data = self.data
 
         sachdr = _io.header_arrays_to_dict(self._hf, self._hi, self._hs,
-                                           nulls=debug_headers)
+                                           nulls=debug_headers,
+                                           encoding=encoding)
         # TODO: logic to use debug_headers for real
 
         stats = _ut.sac_to_obspy_header(sachdr)

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -923,6 +923,13 @@ class CoreTestCase(unittest.TestCase):
         tr0 = read(self.file_encode)[0]
         self.assertEqual(tr0.stats.get('channel'), '????????')
 
+    def test_encoding_flag(self):
+        """
+        Test passing encoding flag through obspy.read
+        """
+        tr0 = read(self.file_encode, encoding='cp1252')[0]
+        self.assertEqual(tr0.stats.get('channel'), 'ÇÏÿÿÇÏÿÿ')
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -15,9 +15,9 @@ from obspy import UTCDateTime, read
 from obspy.core.util import NamedTemporaryFile
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
-from obspy.io.sac import header as _hd
-from obspy.io.sac.sactrace import SACTrace
-from obspy.io.sac.util import SacHeaderError, SacHeaderTimeError
+from .. import header as _hd
+from ..sactrace import SACTrace
+from ..util import SacHeaderError, SacHeaderTimeError
 
 
 class SACTraceTestCase(unittest.TestCase):

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -15,9 +15,9 @@ from obspy import UTCDateTime, read
 from obspy.core.util import NamedTemporaryFile
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
-from .. import header as _hd
-from ..sactrace import SACTrace
-from ..util import SacHeaderError, SacHeaderTimeError
+from obspy.io.sac import header as _hd
+from obspy.io.sac.sactrace import SACTrace
+from obspy.io.sac.util import SacHeaderError, SacHeaderTimeError
 
 
 class SACTraceTestCase(unittest.TestCase):

--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -170,11 +170,6 @@ def _clean_str(value, strip_whitespace=True):
     SACTrace, and in sac_to_obspy_header, to sanitize strings for making a
     Trace that the user may have manually added.
     """
-    try:
-        value = value.decode('ASCII', 'replace')
-    except AttributeError:
-        pass
-
     null_term = value.find('\x00')
     if null_term >= 0:
         value = value[:null_term] + " " * len(value[null_term:])


### PR DESCRIPTION
This PR tries to implementing 'encoding' flag for read/write functions in `io.sac` module. It intends to offer a complete solution to fix the problem for #1768 which only has a band-aid solution in #1773.

@jkmacc-LANL, this is just a place holder pull request to start the conversion. Let's work together on the changes. Let me know how you want to implement this.

### PR Checklist
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
