### PR TITLE
Fix stationtxt write

### DIFF
--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -364,8 +364,8 @@ def inventory_to_station_text(inventory_or_network, level):
                     cha.elevation is not None and
                     cha.elevation or sta.elevation,
                     cha.depth, cha.azimuth, cha.dip,
-                    cha.sensor.type
-                    if (cha.sensor and cha.sensor.type) else None,
+                    cha.sensor.description
+                    if (cha.sensor and cha.sensor.description) else None,
                     sensitivity.value
                     if (sensitivity and sensitivity.value) else None,
                     sensitivity.frequency

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -722,7 +722,7 @@ class StationTextTestCase(unittest.TestCase):
                                 sample_rate=0.0,
                                 sensor=Equipment(
                                     description="Geotech KS-36000-I Borehole "
-                                         "Seismometer"),
+                                                "Seismometer"),
                                 start_date=obspy.UTCDateTime(
                                     "1989-08-29T00:00:00"),
                                 end_date=obspy.UTCDateTime(

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -721,7 +721,7 @@ class StationTextTestCase(unittest.TestCase):
                                 dip=0.0,
                                 sample_rate=0.0,
                                 sensor=Equipment(
-                                    type="Geotech KS-36000-I Borehole "
+                                    description="Geotech KS-36000-I Borehole "
                                          "Seismometer"),
                                 start_date=obspy.UTCDateTime(
                                     "1989-08-29T00:00:00"),
@@ -738,7 +738,7 @@ class StationTextTestCase(unittest.TestCase):
                                 dip=-90.0,
                                 sample_rate=0.0,
                                 sensor=Equipment(
-                                    type="Titan Accelerometer"),
+                                    description="Titan Accelerometer"),
                                 start_date=obspy.UTCDateTime(
                                     "2013-06-20T16:30:00"),
                                 response=resp_2),
@@ -767,7 +767,7 @@ class StationTextTestCase(unittest.TestCase):
                                 dip=0.0,
                                 sample_rate=0.0,
                                 sensor=Equipment(
-                                    type="Reftek 130 Datalogger"),
+                                    description="Reftek 130 Datalogger"),
                                 start_date=obspy.UTCDateTime(
                                     "2013-11-23T00:00:00"),
                                 end_date=obspy.UTCDateTime(


### PR DESCRIPTION
This is a fix for the incorrect field being used as the Sensor Description in the "channel" level StationTXT output.

### What does this PR do?
This PR includes a small update to the to StationTXT write method. Instead of  writing the _cha.sensor.type_ value for the channel level StationTXT SensorDescription, the method has been changed to correctly use _cha.sensor.description_.

### Why was it initiated?  Any relevant Issues?
For more details please see https://github.com/obspy/obspy/pull/1466#issuecomment-315401056

