### PR TITLE
FDSN mass downloader: sanitize_download: check file existence doing anything on it

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -42,6 +42,7 @@ Käufl, Paul
 Köhler, Andreas
 Lecocq, Thomas
 Leeman, John
+Legovini, Paride
 Lesage, Philippe
 Lomax, Anthony
 Lopes, Rui L.

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -368,6 +368,9 @@ class Station(object):
             channel = [_i for _i in self.channels if
                        (_i.location, _i.channel) == id][0]
             for time_interval in channel.intervals:
+                # Check that file exists before proceeding
+                if not os.path.isfile(time_interval.filename):
+                    continue
                 # Check that the time_interval.start and end are correct!
                 time_interval.start, time_interval.end = \
                     get_start_and_end_time(time_interval.filename)


### PR DESCRIPTION
### What does this PR do?

When using the mass downloader to download, for example, one year of data in 1-day chunks, sometimes some days are missing. If, later, the StationXML is missing too, ObsPy tries to do several things, but it fails when the miniseed was not existing in the first place.

This simple fix check that the file exists before trying anything.

### PR Checklist
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
