### PR TITLE
SC3ML event read support for all schema versions

### DIFF
--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -69,7 +69,7 @@ def _xml_doc_from_anything(source):
     Will raise a ValueError if it fails.
     """
     try:
-        xml_doc = etree.parse(source)
+        xml_doc = etree.parse(source).getroot()
     except Exception:
         try:
             xml_doc = etree.fromstring(source)

--- a/obspy/io/seiscomp/core.py
+++ b/obspy/io/seiscomp/core.py
@@ -89,7 +89,8 @@ def validate(path_or_object, version='0.9', verbose=False):
     """
     if version not in SUPPORTED_XSD_VERSION:
         raise ValueError('%s is not a supported version. Use one of these '
-                         'versions: %s' % (version, SUPPORTED_XSD_VERSION))
+                         'versions: [%s].'
+                         % (version, ', '.join(SUPPORTED_XSD_VERSION)))
 
     # Get the schema location.
     xsd_filename = 'sc3ml_%s.xsd' % version

--- a/obspy/io/seiscomp/core.py
+++ b/obspy/io/seiscomp/core.py
@@ -17,7 +17,6 @@ from future.builtins import *  # NOQA
 
 import os
 import re
-import warnings
 
 from lxml import etree
 
@@ -28,7 +27,7 @@ from obspy.io.quakeml.core import _xml_doc_from_anything
 SUPPORTED_XSD_VERSION = ['0.3', '0.5', '0.6', '0.7', '0.8', '0.9']
 
 
-def _is_sc3ml(path_or_file_object, schema_versions):
+def _is_sc3ml(path_or_file_object):
     """
     Simple function checking if the passed object contains a valid sc3ml file
     according to the list of versions given in parameters. Returns True of
@@ -41,8 +40,6 @@ def _is_sc3ml(path_or_file_object, schema_versions):
 
     :type path_or_file_object: str
     :param path_or_file_object: File name or file like object.
-    :type schema_versions: list of strings
-    :param schema_versions: List of supported SC3ML version.
     :rtype: bool
     :return: `True` if file is a SC3ML file.
     """
@@ -73,17 +70,7 @@ def _is_sc3ml(path_or_file_object, schema_versions):
         r'{http://geofon\.gfz-potsdam\.de/ns/seiscomp3-schema/([-+]?'
         r'[0-9]*\.?[0-9]+)}', root.tag)
 
-    if match is None:
-        return False
-
-    # Check if schema version is supported
-    version = match.group(1)
-    if version not in schema_versions:
-        warnings.warn('The sc3ml file has version %s, ObsPy can '
-                      'deal with versions [%s]. Proceed with caution.' % (
-                          version, ', '.join(schema_versions)))
-
-    return True
+    return match is not None
 
 
 def validate(path_or_object, version='0.9', verbose=False):

--- a/obspy/io/seiscomp/core.py
+++ b/obspy/io/seiscomp/core.py
@@ -25,7 +25,7 @@ from obspy.io.quakeml.core import _xml_doc_from_anything
 
 
 # SC3ML version for which an XSD file is available
-SUPPORTED_XSD_VERSION = ['0.7', '0.8', '0.9']
+SUPPORTED_XSD_VERSION = ['0.3', '0.5', '0.6', '0.7', '0.8', '0.9']
 
 
 def _is_sc3ml(path_or_file_object, schema_versions):

