### PR TITLE
Python only CatchOutput

### DIFF
--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
 import os
 import sys
@@ -49,6 +50,18 @@ class UtilMiscTestCase(unittest.TestCase):
             print("test_catch_output #5", file=sys.stderr)
         self.assertEqual(out.stdout, 'test_catch_output #4\n')
         self.assertEqual(out.stderr, 'test_catch_output #5\n')
+
+    def test_catch_output_bytes(self):
+        with CatchOutput() as out:
+            if PY2:
+                sys.stdout.write(b"test_catch_output_bytes #1")
+                sys.stderr.write(b"test_catch_output_bytes #2")
+            else:
+                # PY3 does not allow to write directly bytes into text streams
+                sys.stdout.buffer.write(b"test_catch_output_bytes #1")
+                sys.stderr.buffer.write(b"test_catch_output_bytes #2")
+        self.assertEqual(out.stdout, 'test_catch_output_bytes #1')
+        self.assertEqual(out.stderr, 'test_catch_output_bytes #2')
 
     def test_catch_output_io(self):
         """

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -4,12 +4,9 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 import os
-import platform
 import sys
 import tempfile
 import unittest
-from ctypes import CDLL
-from ctypes.util import find_library
 
 from obspy import UTCDateTime
 from obspy.core.util.misc import CatchOutput, get_window_times
@@ -19,38 +16,39 @@ class UtilMiscTestCase(unittest.TestCase):
     """
     Test suite for obspy.core.util.misc
     """
-    @unittest.skipIf(sys.platform in ("darwin", "win32") and
-                     platform.python_version_tuple()[0] == "3",
-                     "Does not work with Python 3 for some Windows and OSX "
-                     "versions")
+
+    def test_supress_output(self):
+        """
+        Tests that CatchOutput suppresses messages
+        """
+        # this should write nothing to console
+        with CatchOutput():
+            sys.stdout.write("test_suppress_output #1 failed")
+            sys.stderr.write("test_suppress_output #2 failed")
+            print("test_suppress_output #3 failed")
+            print("test_suppress_output #4 failed", file=sys.stdout)
+            print("test_suppress_output #5 failed", file=sys.stderr)
+
     def test_catch_output(self):
         """
-        Tests for CatchOutput context manager.
+        Tests that CatchOutput catches messages
         """
-        libc = CDLL(find_library("c"))
+        with CatchOutput() as out:
+            sys.stdout.write("test_catch_output #1")
+            sys.stderr.write("test_catch_output #2")
+        self.assertEqual(out.stdout, 'test_catch_output #1')
+        self.assertEqual(out.stderr, 'test_catch_output #2')
 
         with CatchOutput() as out:
-            os.system('echo "abc"')
-            libc.printf(b"def\n")
-            # This flush is necessary for Python 3, which uses different
-            # buffering modes. Fortunately, in practice, we do not mix Python
-            # and C writes to stdout. This can also be fixed by setting the
-            # PYTHONUNBUFFERED environment variable, but this must be done
-            # externally, and cannot be done by the script.
-            libc.fflush(None)
-            print("ghi")
-            print("jkl", file=sys.stdout)
-            os.system('echo "123" 1>&2')
-            print("456", file=sys.stderr)
+            print("test_catch_output #3")
+        self.assertEqual(out.stdout, 'test_catch_output #3\n')
+        self.assertEqual(out.stderr, '')
 
-        if platform.system() == "Windows":
-            self.assertEqual(out.stdout.splitlines(),
-                             ['"abc"', 'def', 'ghi', 'jkl'])
-            self.assertEqual(out.stderr.splitlines(),
-                             ['"123" ', '456'])
-        else:
-            self.assertEqual(out.stdout, b"abc\ndef\nghi\njkl\n")
-            self.assertEqual(out.stderr, b"123\n456\n")
+        with CatchOutput() as out:
+            print("test_catch_output #4", file=sys.stdout)
+            print("test_catch_output #5", file=sys.stderr)
+        self.assertEqual(out.stdout, 'test_catch_output #4\n')
+        self.assertEqual(out.stderr, 'test_catch_output #5\n')
 
     def test_catch_output_io(self):
         """

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -33,7 +33,7 @@ from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
                                   BASEMAP_VERSION, CARTOPY_VERSION)
 from obspy.core.util.misc import (BAND_CODE, CatchOutput, complexify_string,
                                   guess_delta, loadtxt, score_at_percentile,
-                                  to_int_or_zero)
+                                  to_int_or_zero, SuppressOutput)
 from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)
 from obspy.core.util.testing import add_doctests, add_unittests

