### PR TITLE
Write SEGY textual file header if given as text

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -106,6 +106,8 @@ master: (doi: 10.5281/zenodo.165135)
       (see #1781).
     * Enable reading SEG-Y files that have day of year 0 in trace header
       (see #1722).
+    * Write textual file headers also if given as a text string
+      (see #1811, #1813).
  - obspy.io.css:
    * Read support for NNSA KB Core format waveform data. (see #1332)
  - obspy.io.mseed:

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -311,7 +311,7 @@ class SEGYFile(object):
         # case the textual file header has no representation in ASCII - this
         # is then the users responsibility.
         if hasattr(textual_header, "encode"):
-            textual_header = textual_header.encode("ASCII")
+            textual_header = textual_header.encode()
 
         length = len(textual_header)
         # Append spaces to the end if its too short.

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -305,12 +305,20 @@ class SEGYFile(object):
         small it will be padded with zeros. If it is too long or an invalid
         encoding is specified an exception will be raised.
         """
-        length = len(self.textual_file_header)
+        textual_header = self.textual_file_header
+
+        # Convert to ASCII bytes if necessary - this will raise an error in
+        # case the textual file header has no representation in ASCII - this
+        # is then the users responsibility.
+        if hasattr(textual_header, "encode"):
+            textual_header = textual_header.encode("ASCII")
+
+        length = len(textual_header)
         # Append spaces to the end if its too short.
         if length < 3200:
-            textual_header = self.textual_file_header + b' ' * (3200 - length)
+            textual_header = textual_header + b' ' * (3200 - length)
         elif length == 3200:
-            textual_header = self.textual_file_header
+            textual_header = textual_header
         # The length must not exceed 3200 byte.
         else:
             msg = 'self.textual_file_header is not allowed to be longer ' + \

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -649,7 +649,7 @@ class SEGYCoreTestCase(unittest.TestCase):
 
     def test_writing_text_and_binary_textual_file_headers(self):
         """
-        Make sure the textual file header can be written if has been passed 
+        Make sure the textual file header can be written if has been passed
         either as text or as a bytestring.
         """
         # Loop over bytes/text and the textual header encoding.

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -15,16 +15,15 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime, read
-from obspy.core.util import NamedTemporaryFile
+from obspy.core.util import NamedTemporaryFile, AttribDict
 from obspy.io.segy.core import (SEGYCoreWritingError, SEGYSampleIntervalError,
                                 _is_segy, _is_su, _read_segy, _read_su,
                                 _write_segy, _write_su)
 from obspy.io.segy.segy import _read_segy as _read_segy_internal
 from obspy.io.segy.segy import SEGYError, SEGYFile, SEGYTrace, \
     SEGYBinaryFileHeader
+from obspy.io.segy.tests import _patch_header
 from obspy.io.segy.tests.header import DTYPES, FILES
-
-from . import _patch_header
 
 
 class SEGYCoreTestCase(unittest.TestCase):
@@ -647,6 +646,32 @@ class SEGYCoreTestCase(unittest.TestCase):
             st = read(buf, format="segy")
         # Results in 1970, 1, 1
         self.assertEqual(st[0].stats.starttime, UTCDateTime(0))
+
+    def test_writing_text_and_binary_textual_file_headers(self):
+        """
+        Make sure the textual file header can be written if has been passed 
+        either as text or as a bytestring.
+        """
+        # Loop over bytes/text and the textual header encoding.
+        for textual_file_header in [b"12345", "12345"]:
+            for encoding in ["ASCII", "EBCDIC"]:
+                st = read()
+                for tr in st:
+                    tr.data = np.require(tr.data, dtype=np.float32)
+                st.stats = AttribDict()
+                st.stats.textual_file_header = textual_file_header
+                with io.BytesIO() as buf:
+                    # Warning raised to create a complete header.
+                    with warnings.catch_warnings(record=True):
+                        st.write(buf, format="SEGY", data_encoding=5,
+                                 textual_header_encoding=encoding)
+                    buf.seek(0, 0)
+                    # Read with SEG-Y to preserve the textual file header.
+                    st2 = _read_segy(buf)
+                self.assertEqual(
+                    # Ignore the auto-generated parts of the header.
+                    st2.stats.textual_file_header.decode().split()[0],
+                    "12345")
 
 
 def suite():


### PR DESCRIPTION
Fixes #1811 

This makes sure that the textual file header will be written if given as a byte string or a unicode string.