### PR TITLE
Fix station format in FDSN client

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -411,7 +411,7 @@ class Client(object):
                      minradius=None, maxradius=None, level=None,
                      includerestricted=None, includeavailability=None,
                      updatedafter=None, matchtimeseries=None, filename=None,
-                     format="xml", **kwargs):
+                     format=None, **kwargs):
         """
         Query the station service of the FDSN client.
 


### PR DESCRIPTION
The [get_stations](https://github.com/obspy/obspy/blob/master/obspy/clients/fdsn/client.py#L406) method of the FDSN client has an optional parameter `format` with `xml` as default value. This parameter is consequently always given to the url of the FDSN webservice. However, this parameter is optional for the FDSN webservice. If the FDSN webservice doesn't implement the `format` parameter, the [get_stations](https://github.com/obspy/obspy/blob/master/obspy/clients/fdsn/client.py#L406) method will crash. Just giving a `None` default value solves the problem. The FDSN webservice returns a StationXML file by default anyway.

Since it's only a small change, I didn't make a unit test for that. Does that suit you?