--- a/obspy/io/seiscomp/data/sc3ml_0.3.xsd
+++ b/obspy/io/seiscomp/data/sc3ml_0.3.xsd
@@ -1,0 +1,1050 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated from Seiscomp Schema, do not edit -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.3" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.3" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:import namespace="http://quakeml.org/xmlns/quakeml/1.0" schemaLocation="quakeml_types.xsd"/>
+  <xs:simpleType name="OriginUncertaintyDescription">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal uncertainty"/>
+      <xs:enumeration value="uncertainty ellipse"/>
+      <xs:enumeration value="confidence ellipsoid"/>
+      <xs:enumeration value="probability density function"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard CMT solution"/>
+      <xs:enumeration value="quick CMT solution"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginDepthType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from location"/>
+      <xs:enumeration value="from moment tensor inversion"/>
+      <xs:enumeration value="from modeling of broad-band P waveforms"/>
+      <xs:enumeration value="constrained by depth phases"/>
+      <xs:enumeration value="constrained by direct phases"/>
+      <xs:enumeration value="operator assigned"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hypocenter"/>
+      <xs:enumeration value="centroid"/>
+      <xs:enumeration value="amplitude"/>
+      <xs:enumeration value="macroseismic"/>
+      <xs:enumeration value="rupture start"/>
+      <xs:enumeration value="rupture end"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="automatic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="preliminary"/>
+      <xs:enumeration value="confirmed"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="rejected"/>
+      <xs:enumeration value="reported"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickOnset">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="emergent"/>
+      <xs:enumeration value="impulsive"/>
+      <xs:enumeration value="questionable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorMethod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CMT - general moment tensor"/>
+      <xs:enumeration value="CMT - moment tensor with zero trace"/>
+      <xs:enumeration value="CMT - double-couple source"/>
+      <xs:enumeration value="teleseismic"/>
+      <xs:enumeration value="regional"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataUsedWaveType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="body waves"/>
+      <xs:enumeration value="P body waves"/>
+      <xs:enumeration value="long-period body waves"/>
+      <xs:enumeration value="surface waves"/>
+      <xs:enumeration value="intermediate-period surface waves"/>
+      <xs:enumeration value="long-period mantle waves"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventDescriptionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="felt report"/>
+      <xs:enumeration value="Flinn-Engdahl region"/>
+      <xs:enumeration value="local time"/>
+      <xs:enumeration value="tectonic summary"/>
+      <xs:enumeration value="nearest cities"/>
+      <xs:enumeration value="earthquake name"/>
+      <xs:enumeration value="region name"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="earthquake"/>
+      <xs:enumeration value="induced earthquake"/>
+      <xs:enumeration value="quarry blast"/>
+      <xs:enumeration value="explosion"/>
+      <xs:enumeration value="chemical explosion"/>
+      <xs:enumeration value="nuclear explosion"/>
+      <xs:enumeration value="landslide"/>
+      <xs:enumeration value="rockslide"/>
+      <xs:enumeration value="snow avalanche"/>
+      <xs:enumeration value="debris avalanche"/>
+      <xs:enumeration value="mine collapse"/>
+      <xs:enumeration value="building collapse"/>
+      <xs:enumeration value="volcanic eruption"/>
+      <xs:enumeration value="meteor impact"/>
+      <xs:enumeration value="plane crash"/>
+      <xs:enumeration value="sonic boom"/>
+      <xs:enumeration value="not existing"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventTypeCertainty">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="known"/>
+      <xs:enumeration value="suspected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceTimeFunctionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="box car"/>
+      <xs:enumeration value="triangle"/>
+      <xs:enumeration value="trapezoid"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickPolarity">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="positive"/>
+      <xs:enumeration value="negative"/>
+      <xs:enumeration value="undecidable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SyntheticComponents">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="Z"/>
+      <xs:enumeration value="R"/>
+      <xs:enumeration value="ZR"/>
+      <xs:enumeration value="T"/>
+      <xs:enumeration value="ZT"/>
+      <xs:enumeration value="RT"/>
+      <xs:enumeration value="ZRT"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StationGroupType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="deployment"/>
+      <xs:enumeration value="array"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TimeQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CreationInfo">
+    <xs:sequence>
+      <xs:element name="agencyID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="agencyURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="authorURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="modificationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EventDescription">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventDescriptionType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Phase">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Comment">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="id" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RealQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="IntegerQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Axis">
+    <xs:sequence>
+      <xs:element name="azimuth" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="plunge" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="length" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PrincipalAxes">
+    <xs:sequence>
+      <xs:element name="tAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="pAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="nAxis" type="scs:Axis" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DataUsed">
+    <xs:sequence>
+      <xs:element name="waveType" type="scs:DataUsedWaveType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="componentCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="shortestPeriod" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CompositeTime">
+    <xs:sequence>
+      <xs:element name="year" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="month" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="day" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="hour" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minute" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="second" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Tensor">
+    <xs:sequence>
+      <xs:element name="Mrr" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mpp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OriginQuality">
+    <xs:sequence>
+      <xs:element name="associatedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="associatedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="standardError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="secondaryAzimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="groundTruthLevel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maximumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minimumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="medianDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlane">
+    <xs:sequence>
+      <xs:element name="strike" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dip" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="rake" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TimeWindow">
+    <xs:sequence>
+      <xs:element name="reference" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="begin" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="WaveformStreamID">
+    <xs:sequence>
+      <xs:element name="resourceURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string"/>
+    <xs:attribute name="channelCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SourceTimeFunction">
+    <xs:sequence>
+      <xs:element name="type" type="scs:SourceTimeFunctionType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="duration" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="riseTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decayTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlanes">
+    <xs:sequence>
+      <xs:element name="nodalPlane1" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlane2" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preferredPlane" type="xs:integer"/>
+  </xs:complexType>
+  <xs:complexType name="ConfidenceEllipsoid">
+    <xs:sequence>
+      <xs:element name="semiMajorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiMinorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiIntermediateAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisPlunge" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisAzimuth" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisRotation" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PickReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AmplitudeReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Reading">
+    <xs:sequence>
+      <xs:element name="pickReference" type="scs:PickReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitudeReference" type="scs:AmplitudeReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMomentTensorContribution">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="zCorrection" type="xs:double"/>
+    <xs:attribute name="weight" type="xs:double"/>
+    <xs:attribute name="components" type="scs:SyntheticComponents"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensor">
+    <xs:sequence>
+      <xs:element name="derivedOriginID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="momentMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalarMoment" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="tensor" type="scs:Tensor" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="variance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="varianceReduction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="doubleCouple" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clvd" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="iso" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="greensFunctionID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceTimeFunction" type="scs:SourceTimeFunction" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="method" type="scs:MomentTensorMethod" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:MomentTensorStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtVersion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="dataUsed" type="scs:DataUsed" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMomentTensorContribution" type="scs:StationMomentTensorContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanism">
+    <xs:sequence>
+      <xs:element name="triggeringOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlanes" type="scs:NodalPlanes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="principalAxes" type="scs:PrincipalAxes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationPolarityCount" type="xs:int" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationDistributionRatio" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="momentTensor" type="scs:MomentTensor" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Amplitude">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="amplitude" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeWindow" type="scs:TimeWindow" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="period" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalingTime" type="scs:TimeQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitudeHint" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitudeContribution">
+    <xs:sequence>
+      <xs:element name="stationMagnitudeID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="residual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Magnitude">
+    <xs:sequence>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitudeContribution" type="scs:StationMagnitudeContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitude">
+    <xs:sequence>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="amplitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Pick">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlowness" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="slownessMethodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="onset" type="scs:PickOnset" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="phaseHint" type="scs:Phase" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="polarity" type="scs:PickPolarity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanismReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Event">
+    <xs:sequence>
+      <xs:element name="preferredOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredFocalMechanismID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="typeCertainty" type="scs:EventTypeCertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="scs:EventDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="originReference" type="scs:OriginReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanismReference" type="scs:FocalMechanismReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginUncertainty">
+    <xs:sequence>
+      <xs:element name="horizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthMaxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceEllipsoid" type="scs:ConfidenceEllipsoid" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredDescription" type="scs:OriginUncertaintyDescription" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Arrival">
+    <xs:sequence>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="phase" type="scs:Phase" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeCorrection" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="distance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preliminary" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:complexType name="Origin">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="latitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="longitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="depth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthType" type="scs:OriginDepthType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="epicenterFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="referenceSystemID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="quality" type="scs:OriginQuality" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="scs:OriginUncertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:OriginType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="compositeTime" type="scs:CompositeTime" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arrival" type="scs:Arrival" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitude" type="scs:StationMagnitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="magnitude" type="scs:Magnitude" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="EventParameters">
+    <xs:sequence>
+      <xs:element name="pick" type="scs:Pick" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitude" type="scs:Amplitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="reading" type="scs:Reading" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="origin" type="scs:Origin" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanism" type="scs:FocalMechanism" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="event" type="scs:Event" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Parameter">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ParameterSet">
+    <xs:sequence>
+      <xs:element name="baseID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="moduleID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="parameter" type="scs:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime"/>
+  </xs:complexType>
+  <xs:complexType name="Setup">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigStation">
+    <xs:sequence>
+      <xs:element name="setup" type="scs:Setup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigModule">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:ConfigStation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Config">
+    <xs:sequence>
+      <xs:element name="parameterSet" type="scs:ParameterSet" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="module" type="scs:ConfigModule" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="QCLog">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="WaveformQuality">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="parameter" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="windowLength" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="xs:string" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Outage">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="QualityControl">
+    <xs:sequence>
+      <xs:element name="log" type="scs:QCLog" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="waveformQuality" type="scs:WaveformQuality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="outage" type="scs:Outage" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Blob">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RealArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:FloatArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="ComplexArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:ComplexArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationGroup">
+    <xs:sequence>
+      <xs:element name="type" type="scs:StationGroupType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationReference" type="scs:StationReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxSource">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="conversion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="AuxDevice">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="scs:AuxSource" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SensorCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Sensor">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="highFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:SensorCalibration" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="response" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePAZ">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFactor" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfZeros" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfPoles" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="zeros" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="poles" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePolynomial">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="frequencyUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationLowerBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationUpperBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="DataloggerCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Decimation">
+    <xs:sequence>
+      <xs:element name="analogueFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitalFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="sampleRateNumerator" type="xs:integer" use="required"/>
+    <xs:attribute name="sampleRateDenominator" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Datalogger">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxClockDrift" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:DataloggerCalibration" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="decimation" type="scs:Decimation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseFIR">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="symmetry" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxStream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="deviceSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="device" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Stream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dip" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainUnit" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="datalogger" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="sensor" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="SensorLocation">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="auxStream" type="scs:AuxStream" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stream" type="scs:Stream" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Station">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="place" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="affiliation" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorLocation" type="scs:SensorLocation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="archiveNetworkCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Network">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="institutions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:Station" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Inventory">
+    <xs:sequence>
+      <xs:element name="stationGroup" type="scs:StationGroup" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="auxDevice" type="scs:AuxDevice" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="sensor" type="scs:Sensor" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="datalogger" type="scs:Datalogger" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePAZ" type="scs:ResponsePAZ" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseFIR" type="scs:ResponseFIR" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePolynomial" type="scs:ResponsePolynomial" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="network" type="scs:Network" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="RouteArclink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RouteSeedlink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Route">
+    <xs:sequence>
+      <xs:element name="arclink" type="scs:RouteArclink" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="seedlink" type="scs:RouteSeedlink" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Access">
+    <xs:sequence>
+      <xs:element name="user" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Routing">
+    <xs:sequence>
+      <xs:element name="route" type="scs:Route" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="access" type="scs:Access" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="JournalEntry">
+    <xs:sequence>
+      <xs:element name="objectID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="created" type="xs:dateTime"/>
+    <xs:attribute name="sender" type="xs:string" use="required"/>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="parameters" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Journaling">
+    <xs:sequence>
+      <xs:element name="entry" type="scs:JournalEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkUser">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkStatusLine">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volumeID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestLine">
+    <xs:sequence>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="streamID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:ArclinkStatusLine" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="start" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestSummary">
+    <xs:sequence>
+      <xs:element name="okLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="totalLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="averageTimeWindow" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequest">
+    <xs:sequence>
+      <xs:element name="requestID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="created" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="header" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" type="scs:ArclinkRequestSummary" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="statusLine" type="scs:ArclinkStatusLine" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="requestLine" type="scs:ArclinkRequestLine" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkLog">
+    <xs:sequence>
+      <xs:element name="arclinkRequest" type="scs:ArclinkRequest" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arclinkUser" type="scs:ArclinkUser" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:element name="seiscomp">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="EventParameters" type="scs:EventParameters" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Config" type="scs:Config" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="QualityControl" type="scs:QualityControl" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Inventory" type="scs:Inventory" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Routing" type="scs:Routing" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Journaling" type="scs:Journaling" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="ArclinkLog" type="scs:ArclinkLog" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="version" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/obspy/io/seiscomp/data/sc3ml_0.5.xsd
+++ b/obspy/io/seiscomp/data/sc3ml_0.5.xsd
@@ -1,0 +1,1063 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated from Seiscomp Schema, do not edit -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.5" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.5" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:import namespace="http://quakeml.org/xmlns/quakeml/1.0" schemaLocation="quakeml_types.xsd"/>
+  <xs:simpleType name="OriginUncertaintyDescription">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal uncertainty"/>
+      <xs:enumeration value="uncertainty ellipse"/>
+      <xs:enumeration value="confidence ellipsoid"/>
+      <xs:enumeration value="probability density function"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard CMT solution"/>
+      <xs:enumeration value="quick CMT solution"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginDepthType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from location"/>
+      <xs:enumeration value="from moment tensor inversion"/>
+      <xs:enumeration value="from modeling of broad-band P waveforms"/>
+      <xs:enumeration value="constrained by depth phases"/>
+      <xs:enumeration value="constrained by direct phases"/>
+      <xs:enumeration value="operator assigned"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hypocenter"/>
+      <xs:enumeration value="centroid"/>
+      <xs:enumeration value="amplitude"/>
+      <xs:enumeration value="macroseismic"/>
+      <xs:enumeration value="rupture start"/>
+      <xs:enumeration value="rupture end"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="automatic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="preliminary"/>
+      <xs:enumeration value="confirmed"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="rejected"/>
+      <xs:enumeration value="reported"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickOnset">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="emergent"/>
+      <xs:enumeration value="impulsive"/>
+      <xs:enumeration value="questionable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorMethod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CMT - general moment tensor"/>
+      <xs:enumeration value="CMT - moment tensor with zero trace"/>
+      <xs:enumeration value="CMT - double-couple source"/>
+      <xs:enumeration value="teleseismic"/>
+      <xs:enumeration value="regional"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataUsedWaveType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="body waves"/>
+      <xs:enumeration value="P body waves"/>
+      <xs:enumeration value="long-period body waves"/>
+      <xs:enumeration value="surface waves"/>
+      <xs:enumeration value="intermediate-period surface waves"/>
+      <xs:enumeration value="long-period mantle waves"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventDescriptionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="felt report"/>
+      <xs:enumeration value="Flinn-Engdahl region"/>
+      <xs:enumeration value="local time"/>
+      <xs:enumeration value="tectonic summary"/>
+      <xs:enumeration value="nearest cities"/>
+      <xs:enumeration value="earthquake name"/>
+      <xs:enumeration value="region name"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="not existing"/>
+      <xs:enumeration value="not locatable"/>
+      <xs:enumeration value="outside of network interest"/>
+      <xs:enumeration value="earthquake"/>
+      <xs:enumeration value="induced earthquake"/>
+      <xs:enumeration value="quarry blast"/>
+      <xs:enumeration value="explosion"/>
+      <xs:enumeration value="chemical explosion"/>
+      <xs:enumeration value="nuclear explosion"/>
+      <xs:enumeration value="landslide"/>
+      <xs:enumeration value="rockslide"/>
+      <xs:enumeration value="snow avalanche"/>
+      <xs:enumeration value="debris avalanche"/>
+      <xs:enumeration value="mine collapse"/>
+      <xs:enumeration value="building collapse"/>
+      <xs:enumeration value="volcanic eruption"/>
+      <xs:enumeration value="meteor impact"/>
+      <xs:enumeration value="plane crash"/>
+      <xs:enumeration value="sonic boom"/>
+      <xs:enumeration value="duplicate"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventTypeCertainty">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="known"/>
+      <xs:enumeration value="suspected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceTimeFunctionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="box car"/>
+      <xs:enumeration value="triangle"/>
+      <xs:enumeration value="trapezoid"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickPolarity">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="positive"/>
+      <xs:enumeration value="negative"/>
+      <xs:enumeration value="undecidable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StationGroupType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="deployment"/>
+      <xs:enumeration value="array"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TimeQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CreationInfo">
+    <xs:sequence>
+      <xs:element name="agencyID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="agencyURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="authorURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="modificationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EventDescription">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventDescriptionType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Phase">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Comment">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="id" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RealQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="IntegerQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Axis">
+    <xs:sequence>
+      <xs:element name="azimuth" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="plunge" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="length" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PrincipalAxes">
+    <xs:sequence>
+      <xs:element name="tAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="pAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="nAxis" type="scs:Axis" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DataUsed">
+    <xs:sequence>
+      <xs:element name="waveType" type="scs:DataUsedWaveType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="componentCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="shortestPeriod" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CompositeTime">
+    <xs:sequence>
+      <xs:element name="year" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="month" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="day" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="hour" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minute" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="second" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Tensor">
+    <xs:sequence>
+      <xs:element name="Mrr" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mpp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OriginQuality">
+    <xs:sequence>
+      <xs:element name="associatedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="associatedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="standardError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="secondaryAzimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="groundTruthLevel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maximumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minimumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="medianDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlane">
+    <xs:sequence>
+      <xs:element name="strike" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dip" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="rake" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TimeWindow">
+    <xs:sequence>
+      <xs:element name="reference" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="begin" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="WaveformStreamID">
+    <xs:sequence>
+      <xs:element name="resourceURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string"/>
+    <xs:attribute name="channelCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SourceTimeFunction">
+    <xs:sequence>
+      <xs:element name="type" type="scs:SourceTimeFunctionType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="duration" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="riseTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decayTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlanes">
+    <xs:sequence>
+      <xs:element name="nodalPlane1" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlane2" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preferredPlane" type="xs:integer"/>
+  </xs:complexType>
+  <xs:complexType name="ConfidenceEllipsoid">
+    <xs:sequence>
+      <xs:element name="semiMajorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiMinorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiIntermediateAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisPlunge" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisAzimuth" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisRotation" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PickReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AmplitudeReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Reading">
+    <xs:sequence>
+      <xs:element name="pickReference" type="scs:PickReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitudeReference" type="scs:AmplitudeReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorComponentContribution">
+    <xs:sequence>
+      <xs:element name="weight" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeShift" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dataTimeWindow" type="qml:FloatArray" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="phaseCode" type="xs:string" use="required"/>
+    <xs:attribute name="component" type="xs:integer" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorStationContribution">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="component" type="scs:MomentTensorComponentContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+    <xs:attribute name="weight" type="xs:double"/>
+    <xs:attribute name="timeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorPhaseSetting">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="lowerPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="upperPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="minimumSNR" type="xs:double"/>
+    <xs:attribute name="maximumTimeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensor">
+    <xs:sequence>
+      <xs:element name="derivedOriginID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="momentMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalarMoment" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="tensor" type="scs:Tensor" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="variance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="varianceReduction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="doubleCouple" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clvd" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="iso" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="greensFunctionID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceTimeFunction" type="scs:SourceTimeFunction" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="method" type="scs:MomentTensorMethod" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:MomentTensorStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtVersion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="dataUsed" type="scs:DataUsed" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="phaseSetting" type="scs:MomentTensorPhaseSetting" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMomentTensorContribution" type="scs:MomentTensorStationContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanism">
+    <xs:sequence>
+      <xs:element name="triggeringOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlanes" type="scs:NodalPlanes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="principalAxes" type="scs:PrincipalAxes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationPolarityCount" type="xs:int" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationDistributionRatio" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="momentTensor" type="scs:MomentTensor" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Amplitude">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="amplitude" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeWindow" type="scs:TimeWindow" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="period" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalingTime" type="scs:TimeQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitudeHint" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitudeContribution">
+    <xs:sequence>
+      <xs:element name="stationMagnitudeID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="residual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Magnitude">
+    <xs:sequence>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitudeContribution" type="scs:StationMagnitudeContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitude">
+    <xs:sequence>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="amplitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Pick">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlowness" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="slownessMethodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="onset" type="scs:PickOnset" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="phaseHint" type="scs:Phase" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="polarity" type="scs:PickPolarity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanismReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Event">
+    <xs:sequence>
+      <xs:element name="preferredOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredFocalMechanismID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="typeCertainty" type="scs:EventTypeCertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="scs:EventDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="originReference" type="scs:OriginReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanismReference" type="scs:FocalMechanismReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginUncertainty">
+    <xs:sequence>
+      <xs:element name="horizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthMaxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceEllipsoid" type="scs:ConfidenceEllipsoid" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredDescription" type="scs:OriginUncertaintyDescription" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Arrival">
+    <xs:sequence>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="phase" type="scs:Phase" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeCorrection" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="distance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preliminary" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:complexType name="Origin">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="latitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="longitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="depth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthType" type="scs:OriginDepthType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="epicenterFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="referenceSystemID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="quality" type="scs:OriginQuality" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="scs:OriginUncertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:OriginType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="compositeTime" type="scs:CompositeTime" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arrival" type="scs:Arrival" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitude" type="scs:StationMagnitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="magnitude" type="scs:Magnitude" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="EventParameters">
+    <xs:sequence>
+      <xs:element name="pick" type="scs:Pick" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitude" type="scs:Amplitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="reading" type="scs:Reading" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="origin" type="scs:Origin" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanism" type="scs:FocalMechanism" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="event" type="scs:Event" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Parameter">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ParameterSet">
+    <xs:sequence>
+      <xs:element name="baseID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="moduleID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="parameter" type="scs:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime"/>
+  </xs:complexType>
+  <xs:complexType name="Setup">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigStation">
+    <xs:sequence>
+      <xs:element name="setup" type="scs:Setup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigModule">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:ConfigStation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Config">
+    <xs:sequence>
+      <xs:element name="parameterSet" type="scs:ParameterSet" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="module" type="scs:ConfigModule" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="QCLog">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="WaveformQuality">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="parameter" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="windowLength" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="xs:string" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Outage">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="QualityControl">
+    <xs:sequence>
+      <xs:element name="log" type="scs:QCLog" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="waveformQuality" type="scs:WaveformQuality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="outage" type="scs:Outage" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Blob">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RealArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:FloatArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="ComplexArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:ComplexArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationGroup">
+    <xs:sequence>
+      <xs:element name="type" type="scs:StationGroupType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationReference" type="scs:StationReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxSource">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="conversion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="AuxDevice">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="scs:AuxSource" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SensorCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Sensor">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="highFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:SensorCalibration" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="response" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePAZ">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFactor" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfZeros" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfPoles" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="zeros" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="poles" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePolynomial">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="frequencyUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationLowerBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationUpperBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="DataloggerCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Decimation">
+    <xs:sequence>
+      <xs:element name="analogueFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitalFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="sampleRateNumerator" type="xs:integer" use="required"/>
+    <xs:attribute name="sampleRateDenominator" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Datalogger">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxClockDrift" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:DataloggerCalibration" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="decimation" type="scs:Decimation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseFIR">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="symmetry" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxStream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="deviceSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="device" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Stream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dip" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="datalogger" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="sensor" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="SensorLocation">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="auxStream" type="scs:AuxStream" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stream" type="scs:Stream" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Station">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="place" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="affiliation" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorLocation" type="scs:SensorLocation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="archiveNetworkCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Network">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="institutions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:Station" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Inventory">
+    <xs:sequence>
+      <xs:element name="stationGroup" type="scs:StationGroup" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="auxDevice" type="scs:AuxDevice" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="sensor" type="scs:Sensor" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="datalogger" type="scs:Datalogger" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePAZ" type="scs:ResponsePAZ" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseFIR" type="scs:ResponseFIR" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePolynomial" type="scs:ResponsePolynomial" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="network" type="scs:Network" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="RouteArclink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RouteSeedlink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Route">
+    <xs:sequence>
+      <xs:element name="arclink" type="scs:RouteArclink" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="seedlink" type="scs:RouteSeedlink" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Access">
+    <xs:sequence>
+      <xs:element name="user" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Routing">
+    <xs:sequence>
+      <xs:element name="route" type="scs:Route" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="access" type="scs:Access" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="JournalEntry">
+    <xs:sequence>
+      <xs:element name="objectID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="created" type="xs:dateTime"/>
+    <xs:attribute name="sender" type="xs:string" use="required"/>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="parameters" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Journaling">
+    <xs:sequence>
+      <xs:element name="entry" type="scs:JournalEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkUser">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkStatusLine">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volumeID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestLine">
+    <xs:sequence>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="streamID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:ArclinkStatusLine" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="start" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestSummary">
+    <xs:sequence>
+      <xs:element name="okLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="totalLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="averageTimeWindow" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequest">
+    <xs:sequence>
+      <xs:element name="requestID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="created" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="header" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" type="scs:ArclinkRequestSummary" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="statusLine" type="scs:ArclinkStatusLine" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="requestLine" type="scs:ArclinkRequestLine" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkLog">
+    <xs:sequence>
+      <xs:element name="arclinkRequest" type="scs:ArclinkRequest" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arclinkUser" type="scs:ArclinkUser" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:element name="seiscomp">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="EventParameters" type="scs:EventParameters" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Config" type="scs:Config" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="QualityControl" type="scs:QualityControl" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Inventory" type="scs:Inventory" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Routing" type="scs:Routing" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Journaling" type="scs:Journaling" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="ArclinkLog" type="scs:ArclinkLog" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="version" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/obspy/io/seiscomp/data/sc3ml_0.5__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.5__quakeml_1.2.xsl
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- **********************************************************************
+ * Copyright (C) 2017 by gempa GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SC3ML 0.5 to QuakeML 1.2 stylesheet converter
+ * Author  : Stephan Herrnkind
+ * Email   : stephan.herrnkind@gempa.de
+ *
+ * ================
+ * Usage
+ * ================
+ *
+ * This stylesheet converts a SC3ML to a QuakeML document. It may be invoked
+ * e.g. using xalan or xsltproc:
+ *
+ *   xalan -in sc3ml.xml -xsl sc3ml_0.5__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -o quakeml.xml sc3ml_0.5__quakeml_1.2.xsl sc3ml.xml
+ *
+ * You can also modify the default ID prefix with the reverse DNS name of your
+ * institute by setting the ID_PREFIX param:
+ *
+ *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.5__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.5__quakeml_1.2.xsl sc3ml.xml
+ *
+ * ================
+ * Transformation
+ * ================
+ *
+ * QuakeML and SC3ML are quite similar schemas. Nevertheless some differences
+ * exist:
+ *
+ *  - IDs : SC3ML does not enforce any particular ID restriction. An ID in
+ *    SC3ML has no semantic, it simply must be unique. Hence QuakeML uses ID
+ *    restrictions, a conversion of a SC3ML to a QuakeML ID must be performed:
+ *    'sc3id' -> 'smi:org.gfz-potsdam.de/geofon/'. If no SC3ML ID is available
+ *    but QuakeML enforces one, a static ID value of 'NA' is used.
+ *    If the ID starts with `smi:` or `quakeml:`, the ID is considered valid
+ *    and let untouched. This can lead to an invalid generated file but avoid
+ *    to always modify IDs, especially when converting several times.
+ *  - Repositioning of nodes: In QuakeML all information is grouped under the
+ *    event element. As a consequence every node not referenced by an event
+ *    will be lost during the conversion.
+ *
+ *    <EventParameters>               <eventParameters>
+ *                                        <event>
+ *        <pick/>                             <pick/>
+ *        <amplitude/>                        <amplitude/>
+ *        <reading/>
+ *        <origin>                            <origin/>
+ *            <stationMagnitude/>             <stationMagnitude/>
+ *            <magnitude/>                    <magnitude/>
+ *        </origin>
+ *        <focalMechanism/>                   <focalMechanism/>
+ *        <event/>                        </event>
+ *    </EventParameters>              </eventParameters>
+ *
+ *  - Renaming of nodes: The following table lists the mapping of names between
+ *    both schema:
+ *
+ *    Parent (SC3)        SC3 name           QuakeML name
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp            EventParameters    eventParameters
+ *    arrival             weight             timeWeight
+ *                        takeOffAngle       takeoffAngle
+ *    magnitude           magnitude          mag
+ *    stationMagnitude    magnitude          mag
+ *    amplitude           amplitude          genericAmplitude
+ *    origin              uncertainty        originUncertainty
+ *    momentTensor        method             category
+ *    waveformID          resourceURI        CDATA
+ *    comment             id                 id (attribute)
+ *
+ *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
+ *
+ *  - Unit conversion: SC3ML uses kilometer for origin depth, origin
+ *    uncertainty and confidence ellipsoid, QuakeML uses meter
+ *
+ *  - Unmapped nodes: The following nodes can not be mapped to the QuakeML
+ *    schema, thus their data is lost:
+ *
+ *    Parent          Element lost
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    creationInfo    modificationTime
+ *    arrival         timeUsed
+ *                    horizontalSlownessUsed
+ *                    backazimuthUsed
+ *    momentTensor    method
+ *                    stationMomentTensorContribution
+ *                    status
+ *                    cmtName
+ *                    cmtVersion
+ *                    phaseSetting
+ *    eventParameters reading
+ *
+ *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
+ *    SC3ML:
+ *
+ *    Parent           Mandatory element
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    Amplitude        genericAmplitude
+ *    StationMagnitude originID
+ *
+ *  - Restriction of data size: QuakeML restricts string length of some
+ *    elements. This length restriction is _NOT_ enforced by this
+ *    stylesheet to prevent data loss. As a consequence QuakeML files
+ *    generated by this XSLT may not validate because of these
+ *    restrictions.
+ *
+ * ================
+ * Change log
+ * ===============
+ *
+ *  * 08.09.2014: Fixed typo in event type conversion (meteo[r] impact)
+ *
+ *  * 25.08.2014: Applied part of the patch proposed by Philipp Kaestli on
+ *                seiscomp-l@gfz-potsdam.de
+ *    - use public id of parent origin if origin id propertery of magnitude
+ *      and station magnitude elements is unset
+ *    - fixed takeOffAngle conversion vom real (SC3ML) to RealQuantity
+ *      (QuakeML)
+ *
+ *  * 04.07.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.11.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.06.2017: Changed license from GPL to LGPL
+ *
+ *  * 08.08.2017: Added some fixes to use this XSLT in ObsPy
+ *    - Change ID_PREFIX variable to a param
+ *    - Do not copy Amplitude if amplitude/amplitude doesn't existing
+ *    - focalMechanism/evaluationMode and focalMechanism/evaluationStatus were
+ *      not copied but can actually be mapped to the QuakeML schema
+ *    - Some event/type enumeration was mapped to `other` instead of
+ *      `other event`
+ *    - Fix origin uncertainty and confidence ellispoid units
+ *    - Rename momentTensor/method to momentTensor/category
+ *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
+ *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
+ *    - Fix Arrival publicID generation
+ *
+ ********************************************************************** -->
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.5"
+        xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
+        xmlns="http://quakeml.org/xmlns/bed/1.2"
+        xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
+        exclude-result-prefixes="scs qml xsl">
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- Define parameters-->
+    <xsl:param name="ID_PREFIX" select="'smi:org.gfz-potsdam.de/geofon/'"/>
+
+    <!-- Define global variables -->
+    <xsl:variable name="PID" select="'publicID'"/>
+
+    <!-- Starting point: Match the root node and select the one and only
+         EventParameters node -->
+    <xsl:template match="/">
+        <xsl:variable name="scsRoot" select="."/>
+        <q:quakeml>
+            <xsl:for-each select="$scsRoot/scs:seiscomp/scs:EventParameters">
+                <eventParameters>
+                    <!-- Mandatory publicID attribute -->
+                    <xsl:attribute name="{$PID}">
+                        <xsl:call-template name="convertOptionalID">
+                            <xsl:with-param name="id" select="@publicID"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+
+                    <xsl:apply-templates/>
+                </eventParameters>
+            </xsl:for-each>
+        </q:quakeml>
+    </xsl:template>
+
+    <!-- event -->
+    <xsl:template match="scs:event">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- search origins referenced by this event -->
+            <xsl:for-each select="scs:originReference">
+                <xsl:for-each select="../../scs:origin[@publicID=current()]">
+                    <!-- stationMagnitudes and referenced amplitudes -->
+                    <xsl:for-each select="scs:stationMagnitude">
+                        <xsl:for-each select="../../scs:amplitude[@publicID=current()/scs:amplitudeID]">
+                            <!-- amplitude/genericAmplitude is mandatory in QuakeML -->
+                            <xsl:if test="scs:amplitude">
+                                <xsl:call-template name="genericNode"/>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- magnitudes -->
+                    <xsl:for-each select="scs:magnitude">
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- picks, referenced by arrivals -->
+                    <xsl:for-each select="scs:arrival">
+                        <!--xsl:value-of select="scs:pickID"/-->
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
+                            <xsl:call-template name="genericNode"/>
+                        </xsl:for-each>
+                    </xsl:for-each>
+
+                    <!-- origin -->
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <!-- search focalMechanisms referenced by this event -->
+            <xsl:for-each select="scs:focalMechanismReference">
+                <xsl:for-each select="../../scs:focalMechanism[@publicID=current()]">
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Default match: Map node 1:1 -->
+    <xsl:template match="*">
+        <xsl:call-template name="genericNode"/>
+    </xsl:template>
+
+    <!-- Delete elements -->
+    <xsl:template match="scs:EventParameters/scs:pick"/>
+    <xsl:template match="scs:EventParameters/scs:amplitude"/>
+    <xsl:template match="scs:EventParameters/scs:reading"/>
+    <xsl:template match="scs:EventParameters/scs:origin"/>
+    <xsl:template match="scs:EventParameters/scs:focalMechanism"/>
+    <xsl:template match="scs:event/scs:originReference"/>
+    <xsl:template match="scs:event/scs:focalMechanismReference"/>
+    <xsl:template match="scs:creationInfo/scs:modificationTime"/>
+    <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:arrival/scs:timeUsed"/>
+    <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
+    <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
+    <xsl:template match="scs:origin/scs:stationMagnitude"/>
+    <xsl:template match="scs:origin/scs:magnitude"/>
+    <xsl:template match="scs:momentTensor/scs:method"/>
+    <xsl:template match="scs:momentTensor/scs:stationMomentTensorContribution"/>
+    <xsl:template match="scs:momentTensor/scs:status"/>
+    <xsl:template match="scs:momentTensor/scs:cmtName"/>
+    <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
+    <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+
+    <!-- Converts a scs magnitude/stationMagnitude to a qml
+         magnitude/stationMagnitude -->
+    <xsl:template match="*" mode="originMagnitude">
+        <xsl:param name="oID"/>
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <!-- if no originID element is available, create one with
+                 the value of the publicID attribute of parent origin -->
+            <xsl:if test="not(scs:originID)">
+                <originID>
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="$oID"/>
+                    </xsl:call-template>
+                </originID>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- event type, enumeration differs slightly -->
+    <xsl:template match="scs:event/scs:type">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='induced earthquake'">induced or triggered event</xsl:when>
+                <xsl:when test="$v='meteor impact'">meteorite</xsl:when>
+                <xsl:when test="$v='not locatable'">other event</xsl:when>
+                <xsl:when test="$v='outside of network interest'">other event</xsl:when>
+                <xsl:when test="$v='duplicate'">other event</xsl:when>
+                <xsl:when test="$v='other'">other event</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin depth, SC3ML uses kilometer, QML meter -->
+    <xsl:template match="scs:origin/scs:depth/scs:value
+                         | scs:origin/scs:depth/scs:uncertainty
+                         | scs:origin/scs:depth/scs:lowerUncertainty
+                         | scs:origin/scs:depth/scs:upperUncertainty
+                         | scs:origin/scs:uncertainty/scs:horizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:minHorizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:maxHorizontalUncertainty
+                         | scs:confidenceEllipsoid/scs:semiMajorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiMinorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiIntermediateAxisLength">
+        <xsl:element name="{local-name()}">
+            <xsl:value-of select="current() * 1000"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- evaluation status, enumeration of QML does not include 'reported' -->
+    <xsl:template match="scs:evaluationStatus">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='reported'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- data used wave type, enumeration differs slightly -->
+    <xsl:template match="scs:dataUsed/scs:waveType">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='P body waves'">P waves</xsl:when>
+                <xsl:when test="$v='long-period body waves'">body waves</xsl:when>
+                <xsl:when test="$v='intermediate-period surface waves'">surface waves</xsl:when>
+                <xsl:when test="$v='long-period mantle waves'">mantle waves</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin uncertainty description, enumeration of QML does not include 'probability density function' -->
+    <xsl:template match="scs:origin/scs:uncertainty/scs:preferredDescription">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='probability density function'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- momentTensor/method -> momentTensor/category -->
+    <xsl:template match="scs:momentTensor/scs:method">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v='teleseismic' or $v='regional'">
+            <xsl:element name="category">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- amplitude/unit is an enumeration in QuakeML, not in SC3ML -->
+    <xsl:template match="scs:amplitude/scs:unit">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:element name="{local-name()}">
+            <xsl:choose>
+                <xsl:when test="$v='m'
+                                or $v='s'
+                                or $v='m/s'
+                                or $v='m/(s*s)'
+                                or $v='m*s'
+                                or $v='dimensionless'">
+                    <xsl:value-of select="$v"/>
+                </xsl:when>
+                <xsl:otherwise>other</xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <xsl:template match="scs:arrival">
+        <xsl:element name="{local-name()}">
+            <xsl:attribute name="{$PID}">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                </xsl:call-template>
+            </xsl:attribute>
+            <!--comment/-->
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Value of ID nodes must be converted to a qml identifier -->
+    <xsl:template match="scs:agencyURI|scs:authorURI|scs:pickID|scs:methodID|scs:earthModelID|scs:amplitudeID|scs:originID|scs:stationMagnitudeID|scs:preferredOriginID|scs:preferredMagnitudeID|scs:originReference|scs:filterID|scs:slownessMethodID|scs:pickReference|scs:amplitudeReference|scs:referenceSystemID|scs:triggeringOriginID|scs:derivedOriginID|momentMagnitudeID|scs:preferredFocalMechanismID|scs:focalMechanismReference|scs:momentMagnitudeID|scs:greensFunctionID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="valueOfIDNode"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- arrival/weight -> arrival/timeWeight-->
+    <xsl:template match="scs:arrival/scs:weight">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'timeWeight'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->
+    <xsl:template match="scs:arrival/scs:takeOffAngle">
+        <xsl:element name="takeoffAngle">
+            <xsl:element name="value">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- stationMagnitude/magnitude -> stationMagnitude/mag -->
+    <xsl:template match="scs:stationMagnitude/scs:magnitude|scs:magnitude/scs:magnitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'mag'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- amplitude/amplitude -> amplitude/genericAmplitude -->
+    <xsl:template match="scs:amplitude/scs:amplitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'genericAmplitude'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- origin/uncertainty -> origin/originUncertainty -->
+    <xsl:template match="scs:origin/scs:uncertainty">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'originUncertainty'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- waveformID: SCS uses a child element 'resourceURI', QML
+         inserts the URI directly as value -->
+    <xsl:template match="scs:waveformID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="scs:resourceURI">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="scs:resourceURI"/>
+                </xsl:call-template>
+            </xsl:if>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- comment: SCS uses a child element 'id', QML an attribute 'id' -->
+    <xsl:template match="scs:comment">
+        <xsl:element name="{local-name()}">
+            <xsl:if test="scs:id">
+                <xsl:attribute name="id">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="scs:id"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Generic transformation of all attributes of an element. If the
+         attribute name is 'eventID' it is transfered to a QML id -->
+    <xsl:template match="@*">
+        <xsl:variable name="attName" select="local-name()"/>
+        <xsl:attribute name="{$attName}">
+            <xsl:choose>
+                <xsl:when test="$attName=$PID">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="string(.)"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="string(.)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+    </xsl:template>
+
+<!--
+    ************************************************************************
+    Named Templates
+    ************************************************************************
+-->
+
+    <!-- Generic and recursively transformation of elements and their
+         attributes -->
+    <xsl:template name="genericNode">
+        <xsl:param name="name"/>
+        <xsl:param name="reqPID"/>
+        <xsl:variable name="nodeName">
+            <xsl:choose>
+                <xsl:when test="$name">
+                    <xsl:value-of select="$name"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="local-name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="{$nodeName}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="$reqPID">
+                <xsl:attribute name="{$PID}">
+                    <xsl:call-template name="convertOptionalID">
+                        <xsl:with-param name="id" select="@publicID"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Converts and returns value of an id node -->
+    <xsl:template name="valueOfIDNode">
+        <xsl:call-template name="convertOptionalID">
+            <xsl:with-param name="id" select="string(.)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id. If the scs id is not set
+         the constant 'NA' is used -->
+    <xsl:template name="convertOptionalID">
+        <xsl:param name="id"/>
+        <xsl:choose>
+            <xsl:when test="$id">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="$id"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="convertID">
+                    <!--xsl:with-param name="id" select="concat('NA-', generate-id())"/-->
+                    <xsl:with-param name="id" select="'NA'"/>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id -->
+    <xsl:template name="convertID">
+        <xsl:param name="id"/>
+        <!-- If the id starts with 'smi:' or 'quakeml:', consider that the id
+             is already well formated -->
+        <xsl:choose>
+            <xsl:when test="starts-with($id, 'smi:')
+                            or starts-with($id, 'quakeml:')">
+                <xsl:value-of select="$id"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="concat($ID_PREFIX, translate($id, ' :', '__'))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/obspy/io/seiscomp/data/sc3ml_0.6.xsd
+++ b/obspy/io/seiscomp/data/sc3ml_0.6.xsd
@@ -1,0 +1,1064 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated from Seiscomp Schema, do not edit -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.6" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.6" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:import namespace="http://quakeml.org/xmlns/quakeml/1.0" schemaLocation="quakeml_types.xsd"/>
+  <xs:simpleType name="OriginUncertaintyDescription">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal uncertainty"/>
+      <xs:enumeration value="uncertainty ellipse"/>
+      <xs:enumeration value="confidence ellipsoid"/>
+      <xs:enumeration value="probability density function"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard CMT solution"/>
+      <xs:enumeration value="quick CMT solution"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginDepthType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from location"/>
+      <xs:enumeration value="from moment tensor inversion"/>
+      <xs:enumeration value="from modeling of broad-band P waveforms"/>
+      <xs:enumeration value="constrained by depth phases"/>
+      <xs:enumeration value="constrained by direct phases"/>
+      <xs:enumeration value="operator assigned"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hypocenter"/>
+      <xs:enumeration value="centroid"/>
+      <xs:enumeration value="amplitude"/>
+      <xs:enumeration value="macroseismic"/>
+      <xs:enumeration value="rupture start"/>
+      <xs:enumeration value="rupture end"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="automatic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="preliminary"/>
+      <xs:enumeration value="confirmed"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="rejected"/>
+      <xs:enumeration value="reported"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickOnset">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="emergent"/>
+      <xs:enumeration value="impulsive"/>
+      <xs:enumeration value="questionable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorMethod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CMT - general moment tensor"/>
+      <xs:enumeration value="CMT - moment tensor with zero trace"/>
+      <xs:enumeration value="CMT - double-couple source"/>
+      <xs:enumeration value="teleseismic"/>
+      <xs:enumeration value="regional"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataUsedWaveType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="body waves"/>
+      <xs:enumeration value="P body waves"/>
+      <xs:enumeration value="long-period body waves"/>
+      <xs:enumeration value="surface waves"/>
+      <xs:enumeration value="intermediate-period surface waves"/>
+      <xs:enumeration value="long-period mantle waves"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventDescriptionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="felt report"/>
+      <xs:enumeration value="Flinn-Engdahl region"/>
+      <xs:enumeration value="local time"/>
+      <xs:enumeration value="tectonic summary"/>
+      <xs:enumeration value="nearest cities"/>
+      <xs:enumeration value="earthquake name"/>
+      <xs:enumeration value="region name"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="not existing"/>
+      <xs:enumeration value="not locatable"/>
+      <xs:enumeration value="outside of network interest"/>
+      <xs:enumeration value="earthquake"/>
+      <xs:enumeration value="induced earthquake"/>
+      <xs:enumeration value="quarry blast"/>
+      <xs:enumeration value="explosion"/>
+      <xs:enumeration value="chemical explosion"/>
+      <xs:enumeration value="nuclear explosion"/>
+      <xs:enumeration value="landslide"/>
+      <xs:enumeration value="rockslide"/>
+      <xs:enumeration value="snow avalanche"/>
+      <xs:enumeration value="debris avalanche"/>
+      <xs:enumeration value="mine collapse"/>
+      <xs:enumeration value="building collapse"/>
+      <xs:enumeration value="volcanic eruption"/>
+      <xs:enumeration value="meteor impact"/>
+      <xs:enumeration value="plane crash"/>
+      <xs:enumeration value="sonic boom"/>
+      <xs:enumeration value="duplicate"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventTypeCertainty">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="known"/>
+      <xs:enumeration value="suspected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceTimeFunctionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="box car"/>
+      <xs:enumeration value="triangle"/>
+      <xs:enumeration value="trapezoid"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickPolarity">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="positive"/>
+      <xs:enumeration value="negative"/>
+      <xs:enumeration value="undecidable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StationGroupType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="deployment"/>
+      <xs:enumeration value="array"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TimeQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CreationInfo">
+    <xs:sequence>
+      <xs:element name="agencyID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="agencyURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="authorURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="modificationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EventDescription">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventDescriptionType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Phase">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Comment">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="id" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RealQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="IntegerQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Axis">
+    <xs:sequence>
+      <xs:element name="azimuth" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="plunge" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="length" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PrincipalAxes">
+    <xs:sequence>
+      <xs:element name="tAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="pAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="nAxis" type="scs:Axis" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DataUsed">
+    <xs:sequence>
+      <xs:element name="waveType" type="scs:DataUsedWaveType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="componentCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="shortestPeriod" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CompositeTime">
+    <xs:sequence>
+      <xs:element name="year" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="month" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="day" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="hour" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minute" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="second" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Tensor">
+    <xs:sequence>
+      <xs:element name="Mrr" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mpp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OriginQuality">
+    <xs:sequence>
+      <xs:element name="associatedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="associatedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="standardError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="secondaryAzimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="groundTruthLevel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maximumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minimumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="medianDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlane">
+    <xs:sequence>
+      <xs:element name="strike" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dip" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="rake" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TimeWindow">
+    <xs:sequence>
+      <xs:element name="reference" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="begin" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="WaveformStreamID">
+    <xs:sequence>
+      <xs:element name="resourceURI" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string"/>
+    <xs:attribute name="channelCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SourceTimeFunction">
+    <xs:sequence>
+      <xs:element name="type" type="scs:SourceTimeFunctionType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="duration" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="riseTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decayTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlanes">
+    <xs:sequence>
+      <xs:element name="nodalPlane1" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlane2" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preferredPlane" type="xs:integer"/>
+  </xs:complexType>
+  <xs:complexType name="ConfidenceEllipsoid">
+    <xs:sequence>
+      <xs:element name="semiMajorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiMinorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiIntermediateAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisPlunge" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisAzimuth" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisRotation" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PickReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AmplitudeReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Reading">
+    <xs:sequence>
+      <xs:element name="pickReference" type="scs:PickReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitudeReference" type="scs:AmplitudeReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorComponentContribution">
+    <xs:sequence>
+      <xs:element name="weight" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeShift" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dataTimeWindow" type="qml:FloatArray" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="phaseCode" type="xs:string" use="required"/>
+    <xs:attribute name="component" type="xs:integer" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorStationContribution">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="component" type="scs:MomentTensorComponentContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+    <xs:attribute name="weight" type="xs:double"/>
+    <xs:attribute name="timeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorPhaseSetting">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="lowerPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="upperPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="minimumSNR" type="xs:double"/>
+    <xs:attribute name="maximumTimeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensor">
+    <xs:sequence>
+      <xs:element name="derivedOriginID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="momentMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalarMoment" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="tensor" type="scs:Tensor" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="variance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="varianceReduction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="doubleCouple" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clvd" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="iso" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="greensFunctionID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceTimeFunction" type="scs:SourceTimeFunction" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="method" type="scs:MomentTensorMethod" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:MomentTensorStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtVersion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="dataUsed" type="scs:DataUsed" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="phaseSetting" type="scs:MomentTensorPhaseSetting" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMomentTensorContribution" type="scs:MomentTensorStationContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanism">
+    <xs:sequence>
+      <xs:element name="triggeringOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlanes" type="scs:NodalPlanes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="principalAxes" type="scs:PrincipalAxes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationPolarityCount" type="xs:int" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationDistributionRatio" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="momentTensor" type="scs:MomentTensor" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Amplitude">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="amplitude" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeWindow" type="scs:TimeWindow" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="period" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalingTime" type="scs:TimeQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitudeHint" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitudeContribution">
+    <xs:sequence>
+      <xs:element name="stationMagnitudeID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="residual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Magnitude">
+    <xs:sequence>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitudeContribution" type="scs:StationMagnitudeContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitude">
+    <xs:sequence>
+      <xs:element name="originID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="amplitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Pick">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="filterID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlowness" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="slownessMethodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="onset" type="scs:PickOnset" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="phaseHint" type="scs:Phase" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="polarity" type="scs:PickPolarity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanismReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Event">
+    <xs:sequence>
+      <xs:element name="preferredOriginID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredMagnitudeID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredFocalMechanismID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="typeCertainty" type="scs:EventTypeCertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="scs:EventDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="originReference" type="scs:OriginReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanismReference" type="scs:FocalMechanismReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginUncertainty">
+    <xs:sequence>
+      <xs:element name="horizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthMaxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceEllipsoid" type="scs:ConfidenceEllipsoid" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredDescription" type="scs:OriginUncertaintyDescription" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Arrival">
+    <xs:sequence>
+      <xs:element name="pickID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="phase" type="scs:Phase" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeCorrection" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="distance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="takeOffAngle" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preliminary" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:complexType name="Origin">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="latitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="longitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="depth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthType" type="scs:OriginDepthType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="epicenterFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="referenceSystemID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="quality" type="scs:OriginQuality" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="scs:OriginUncertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:OriginType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="compositeTime" type="scs:CompositeTime" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arrival" type="scs:Arrival" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitude" type="scs:StationMagnitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="magnitude" type="scs:Magnitude" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="EventParameters">
+    <xs:sequence>
+      <xs:element name="pick" type="scs:Pick" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitude" type="scs:Amplitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="reading" type="scs:Reading" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="origin" type="scs:Origin" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanism" type="scs:FocalMechanism" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="event" type="scs:Event" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Parameter">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ParameterSet">
+    <xs:sequence>
+      <xs:element name="baseID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="moduleID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="parameter" type="scs:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime"/>
+  </xs:complexType>
+  <xs:complexType name="Setup">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigStation">
+    <xs:sequence>
+      <xs:element name="setup" type="scs:Setup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigModule">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="qml:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:ConfigStation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Config">
+    <xs:sequence>
+      <xs:element name="parameterSet" type="scs:ParameterSet" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="module" type="scs:ConfigModule" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="QCLog">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="WaveformQuality">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="parameter" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="windowLength" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="xs:string" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Outage">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="QualityControl">
+    <xs:sequence>
+      <xs:element name="log" type="scs:QCLog" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="waveformQuality" type="scs:WaveformQuality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="outage" type="scs:Outage" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Blob">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RealArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:FloatArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="ComplexArray">
+    <xs:simpleContent>
+      <xs:extension base="qml:ComplexArray"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationReference">
+    <xs:simpleContent>
+      <xs:extension base="qml:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationGroup">
+    <xs:sequence>
+      <xs:element name="type" type="scs:StationGroupType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationReference" type="scs:StationReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxSource">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="conversion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="AuxDevice">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="scs:AuxSource" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SensorCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Sensor">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="highFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:SensorCalibration" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="response" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePAZ">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFactor" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfZeros" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfPoles" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="zeros" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="poles" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePolynomial">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="frequencyUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationLowerBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationUpperBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="DataloggerCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Decimation">
+    <xs:sequence>
+      <xs:element name="analogueFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitalFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="sampleRateNumerator" type="xs:integer" use="required"/>
+    <xs:attribute name="sampleRateDenominator" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Datalogger">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxClockDrift" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:DataloggerCalibration" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="decimation" type="scs:Decimation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseFIR">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="symmetry" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxStream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="deviceSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="device" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Stream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dip" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="datalogger" type="qml:ResourceIdentifier"/>
+    <xs:attribute name="sensor" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="SensorLocation">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="auxStream" type="scs:AuxStream" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stream" type="scs:Stream" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Station">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="place" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="affiliation" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorLocation" type="scs:SensorLocation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="archiveNetworkCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Network">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="institutions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:Station" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Inventory">
+    <xs:sequence>
+      <xs:element name="stationGroup" type="scs:StationGroup" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="auxDevice" type="scs:AuxDevice" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="sensor" type="scs:Sensor" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="datalogger" type="scs:Datalogger" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePAZ" type="scs:ResponsePAZ" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseFIR" type="scs:ResponseFIR" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePolynomial" type="scs:ResponsePolynomial" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="network" type="scs:Network" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="RouteArclink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RouteSeedlink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Route">
+    <xs:sequence>
+      <xs:element name="arclink" type="scs:RouteArclink" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="seedlink" type="scs:RouteSeedlink" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Access">
+    <xs:sequence>
+      <xs:element name="user" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Routing">
+    <xs:sequence>
+      <xs:element name="route" type="scs:Route" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="access" type="scs:Access" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="JournalEntry">
+    <xs:sequence>
+      <xs:element name="objectID" type="qml:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="created" type="xs:dateTime"/>
+    <xs:attribute name="sender" type="xs:string" use="required"/>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="parameters" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Journaling">
+    <xs:sequence>
+      <xs:element name="entry" type="scs:JournalEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkUser">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkStatusLine">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volumeID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestLine">
+    <xs:sequence>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="streamID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:ArclinkStatusLine" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="start" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestSummary">
+    <xs:sequence>
+      <xs:element name="okLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="totalLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="averageTimeWindow" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequest">
+    <xs:sequence>
+      <xs:element name="requestID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="created" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="header" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" type="scs:ArclinkRequestSummary" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="statusLine" type="scs:ArclinkStatusLine" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="requestLine" type="scs:ArclinkRequestLine" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkLog">
+    <xs:sequence>
+      <xs:element name="arclinkRequest" type="scs:ArclinkRequest" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arclinkUser" type="scs:ArclinkUser" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="qml:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:element name="seiscomp">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="EventParameters" type="scs:EventParameters" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Config" type="scs:Config" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="QualityControl" type="scs:QualityControl" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Inventory" type="scs:Inventory" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Routing" type="scs:Routing" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Journaling" type="scs:Journaling" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="ArclinkLog" type="scs:ArclinkLog" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="version" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/obspy/io/seiscomp/data/sc3ml_0.6__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.6__quakeml_1.2.xsl
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- **********************************************************************
+ * Copyright (C) 2017 by gempa GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SC3ML 0.6 to QuakeML 1.2 stylesheet converter
+ * Author  : Stephan Herrnkind
+ * Email   : stephan.herrnkind@gempa.de
+ *
+ * ================
+ * Usage
+ * ================
+ *
+ * This stylesheet converts a SC3ML to a QuakeML document. It may be invoked
+ * e.g. using xalan or xsltproc:
+ *
+ *   xalan -in sc3ml.xml -xsl sc3ml_0.6__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -o quakeml.xml sc3ml_0.6__quakeml_1.2.xsl sc3ml.xml
+ *
+ * You can also modify the default ID prefix with the reverse DNS name of your
+ * institute by setting the ID_PREFIX param:
+ *
+ *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.6__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.6__quakeml_1.2.xsl sc3ml.xml
+ *
+ * ================
+ * Transformation
+ * ================
+ *
+ * QuakeML and SC3ML are quite similar schemas. Nevertheless some differences
+ * exist:
+ *
+ *  - IDs : SC3ML does not enforce any particular ID restriction. An ID in
+ *    SC3ML has no semantic, it simply must be unique. Hence QuakeML uses ID
+ *    restrictions, a conversion of a SC3ML to a QuakeML ID must be performed:
+ *    'sc3id' -> 'smi:org.gfz-potsdam.de/geofon/'. If no SC3ML ID is available
+ *    but QuakeML enforces one, a static ID value of 'NA' is used.
+ *    If the ID starts with `smi:` or `quakeml:`, the ID is considered valid
+ *    and let untouched. This can lead to an invalid generated file but avoid
+ *    to always modify IDs, especially when converting several times.
+ *  - Repositioning of nodes: In QuakeML all information is grouped under the
+ *    event element. As a consequence every node not referenced by an event
+ *    will be lost during the conversion.
+ *
+ *    <EventParameters>               <eventParameters>
+ *                                        <event>
+ *        <pick/>                             <pick/>
+ *        <amplitude/>                        <amplitude/>
+ *        <reading/>
+ *        <origin>                            <origin/>
+ *            <stationMagnitude/>             <stationMagnitude/>
+ *            <magnitude/>                    <magnitude/>
+ *        </origin>
+ *        <focalMechanism/>                   <focalMechanism/>
+ *        <event/>                        </event>
+ *    </EventParameters>              </eventParameters>
+ *
+ *  - Renaming of nodes: The following table lists the mapping of names between
+ *    both schema:
+ *
+ *    Parent (SC3)        SC3 name           QuakeML name
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp            EventParameters    eventParameters
+ *    arrival             weight             timeWeight
+ *                        takeOffAngle       takeoffAngle
+ *    magnitude           magnitude          mag
+ *    stationMagnitude    magnitude          mag
+ *    amplitude           amplitude          genericAmplitude
+ *    origin              uncertainty        originUncertainty
+ *    momentTensor        method             category
+ *    waveformID          resourceURI        CDATA
+ *    comment             id                 id (attribute)
+ *
+ *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
+ *
+ *  - Unit conversion: SC3ML uses kilometer for origin depth, origin
+ *    uncertainty and confidence ellipsoid, QuakeML uses meter
+ *
+ *  - Unmapped nodes: The following nodes can not be mapped to the QuakeML
+ *    schema, thus their data is lost:
+ *
+ *    Parent          Element lost
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    creationInfo    modificationTime
+ *    arrival         timeUsed
+ *                    horizontalSlownessUsed
+ *                    backazimuthUsed
+ *    momentTensor    method
+ *                    stationMomentTensorContribution
+ *                    status
+ *                    cmtName
+ *                    cmtVersion
+ *                    phaseSetting
+ *    eventParameters reading
+ *
+ *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
+ *    SC3ML:
+ *
+ *    Parent           Mandatory element
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    Amplitude        genericAmplitude
+ *    StationMagnitude originID
+ *
+ *  - Restriction of data size: QuakeML restricts string length of some
+ *    elements. This length restriction is _NOT_ enforced by this
+ *    stylesheet to prevent data loss. As a consequence QuakeML files
+ *    generated by this XSLT may not validate because of these
+ *    restrictions.
+ *
+ * ================
+ * Change log
+ * ===============
+ *
+ *  * 08.09.2014: Fixed typo in event type conversion (meteo[r] impact)
+ *
+ *  * 25.08.2014: Applied part of the patch proposed by Philipp Kaestli on
+ *                seiscomp-l@gfz-potsdam.de
+ *    - use public id of parent origin if origin id propertery of magnitude
+ *      and station magnitude elements is unset
+ *    - fixed takeOffAngle conversion vom real (SC3ML) to RealQuantity
+ *      (QuakeML)
+ *
+ *  * 04.07.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.11.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.06.2017: Changed license from GPL to LGPL
+ *
+ *  * 08.08.2017: Added some fixes to use this XSLT in ObsPy
+ *    - Change ID_PREFIX variable to a param
+ *    - Do not copy Amplitude if amplitude/amplitude doesn't existing
+ *    - focalMechanism/evaluationMode and focalMechanism/evaluationStatus were
+ *      not copied but can actually be mapped to the QuakeML schema
+ *    - Some event/type enumeration was mapped to `other` instead of
+ *      `other event`
+ *    - Fix origin uncertainty and confidence ellispoid units
+ *    - Rename momentTensor/method to momentTensor/category
+ *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
+ *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
+ *    - Fix Arrival publicID generation
+ *
+ ********************************************************************** -->
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.6"
+        xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
+        xmlns="http://quakeml.org/xmlns/bed/1.2"
+        xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
+        exclude-result-prefixes="scs qml xsl">
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- Define parameters-->
+    <xsl:param name="ID_PREFIX" select="'smi:org.gfz-potsdam.de/geofon/'"/>
+
+    <!-- Define global variables -->
+    <xsl:variable name="PID" select="'publicID'"/>
+
+    <!-- Starting point: Match the root node and select the one and only
+         EventParameters node -->
+    <xsl:template match="/">
+        <xsl:variable name="scsRoot" select="."/>
+        <q:quakeml>
+            <xsl:for-each select="$scsRoot/scs:seiscomp/scs:EventParameters">
+                <eventParameters>
+                    <!-- Mandatory publicID attribute -->
+                    <xsl:attribute name="{$PID}">
+                        <xsl:call-template name="convertOptionalID">
+                            <xsl:with-param name="id" select="@publicID"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+
+                    <xsl:apply-templates/>
+                </eventParameters>
+            </xsl:for-each>
+        </q:quakeml>
+    </xsl:template>
+
+    <!-- event -->
+    <xsl:template match="scs:event">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- search origins referenced by this event -->
+            <xsl:for-each select="scs:originReference">
+                <xsl:for-each select="../../scs:origin[@publicID=current()]">
+                    <!-- stationMagnitudes and referenced amplitudes -->
+                    <xsl:for-each select="scs:stationMagnitude">
+                        <xsl:for-each select="../../scs:amplitude[@publicID=current()/scs:amplitudeID]">
+                            <!-- amplitude/genericAmplitude is mandatory in QuakeML -->
+                            <xsl:if test="scs:amplitude">
+                                <xsl:call-template name="genericNode"/>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- magnitudes -->
+                    <xsl:for-each select="scs:magnitude">
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- picks, referenced by arrivals -->
+                    <xsl:for-each select="scs:arrival">
+                        <!--xsl:value-of select="scs:pickID"/-->
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
+                            <xsl:call-template name="genericNode"/>
+                        </xsl:for-each>
+                    </xsl:for-each>
+
+                    <!-- origin -->
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <!-- search focalMechanisms referenced by this event -->
+            <xsl:for-each select="scs:focalMechanismReference">
+                <xsl:for-each select="../../scs:focalMechanism[@publicID=current()]">
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Default match: Map node 1:1 -->
+    <xsl:template match="*">
+        <xsl:call-template name="genericNode"/>
+    </xsl:template>
+
+    <!-- Delete elements -->
+    <xsl:template match="scs:EventParameters/scs:pick"/>
+    <xsl:template match="scs:EventParameters/scs:amplitude"/>
+    <xsl:template match="scs:EventParameters/scs:reading"/>
+    <xsl:template match="scs:EventParameters/scs:origin"/>
+    <xsl:template match="scs:EventParameters/scs:focalMechanism"/>
+    <xsl:template match="scs:event/scs:originReference"/>
+    <xsl:template match="scs:event/scs:focalMechanismReference"/>
+    <xsl:template match="scs:creationInfo/scs:modificationTime"/>
+    <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:arrival/scs:timeUsed"/>
+    <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
+    <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
+    <xsl:template match="scs:origin/scs:stationMagnitude"/>
+    <xsl:template match="scs:origin/scs:magnitude"/>
+    <xsl:template match="scs:momentTensor/scs:method"/>
+    <xsl:template match="scs:momentTensor/scs:stationMomentTensorContribution"/>
+    <xsl:template match="scs:momentTensor/scs:status"/>
+    <xsl:template match="scs:momentTensor/scs:cmtName"/>
+    <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
+    <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+
+    <!-- Converts a scs magnitude/stationMagnitude to a qml
+         magnitude/stationMagnitude -->
+    <xsl:template match="*" mode="originMagnitude">
+        <xsl:param name="oID"/>
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <!-- if no originID element is available, create one with
+                 the value of the publicID attribute of parent origin -->
+            <xsl:if test="not(scs:originID)">
+                <originID>
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="$oID"/>
+                    </xsl:call-template>
+                </originID>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- event type, enumeration differs slightly -->
+    <xsl:template match="scs:event/scs:type">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='induced earthquake'">induced or triggered event</xsl:when>
+                <xsl:when test="$v='meteor impact'">meteorite</xsl:when>
+                <xsl:when test="$v='not locatable'">other event</xsl:when>
+                <xsl:when test="$v='outside of network interest'">other event</xsl:when>
+                <xsl:when test="$v='duplicate'">other event</xsl:when>
+                <xsl:when test="$v='other'">other event</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin depth, SC3ML uses kilometer, QML meter -->
+    <xsl:template match="scs:origin/scs:depth/scs:value
+                         | scs:origin/scs:depth/scs:uncertainty
+                         | scs:origin/scs:depth/scs:lowerUncertainty
+                         | scs:origin/scs:depth/scs:upperUncertainty
+                         | scs:origin/scs:uncertainty/scs:horizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:minHorizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:maxHorizontalUncertainty
+                         | scs:confidenceEllipsoid/scs:semiMajorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiMinorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiIntermediateAxisLength">
+        <xsl:element name="{local-name()}">
+            <xsl:value-of select="current() * 1000"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- evaluation status, enumeration of QML does not include 'reported' -->
+    <xsl:template match="scs:evaluationStatus">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='reported'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- data used wave type, enumeration differs slightly -->
+    <xsl:template match="scs:dataUsed/scs:waveType">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='P body waves'">P waves</xsl:when>
+                <xsl:when test="$v='long-period body waves'">body waves</xsl:when>
+                <xsl:when test="$v='intermediate-period surface waves'">surface waves</xsl:when>
+                <xsl:when test="$v='long-period mantle waves'">mantle waves</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin uncertainty description, enumeration of QML does not include 'probability density function' -->
+    <xsl:template match="scs:origin/scs:uncertainty/scs:preferredDescription">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='probability density function'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- momentTensor/method -> momentTensor/category -->
+    <xsl:template match="scs:momentTensor/scs:method">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v='teleseismic' or $v='regional'">
+            <xsl:element name="category">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- amplitude/unit is an enumeration in QuakeML, not in SC3ML -->
+    <xsl:template match="scs:amplitude/scs:unit">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:element name="{local-name()}">
+            <xsl:choose>
+                <xsl:when test="$v='m'
+                                or $v='s'
+                                or $v='m/s'
+                                or $v='m/(s*s)'
+                                or $v='m*s'
+                                or $v='dimensionless'">
+                    <xsl:value-of select="$v"/>
+                </xsl:when>
+                <xsl:otherwise>other</xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <xsl:template match="scs:arrival">
+        <xsl:element name="{local-name()}">
+            <xsl:attribute name="{$PID}">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                </xsl:call-template>
+            </xsl:attribute>
+            <!--comment/-->
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Value of ID nodes must be converted to a qml identifier -->
+    <xsl:template match="scs:agencyURI|scs:authorURI|scs:pickID|scs:methodID|scs:earthModelID|scs:amplitudeID|scs:originID|scs:stationMagnitudeID|scs:preferredOriginID|scs:preferredMagnitudeID|scs:originReference|scs:filterID|scs:slownessMethodID|scs:pickReference|scs:amplitudeReference|scs:referenceSystemID|scs:triggeringOriginID|scs:derivedOriginID|momentMagnitudeID|scs:preferredFocalMechanismID|scs:focalMechanismReference|scs:momentMagnitudeID|scs:greensFunctionID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="valueOfIDNode"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- arrival/weight -> arrival/timeWeight-->
+    <xsl:template match="scs:arrival/scs:weight">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'timeWeight'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->
+    <xsl:template match="scs:arrival/scs:takeOffAngle">
+        <xsl:element name="takeoffAngle">
+            <xsl:element name="value">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- stationMagnitude/magnitude -> stationMagnitude/mag -->
+    <xsl:template match="scs:stationMagnitude/scs:magnitude|scs:magnitude/scs:magnitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'mag'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- amplitude/amplitude -> amplitude/genericAmplitude -->
+    <xsl:template match="scs:amplitude/scs:amplitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'genericAmplitude'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- origin/uncertainty -> origin/originUncertainty -->
+    <xsl:template match="scs:origin/scs:uncertainty">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'originUncertainty'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- waveformID: SCS uses a child element 'resourceURI', QML
+         inserts the URI directly as value -->
+    <xsl:template match="scs:waveformID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="scs:resourceURI">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="scs:resourceURI"/>
+                </xsl:call-template>
+            </xsl:if>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- comment: SCS uses a child element 'id', QML an attribute 'id' -->
+    <xsl:template match="scs:comment">
+        <xsl:element name="{local-name()}">
+            <xsl:if test="scs:id">
+                <xsl:attribute name="id">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="scs:id"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Generic transformation of all attributes of an element. If the
+         attribute name is 'eventID' it is transfered to a QML id -->
+    <xsl:template match="@*">
+        <xsl:variable name="attName" select="local-name()"/>
+        <xsl:attribute name="{$attName}">
+            <xsl:choose>
+                <xsl:when test="$attName=$PID">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="string(.)"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="string(.)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+    </xsl:template>
+
+<!--
+    ************************************************************************
+    Named Templates
+    ************************************************************************
+-->
+
+    <!-- Generic and recursively transformation of elements and their
+         attributes -->
+    <xsl:template name="genericNode">
+        <xsl:param name="name"/>
+        <xsl:param name="reqPID"/>
+        <xsl:variable name="nodeName">
+            <xsl:choose>
+                <xsl:when test="$name">
+                    <xsl:value-of select="$name"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="local-name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="{$nodeName}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="$reqPID">
+                <xsl:attribute name="{$PID}">
+                    <xsl:call-template name="convertOptionalID">
+                        <xsl:with-param name="id" select="@publicID"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Converts and returns value of an id node -->
+    <xsl:template name="valueOfIDNode">
+        <xsl:call-template name="convertOptionalID">
+            <xsl:with-param name="id" select="string(.)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id. If the scs id is not set
+         the constant 'NA' is used -->
+    <xsl:template name="convertOptionalID">
+        <xsl:param name="id"/>
+        <xsl:choose>
+            <xsl:when test="$id">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="$id"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="convertID">
+                    <!--xsl:with-param name="id" select="concat('NA-', generate-id())"/-->
+                    <xsl:with-param name="id" select="'NA'"/>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id -->
+    <xsl:template name="convertID">
+        <xsl:param name="id"/>
+        <!-- If the id starts with 'smi:' or 'quakeml:', consider that the id
+             is already well formated -->
+        <xsl:choose>
+            <xsl:when test="starts-with($id, 'smi:')
+                            or starts-with($id, 'quakeml:')">
+                <xsl:value-of select="$id"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="concat($ID_PREFIX, translate($id, ' :', '__'))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/obspy/io/seiscomp/data/sc3ml_0.7__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.7__quakeml_1.2.xsl
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- **********************************************************************
+ * Copyright (C) 2017 by gempa GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SC3ML 0.7 to QuakeML 1.2 stylesheet converter
+ * Author  : Stephan Herrnkind
+ * Email   : stephan.herrnkind@gempa.de
+ * Version : 2014.251.01
+ *
+ * ================
+ * Usage
+ * ================
+ *
+ * This stylesheet converts a SC3ML to a QuakeML document. It may be invoked
+ * e.g. using xalan or xsltproc:
+ *
+ *   xalan -in sc3ml.xml -xsl sc3ml_0.7__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -o quakeml.xml sc3ml_0.7__quakeml_1.2.xsl sc3ml.xml
+ *
+ * You can also modify the default ID prefix with the reverse DNS name of your
+ * institute by setting the ID_PREFIX param:
+ *
+ *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.7__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.7__quakeml_1.2.xsl sc3ml.xml
+ *
+ * ================
+ * Transformation
+ * ================
+ *
+ * QuakeML and SC3ML are quite similar schemas. Nevertheless some differences
+ * exist:
+ *
+ *  - IDs : SC3ML does not enforce any particular ID restriction. An ID in
+ *    SC3ML has no semantic, it simply must be unique. Hence QuakeML uses ID
+ *    restrictions, a conversion of a SC3ML to a QuakeML ID must be performed:
+ *    'sc3id' -> 'smi:org.gfz-potsdam.de/geofon/'. If no SC3ML ID is available
+ *    but QuakeML enforces one, a static ID value of 'NA' is used.
+ *    If the ID starts with `smi:` or `quakeml:`, the ID is considered valid
+ *    and let untouched. This can lead to an invalid generated file but avoid
+ *    to always modify IDs, especially when converting several times.
+ *  - Repositioning of nodes: In QuakeML all information is grouped under the
+ *    event element. As a consequence every node not referenced by an event
+ *    will be lost during the conversion.
+ *
+ *    <EventParameters>               <eventParameters>
+ *                                        <event>
+ *        <pick/>                             <pick/>
+ *        <amplitude/>                        <amplitude/>
+ *        <reading/>
+ *        <origin>                            <origin/>
+ *            <stationMagnitude/>             <stationMagnitude/>
+ *            <magnitude/>                    <magnitude/>
+ *        </origin>
+ *        <focalMechanism/>                   <focalMechanism/>
+ *        <event/>                        </event>
+ *    </EventParameters>              </eventParameters>
+ *
+ *  - Renaming of nodes: The following table lists the mapping of names between
+ *    both schema:
+ *
+ *    Parent (SC3)        SC3 name           QuakeML name
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp            EventParameters    eventParameters
+ *    arrival             weight             timeWeight
+ *                        takeOffAngle       takeoffAngle
+ *    magnitude           magnitude          mag
+ *    stationMagnitude    magnitude          mag
+ *    amplitude           amplitude          genericAmplitude
+ *    origin              uncertainty        originUncertainty
+ *    momentTensor        method             category
+ *    waveformID          resourceURI        CDATA
+ *    comment             id                 id (attribute)
+ *
+ *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
+ *
+ *  - Unit conversion: SC3ML uses kilometer for origin depth, origin
+ *    uncertainty and confidence ellipsoid, QuakeML uses meter
+ *
+ *  - Unmapped nodes: The following nodes can not be mapped to the QuakeML
+ *    schema, thus their data is lost:
+ *
+ *    Parent          Element lost
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    creationInfo    modificationTime
+ *    arrival         timeUsed
+ *                    horizontalSlownessUsed
+ *                    backazimuthUsed
+ *    momentTensor    method
+ *                    stationMomentTensorContribution
+ *                    status
+ *                    cmtName
+ *                    cmtVersion
+ *                    phaseSetting
+ *    eventParameters reading
+ *
+ *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
+ *    SC3ML:
+ *
+ *    Parent           Mandatory element
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    Amplitude        genericAmplitude
+ *    StationMagnitude originID
+ *
+ *  - Restriction of data size: QuakeML restricts string length of some
+ *    elements. This length restriction is _NOT_ enforced by this
+ *    stylesheet to prevent data loss. As a consequence QuakeML files
+ *    generated by this XSLT may not validate because of these
+ *    restrictions.
+ *
+ * ================
+ * Change log
+ * ===============
+ *
+ *  * 08.09.2014: Fixed typo in event type conversion (meteo[r] impact)
+ *
+ *  * 25.08.2014: Applied part of the patch proposed by Philipp Kaestli on
+ *                seiscomp-l@gfz-potsdam.de
+ *    - use public id of parent origin if origin id propertery of magnitude
+ *      and station magnitude elements is unset
+ *    - fixed takeOffAngle conversion vom real (SC3ML) to RealQuantity
+ *      (QuakeML)
+ *
+ *  * 04.07.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.11.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.06.2017: Changed license from GPL to LGPL
+ *
+ *  * 08.08.2017: Added some fixes to use this XSLT in ObsPy
+ *    - Change ID_PREFIX variable to a param
+ *    - Do not copy Amplitude if amplitude/amplitude doesn't existing
+ *    - focalMechanism/evaluationMode and focalMechanism/evaluationStatus were
+ *      not copied but can actually be mapped to the QuakeML schema
+ *    - Some event/type enumeration was mapped to `other` instead of
+ *      `other event`
+ *    - Fix origin uncertainty and confidence ellispoid units
+ *    - Rename momentTensor/method to momentTensor/category
+ *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
+ *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
+ *    - Fix Arrival publicID generation
+ *
+ ********************************************************************** -->
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7"
+        xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
+        xmlns="http://quakeml.org/xmlns/bed/1.2"
+        xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
+        exclude-result-prefixes="scs qml xsl">
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- Define parameters-->
+    <xsl:param name="ID_PREFIX" select="'smi:org.gfz-potsdam.de/geofon/'"/>
+
+    <!-- Define global variables -->
+    <xsl:variable name="PID" select="'publicID'"/>
+
+    <!-- Starting point: Match the root node and select the one and only
+         EventParameters node -->
+    <xsl:template match="/">
+        <xsl:variable name="scsRoot" select="."/>
+        <q:quakeml>
+            <xsl:for-each select="$scsRoot/scs:seiscomp/scs:EventParameters">
+                <eventParameters>
+                    <!-- Mandatory publicID attribute -->
+                    <xsl:attribute name="{$PID}">
+                        <xsl:call-template name="convertOptionalID">
+                            <xsl:with-param name="id" select="@publicID"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+
+                    <xsl:apply-templates/>
+                </eventParameters>
+            </xsl:for-each>
+        </q:quakeml>
+    </xsl:template>
+
+    <!-- event -->
+    <xsl:template match="scs:event">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- search origins referenced by this event -->
+            <xsl:for-each select="scs:originReference">
+                <xsl:for-each select="../../scs:origin[@publicID=current()]">
+                    <!-- stationMagnitudes and referenced amplitudes -->
+                    <xsl:for-each select="scs:stationMagnitude">
+                        <xsl:for-each select="../../scs:amplitude[@publicID=current()/scs:amplitudeID]">
+                            <!-- amplitude/genericAmplitude is mandatory in QuakeML -->
+                            <xsl:if test="scs:amplitude">
+                                <xsl:call-template name="genericNode"/>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- magnitudes -->
+                    <xsl:for-each select="scs:magnitude">
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- picks, referenced by arrivals -->
+                    <xsl:for-each select="scs:arrival">
+                        <!--xsl:value-of select="scs:pickID"/-->
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
+                            <xsl:call-template name="genericNode"/>
+                        </xsl:for-each>
+                    </xsl:for-each>
+
+                    <!-- origin -->
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <!-- search focalMechanisms referenced by this event -->
+            <xsl:for-each select="scs:focalMechanismReference">
+                <xsl:for-each select="../../scs:focalMechanism[@publicID=current()]">
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Default match: Map node 1:1 -->
+    <xsl:template match="*">
+        <xsl:call-template name="genericNode"/>
+    </xsl:template>
+
+    <!-- Delete elements -->
+    <xsl:template match="scs:EventParameters/scs:pick"/>
+    <xsl:template match="scs:EventParameters/scs:amplitude"/>
+    <xsl:template match="scs:EventParameters/scs:reading"/>
+    <xsl:template match="scs:EventParameters/scs:origin"/>
+    <xsl:template match="scs:EventParameters/scs:focalMechanism"/>
+    <xsl:template match="scs:event/scs:originReference"/>
+    <xsl:template match="scs:event/scs:focalMechanismReference"/>
+    <xsl:template match="scs:creationInfo/scs:modificationTime"/>
+    <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:arrival/scs:timeUsed"/>
+    <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
+    <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
+    <xsl:template match="scs:origin/scs:stationMagnitude"/>
+    <xsl:template match="scs:origin/scs:magnitude"/>
+    <xsl:template match="scs:momentTensor/scs:method"/>
+    <xsl:template match="scs:momentTensor/scs:stationMomentTensorContribution"/>
+    <xsl:template match="scs:momentTensor/scs:status"/>
+    <xsl:template match="scs:momentTensor/scs:cmtName"/>
+    <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
+    <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+
+    <!-- Converts a scs magnitude/stationMagnitude to a qml
+         magnitude/stationMagnitude -->
+    <xsl:template match="*" mode="originMagnitude">
+        <xsl:param name="oID"/>
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <!-- if no originID element is available, create one with
+                 the value of the publicID attribute of parent origin -->
+            <xsl:if test="not(scs:originID)">
+                <originID>
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="$oID"/>
+                    </xsl:call-template>
+                </originID>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- event type, enumeration differs slightly -->
+    <xsl:template match="scs:event/scs:type">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='induced earthquake'">induced or triggered event</xsl:when>
+                <xsl:when test="$v='meteor impact'">meteorite</xsl:when>
+                <xsl:when test="$v='not locatable'">other event</xsl:when>
+                <xsl:when test="$v='outside of network interest'">other event</xsl:when>
+                <xsl:when test="$v='duplicate'">other event</xsl:when>
+                <xsl:when test="$v='other'">other event</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin depth, SC3ML uses kilometer, QML meter -->
+    <xsl:template match="scs:origin/scs:depth/scs:value
+                         | scs:origin/scs:depth/scs:uncertainty
+                         | scs:origin/scs:depth/scs:lowerUncertainty
+                         | scs:origin/scs:depth/scs:upperUncertainty
+                         | scs:origin/scs:uncertainty/scs:horizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:minHorizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:maxHorizontalUncertainty
+                         | scs:confidenceEllipsoid/scs:semiMajorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiMinorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiIntermediateAxisLength">
+        <xsl:element name="{local-name()}">
+            <xsl:value-of select="current() * 1000"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- evaluation status, enumeration of QML does not include 'reported' -->
+    <xsl:template match="scs:evaluationStatus">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='reported'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- data used wave type, enumeration differs slightly -->
+    <xsl:template match="scs:dataUsed/scs:waveType">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='P body waves'">P waves</xsl:when>
+                <xsl:when test="$v='long-period body waves'">body waves</xsl:when>
+                <xsl:when test="$v='intermediate-period surface waves'">surface waves</xsl:when>
+                <xsl:when test="$v='long-period mantle waves'">mantle waves</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin uncertainty description, enumeration of QML does not include 'probability density function' -->
+    <xsl:template match="scs:origin/scs:uncertainty/scs:preferredDescription">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='probability density function'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- momentTensor/method -> momentTensor/category -->
+    <xsl:template match="scs:momentTensor/scs:method">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v='teleseismic' or $v='regional'">
+            <xsl:element name="category">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- amplitude/unit is an enumeration in QuakeML, not in SC3ML -->
+    <xsl:template match="scs:amplitude/scs:unit">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:element name="{local-name()}">
+            <xsl:choose>
+                <xsl:when test="$v='m'
+                                or $v='s'
+                                or $v='m/s'
+                                or $v='m/(s*s)'
+                                or $v='m*s'
+                                or $v='dimensionless'">
+                    <xsl:value-of select="$v"/>
+                </xsl:when>
+                <xsl:otherwise>other</xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <xsl:template match="scs:arrival">
+        <xsl:element name="{local-name()}">
+            <xsl:attribute name="{$PID}">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                </xsl:call-template>
+            </xsl:attribute>
+            <!--comment/-->
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Value of ID nodes must be converted to a qml identifier -->
+    <xsl:template match="scs:agencyURI|scs:authorURI|scs:pickID|scs:methodID|scs:earthModelID|scs:amplitudeID|scs:originID|scs:stationMagnitudeID|scs:preferredOriginID|scs:preferredMagnitudeID|scs:originReference|scs:filterID|scs:slownessMethodID|scs:pickReference|scs:amplitudeReference|scs:referenceSystemID|scs:triggeringOriginID|scs:derivedOriginID|momentMagnitudeID|scs:preferredFocalMechanismID|scs:focalMechanismReference|scs:momentMagnitudeID|scs:greensFunctionID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="valueOfIDNode"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- arrival/weight -> arrival/timeWeight-->
+    <xsl:template match="scs:arrival/scs:weight">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'timeWeight'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->
+    <xsl:template match="scs:arrival/scs:takeOffAngle">
+        <xsl:element name="takeoffAngle">
+            <xsl:element name="value">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- stationMagnitude/magnitude -> stationMagnitude/mag -->
+    <xsl:template match="scs:stationMagnitude/scs:magnitude|scs:magnitude/scs:magnitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'mag'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- amplitude/amplitude -> amplitude/genericAmplitude -->
+    <xsl:template match="scs:amplitude/scs:amplitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'genericAmplitude'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- origin/uncertainty -> origin/originUncertainty -->
+    <xsl:template match="scs:origin/scs:uncertainty">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'originUncertainty'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- waveformID: SCS uses a child element 'resourceURI', QML
+         inserts the URI directly as value -->
+    <xsl:template match="scs:waveformID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="scs:resourceURI">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="scs:resourceURI"/>
+                </xsl:call-template>
+            </xsl:if>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- comment: SCS uses a child element 'id', QML an attribute 'id' -->
+    <xsl:template match="scs:comment">
+        <xsl:element name="{local-name()}">
+            <xsl:if test="scs:id">
+                <xsl:attribute name="id">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="scs:id"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Generic transformation of all attributes of an element. If the
+         attribute name is 'eventID' it is transfered to a QML id -->
+    <xsl:template match="@*">
+        <xsl:variable name="attName" select="local-name()"/>
+        <xsl:attribute name="{$attName}">
+            <xsl:choose>
+                <xsl:when test="$attName=$PID">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="string(.)"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="string(.)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+    </xsl:template>
+
+<!--
+    ************************************************************************
+    Named Templates
+    ************************************************************************
+-->
+
+    <!-- Generic and recursively transformation of elements and their
+         attributes -->
+    <xsl:template name="genericNode">
+        <xsl:param name="name"/>
+        <xsl:param name="reqPID"/>
+        <xsl:variable name="nodeName">
+            <xsl:choose>
+                <xsl:when test="$name">
+                    <xsl:value-of select="$name"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="local-name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="{$nodeName}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="$reqPID">
+                <xsl:attribute name="{$PID}">
+                    <xsl:call-template name="convertOptionalID">
+                        <xsl:with-param name="id" select="@publicID"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Converts and returns value of an id node -->
+    <xsl:template name="valueOfIDNode">
+        <xsl:call-template name="convertOptionalID">
+            <xsl:with-param name="id" select="string(.)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id. If the scs id is not set
+         the constant 'NA' is used -->
+    <xsl:template name="convertOptionalID">
+        <xsl:param name="id"/>
+        <xsl:choose>
+            <xsl:when test="$id">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="$id"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="convertID">
+                    <!--xsl:with-param name="id" select="concat('NA-', generate-id())"/-->
+                    <xsl:with-param name="id" select="'NA'"/>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id -->
+    <xsl:template name="convertID">
+        <xsl:param name="id"/>
+        <!-- If the id starts with 'smi:' or 'quakeml:', consider that the id
+             is already well formated -->
+        <xsl:choose>
+            <xsl:when test="starts-with($id, 'smi:')
+                            or starts-with($id, 'quakeml:')">
+                <xsl:value-of select="$id"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="concat($ID_PREFIX, translate($id, ' :', '__'))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/obspy/io/seiscomp/data/sc3ml_0.8__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.8__quakeml_1.2.xsl
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- **********************************************************************
+ * Copyright (C) 2017 by gempa GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * SC3ML 0.8 to QuakeML 1.2 stylesheet converter
+ * Author  : Stephan Herrnkind
+ * Email   : stephan.herrnkind@gempa.de
+ * Version : 2016.161.01
+ *
+ * ================
+ * Usage
+ * ================
+ *
+ * This stylesheet converts a SC3ML to a QuakeML document. It may be invoked
+ * e.g. using xalan or xsltproc:
+ *
+ *   xalan -in sc3ml.xml -xsl sc3ml_0.8__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -o quakeml.xml sc3ml_0.8__quakeml_1.2.xsl sc3ml.xml
+ *
+ * You can also modify the default ID prefix with the reverse DNS name of your
+ * institute by setting the ID_PREFIX param:
+ *
+ *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.8__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.8__quakeml_1.2.xsl sc3ml.xml
+ *
+ * ================
+ * Transformation
+ * ================
+ *
+ * QuakeML and SC3ML are quite similar schemas. Nevertheless some differences
+ * exist:
+ *
+ *  - IDs : SC3ML does not enforce any particular ID restriction. An ID in
+ *    SC3ML has no semantic, it simply must be unique. Hence QuakeML uses ID
+ *    restrictions, a conversion of a SC3ML to a QuakeML ID must be performed:
+ *    'sc3id' -> 'smi:org.gfz-potsdam.de/geofon/'. If no SC3ML ID is available
+ *    but QuakeML enforces one, a static ID value of 'NA' is used.
+ *    If the ID starts with `smi:` or `quakeml:`, the ID is considered valid
+ *    and let untouched. This can lead to an invalid generated file but avoid
+ *    to always modify IDs, especially when converting several times.
+ *  - Repositioning of nodes: In QuakeML all information is grouped under the
+ *    event element. As a consequence every node not referenced by an event
+ *    will be lost during the conversion.
+ *
+ *    <EventParameters>               <eventParameters>
+ *                                        <event>
+ *        <pick/>                             <pick/>
+ *        <amplitude/>                        <amplitude/>
+ *        <reading/>
+ *        <origin>                            <origin/>
+ *            <stationMagnitude/>             <stationMagnitude/>
+ *            <magnitude/>                    <magnitude/>
+ *        </origin>
+ *        <focalMechanism/>                   <focalMechanism/>
+ *        <event/>                        </event>
+ *    </EventParameters>              </eventParameters>
+ *
+ *  - Renaming of nodes: The following table lists the mapping of names between
+ *    both schema:
+ *
+ *    Parent (SC3)        SC3 name           QuakeML name
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp            EventParameters    eventParameters
+ *    arrival             weight             timeWeight
+ *                        takeOffAngle       takeoffAngle
+ *    magnitude           magnitude          mag
+ *    stationMagnitude    magnitude          mag
+ *    amplitude           amplitude          genericAmplitude
+ *    origin              uncertainty        originUncertainty
+ *    momentTensor        method             category
+ *    waveformID          resourceURI        CDATA
+ *    comment             id                 id (attribute)
+ *
+ *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
+ *
+ *  - Unit conversion: SC3ML uses kilometer for origin depth, origin
+ *    uncertainty and confidence ellipsoid, QuakeML uses meter
+ *
+ *  - Unmapped nodes: The following nodes can not be mapped to the QuakeML
+ *    schema, thus their data is lost:
+ *
+ *    Parent          Element lost
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    creationInfo    modificationTime
+ *    arrival         timeUsed
+ *                    horizontalSlownessUsed
+ *                    backazimuthUsed
+ *    momentTensor    method
+ *                    stationMomentTensorContribution
+ *                    status
+ *                    cmtName
+ *                    cmtVersion
+ *                    phaseSetting
+ *    eventParameters reading
+ *
+ *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
+ *    SC3ML:
+ *
+ *    Parent           Mandatory element
+ *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    Amplitude        genericAmplitude
+ *    StationMagnitude originID
+ *
+ *  - Restriction of data size: QuakeML restricts string length of some
+ *    elements. This length restriction is _NOT_ enforced by this
+ *    stylesheet to prevent data loss. As a consequence QuakeML files
+ *    generated by this XSLT may not validate because of these
+ *    restrictions.
+ *
+ * ================
+ * Change log
+ * ===============
+ *
+ *  * 08.09.2014: Fixed typo in event type conversion (meteo[r] impact)
+ *
+ *  * 25.08.2014: Applied part of the patch proposed by Philipp Kaestli on
+ *                seiscomp-l@gfz-potsdam.de
+ *    - use public id of parent origin if origin id propertery of magnitude
+ *      and station magnitude elements is unset
+ *    - fixed takeOffAngle conversion vom real (SC3ML) to RealQuantity
+ *      (QuakeML)
+ *
+ *  * 04.07.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.11.2016: Version bump. No modification here, SC3 datamodel was updated
+ *                on the inventory side.
+ *
+ *  * 28.06.2017: Changed license from GPL to LGPL
+ *
+ *  * 08.08.2017: Added some fixes to use this XSLT in ObsPy
+ *    - Change ID_PREFIX variable to a param
+ *    - Do not copy Amplitude if amplitude/amplitude doesn't existing
+ *    - focalMechanism/evaluationMode and focalMechanism/evaluationStatus were
+ *      not copied but can actually be mapped to the QuakeML schema
+ *    - Some event/type enumeration was mapped to `other` instead of
+ *      `other event`
+ *    - Fix origin uncertainty and confidence ellispoid units
+ *    - Rename momentTensor/method to momentTensor/category
+ *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
+ *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
+ *    - Fix Arrival publicID generation
+ *
+ ********************************************************************** -->
+<xsl:stylesheet version="1.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8"
+        xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
+        xmlns="http://quakeml.org/xmlns/bed/1.2"
+        xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
+        exclude-result-prefixes="scs qml xsl">
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- Define parameters-->
+    <xsl:param name="ID_PREFIX" select="'smi:org.gfz-potsdam.de/geofon/'"/>
+
+    <!-- Define global variables -->
+    <xsl:variable name="PID" select="'publicID'"/>
+
+    <!-- Starting point: Match the root node and select the one and only
+         EventParameters node -->
+    <xsl:template match="/">
+        <xsl:variable name="scsRoot" select="."/>
+        <q:quakeml>
+            <xsl:for-each select="$scsRoot/scs:seiscomp/scs:EventParameters">
+                <eventParameters>
+                    <!-- Mandatory publicID attribute -->
+                    <xsl:attribute name="{$PID}">
+                        <xsl:call-template name="convertOptionalID">
+                            <xsl:with-param name="id" select="@publicID"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+
+                    <xsl:apply-templates/>
+                </eventParameters>
+            </xsl:for-each>
+        </q:quakeml>
+    </xsl:template>
+
+    <!-- event -->
+    <xsl:template match="scs:event">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- search origins referenced by this event -->
+            <xsl:for-each select="scs:originReference">
+                <xsl:for-each select="../../scs:origin[@publicID=current()]">
+                    <!-- stationMagnitudes and referenced amplitudes -->
+                    <xsl:for-each select="scs:stationMagnitude">
+                        <xsl:for-each select="../../scs:amplitude[@publicID=current()/scs:amplitudeID]">
+                            <!-- amplitude/genericAmplitude is mandatory in QuakeML -->
+                            <xsl:if test="scs:amplitude">
+                                <xsl:call-template name="genericNode"/>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- magnitudes -->
+                    <xsl:for-each select="scs:magnitude">
+                        <xsl:apply-templates select="." mode="originMagnitude">
+                            <xsl:with-param name="oID" select="../@publicID"/>
+                        </xsl:apply-templates>
+                    </xsl:for-each>
+
+                    <!-- picks, referenced by arrivals -->
+                    <xsl:for-each select="scs:arrival">
+                        <!--xsl:value-of select="scs:pickID"/-->
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
+                            <xsl:call-template name="genericNode"/>
+                        </xsl:for-each>
+                    </xsl:for-each>
+
+                    <!-- origin -->
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <!-- search focalMechanisms referenced by this event -->
+            <xsl:for-each select="scs:focalMechanismReference">
+                <xsl:for-each select="../../scs:focalMechanism[@publicID=current()]">
+                    <xsl:call-template name="genericNode"/>
+                </xsl:for-each>
+            </xsl:for-each>
+
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Default match: Map node 1:1 -->
+    <xsl:template match="*">
+        <xsl:call-template name="genericNode"/>
+    </xsl:template>
+
+    <!-- Delete elements -->
+    <xsl:template match="scs:EventParameters/scs:pick"/>
+    <xsl:template match="scs:EventParameters/scs:amplitude"/>
+    <xsl:template match="scs:EventParameters/scs:reading"/>
+    <xsl:template match="scs:EventParameters/scs:origin"/>
+    <xsl:template match="scs:EventParameters/scs:focalMechanism"/>
+    <xsl:template match="scs:event/scs:originReference"/>
+    <xsl:template match="scs:event/scs:focalMechanismReference"/>
+    <xsl:template match="scs:creationInfo/scs:modificationTime"/>
+    <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:arrival/scs:timeUsed"/>
+    <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
+    <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
+    <xsl:template match="scs:origin/scs:stationMagnitude"/>
+    <xsl:template match="scs:origin/scs:magnitude"/>
+    <xsl:template match="scs:momentTensor/scs:method"/>
+    <xsl:template match="scs:momentTensor/scs:stationMomentTensorContribution"/>
+    <xsl:template match="scs:momentTensor/scs:status"/>
+    <xsl:template match="scs:momentTensor/scs:cmtName"/>
+    <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
+    <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+
+    <!-- Converts a scs magnitude/stationMagnitude to a qml
+         magnitude/stationMagnitude -->
+    <xsl:template match="*" mode="originMagnitude">
+        <xsl:param name="oID"/>
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <!-- if no originID element is available, create one with
+                 the value of the publicID attribute of parent origin -->
+            <xsl:if test="not(scs:originID)">
+                <originID>
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="$oID"/>
+                    </xsl:call-template>
+                </originID>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- event type, enumeration differs slightly -->
+    <xsl:template match="scs:event/scs:type">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='induced earthquake'">induced or triggered event</xsl:when>
+                <xsl:when test="$v='meteor impact'">meteorite</xsl:when>
+                <xsl:when test="$v='not locatable'">other event</xsl:when>
+                <xsl:when test="$v='outside of network interest'">other event</xsl:when>
+                <xsl:when test="$v='duplicate'">other event</xsl:when>
+                <xsl:when test="$v='other'">other event</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin depth, SC3ML uses kilometer, QML meter -->
+    <xsl:template match="scs:origin/scs:depth/scs:value
+                         | scs:origin/scs:depth/scs:uncertainty
+                         | scs:origin/scs:depth/scs:lowerUncertainty
+                         | scs:origin/scs:depth/scs:upperUncertainty
+                         | scs:origin/scs:uncertainty/scs:horizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:minHorizontalUncertainty
+                         | scs:origin/scs:uncertainty/scs:maxHorizontalUncertainty
+                         | scs:confidenceEllipsoid/scs:semiMajorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiMinorAxisLength
+                         | scs:confidenceEllipsoid/scs:semiIntermediateAxisLength">
+        <xsl:element name="{local-name()}">
+            <xsl:value-of select="current() * 1000"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- evaluation status, enumeration of QML does not include 'reported' -->
+    <xsl:template match="scs:evaluationStatus">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='reported'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- data used wave type, enumeration differs slightly -->
+    <xsl:template match="scs:dataUsed/scs:waveType">
+        <xsl:element name="{local-name()}">
+            <xsl:variable name="v" select="current()"/>
+            <xsl:choose>
+                <xsl:when test="$v='P body waves'">P waves</xsl:when>
+                <xsl:when test="$v='long-period body waves'">body waves</xsl:when>
+                <xsl:when test="$v='intermediate-period surface waves'">surface waves</xsl:when>
+                <xsl:when test="$v='long-period mantle waves'">mantle waves</xsl:when>
+                <xsl:otherwise><xsl:value-of select="$v"/></xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin uncertainty description, enumeration of QML does not include 'probability density function' -->
+    <xsl:template match="scs:origin/scs:uncertainty/scs:preferredDescription">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v!='probability density function'">
+            <xsl:element name="{local-name()}">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- momentTensor/method -> momentTensor/category -->
+    <xsl:template match="scs:momentTensor/scs:method">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:if test="$v='teleseismic' or $v='regional'">
+            <xsl:element name="category">
+                <xsl:value-of select="$v"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- amplitude/unit is an enumeration in QuakeML, not in SC3ML -->
+    <xsl:template match="scs:amplitude/scs:unit">
+        <xsl:variable name="v" select="current()"/>
+        <xsl:element name="{local-name()}">
+            <xsl:choose>
+                <xsl:when test="$v='m'
+                                or $v='s'
+                                or $v='m/s'
+                                or $v='m/(s*s)'
+                                or $v='m*s'
+                                or $v='dimensionless'">
+                    <xsl:value-of select="$v"/>
+                </xsl:when>
+                <xsl:otherwise>other</xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <xsl:template match="scs:arrival">
+        <xsl:element name="{local-name()}">
+            <xsl:attribute name="{$PID}">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                </xsl:call-template>
+            </xsl:attribute>
+            <!--comment/-->
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Value of ID nodes must be converted to a qml identifier -->
+    <xsl:template match="scs:agencyURI|scs:authorURI|scs:pickID|scs:methodID|scs:earthModelID|scs:amplitudeID|scs:originID|scs:stationMagnitudeID|scs:preferredOriginID|scs:preferredMagnitudeID|scs:originReference|scs:filterID|scs:slownessMethodID|scs:pickReference|scs:amplitudeReference|scs:referenceSystemID|scs:triggeringOriginID|scs:derivedOriginID|momentMagnitudeID|scs:preferredFocalMechanismID|scs:focalMechanismReference|scs:momentMagnitudeID|scs:greensFunctionID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="valueOfIDNode"/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- arrival/weight -> arrival/timeWeight-->
+    <xsl:template match="scs:arrival/scs:weight">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'timeWeight'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->
+    <xsl:template match="scs:arrival/scs:takeOffAngle">
+        <xsl:element name="takeoffAngle">
+            <xsl:element name="value">
+                <xsl:value-of select="."/>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- stationMagnitude/magnitude -> stationMagnitude/mag -->
+    <xsl:template match="scs:stationMagnitude/scs:magnitude|scs:magnitude/scs:magnitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'mag'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- amplitude/amplitude -> amplitude/genericAmplitude -->
+    <xsl:template match="scs:amplitude/scs:amplitude">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'genericAmplitude'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- origin/uncertainty -> origin/originUncertainty -->
+    <xsl:template match="scs:origin/scs:uncertainty">
+        <xsl:call-template name="genericNode">
+            <xsl:with-param name="name" select="'originUncertainty'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- waveformID: SCS uses a child element 'resourceURI', QML
+         inserts the URI directly as value -->
+    <xsl:template match="scs:waveformID">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="scs:resourceURI">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="scs:resourceURI"/>
+                </xsl:call-template>
+            </xsl:if>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- comment: SCS uses a child element 'id', QML an attribute 'id' -->
+    <xsl:template match="scs:comment">
+        <xsl:element name="{local-name()}">
+            <xsl:if test="scs:id">
+                <xsl:attribute name="id">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="scs:id"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Generic transformation of all attributes of an element. If the
+         attribute name is 'eventID' it is transfered to a QML id -->
+    <xsl:template match="@*">
+        <xsl:variable name="attName" select="local-name()"/>
+        <xsl:attribute name="{$attName}">
+            <xsl:choose>
+                <xsl:when test="$attName=$PID">
+                    <xsl:call-template name="convertID">
+                        <xsl:with-param name="id" select="string(.)"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="string(.)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
+    </xsl:template>
+
+<!--
+    ************************************************************************
+    Named Templates
+    ************************************************************************
+-->
+
+    <!-- Generic and recursively transformation of elements and their
+         attributes -->
+    <xsl:template name="genericNode">
+        <xsl:param name="name"/>
+        <xsl:param name="reqPID"/>
+        <xsl:variable name="nodeName">
+            <xsl:choose>
+                <xsl:when test="$name">
+                    <xsl:value-of select="$name"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="local-name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="{$nodeName}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="$reqPID">
+                <xsl:attribute name="{$PID}">
+                    <xsl:call-template name="convertOptionalID">
+                        <xsl:with-param name="id" select="@publicID"/>
+                    </xsl:call-template>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates/>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Converts and returns value of an id node -->
+    <xsl:template name="valueOfIDNode">
+        <xsl:call-template name="convertOptionalID">
+            <xsl:with-param name="id" select="string(.)"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id. If the scs id is not set
+         the constant 'NA' is used -->
+    <xsl:template name="convertOptionalID">
+        <xsl:param name="id"/>
+        <xsl:choose>
+            <xsl:when test="$id">
+                <xsl:call-template name="convertID">
+                    <xsl:with-param name="id" select="$id"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="convertID">
+                    <!--xsl:with-param name="id" select="concat('NA-', generate-id())"/-->
+                    <xsl:with-param name="id" select="'NA'"/>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Converts a scs id to a quakeml id -->
+    <xsl:template name="convertID">
+        <xsl:param name="id"/>
+        <!-- If the id starts with 'smi:' or 'quakeml:', consider that the id
+             is already well formated -->
+        <xsl:choose>
+            <xsl:when test="starts-with($id, 'smi:')
+                            or starts-with($id, 'quakeml:')">
+                <xsl:value-of select="$id"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="concat($ID_PREFIX, translate($id, ' :', '__'))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -37,7 +37,7 @@ from obspy.io.seiscomp.core import _is_sc3ml as _is_sc3ml_version
 
 SOFTWARE_MODULE = "ObsPy %s" % obspy.__version__
 SOFTWARE_URI = "http://www.obspy.org"
