### PR TITLE
Fix the catchoutput errors

### DIFF
--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -365,7 +365,8 @@ def _py36_windowsconsoleio_workaround():
     """
     if not WIN32 or sys.version_info[:2] < (3, 6):
         return
-
+    if not hasattr(sys.stdout, 'buffer'):
+        return
     buffered = hasattr(sys.stdout.buffer, 'raw')
     raw_stdout = sys.stdout.buffer.raw if buffered else sys.stdout.buffer
 

--- a/obspy/io/gse2/src/GSE_UTI/gse_functions.c
+++ b/obspy/io/gse2/src/GSE_UTI/gse_functions.c
@@ -207,8 +207,7 @@ int decomp_6b_buffer (int n_of_samples, int32_t *dta, char * (* reader)(char *, 
   int i, ibuf=-1, k, inn, jsign=0, joflow=0;
   int32_t itemp;
   char cbuf[83]=" ";
-  setbuf(stdout, NULL);
-  if (n_of_samples == 0) { printf ("decomp_6b: no action.\n"); return 0; }
+  if (n_of_samples == 0) { fprintf (stdout, "decomp_6b: no action.\n"); return 0; }
   
   while (1) {
       /* read until we encounter DAT1 or DAT2 */
@@ -220,22 +219,22 @@ int decomp_6b_buffer (int n_of_samples, int32_t *dta, char * (* reader)(char *, 
       }
       /* print error if we reached the end of the file */
     if ((*reader)(cbuf, vptr) == NULL) {
-          printf ("decomp_6b: Neither DAT2 or DAT1 found!\n"); 
+          fprintf (stderr, "decomp_6b: Neither DAT2 or DAT1 found!\n"); 
           return -1;
       }
   }
     if ((*reader)(cbuf, vptr) == NULL) /* read first char line */
-  	{printf ("decomp_6b: Whoops! No data after DAT2 or DAT1.\n"); return -1; }
+  	{fprintf (stderr, "decomp_6b: Whoops! No data after DAT2 or DAT1.\n"); return -1; }
   for (i = 0; i < n_of_samples; i++)		/* loop over expected samples */
   {
   	ibuf += 1;
   	if (ibuf > 79 || isspace(cbuf[ibuf])) { 
   	if ((*reader)(cbuf, vptr) == NULL) /* get next line */
-  		{printf ("decomp_6b: missing input line?\n"); return -1; }
+  		{fprintf (stderr, "decomp_6b: missing input line?\n"); return -1; }
       /* We need a space to be sure that CHK2 is not occuring in the middle
        * of the encoded string/buffer */
   	  if (!(strncmp(cbuf,"CHK2 ",5)) || !(strncmp(cbuf,"CHK1 ", 5)))
-  		{printf ("decomp_6b: CHK2 or CHK1 reached prematurely!\n"); return i; }
+  		{fprintf (stderr, "decomp_6b: CHK2 or CHK1 reached prematurely!\n"); return i; }
   	  ibuf = 0;
   	}
 
@@ -254,7 +253,7 @@ int decomp_6b_buffer (int n_of_samples, int32_t *dta, char * (* reader)(char *, 
   	  ibuf += 1;
   	  if (ibuf > 79 || isspace(cbuf[ibuf])) {
   	    if ((*reader)(cbuf, vptr) == NULL) /* get next line */
-  		{printf ("decomp_6b: missing input line.\n"); return -1; }
+  		{fprintf (stderr, "decomp_6b: missing input line.\n"); return -1; }
   	    ibuf = 0;
 	  }
   					/* now the same procedure as above */

--- a/obspy/io/gse2/src/GSE_UTI/gse_functions.c
+++ b/obspy/io/gse2/src/GSE_UTI/gse_functions.c
@@ -207,7 +207,7 @@ int decomp_6b_buffer (int n_of_samples, int32_t *dta, char * (* reader)(char *, 
   int i, ibuf=-1, k, inn, jsign=0, joflow=0;
   int32_t itemp;
   char cbuf[83]=" ";
-
+  setbuf(stdout, NULL);
   if (n_of_samples == 0) { printf ("decomp_6b: no action.\n"); return 0; }
   
   while (1) {

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -16,7 +16,7 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime
-from obspy.core.util import CatchOutput, NamedTemporaryFile
+from obspy.core.util import SuppressOutput, NamedTemporaryFile
 from obspy.io.gse2 import libgse2
 from obspy.io.gse2.libgse2 import (ChksumError, GSEUtiError, compile_sta2,
                                    parse_sta2)
@@ -205,12 +205,9 @@ class LibGSE2TestCase(unittest.TestCase):
             lines = (l for l in fin if not l.startswith(b'DAT2'))
             fout.write(b"".join(lines))
         fout.seek(0)
-        # with CatchOutput() as out:
-        with CatchOutput():
+        with SuppressOutput():
+            # omit C level error "decomp_6b: Neither DAT2 or DAT1 found!"
             self.assertRaises(GSEUtiError, libgse2.read, fout)
-        # XXX: CatchOutput does not work on Py3k, skipping for now
-        # self.assertEqual(out.stdout,
-        #                 "decomp_6b: Neither DAT2 or DAT1 found!\n")
 
     def test_parse_sta2(self):
         """


### PR DESCRIPTION
* solves the import of obspy from Jupyter Notebooks (https://github.com/obspy/obspy/issues/1866)
* solves part of the catch output complexity (https://github.com/obspy/obspy/pull/1684)

