### PR TITLE
QuakeML: fix a bug in reading QuakeML (empty stub MomentTensor added)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,10 @@ master: (doi: 10.5281/zenodo.165135)
       beta branch (see #1760 and #1783)
  - obspy.io.quakeml:
     * Read and write support for nested custom tags (see #1463)
+    * Fix some minor bugs that could lead to empty stub elements, e.g. like
+      empty MomentTensor when reading and later writing again a QuakeML file
+      with a FocalMechanism but no MomentTensor, potentially resulting in
+      QuakeML files that breach the QuakeML schema (see #1896)
  - obspy.io.seiscomp:
     * Read and write support for SC3ML event (see #1638 and #1848)
     * Fix bug where files with arbitrary publicIDs and files with missing

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -696,11 +696,11 @@ class Unpickler(object):
         :param name: tag name of sub nodal plane
         :rtype: :class:`~obspy.core.event.NodalPlane`
         """
-        obj = NodalPlane()
         try:
             sub_el = self._xpath(name, parent)[0]
         except IndexError:
-            return obj
+            return None
+        obj = NodalPlane()
         # required parameter
         obj.strike, obj.strike_errors = self._float_value(sub_el, 'strike')
         obj.dip, obj.dip_errors = self._float_value(sub_el, 'dip')
@@ -715,11 +715,11 @@ class Unpickler(object):
         :type parent: etree.Element
         :rtype: :class:`~obspy.core.event.NodalPlanes`
         """
-        obj = NodalPlanes()
         try:
             sub_el = self._xpath('nodalPlanes', parent)[0]
         except IndexError:
-            return obj
+            return None
+        obj = NodalPlanes()
         # optional parameter
         obj.nodal_plane_1 = self._nodal_plane(sub_el, 'nodalPlane1')
         obj.nodal_plane_2 = self._nodal_plane(sub_el, 'nodalPlane2')
@@ -738,11 +738,11 @@ class Unpickler(object):
         :type parent: etree.Element
         :rtype: :class:`~obspy.core.event.SourceTimeFunction`
         """
-        obj = SourceTimeFunction()
         try:
             sub_el = self._xpath('sourceTimeFunction', parent)[0]
         except IndexError:
-            return obj
+            return None
+        obj = SourceTimeFunction()
         # required parameters
         obj.type = self._xpath2obj('type', sub_el)
         obj.duration = self._xpath2obj('duration', sub_el, float)
@@ -759,11 +759,11 @@ class Unpickler(object):
         :type parent: etree.Element
         :rtype: :class:`~obspy.core.event.Tensor`
         """
-        obj = Tensor()
         try:
             sub_el = self._xpath('tensor', parent)[0]
         except IndexError:
-            return obj
+            return None
+        obj = Tensor()
         # required parameters
         obj.m_rr, obj.m_rr_errors = self._float_value(sub_el, 'Mrr')
         obj.m_tt, obj.m_tt_errors = self._float_value(sub_el, 'Mtt')
@@ -1525,9 +1525,11 @@ class Pickler(object):
         """
         Converts a NodalPlanes into etree.Element object.
 
-        :type pick: :class:`~obspy.core.event.NodalPlanes`
+        :type obj: :class:`~obspy.core.event.NodalPlanes`
         :rtype: etree.Element
         """
+        if obj is None:
+            return
         subelement = etree.Element('nodalPlanes')
         # optional
         if obj.nodal_plane_1:
@@ -1561,7 +1563,7 @@ class Pickler(object):
         """
         Converts a PrincipalAxes into etree.Element object.
 
-        :type pick: :class:`~obspy.core.event.PrincipalAxes`
+        :type obj: :class:`~obspy.core.event.PrincipalAxes`
         :rtype: etree.Element
         """
         if obj is None:
@@ -1671,9 +1673,11 @@ class Pickler(object):
         """
         Converts a FocalMechanism into etree.Element object.
 
-        :type pick: :class:`~obspy.core.event.FocalMechanism`
+        :type focal_mechanism: :class:`~obspy.core.event.FocalMechanism`
         :rtype: etree.Element
         """
+        if focal_mechanism is None:
+            return
         element = etree.Element(
             'focalMechanism',
             attrib={'publicID': self._id(focal_mechanism.resource_id)})
@@ -1688,10 +1692,8 @@ class Pickler(object):
         self._str(focal_mechanism.misfit, element, 'misfit')
         self._str(focal_mechanism.station_distribution_ratio, element,
                   'stationDistributionRatio')
-        if focal_mechanism.nodal_planes:
-            self._nodal_planes(focal_mechanism.nodal_planes, element)
-        if focal_mechanism.principal_axes:
-            self._principal_axes(focal_mechanism.principal_axes, element)
+        self._nodal_planes(focal_mechanism.nodal_planes, element)
+        self._principal_axes(focal_mechanism.principal_axes, element)
         self._str(focal_mechanism.method_id, element, 'methodID')
         self._moment_tensor(focal_mechanism.moment_tensor, element)
         self._str(focal_mechanism.evaluation_mode, element, 'evaluationMode')

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -807,11 +807,11 @@ class Unpickler(object):
         :type parent: etree.Element
         :rtype: :class:`~obspy.core.event.MomentTensor`
         """
-        obj = MomentTensor(force_resource_id=False)
         try:
             mt_el = self._xpath('momentTensor', parent)[0]
         except IndexError:
-            return obj
+            return None
+        obj = MomentTensor(force_resource_id=False)
         # required parameters
         obj.derived_origin_id = self._xpath2obj('derivedOriginID', mt_el)
         # optional parameter
@@ -1605,7 +1605,7 @@ class Pickler(object):
         """
         Converts a MomentTensor into etree.Element object.
 
-        :type pick: :class:`~obspy.core.event.MomentTensor`
+        :type moment_tensor: :class:`~obspy.core.event.MomentTensor`
         :rtype: etree.Element
         """
         if moment_tensor is None:

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1020,7 +1020,7 @@ class QuakeMLTestCase(unittest.TestCase):
         fm = FocalMechanism()
         event = Event(focal_mechanisms=[fm])
         cat = Catalog(events=[event])
-        cat.write(memfile, format="QUAKEML")
+        cat.write(memfile, format="QUAKEML", validate=True)
         # now read again, and make sure there's no stub MomentTensor, but
         # rather `None`
         memfile.seek(0)
@@ -1035,13 +1035,13 @@ class QuakeMLTestCase(unittest.TestCase):
         # Test 1: Test subelements of moment_tensor
         memfile = io.BytesIO()
         # create virtually empty FocalMechanism
-        mt = MomentTensor()
+        mt = MomentTensor(derived_origin_id='smi:local/abc')
         fm = FocalMechanism(moment_tensor=mt)
         event = Event(focal_mechanisms=[fm])
         cat = Catalog(events=[event])
-        cat.write(memfile, format="QUAKEML")
-        # now read again, and make sure there's no stub MomentTensor, but
-        # rather `None`
+        cat.write(memfile, format="QUAKEML", validate=True)
+        # now read again, and make sure there's no stub subelements on
+        # MomentTensor, but rather `None`
         memfile.seek(0)
         cat = read_events(memfile, format="QUAKEML")
         self.assertEqual(cat[0].focal_mechanisms[0].moment_tensor.tensor, None)
@@ -1054,7 +1054,7 @@ class QuakeMLTestCase(unittest.TestCase):
         fm = FocalMechanism()
         event = Event(focal_mechanisms=[fm])
         cat = Catalog(events=[event])
-        cat.write(memfile, format="QUAKEML")
+        cat.write(memfile, format="QUAKEML", validate=True)
         # now read again, and make sure there's no stub MomentTensor, but
         # rather `None`
         memfile.seek(0)

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1060,8 +1060,7 @@ class QuakeMLTestCase(unittest.TestCase):
         memfile.seek(0)
         cat = read_events(memfile, format="QUAKEML")
         self.assertEqual(cat[0].focal_mechanisms[0].nodal_planes, None)
-        self.assertEqual(
-            cat[0].focal_mechanisms[0].moment_tensor.principal_axes, None)
+        self.assertEqual(cat[0].focal_mechanisms[0].principal_axes, None)
 
 
 def suite():

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1009,6 +1009,24 @@ class QuakeMLTestCase(unittest.TestCase):
         # No warning should have been raised.
         self.assertEqual(len(w), 0)
 
+    def test_focal_mechanism_write_read(self):
+        """
+        Test for a bug in reading a FocalMechanism without MomentTensor from
+        QuakeML file. Makes sure that FocalMechanism.moment_tensor stays None
+        if no MomentTensor is in the file.
+        """
+        memfile = io.BytesIO()
+        # create virtually empty FocalMechanism
+        fm = FocalMechanism()
+        event = Event(focal_mechanisms=[fm])
+        cat = Catalog(events=[event])
+        cat.write(memfile, format="QUAKEML")
+        # now read again, and make sure there's no stub MomentTensor, but
+        # rather `None`
+        memfile.seek(0)
+        cat = read_events(memfile, format="QUAKEML")
+        self.assertEqual(cat[0].focal_mechanisms[0].moment_tensor, None)
+
 
 def suite():
     return unittest.makeSuite(QuakeMLTestCase, 'test')

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1027,6 +1027,42 @@ class QuakeMLTestCase(unittest.TestCase):
         cat = read_events(memfile, format="QUAKEML")
         self.assertEqual(cat[0].focal_mechanisms[0].moment_tensor, None)
 
+    def test_avoid_empty_stub_elements(self):
+        """
+        Test for a bug in reading QuakeML. Makes sure that some subelements do
+        not get assigned stub elements, but rather stay None.
+        """
+        # Test 1: Test subelements of moment_tensor
+        memfile = io.BytesIO()
+        # create virtually empty FocalMechanism
+        mt = MomentTensor()
+        fm = FocalMechanism(moment_tensor=mt)
+        event = Event(focal_mechanisms=[fm])
+        cat = Catalog(events=[event])
+        cat.write(memfile, format="QUAKEML")
+        # now read again, and make sure there's no stub MomentTensor, but
+        # rather `None`
+        memfile.seek(0)
+        cat = read_events(memfile, format="QUAKEML")
+        self.assertEqual(cat[0].focal_mechanisms[0].moment_tensor.tensor, None)
+        self.assertEqual(
+            cat[0].focal_mechanisms[0].moment_tensor.source_time_function,
+            None)
+        # Test 2: Test subelements of focal_mechanism
+        memfile = io.BytesIO()
+        # create virtually empty FocalMechanism
+        fm = FocalMechanism()
+        event = Event(focal_mechanisms=[fm])
+        cat = Catalog(events=[event])
+        cat.write(memfile, format="QUAKEML")
+        # now read again, and make sure there's no stub MomentTensor, but
+        # rather `None`
+        memfile.seek(0)
+        cat = read_events(memfile, format="QUAKEML")
+        self.assertEqual(cat[0].focal_mechanisms[0].nodal_planes, None)
+        self.assertEqual(
+            cat[0].focal_mechanisms[0].moment_tensor.principal_axes, None)
+
 
 def suite():
     return unittest.makeSuite(QuakeMLTestCase, 'test')


### PR DESCRIPTION
Reading an event with focal mechanism without moment tensor introduces an empty stub moment tensor (instead of keeping it None), which in turn can result in invalid QuakeML files when saving again later.