-SCHEMA_VERSION = ["0.7", "0.8", "0.9"]
+SCHEMA_VERSION = ['0.5', '0.6', '0.7', '0.8', '0.9']
 
 
 def _is_sc3ml(path_or_file_object):

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -32,30 +32,11 @@ from obspy.core.inventory import (CoefficientsTypeResponseStage,
                                   PolesZerosResponseStage,
                                   PolynomialResponseStage)
 from obspy.io.stationxml.core import _read_floattype
-from obspy.io.seiscomp.core import _is_sc3ml as _is_sc3ml_version
 
 
 SOFTWARE_MODULE = "ObsPy %s" % obspy.__version__
 SOFTWARE_URI = "http://www.obspy.org"
 SCHEMA_VERSION = ['0.5', '0.6', '0.7', '0.8', '0.9']
-
-
-def _is_sc3ml(path_or_file_object):
-    """
-    Simple function checking if the passed object contains a valid sc3ml file.
-    Returns True of False.
-
-    The test is not exhaustive - it only checks the root tag but that should
-    be good enough for most real world use cases. If the schema is used to
-    test for a StationXML file, many real world files are false negatives as
-    they don't adhere to the standard.
-
-    :type path_or_file_object: str
-    :param path_or_file_object: File name or file like object.
-    :rtype: bool
-    :return: ``True`` if SC3ML file is valid.
-    """
-    return _is_sc3ml_version(path_or_file_object, SCHEMA_VERSION)
 
 
 def _read_sc3ml(path_or_file_object):