--- a/obspy/geodetics/tests/test_util_flinnengdahl.py
+++ b/obspy/geodetics/tests/test_util_flinnengdahl.py
@@ -52,7 +52,7 @@ class UtilFlinnEngdahlTestCase(unittest.TestCase):
 
             self.assertEqual(
                 region,
-                checked_region.encode('utf-8'),
+                checked_region,
                 msg='(%s, %s) got %s instead of %s' % (
                     longitude,
                     latitude,

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -5113,7 +5113,7 @@ The 'source mechanism' as a comma-separated list of length:
         try:
             print(aa)
         except Exception:
-            print(aa.replace('°', ' deg'))
+            print(str(aa).replace('°', ' deg'))
 
 
 if __name__ == '__main__':

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -34,6 +34,17 @@ class MopadTestCase(unittest.TestCase):
         self.path = os.path.join(os.path.dirname(__file__), 'images')
         self.mt = [0.91, -0.89, -0.02, 1.78, -1.55, 0.47]
 
+    def _normalized_assert_equal(self, expected, result):
+        """
+        PY2 console uses ASCII as default encoding and writing '°' to stdout
+        raises an exception which is handled by mopad replacing it with 'deg'
+        here we normalize it across Python versions - can be removed once
+        PY2 support is dropped
+        """
+        result = result.replace('°', ' deg')
+        expected = expected.replace('°', ' deg')
+        return self.assertEqual(expected, result)
+
     #
     # obspy-mopad convert
     #
@@ -47,7 +58,7 @@ Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
         result = out.stdout[:-1]
-        self.assertEqual(expected, result)
+        self._normalized_assert_equal(expected, result)
 
     def test_script_convert_type_tensor(self):
         with CatchOutput() as out:
@@ -136,7 +147,7 @@ Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
         result = out.stdout[:-1]
-        self.assertEqual(expected, result)
+        self._normalized_assert_equal(expected, result)
 
     #
     # obspy-mopad gmt
@@ -165,7 +176,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 
         # Test actual data
         exp_data = np.genfromtxt(expected, comments='>')
-        with io.BytesIO(out.stdout.encode(sys.stdout.encoding)) as bio:
+        with io.BytesIO(out.stdout.encode('utf-8')) as bio:
             out_data = np.genfromtxt(bio, comments='>')
         self.assertEqual(exp_data.shape, out_data.shape,
                          msg='Data does not match!')

--- a/obspy/imaging/tests/test_mopad_script.py
+++ b/obspy/imaging/tests/test_mopad_script.py
@@ -42,32 +42,17 @@ class MopadTestCase(unittest.TestCase):
         with CatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 'sdr',
                          ','.join(str(x) for x in self.mt)])
-
         expected = '''
 Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
-
         result = out.stdout[:-1]
-        try:
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-        except Exception:
-            expected = expected.replace('°', ' deg')
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-
         self.assertEqual(expected, result)
 
     def test_script_convert_type_tensor(self):
         with CatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 't',
                          ','.join(str(x) for x in self.mt)])
-
         expected = '''
    Full moment tensor in NED-coordinates:
 
@@ -76,15 +61,12 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
   \ -1.55  0.47 -0.02 /
 
 '''
-
-        self.assertEqual(expected.encode("utf-8"),
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)
 
     def test_script_convert_type_tensor_large(self):
         with CatchOutput() as out:
             obspy_mopad(['convert', '--fancy', '-t', 't',
                          ','.join(str(x * 100) for x in self.mt)])
-
         expected = '''
    Full moment tensor in NED-coordinates:
 
@@ -93,9 +75,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
   \ -0.87  0.26 -0.01 /
 
 '''
-
-        self.assertEqual(expected.encode("utf-8"),
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)
 
     def test_script_convert_basis(self):
         expected = [
@@ -136,11 +116,8 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
         with CatchOutput() as out:
             obspy_mopad(['convert', '-v', 'NED', 'NED',
                          ','.join(str(x) for x in self.mt)])
-
         expected = str(self.mt) + '\n'
-
-        self.assertEqual(expected.encode("utf-8"),
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)
 
     #
     # obspy-mopad decompose
@@ -149,7 +126,6 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
     def test_script_decompose(self):
         with CatchOutput() as out:
             obspy_mopad(['decompose', '-y', ','.join(str(x) for x in self.mt)])
-
         expected = '''
 Scalar Moment: M0 = 2.61206 Nm (Mw = -5.8)
 Moment Tensor: Mnn =  0.091,  Mee = -0.089, Mdd = -0.002,
