### PR TITLE
Add Depsy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.49636.svg)](http://dx.doi.org/10.5281/zenodo.49636)
 [![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/obspy/obspy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![LGPLv3](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
+[![Depsy](http://depsy.org/api/package/pypi/obspy/badge.svg)](http://depsy.org/package/python/obspy)
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 [![TravisCI Status](https://travis-ci.org/obspy/obspy.svg?branch=master)](https://travis-ci.org/obspy/obspy)
 [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/xqrbaj9phjm6l2vw/branch/master?svg=true)](https://ci.appveyor.com/project/obspy/obspy)
 [![Coverage Status](https://codecov.io/gh/obspy/obspy/branch/master/graph/badge.svg)](https://codecov.io/gh/obspy/obspy)
-[![PyPI Version](https://img.shields.io/pypi/v/obspy.svg)](https://pypi.python.org/pypi/obspy)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/obspy.svg)](https://pypi.python.org/pypi/obspy/)
+
 [![License](https://img.shields.io/pypi/l/obspy.svg)](https://pypi.python.org/pypi/obspy/)
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.49636.svg)](http://dx.doi.org/10.5281/zenodo.49636)
-[![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/obspy/obspy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![LGPLv3](https://www.gnu.org/graphics/lgplv3-88x31.png)](https://www.gnu.org/licenses/lgpl.html)
+
+[![PyPI Version](https://img.shields.io/pypi/v/obspy.svg)](https://pypi.python.org/pypi/obspy)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.49636.svg)](http://dx.doi.org/10.5281/zenodo.49636)
 [![Depsy](http://depsy.org/api/package/pypi/obspy/badge.svg)](http://depsy.org/package/python/obspy)
+
+[![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/obspy/obspy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 


### PR DESCRIPTION
Just stumbled over this research software metrics tool/website/API called "Depsy":

- http://depsy.org/package/python/obspy
- http://www.nature.com/news/the-unsung-heroes-of-scientific-software-1.19100

Although their metrics (esp. citation lookup) might not be perfect, maybe we still want to add the badge.. mostly in order to raise awareness and aid their efforts?

[This is how README.md would look like with this PR](https://github.com/obspy/obspy/blob/depsy_badge/README.md) (I also tried to group badges logically a bit):

![screenshot from 2017-06-06 13 41 23](https://cloud.githubusercontent.com/assets/1842780/26827530/ff860b50-4abd-11e7-8e77-7a3b34d58bcd.png)
