### PR TITLE
Fix sc3ml event unit

### DIFF
--- a/obspy/io/seiscomp/data/quakeml_1.2__sc3ml_0.9.xsl
+++ b/obspy/io/seiscomp/data/quakeml_1.2__sc3ml_0.9.xsl
@@ -86,7 +86,8 @@ Both schema use enumerations. Numerous mappings are applied.
 Unit conversion
 ```````````````
 
-QuakeML uses meter for origin depth, SC3ML uses kilometer.
+QuakeML uses meter for origin depth, origin uncertainty and confidence
+ellipsoid, SC3ML uses kilometer.
 
 Unmapped node
 `````````````
@@ -421,7 +422,13 @@ SC3ML. Unnecessary attributes must also be removed.
     <xsl:template match="qml:origin/qml:depth/qml:value
                          | qml:origin/qml:depth/qml:uncertainty
                          | qml:origin/qml:depth/qml:lowerUncertainty
-                         | qml:origin/qml:depth/qml:upperUncertainty">
+                         | qml:origin/qml:depth/qml:upperUncertainty
+                         | qml:origin/qml:originUncertainty/qml:horizontalUncertainty
+                         | qml:origin/qml:originUncertainty/qml:minHorizontalUncertainty
+                         | qml:origin/qml:originUncertainty/qml:maxHorizontalUncertainty
+                         | qml:confidenceEllipsoid/qml:semiMajorAxisLength
+                         | qml:confidenceEllipsoid/qml:semiMinorAxisLength
+                         | qml:confidenceEllipsoid/qml:semiIntermediateAxisLength">
         <xsl:element name="{local-name()}">
             <xsl:value-of select="current() div 1000"/>
         </xsl:element>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
@@ -28,14 +28,14 @@
         <minimumDistance>2.45</minimumDistance>
       </quality>
       <uncertainty>
-        <horizontalUncertainty>9000.0</horizontalUncertainty>
-        <minHorizontalUncertainty>6000.0</minHorizontalUncertainty>
-        <maxHorizontalUncertainty>10000.0</maxHorizontalUncertainty>
+        <horizontalUncertainty>9</horizontalUncertainty>
+        <minHorizontalUncertainty>6</minHorizontalUncertainty>
+        <maxHorizontalUncertainty>10</maxHorizontalUncertainty>
         <azimuthMaxHorizontalUncertainty>80.0</azimuthMaxHorizontalUncertainty>
         <confidenceEllipsoid>
-          <semiMajorAxisLength>0.123</semiMajorAxisLength>
-          <semiMinorAxisLength>1.123</semiMinorAxisLength>
-          <semiIntermediateAxisLength>2.123</semiIntermediateAxisLength>
+          <semiMajorAxisLength>0.000123</semiMajorAxisLength>
+          <semiMinorAxisLength>0.001123</semiMinorAxisLength>
+          <semiIntermediateAxisLength>0.002123</semiIntermediateAxisLength>
           <majorAxisPlunge>3.123</majorAxisPlunge>
           <majorAxisAzimuth>4.123</majorAxisAzimuth>
           <majorAxisRotation>5.123</majorAxisRotation>

--- a/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
+++ b/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
@@ -23,7 +23,7 @@
         <minimumDistance>0.1164</minimumDistance>
       </quality>
       <uncertainty>
-        <horizontalUncertainty>500.0</horizontalUncertainty>
+        <horizontalUncertainty>0.5</horizontalUncertainty>
         <preferredDescription>horizontal uncertainty</preferredDescription>
       </uncertainty>
       <evaluationMode>manual</evaluationMode>


### PR DESCRIPTION
This small PR fix the origin uncertainty units in the seiscomp event module.

In the QuakeML format, the origin uncertainty is in meter but seiscomp use kilometers.