@@ -159,20 +135,7 @@ Moment Tensor: Mnn =  0.091,  Mee = -0.089, Mdd = -0.002,
 Fault plane 1: strike =  77°, dip =  89°, slip-rake = -141°
 Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 '''
-
         result = out.stdout[:-1]
-        try:
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-        except Exception:
-            expected = expected.replace('°', ' deg')
-            if sys.stdout.encoding is not None:
-                expected = expected.encode(sys.stdout.encoding)
-            else:
-                expected = expected.encode()
-
         self.assertEqual(expected, result)
 
     #
@@ -191,7 +154,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 
         # Test headers
         with open(expected, 'rt') as expf:
-            bio = out.stdout.decode('utf-8')
+            bio = out.stdout
             # expf.read().splitlines() differs to expf.readlines() ?!?!?!
             for exp_line, out_line in zip_longest(expf.read().splitlines(),
                                                   bio.splitlines(),
@@ -202,7 +165,7 @@ Fault plane 2: strike = 346°, dip =  51°, slip-rake =   -1°
 
         # Test actual data
         exp_data = np.genfromtxt(expected, comments='>')
-        with io.BytesIO(out.stdout) as bio:
+        with io.BytesIO(out.stdout.encode(sys.stdout.encoding)) as bio:
             out_data = np.genfromtxt(bio, comments='>')
         self.assertEqual(exp_data.shape, out_data.shape,
                          msg='Data does not match!')

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -150,13 +150,13 @@ class ScanTestCase(unittest.TestCase):
             "TIMESERIES XX_TEST__BHZ_R, 200 samples, 200 sps, "
             "2008-01-15T00:00:02.000000, SLIST, INTEGER, Counts",
         ]
-
         files = []
-        expected_stdout_lines = [
+        expected = [
             "XX.TEST..BHZ 2008-01-15T00:00:01.000000Z "
             "2008-01-15T00:00:00.899995Z -0.100",
             "XX.TEST..BHZ 2008-01-15T00:00:01.899999Z "
-            "2008-01-15T00:00:02.000000Z 0.100"]
+            "2008-01-15T00:00:02.000000Z 0.100"
+        ]
         with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2, \
                 NamedTemporaryFile() as f3:
             for i, fp in enumerate([f1, f2, f3]):
@@ -169,8 +169,7 @@ class ScanTestCase(unittest.TestCase):
                     as ic:
                 with CatchOutput() as out:
                     obspy_scan(files + ['--output', ic.name, '--print-gaps'])
-                self.assertEqual(
-                    expected_stdout_lines, out.stdout.decode().splitlines())
+                self.assertEqual(expected, out.stdout.splitlines())
 
 
 def suite():

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1148,8 +1148,8 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         self.assertEqual(len(w), 1)
         self.assertEqual(w[0].category, InternalMSEEDWarning)
 
-        self.assertIn(b"calling msr_parse with", out.stdout)
-        self.assertIn(b"buflen=512, reclen=-1, dataflag=0, verbose=2",
+        self.assertIn("calling msr_parse with", out.stdout)
+        self.assertIn("buflen=512, reclen=-1, dataflag=0, verbose=2",
                       out.stdout)
         self.assertEqual(st[0].stats.station, 'UH3')
 

--- a/obspy/io/mseed/tests/test_recordanalyzer.py
+++ b/obspy/io/mseed/tests/test_recordanalyzer.py
@@ -57,8 +57,7 @@ CALCULATED VALUES
 	Corrected Starttime: 2007-12-31T23:59:59.765000Z
 
 ''' % (self.test_file,)  # noqa
-        self.assertEqual(expected.encode('utf-8'),  # noqa
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)  # noqa
 
     def test_second_record(self):
         with CatchOutput() as out:
@@ -100,8 +99,7 @@ CALCULATED VALUES
 	Corrected Starttime: 2008-01-01T00:00:01.825000Z
 
 ''' % (self.test_file,)  # noqa
-        self.assertEqual(expected.encode('utf-8'),  # noqa
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)  # noqa
 
     def test_record_with_data_offset_zero(self):
         """
@@ -148,8 +146,7 @@ CALCULATED VALUES
 	Corrected Starttime: 2016-08-21T01:43:37.000000Z
 
 ''' % (filename,)  # noqa
-        self.assertEqual(expected.encode('utf-8'),  # noqa
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)  # noqa
 
         with CatchOutput() as out:
             obspy_recordanalyzer(['-n', '2', filename])