--- a/obspy/io/seiscomp/tests/data/version0.10
+++ b/obspy/io/seiscomp/tests/data/version0.10
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.3
+++ b/obspy/io/seiscomp/tests/data/version0.3
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.3" version="0.3">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.3
+++ b/obspy/io/seiscomp/tests/data/version0.3
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.3" version="0.3">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.5
+++ b/obspy/io/seiscomp/tests/data/version0.5
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.5" version="0.5">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.5
+++ b/obspy/io/seiscomp/tests/data/version0.5
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.5" version="0.5">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.6
+++ b/obspy/io/seiscomp/tests/data/version0.6
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.6" version="0.6">
+   <Inventory>
+   </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.6
+++ b/obspy/io/seiscomp/tests/data/version0.6
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.6" version="0.6">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.7
+++ b/obspy/io/seiscomp/tests/data/version0.7
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7" version="0.7">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.8
+++ b/obspy/io/seiscomp/tests/data/version0.8
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8" version="0.8">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/data/version0.9
+++ b/obspy/io/seiscomp/tests/data/version0.9
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
-   <Inventory>
-   </Inventory>
+    <EventParameters />
+    <Inventory />
 </seiscomp>

--- a/obspy/io/seiscomp/tests/test_core.py
+++ b/obspy/io/seiscomp/tests/test_core.py
@@ -17,7 +17,6 @@ from future.builtins import *  # NOQA
 
 import os
 import unittest
