### PR TITLE
Stream.select() for components now also works for components with less than 3 letters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,8 @@ master: (doi: 10.5281/zenodo.165135)
    * Order of extra tags for event type classes serialized to QuakeML can now
      be controlled by using an OrderedDict (see #1617)
    * Bode plots can now optionally plot the phase in degrees (see #1763).
+   * `Stream.select()` now also works on the component level if channels only
+     have one letter (see #1847).
  - obspy.clients.earthworm:
    * Much faster trace unpacking (see #1762).
  - obspy.clients.fdsn:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1809,8 +1809,6 @@ class Stream(object):
             if npts is not None and int(npts) != trace.stats.npts:
                 continue
             if component is not None:
-                if len(trace.stats.channel) < 3:
-                    continue
                 if not fnmatch.fnmatch(trace.stats.channel[-1].upper(),
                                        component.upper()):
                     continue

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -656,6 +656,22 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(len(stream2), 1)
         self.assertIn(stream[4], stream2)
 
+    def test_select_on_single_letter_channels(self):
+        st = read()
+        st[0].stats.channel = "Z"
+        st[1].stats.channel = "N"
+        st[2].stats.channel = "E"
+
+        self.assertEqual([tr.stats.channel for tr in st], ["Z", "N", "E"])
+
+        self.assertEqual(st.select(component="Z")[0], st[0])
+        self.assertEqual(st.select(component="N")[0], st[1])
+        self.assertEqual(st.select(component="E")[0], st[2])
+
+        self.assertEqual(len(st.select(component="Z")), 1)
+        self.assertEqual(len(st.select(component="N")), 1)
+        self.assertEqual(len(st.select(component="E")), 1)
+
     def test_sort(self):
         """
         Tests the sort method of the Stream object.
@@ -2167,22 +2183,6 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(st.select(station=""), st2)
         self.assertEqual(st.select(channel=""), st2)
         self.assertEqual(st.select(npts=0), st2)
-
-    def test_select_short_channel_code(self):
-        """
-        Test that select by component only checks channel codes longer than two
-        characters.
-        """
-        st = Stream([Trace(), Trace(), Trace(), Trace(), Trace(), Trace()])
-        st[0].stats.channel = "EHZ"
-        st[1].stats.channel = "HZ"
-        st[2].stats.channel = "Z"
-        st[3].stats.channel = "E"
-        st[4].stats.channel = "N"
-        st[5].stats.channel = "EHN"
-        self.assertEqual(len(st.select(component="Z")), 1)
-        self.assertEqual(len(st.select(component="N")), 1)
-        self.assertEqual(len(st.select(component="E")), 0)
 
     def test_remove_response(self):
         """


### PR DESCRIPTION
A fair number of data (synthetics, active source data, ...) does not have three letter channel names so `Stream.select(component="X")` did not work as it only worked for traces that has three letters. With this PR it now just takes the last letter.

@megies I've see that this is intentional behavior (including a test case) from you. Why is this needed? I've been bitten by this quite a number of times so I've written this PR but if there is a good reason not to have this I'm also fine with dropping it.