### PR TITLE
Cache entry point lookup

### DIFF
--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -29,13 +29,13 @@ import os
 import warnings
 
 import numpy as np
-from pkg_resources import load_entry_point
 
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, _read_from_plugin
 from obspy.core.util.base import ENTRY_POINTS, download_to_file
 from obspy.core.util.decorator import (map_example_filename, rlock,
                                        uncompress_file)
+from obspy.core.util.misc import buffered_load_entry_point
 from obspy.imaging.cm import obspy_sequential
 
 from .base import CreationInfo, ResourceIdentifier
@@ -493,7 +493,7 @@ class Catalog(object):
             # get format specific entry point
             format_ep = EVENT_ENTRY_POINTS_WRITE[format]
             # search writeFormat method for given entry point
-            write_format = load_entry_point(
+            write_format = buffered_load_entry_point(
                 format_ep.dist.key, 'obspy.plugin.event.%s' % (format_ep.name),
                 'writeFormat')
         except (IndexError, ImportError):

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -17,7 +17,6 @@ from future.utils import python_2_unicode_compatible, native_str
 import copy
 import fnmatch
 import os
-from pkg_resources import load_entry_point
 import textwrap
 import warnings
 
@@ -26,6 +25,7 @@ from obspy.core.util.base import (ENTRY_POINTS, ComparingObject,
                                   _read_from_plugin, NamedTemporaryFile,
                                   download_to_file)
 from obspy.core.util.decorator import map_example_filename
+from obspy.core.util.misc import buffered_load_entry_point
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .network import Network
@@ -270,7 +270,7 @@ class Inventory(ComparingObject):
             # get format specific entry point
             format_ep = ENTRY_POINTS['inventory_write'][format]
             # search writeFormat method for given entry point
-            write_format = load_entry_point(
+            write_format = buffered_load_entry_point(
                 format_ep.dist.key,
                 'obspy.plugin.inventory.%s' % (format_ep.name), 'writeFormat')
         except (IndexError, ImportError, KeyError):

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -22,7 +22,6 @@ import re
 import warnings
 from glob import glob, has_magic
 
-from pkg_resources import load_entry_point
 import numpy as np
 
 from obspy.core import compatibility
@@ -33,7 +32,7 @@ from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
                                   _read_from_plugin, download_to_file)
 from obspy.core.util.decorator import (map_example_filename,
                                        raise_if_masked, uncompress_file)
-from obspy.core.util.misc import get_window_times
+from obspy.core.util.misc import get_window_times, buffered_load_entry_point
 
 
 _headonly_warning_msg = (
@@ -1433,7 +1432,7 @@ class Stream(object):
             # get format specific entry point
             format_ep = ENTRY_POINTS['waveform_write'][format]
             # search writeFormat method for given entry point
-            write_format = load_entry_point(
+            write_format = buffered_load_entry_point(
                 format_ep.dist.key,
                 'obspy.plugin.waveform.%s' % (format_ep.name), 'writeFormat')
         except (IndexError, ImportError, KeyError):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2506,6 +2506,7 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(tar_p.call_count, 1)
         self.assertGreaterEqual(zip_p.call_count, 1)
 
+
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2494,15 +2494,24 @@ class StreamTestCase(unittest.TestCase):
         st = read()
         st.write(file_name, 'mseed')  # maybe read from test data instead?
 
-        with mock.patch("tarfile.is_tarfile") as tar_patch:
-            with mock.patch("zipfile.is_zipfile") as zip_patch:
+        with mock.patch("tarfile.is_tarfile") as tar_p:
+            with mock.patch("zipfile.is_zipfile") as zip_p:
                 read(file_name, check_compression=False)
+
+        # assert neither compression check function was called.
+        self.assertEqual(tar_p.call_count, 0)
+        self.assertEqual(zip_p.call_count, 0)
+
+        # ensure compression checks get called when check_compression is True
+        with mock.patch("tarfile.is_tarfile", return_value=0) as tar_p:
+            with mock.patch("zipfile.is_zipfile", return_value=0) as zip_p:
+                read(file_name, check_compression=True)
+        self.assertEqual(tar_p.call_count, 1)
+        self.assertGreaterEqual(zip_p.call_count, 1)
 
         # delete temp file
         os.remove(file_name)
-        # assert neither compression check function was called.
-        self.assertEqual(tar_patch.call_count, 0)
-        self.assertEqual(zip_patch.call_count, 0)
+
 
 
 def suite():

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2484,19 +2484,15 @@ class StreamTestCase(unittest.TestCase):
             self.assertEqual(arg[1]["order"], 2)
             self.assertEqual(arg[1]["plot"], True)
 
-    def test_read_no_check_compression(self):
+    def test_read_check_compression(self):
         """
         Test to ensure calling read with check_compression=False does not
         call expensive tar or zip functions.
         """
-        # write a file to disk
-        file_name = 'temp.mseed'
-        st = read()
-        st.write(file_name, 'mseed')  # maybe read from test data instead?
-
         with mock.patch("tarfile.is_tarfile") as tar_p:
             with mock.patch("zipfile.is_zipfile") as zip_p:
-                read(file_name, check_compression=False)
+                read('/path/to/slist.ascii', format='SLIST',
+                     check_compression=False)
 
         # assert neither compression check function was called.
         self.assertEqual(tar_p.call_count, 0)
@@ -2505,13 +2501,10 @@ class StreamTestCase(unittest.TestCase):
         # ensure compression checks get called when check_compression is True
         with mock.patch("tarfile.is_tarfile", return_value=0) as tar_p:
             with mock.patch("zipfile.is_zipfile", return_value=0) as zip_p:
-                read(file_name, check_compression=True)
+                read('/path/to/slist.ascii', format='SLIST',
+                     check_compression=True)
         self.assertEqual(tar_p.call_count, 1)
         self.assertGreaterEqual(zip_p.call_count, 1)
-
-        # delete temp file
-        os.remove(file_name)
-
 
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2513,7 +2513,6 @@ class StreamTestCase(unittest.TestCase):
         os.remove(file_name)
 
 
-
 def suite():
     return unittest.makeSuite(StreamTestCase, 'test')
 

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -8,7 +8,6 @@ import os
 import sys
 import tempfile
 import unittest
-from pkg_resources import load_entry_point
 
 import obspy.core.util.misc as misc
 from obspy import UTCDateTime, read

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -467,7 +467,7 @@ class WaveformPluginsTestCase(unittest.TestCase):
             entry_point_list = ["obspy", "obspy.plugin.waveform.%s" % suffix,
                                 "writeFormat"]
             # load entry point to make sure it is in the cache.
-            _ = buffered_load_entry_point(*entry_point_list)
+            buffered_load_entry_point(*entry_point_list)
             # get the cache name for monkey patching.
             entry_point_name = '/'.join(entry_point_list)
             # For stream and trace.
@@ -475,7 +475,8 @@ class WaveformPluginsTestCase(unittest.TestCase):
                 # Various versions of the suffix.
                 for s in [suffix.capitalize(), suffix.lower(), suffix.upper()]:
                     # create a mock function and patch the entry point cache.
-                    mocked_func = mock.MagicMock(_ENTRY_POINT_CACHE[entry_point_name])
+                    write_func = _ENTRY_POINT_CACHE[entry_point_name]
+                    mocked_func = mock.MagicMock(write_func)
                     mock_dict = {entry_point_name: mocked_func}
                     with mock.patch.dict(_ENTRY_POINT_CACHE, mock_dict):
                         obj.write("temp." + s)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -25,9 +25,10 @@ import numpy as np
 import pkg_resources
 import requests
 from future.utils import native_str
-from pkg_resources import iter_entry_points, load_entry_point
+from pkg_resources import iter_entry_points
 
-from obspy.core.util.misc import to_int_or_zero
+from obspy.core.util.misc import to_int_or_zero, buffered_load_entry_point
+
 
 # defining ObsPy modules currently used by runtests and the path function
 DEFAULT_MODULES = ['clients.filesystem', 'core', 'db', 'geodetics', 'imaging',
@@ -57,30 +58,6 @@ WAVEFORM_ACCEPT_BYTEORDER = ['MSEED', 'Q', 'SAC', 'SEGY', 'SU']
 
 _sys_is_le = sys.byteorder == 'little'
 NATIVE_BYTEORDER = _sys_is_le and '<' or '>'
-
-
-# apply simple memoization cache on load_entry_points
-# this function cannot go in decorator.py due to circular import issues
-def _load_entry_point_decorator(func):
-    """
-    Decorate pkg_resources' load_entry_point function to cache outputs.
-    """
-    cache = {}
-    expected_keys = ('dist', 'group', 'name')
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        # make a str key from the inputs to func for hashing in cache
-        input_dict = inspect.getcallargs(func, *args, **kwargs)
-        hash_str = '/'.join([input_dict[x] for x in expected_keys])
-        if hash_str not in cache:
-            cache[hash_str] = func(*args, **kwargs)
-        return cache[hash_str]
-
-    return wrapper
-
-
-load_entry_point = _load_entry_point_decorator(load_entry_point)
 
 
 class NamedTemporaryFile(io.BufferedIOBase):
@@ -343,8 +320,9 @@ def _get_function_from_entry_point(group, type):
     # import function point
     # any issue during import of entry point should be raised, so the user has
     # a chance to correct the problem
-    func = load_entry_point(entry_point.dist.key, 'obspy.plugin.%s' % (group),
-                            entry_point.name)
+    func = buffered_load_entry_point(entry_point.dist.key,
+                                     'obspy.plugin.%s' % (group),
+                                     entry_point.name)
     return func
 
 
@@ -392,7 +370,7 @@ def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
         # auto detect format - go through all known formats in given sort order
         for format_ep in eps.values():
             # search isFormat for given entry point
-            is_format = load_entry_point(
+            is_format = buffered_load_entry_point(
                 format_ep.dist.key,
                 'obspy.plugin.%s.%s' % (plugin_type, format_ep.name),
                 'isFormat')
@@ -422,7 +400,7 @@ def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
     # file format should be known by now
     try:
         # search readFormat for given entry point
-        read_format = load_entry_point(
+        read_format = buffered_load_entry_point(
             format_ep.dist.key,
             'obspy.plugin.%s.%s' % (plugin_type, format_ep.name),
             'readFormat')
@@ -491,7 +469,7 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     mod_list = []
     for name, ep in eps.items():
         module_short = ":mod:`%s`" % ".".join(ep.module_name.split(".")[:3])
-        func = load_entry_point(ep.dist.key,
+        func = buffered_load_entry_point(ep.dist.key,
                                 "obspy.plugin.%s.%s" % (group, name), method)
         func_str = ':func:`%s`' % ".".join((ep.module_name, func.__name__))
         mod_list.append((name, module_short, func_str))

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -13,7 +13,6 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 import doctest
-import functools
 import inspect
 import io
 import os
@@ -469,8 +468,8 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     mod_list = []
     for name, ep in eps.items():
         module_short = ":mod:`%s`" % ".".join(ep.module_name.split(".")[:3])
-        func = buffered_load_entry_point(ep.dist.key,
-                                "obspy.plugin.%s.%s" % (group, name), method)
+        ep_list = [ep.dist.key, "obspy.plugin.%s.%s" % (group, name), method]
+        func = buffered_load_entry_point(*ep_list)
         func_str = ':func:`%s`' % ".".join((ep.module_name, func.__name__))
         mod_list.append((name, module_short, func_str))
 

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -24,6 +24,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 import sys
 import tempfile
 import warnings
+from pkg_resources import load_entry_point
 
 from future.builtins import *  # NOQA
 
@@ -54,6 +55,12 @@ BAND_CODE = {'F': 1000.0,
              'P': 0.000001,
              'T': 0.0000001,
              'Q': 0.00000001}
+
+# Dict that stores results from load entry points
+_ENTRY_POINT_CACHE = {}
+
+# The kwargs used by load_entry_point function
+_LOAD_ENTRY_POINT_KEYS = ('dist', 'group', 'name')
 
 
 def guess_delta(channel):
@@ -612,6 +619,23 @@ def limit_numpy_fft_cache(max_size_in_mb_per_cache=100):
             continue
         if total_size > max_size_in_mb_per_cache * 1024 * 1024:
             cache.clear()
+
+
+def buffered_load_entry_point(dist, group, name):
+    """
+    Return `name` entry point of `group` for `dist` or raise ImportError
+    :type dist: str
+    :param dist: The name of the distribution containing the entry point.
+    :type group: str
+    :param group: The name of the group containing the entry point.
+    :type name: str
+    :param name: The name of the entry point. 
+    :return: The loaded entry point. 
+    """
+    hash_str = '/'.join([dist, group, name])
+    if hash_str not in _ENTRY_POINT_CACHE:
+        _ENTRY_POINT_CACHE[hash_str] = load_entry_point(dist, group, name)
+    return _ENTRY_POINT_CACHE[hash_str]
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -629,8 +629,8 @@ def buffered_load_entry_point(dist, group, name):
     :type group: str
     :param group: The name of the group containing the entry point.
     :type name: str
-    :param name: The name of the entry point. 
-    :return: The loaded entry point. 
+    :param name: The name of the entry point.
+    :return: The loaded entry point
     """
     hash_str = '/'.join([dist, group, name])
     if hash_str not in _ENTRY_POINT_CACHE:


### PR DESCRIPTION
### What does this PR do?
Fixes PR #1845 to conform to suggestions outlined in that PR's thread:

    1. Removed load_entry_point decorator from obspy.core.util.base
    2. Defined a new function in obspy.util.core.misc called buffered_load_entry_point
    3. Replaced all obspy uses of pkg_resources.load_entry_point with buffered_load_entry_point
    4. Added test for buffered_load_entry_point
    5. Added test for obspy.read when check_compression=True 
 
### Why was it initiated?  Any relevant Issues?
see https://github.com/obspy/obspy/pull/1845

### PR Checklist
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