-import warnings
 
 from obspy.io.seiscomp.core import _is_sc3ml, validate
 
@@ -33,35 +32,13 @@ class CoreTestCase(unittest.TestCase):
         """
         Test multiple schema versions
         """
-        filename_07 = os.path.join(self.data_dir, 'version0.7')
-        filename_08 = os.path.join(self.data_dir, 'version0.8')
-        filename_09 = os.path.join(self.data_dir, 'version0.9')
-
-        self.assertTrue(_is_sc3ml(filename_07, ['0.7', '0.8']))
-        self.assertTrue(_is_sc3ml(filename_08, ['0.7', '0.8']))
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.assertTrue(_is_sc3ml(filename_09, ['0.7', '0.8']))
-
-            self.assertEqual(len(w), 1)
-            expected_message = ("The sc3ml file has version 0.9, ObsPy can "
-                                "deal with versions [0.7, 0.8]. Proceed "
-                                "with caution.")
-            self.assertEqual(str(w[0].message), expected_message)
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            self.assertTrue(_is_sc3ml(filename_09, []))
-
-            self.assertEqual(len(w), 1)
-            expected_message = ("The sc3ml file has version 0.9, ObsPy can "
-                                "deal with versions []. Proceed with caution.")
-            self.assertEqual(str(w[0].message), expected_message)
+        for version in ['0.3', '0.5', '0.9', '0.10']:
+            filename = os.path.join(self.data_dir, 'version%s' % version)
+            self.assertTrue(_is_sc3ml(filename))
 
     def test_sc3ml_no_version_attribute(self):
         filename = os.path.join(self.data_dir, 'no_version_attribute.sc3ml')