@@ -190,8 +187,7 @@ CALCULATED VALUES
 	Corrected Starttime: 2016-08-21T01:45:31.000000Z
 
 ''' % (filename,)  # noqa
-        self.assertEqual(expected.encode('utf-8'),  # noqa
-                         out.stdout)
+        self.assertEqual(expected, out.stdout)  # noqa
 
 
 def suite():

--- a/obspy/io/xseed/tests/test_scripts.py
+++ b/obspy/io/xseed/tests/test_scripts.py
@@ -38,8 +38,7 @@ class ScriptTestCase(unittest.TestCase):
             expected = '''Found 1 files.
 Parsing file %s
 ''' % (self.dataless_file,)
-            self.assertEqual(expected.encode('utf-8'),
-                             out.stdout)
+            self.assertEqual(expected, out.stdout)
 
             expected = ['RESP.BW.FURT..EHE',
                         'RESP.BW.FURT..EHN',
@@ -55,8 +54,7 @@ Parsing file %s
             expected = '''Found 1 files.
 Parsing file %s
 ''' % (self.dataless_file,)
-            self.assertEqual(expected.encode('utf-8'),
-                             out.stdout)
+            self.assertEqual(expected, out.stdout)
 
             self.assertTrue(os.path.exists('dataless.seed.BW_FURT.zip'))
 
@@ -80,8 +78,7 @@ Parsing file %s
             expected = '''Found 1 files.
 Parsing file %s
 ''' % (self.dataless_file,)
-            self.assertEqual(expected.encode('utf-8'),
-                             out.stdout)
+            self.assertEqual(expected, out.stdout)
 
             self.assertTrue(os.path.exists(self.xseed_name))
 
@@ -103,8 +100,7 @@ Parsing file %s
             expected = '''Found 1 files.
 Parsing file %s
 ''' % (dataless_multi_file,)
-            self.assertEqual(expected.encode('utf-8'),
-                             out.stdout)
+            self.assertEqual(expected, out.stdout)
 
             expected = ['CL.AIO.dataless.xml',
                         'CL.AIO.dataless.xml.1028697240.0.xml',
@@ -126,8 +122,7 @@ Parsing file %s
             expected = '''Found 1 files.
 Parsing file %s
 ''' % (self.xseed_file,)
-            self.assertEqual(expected.encode('utf-8'),
-                             out.stdout)
+            self.assertEqual(expected, out.stdout)
 
             with open(self.dataless_file, 'rb') as fh:
                 expected = fh.read()

--- a/obspy/scripts/tests/test_print.py
+++ b/obspy/scripts/tests/test_print.py
@@ -22,24 +22,20 @@ class PrintTestCase(unittest.TestCase):
         with CatchOutput() as out:
             obspy_print(self.all_files)
 
-        self.assertEqual(
-            '''1 Trace(s) in Stream:
+        expected = '''1 Trace(s) in Stream:
 XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 Hz, 635 samples
-'''.encode('utf-8'),  # noqa
-            out.stdout
-        )
+'''  # noqa
+        self.assertEqual(expected, out.stdout)
 
     def test_print_nomerge(self):
         with CatchOutput() as out:
             obspy_print(['--no-merge'] + self.all_files)
 
-        self.assertEqual(
-            '''2 Trace(s) in Stream:
+        expected = '''2 Trace(s) in Stream:
 XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 Hz, 635 samples
 XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 Hz, 635 samples
-'''.encode('utf-8'),  # noqa
-            out.stdout
-        )
+'''  # noqa
+        self.assertEqual(expected, out.stdout)
 
 
 def suite():

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from obspy import Trace, UTCDateTime, read, read_inventory
 from obspy.core.util.base import NamedTemporaryFile
-from obspy.core.util.misc import CatchOutput
+from obspy.core.util.misc import SuppressOutput
 from obspy.io.sac import attach_paz
 from obspy.signal.headers import clibevresp
 from obspy.signal.invsim import (
@@ -433,7 +433,8 @@ class InvSimTestCase(unittest.TestCase):
         filename = os.path.join(self.path, "segfaulting_RESPs",
                                 "RESP.IE.LLRI..EHZ")
         date = UTCDateTime(2003, 11, 1, 0, 0, 0)
-        with CatchOutput():
+        # raises C-level EVRESP ERROR
+        with SuppressOutput():
             self.assertRaises(ValueError, evalresp, t_samp=10.0, nfft=256,
                               filename=filename, date=date, station="LLRI",
                               channel="EHZ", network="IE", locid="*",
@@ -465,9 +466,9 @@ class InvSimTestCase(unittest.TestCase):
 
         # The RESP file only contains two channels.
         kwargs["channel"] = "BHZ"
-        with CatchOutput() as out:
+        # suppress a C-level "no response found" warning
+        with SuppressOutput():
             self.assertRaises(ValueError, evalresp, **kwargs)
-        self.assertIn(b"no response found for", out.stderr.lower())
 
     def test_evalresp_spline(self):
         """


### PR DESCRIPTION
had to remove C level support due to http://bugs.python.org/issue30555
(_io._WindowsConsoleIO breaks in the face of fd redirection)

continues #1684 - had to close the other one as merging current master became a real pain ;/