### PR TITLE
Replace relative import due to unittest fail in individual module (io.sac)

### DIFF
--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -15,9 +15,9 @@ from obspy import UTCDateTime, read
 from obspy.core.util import NamedTemporaryFile
 from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
-from .. import header as _hd
-from ..sactrace import SACTrace
-from ..util import SacHeaderError, SacHeaderTimeError
+from obspy.io.sac import header as _hd
+from obspy.io.sac.sactrace import SACTrace
+from obspy.io.sac.util import SacHeaderError, SacHeaderTimeError
 
 
 class SACTraceTestCase(unittest.TestCase):


### PR DESCRIPTION
I've noticed this problem while working on the other PR. The test ran OK when typing `obspy-runtests`; however, it fails while running individual tests in `io.sac` as following:

```Python
lijun@Lijuns-MacBook-Pro:~/git/obspy$ python obspy/io/sac/tests/test_sactrace.py -v
Traceback (most recent call last):
  File "obspy/io/sac/tests/test_sactrace.py", line 18, in <module>
    from .. import header as _hd
ValueError: attempted relative import beyond top-level package
```

This is different from the behavior describe in Page [Testing, Debugging & Profiling](https://github.com/obspy/obspy/wiki/Testing%2C-Debugging-%26-Profiling):

>```
>obspy-runtests    # Run all tests
>obspy-runtests -r -v # Run all tests in verbose mode and post output to tests.obspy.org
>
>python -m 'obspy.core.scripts.runtests.__init__'             # Run all tests
>obspy-runtests -v obspy.core.tests.test_stream.StreamTestCase.test_adding
>python obspy/core/tests/test_stats.py -v
>python obspy/core/tests/test_stats.py -v StatsTestCase.test_pickleStats
>
>python __init__.py -v test_mseed_util.MSEEDUtilTestCase.test_unpackSteim2
>```

The problem lies in the following [lines](https://github.com/obspy/obspy/blob/ddc3cd073724bd8b5ff1d50d5708a383416bc3e0/obspy/io/sac/tests/test_sactrace.py#L18-L20). There are several ways to fix this problem. Here is one that would work. Let me know how you guys like it, @jkmacc-LANL @megies 

- [x] All tests still pass.