-        self.assertTrue(_is_sc3ml(filename, ['0.9']))
+        self.assertTrue(_is_sc3ml(filename))
 
     def test_validate(self):
         filename = os.path.join(self.data_dir, 'qml-example-1.2-RC3.sc3ml')

--- a/obspy/io/seiscomp/tests/test_core.py
+++ b/obspy/io/seiscomp/tests/test_core.py
@@ -47,9 +47,10 @@ class CoreTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError) as e:
             validate(filename, version='0.10')
-            expected_error = ("0.10 is not a supported version. Use one of "
-                              "these versions: ['0.7', '0.8', '0.9'].")
-            self.assertEqual(e.exception.args[0], expected_error)
+
+        expected_error = ("0.10 is not a supported version. Use one of these "
+                          "versions: [0.3, 0.5, 0.6, 0.7, 0.8, 0.9].")
+        self.assertEqual(e.exception.args[0], expected_error)
 
 
 def suite():

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -86,9 +86,11 @@ class EventTestCase(unittest.TestCase):
         """
         Test multiple schema versions
         """
-        self.assertTrue(_is_sc3ml(os.path.join(self.path, 'version0.9')))
+        for version in ['0.5', '0.6', '0.7', '0.8', '0.9']:
+            filename = os.path.join(self.path, 'version%s' % version)
+            self.assertTrue(_is_sc3ml(filename))
 
