### PR TITLE
Directly return response objects in NRL

### DIFF
--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -262,7 +262,7 @@ class LocalNRL(NRL):
         """
         Returns a configparser from a path to an index.txt
         """
-        cp = configparser.SafeConfigParser()
+        cp = configparser.ConfigParser()
         with codecs.open(path, mode='r', encoding='UTF-8') as f:
             if sys.version_info.major == 2:  # pragma: no cover
                 cp.readfp(f)


### PR DESCRIPTION
Two helper functions used to return RESP strings - they now return fully formed `Response` objects. I also renamed the functions a bit.
 
CC: @nick-iris @dsentinel @andreww @jdassink 

Feel free to veto.

Fixes #1897 