### PR TITLE
Add level parameter to inventory.write stationXML

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,8 @@ master: (doi: 10.5281/zenodo.165135)
     * Read and write support for custom tags (see #1024)
     * No longer add the (unused) time zone field to StationXML datetimes to
       follow the example of big data centers. (see #1572)
+    * Level of detail can be specified during inventory write (see #1830)
+      using the level keyword (one of: network, station, channel, response).
  - obspy.io.segy:
     * Fixing an issue when comparing two still packed SEG-Y trace headers
       (see #1735).

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -825,8 +825,12 @@ def _write_stationxml(inventory, file_or_file_object, validate=False,
 
     etree.SubElement(root, "Created").text = _format_time(inventory.created)
 
+    level = kwargs.get("level") or "response"
+    if level not in ["network", "station", "channel", "response"]:
+        raise ValueError("Requested stationXML write level is unsupported.")
+
     for network in inventory.networks:
-        _write_network(root, network)
+        _write_network(root, network, level)
 
     # Add custom namespace tags to root element
     _write_extra(root, inventory)
@@ -882,7 +886,7 @@ def _write_base_node(element, object_to_read_from):
     _write_extra(element, object_to_read_from)
 
 
-def _write_network(parent, network):
+def _write_network(parent, network, level):
     """
     Helper function converting a Network instance to an etree.Element.
     """
@@ -898,8 +902,11 @@ def _write_network(parent, network):
         etree.SubElement(network_elem, "SelectedNumberStations").text = \
             str(network.selected_number_of_stations)
 
+    if level == "network":
+        return
+
     for station in network.stations:
-        _write_station(network_elem, station)
+        _write_station(network_elem, station, level)
 
 
 def _write_floattype(parent, obj, attr_name, tag, additional_mapping={}):
@@ -992,7 +999,7 @@ def _write_polezero_list(parent, obj):
     _write_extra(parent, obj)
 
 
-def _write_station(parent, station):
+def _write_station(parent, station, level):
     # Write the base node type fields.
     attribs = _get_base_node_attributes(station)
     station_elem = etree.SubElement(parent, "Station", attribs)
@@ -1034,11 +1041,14 @@ def _write_station(parent, station):
     for ref in station.external_references:
         _write_external_reference(station_elem, ref)
 
+    if level == "station":
+        return
+
     for channel in station.channels:
-        _write_channel(station_elem, channel)
+        _write_channel(station_elem, channel, level)
 
 
-def _write_channel(parent, channel):
+def _write_channel(parent, channel, level):
     # Write the base node type fields.
     attribs = _get_base_node_attributes(channel)
     attribs['locationCode'] = channel.location_code
@@ -1092,6 +1102,10 @@ def _write_channel(parent, channel):
     _write_equipment(channel_elem, channel.pre_amplifier, "PreAmplifier")
     _write_equipment(channel_elem, channel.data_logger, "DataLogger")
     _write_equipment(channel_elem, channel.equipment, "Equipment")
+
+    if level == "channel":
+        return
+
     if channel.response is not None:
         _write_response(channel_elem, channel.response)
 

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -755,7 +755,7 @@ def _read_phone(phone_element, _ns):
 
 
 def _write_stationxml(inventory, file_or_file_object, validate=False,
-                      nsmap=None, **kwargs):
+                      nsmap=None, level="response", **kwargs):
     """
     Writes an inventory object to a buffer.
     :type inventory: :class:`~obspy.core.inventory.Inventory`
@@ -825,7 +825,6 @@ def _write_stationxml(inventory, file_or_file_object, validate=False,
 
     etree.SubElement(root, "Created").text = _format_time(inventory.created)
 
-    level = kwargs.get("level", "response")
     if level not in ["network", "station", "channel", "response"]:
         raise ValueError("Requested stationXML write level is unsupported.")
 

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -825,7 +825,7 @@ def _write_stationxml(inventory, file_or_file_object, validate=False,
 
     etree.SubElement(root, "Created").text = _format_time(inventory.created)
 
-    level = kwargs.get("level") or "response"
+    level = kwargs.get("level", "response")
     if level not in ["network", "station", "channel", "response"]:
         raise ValueError("Requested stationXML write level is unsupported.")
 

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -136,7 +136,7 @@ class StationXMLTestCase(unittest.TestCase):
                 self.assertTrue(len(sta.channels) == len(inv[0][0].channels))
                 for cha in sta.channels:
                     self.assertTrue(cha.response is None)
- 
+
     def test_read_and_write_minimal_file(self):
         """
         Test that writing the most basic StationXML document possible works.

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -100,7 +100,7 @@ class StationXMLTestCase(unittest.TestCase):
         inv = obspy.read_inventory(filename)
 
         # Write to network level
-        file_buffer = io.BytesIO();
+        file_buffer = io.BytesIO()
         inv.write(file_buffer, format="StationXML", level="network")
         file_buffer.seek(0, 0)
 
@@ -112,7 +112,7 @@ class StationXMLTestCase(unittest.TestCase):
             self.assertTrue(len(net.stations) == 0)
 
         # Write to station level
-        file_buffer = io.BytesIO();
+        file_buffer = io.BytesIO()
         inv.write(file_buffer, format="StationXML", level="station")
         file_buffer.seek(0, 0)
 
@@ -124,7 +124,7 @@ class StationXMLTestCase(unittest.TestCase):
                 self.assertTrue(len(sta.channels) == 0)
 
         # Write to channel level
-        file_buffer = io.BytesIO();
+        file_buffer = io.BytesIO()
         inv.write(file_buffer, format="StationXML", level="channel")
         file_buffer.seek(0, 0)
 
@@ -136,7 +136,7 @@ class StationXMLTestCase(unittest.TestCase):
                 self.assertTrue(len(sta.channels) == len(inv[0][0].channels))
                 for cha in sta.channels:
                     self.assertTrue(cha.response is None)
-        
+ 
     def test_read_and_write_minimal_file(self):
         """
         Test that writing the most basic StationXML document possible works.


### PR DESCRIPTION
Adds kwarg `level` for Inventory.write for StationXML. `FDSNWS-Station` supports these four levels and I wanted to try to use ObsPy running behind FDSNWS Station writing at different levels. Maybe it's useful.