### PR TITLE
implemented load_entry_point cache and check_compression param of read

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -43,7 +43,7 @@ _headonly_warning_msg = (
 @map_example_filename("pathname_or_url")
 def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
          endtime=None, nearest_sample=True, dtype=None, apply_calib=False,
-         **kwargs):
+         check_compression=True, **kwargs):
     """
     Read waveform files into an ObsPy Stream object.
 
@@ -85,6 +85,9 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     :type apply_calib: bool, optional
     :param apply_calib: Automatically applies the calibration factor
         ``trace.stats.calib`` for each trace, if set. Defaults to ``False``.
+    :param check_compression: Check for compression on file and decompress
+        if needed. This may be disabled for a moderate speed up.
+    :type check_compression: bool, optional
     :param kwargs: Additional keyword arguments passed to the underlying
         waveform reader method.
     :return: An ObsPy :class:`~obspy.core.stream.Stream` object.
@@ -197,6 +200,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     kwargs['starttime'] = starttime
     kwargs['endtime'] = endtime
     kwargs['nearest_sample'] = nearest_sample
+    kwargs['check_compression'] = check_compression
     # create stream
     st = Stream()
     if pathname_or_url is None:

--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -83,7 +83,7 @@ class CodeFormattingTestCase(unittest.TestCase):
                 files.append(filename)
         report = style_guide.check_files(files)
 
-        # Make sure no error occured.
+        # Make sure no error occurred.
         assert report.total_errors == 0
 
     @unittest.skipIf(CLEAN_VERSION_NUMBER,

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2484,6 +2484,26 @@ class StreamTestCase(unittest.TestCase):
             self.assertEqual(arg[1]["order"], 2)
             self.assertEqual(arg[1]["plot"], True)
 
+    def test_read_no_check_compression(self):
+        """
+        Test to ensure calling read with check_compression=False does not 
+        call expensive tar or zip functions  
+        """
+        # write a file to disk
+        file_name = 'temp.mseed'
+        st = read()
+        st.write(file_name, 'mseed')  # maybe read from test data instead?
+
+        with mock.patch("tarfile.is_tarfile") as tar_patch:
+            with mock.patch("zipfile.is_zipfile") as zip_patch:
+                _ = read(file_name, check_compression=False)
+
+        # delete temp file
+        os.remove(file_name)
+        # assert neither compression check function was called.
+        self.assertEqual(tar_patch.call_count, 0)
+        self.assertEqual(zip_patch.call_count, 0)
+
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2486,8 +2486,8 @@ class StreamTestCase(unittest.TestCase):
 
     def test_read_no_check_compression(self):
         """
-        Test to ensure calling read with check_compression=False does not 
-        call expensive tar or zip functions  
+        Test to ensure calling read with check_compression=False does not
+        call expensive tar or zip functions.
         """
         # write a file to disk
         file_name = 'temp.mseed'
@@ -2496,7 +2496,7 @@ class StreamTestCase(unittest.TestCase):
 
         with mock.patch("tarfile.is_tarfile") as tar_patch:
             with mock.patch("zipfile.is_zipfile") as zip_patch:
-                _ = read(file_name, check_compression=False)
+                read(file_name, check_compression=False)
 
         # delete temp file
         os.remove(file_name)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -14,6 +14,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 from future.utils import native_str
 
 import doctest
+import functools
 import inspect
 import io
 import os
@@ -58,6 +59,24 @@ WAVEFORM_ACCEPT_BYTEORDER = ['MSEED', 'Q', 'SAC', 'SEGY', 'SU']
 
 _sys_is_le = sys.byteorder == 'little'
 NATIVE_BYTEORDER = _sys_is_le and '<' or '>'
+
+
+# apply simple memoization cache to load_entry_points
+def decorate_load_entry_point(func):
+    cache = {}
+    sig = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        b = sig.bind(*args, **kwargs).args
+        if not b in cache:
+            cache[b] = func(*args, **kwargs)
+        return cache[b]
+
+    return wrapper
+
+
+load_entry_point = decorate_load_entry_point(load_entry_point)
 
 
 class NamedTemporaryFile(io.BufferedIOBase):

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -11,7 +11,6 @@ Decorator used in ObsPy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2, native_str
 
 import functools
 import inspect
@@ -26,6 +25,7 @@ import zipfile
 
 import numpy as np
 from decorator import decorator
+from future.utils import PY2, native_str
 
 from obspy.core.util import get_example_file
 from obspy.core.util.base import NamedTemporaryFile
@@ -322,7 +322,7 @@ def _decorate_polyfill(func, caller):
 
 def rlock(func):
     """
-    Place a threading recursive lock (Rlock) on the wrapped function
+    Place a threading recursive lock (Rlock) on the wrapped function.
     """
     # This lock will be instantiated at function creation time, i.e. at the
     # time the Python interpreter sees the decorated function the very

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -145,6 +145,8 @@ def uncompress_file(func, filename, *args, **kwargs):
     """
     Decorator used for temporary uncompressing file if .gz or .bz2 archive.
     """
+    if not kwargs.get('check_compression', True):
+        return func(filename, *args, **kwargs)
     if not isinstance(filename, (str, native_str)):
         return func(filename, *args, **kwargs)
     elif not os.path.exists(filename):


### PR DESCRIPTION
### What does this PR do?

This PR is intended to speed up reading mseed files through two methods:

1. Caching outputs of pkg_resources.load_entry_point which can be rather slow 

2. Add the check_compression parameter to obspy.read function for skipping potentially expensive compression checks (from tar and zip libraries).  

This has also reduced the run time of the entire obspy test suit by 5% to 10%, and since obspy uses plugins heavily I suspect it will speed up many other obspy functions. 

### Why was it initiated?  Any relevant Issues?

See [this gist](https://gist.github.com/d-chambers/1eabd9c2147b11db0e68cf57ac3a8ad1)

### PR Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