-        for version in ['0.7', '0.8', '0.10']:
+        for version in ['0.3', '0.10']:
             filename = os.path.join(self.path, 'version%s' % version)
 
             with warnings.catch_warnings(record=True) as w:

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -93,17 +93,17 @@ class EventTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             read_events(filename)
 
-            expected_message = ("Can't read SC3ML version 0.3, ObsPy can deal "
-                                "with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
-            self.assertEqual(e.exception.args[0], expected_message)
+        expected_message = ("Can't read SC3ML version 0.3, ObsPy can deal "
+                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
+        self.assertEqual(e.exception.args[0], expected_message)
 
         filename = os.path.join(self.path, 'version0.10')
         with self.assertRaises(ValueError) as e:
             read_events(filename)
 
-            expected_message = ("Can't read SC3ML version 0.10, ObsPy can deal"
-                                " with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
-            self.assertEqual(e.exception.args[0], expected_message)
+        expected_message = ("Can't read SC3ML version 0.10, ObsPy can deal "
+                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
+        self.assertEqual(e.exception.args[0], expected_message)
 
     def test_read_xslt_event(self):
         self.cmp_read_xslt_file('quakeml_1.2_event.sc3ml',
@@ -208,8 +208,8 @@ class EventTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             read_events(filename, format='SC3ML')
 
-            expected_message = "Not a SC3ML compatible file or string."
-            self.assertEqual(e.exception.args[0], expected_message)
+        expected_message = "Not a SC3ML compatible file or string."
+        self.assertEqual(e.exception.args[0], expected_message)
 
     def test_write_xslt_event(self):
         self.cmp_write_xslt_file('quakeml_1.2_event.xml',

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -57,8 +57,8 @@ class SC3MLTestCase(unittest.TestCase):
                     warnings.simplefilter("ignore")
                     read_inventory(filename)
 
-                self.assertEqual(e.exception.args[0],
-                                 "Schema version not supported.")
+            self.assertEqual(e.exception.args[0],
+                             "Schema version not supported.")
 
     def test_channel_level(self):
         """

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -45,17 +45,20 @@ class SC3MLTestCase(unittest.TestCase):
         """
         Test multiple schema versions
         """
-        read_inventory(os.path.join(self.data_dir, "version0.7"))
-        read_inventory(os.path.join(self.data_dir, "version0.8"))
-        read_inventory(os.path.join(self.data_dir, "version0.9"))
+        for version in ['0.5', '0.6', '0.7', '0.8', '0.9']:
+            filename = os.path.join(self.data_dir, 'version%s' % version)
+            read_inventory(filename)
 
-        with self.assertRaises(ValueError) as e:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                read_inventory(os.path.join(self.data_dir,
-                                            "version0.10"))
+        for version in ['0.3', '0.10']:
+            filename = os.path.join(self.data_dir, 'version%s' % version)
 
-        self.assertEqual(e.exception.args[0], "Schema version not supported.")
+            with self.assertRaises(ValueError) as e:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    read_inventory(filename)
+
+                self.assertEqual(e.exception.args[0],
+                                 "Schema version not supported.")
 
     def test_channel_level(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ ENTRY_POINTS = {
         'writeFormat = obspy.io.quakeml.core:_write_quakeml',
         ],
     'obspy.plugin.event.SC3ML': [
-        'isFormat = obspy.io.seiscomp.event:_is_sc3ml',
+        'isFormat = obspy.io.seiscomp.core:_is_sc3ml',
         'readFormat = obspy.io.seiscomp.event:_read_sc3ml',
         'writeFormat = obspy.io.seiscomp.event:_write_sc3ml',
         ],
@@ -384,7 +384,7 @@ ENTRY_POINTS = {
         'readFormat = obspy.io.arclink.inventory:_read_inventory_xml',
         ],
     'obspy.plugin.inventory.SC3ML': [
-        'isFormat = obspy.io.seiscomp.inventory:_is_sc3ml',
+        'isFormat = obspy.io.seiscomp.core:_is_sc3ml',
         'readFormat = obspy.io.seiscomp.inventory:_read_sc3ml',
         ],
     'obspy.plugin.inventory.SACPZ': [


### PR DESCRIPTION
Read support for SC3ML event data was added in #1848 by @Brtle. However it restricts read support to schema version 0.9 currently. Since stylesheets provided by upstream maintainers (http://geofon.gfz-potsdam.de/schema/) are used for the conversion to QuakeML, it is trivial to support all schema versions, [like also done in the SC3ML inventory read routine](https://github.com/obspy/obspy/blob/5838487227913be0ab5e382a0fe115706928a576/obspy/io/seiscomp/inventory.py#L69-L76). I suppose there's a wide variety of SeisComp installations out there and thus also SC3ML files at different schema versions.

Since you did #1848 already, can I task you with this trivial extension, @Brtle?
I'd like to have this in 1.1.0 since it might be useful for quite a few people. Do you have some time to work on this in the next weeks? (I've added you to developers, so ideally work in a branch in the main repo for easier collaboration)