### PR TITLE
Fix a bug in coincidence_trigger() with event templates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -152,6 +152,9 @@ master: (doi: 10.5281/zenodo.165135)
  - obspy.signal:
    * fixed a bug in calibration.rel_calib_stack (resulting amplitude response
      had wrong scaling if using non-default "overlap_fraction", see #1821)
+   * fixed a bug in coincidence_trigger() with event templates. when a template
+     with mismatching SEED ID was encountered all following (potentially valid)
+     templates were skipped as well (see #1850)
    * New obspy.signal.quality_control module to compute quality metrics from
      MiniSEED files. (see #1141)
    * New correlate function for calculating the cross-correlation function

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -625,6 +625,14 @@ def templates_max_similarity(st, time, streams_templates):
                       "(not present in stream to check)."
                 warnings.warn(msg % id_)
                 ids.remove(id_)
+        if not ids:
+            msg = ("Skipping template(s) for station '{}': No common SEED IDs "
+                   "when comparing template ({}) and data streams ({}).")
+            warnings.warn(msg.format(
+                st_tmpl[0].stats.station,
+                ', '.join(sorted(set(tr.id for tr in st_tmpl))),
+                ', '.join(sorted(set(tr.id for tr in st_)))))
+            continue
         # determine best (combined) shift of multi-component data
         for id_ in ids:
             tr1 = st_.select(id=id_)[0]

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -649,7 +649,7 @@ def templates_max_similarity(st, time, streams_templates):
             msg = "Skipping template(s) for station %s due to problems in " + \
                   "three component correlation (gappy traces?)"
             warnings.warn(msg % st_tmpl[0].stats.station)
-            break
+            continue
         ind = cc.argmax()
         ind2 = ind + len(data_short)
         coef = 0.0

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -410,8 +410,26 @@ class TriggerTestCase(unittest.TestCase):
                 "classicstalta", 5, 1, st.copy(), 4, sta=0.5, lta=10,
                 trace_ids=trace_ids, event_templates=templ,
                 similarity_threshold=similarity_thresholds)
-            # two warnings get raised
-            self.assertEqual(len(w), 2)
+        # four warnings get raised
+        self.assertEqual(len(w), 4)
+        self.assertEqual(
+            str(w[0].message),
+            "At least one trace's ID was not found in the trace ID list and "
+            "was disregarded (BW.UH3..SHN)")
+        self.assertEqual(
+            str(w[1].message),
+            "At least one trace's ID was not found in the trace ID list and "
+            "was disregarded (BW.UH3..SHE)")
+        self.assertEqual(
+            str(w[2].message),
+            'Skipping trace BW.UH1..XHZ in template correlation (not present '
+            'in stream to check).')
+        self.assertEqual(
+            str(w[3].message),
+            "Skipping template(s) for station 'UH1': No common SEED IDs when "
+            "comparing template (BW.UH1..XHZ) and data streams (BW.UH1..SHZ, "
+            "BW.UH2..SHZ, BW.UH3..SHE, BW.UH3..SHN, BW.UH3..SHZ, "
+            "BW.UH4..EHZ).")
         # check floats in resulting dictionary separately
         self.assertAlmostEqual(trig[0].pop('duration'), 3.96, places=6)
         self.assertAlmostEqual(trig[1].pop('duration'), 1.99, places=6)

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -389,6 +389,13 @@ class TriggerTestCase(unittest.TestCase):
             t = UTCDateTime(t)
             st_ = st.select(station="UH1").slice(t, t + 2.5).copy()
             templ.setdefault("UH1", []).append(st_)
+        # add another template with different SEED ID, it should be ignored
+        # (this can happen when using many templates over a long time period
+        # and instrument changes over time)
+        st_ = st_.copy()
+        for tr in st_:
+            tr.stats.channel = 'X' + tr.stats.channel[1:]
+        templ['UH1'].insert(0, st_)
         trace_ids = {"BW.UH1..SHZ": 1,
                      "BW.UH2..SHZ": 1,
                      "BW.UH3..SHZ": 1,


### PR DESCRIPTION
This fixes a bug in `coincidence_trigger()` when using event templates for similarity calculations. When a template with mismatched SEED ID was encountered (e.g. a template recorded by a different instrument when e.g. the instrument at a station was changed from short period 'EHZ' to broad band 'HHZ') all following templates were skipped as well, due to a `break` statement when there should've been a `continue`.

Also, warning messages are improved if problems with event templates appear.