### PR TITLE
Default the fdsnws mappings to HTTP

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -64,7 +64,6 @@ master: (doi: 10.5281/zenodo.165135)
      the more general `FDSNException`.
    * Fixing cross implementation of bulk waveform and station requests (see
      #1685).
-   * Updating some endpoint mappings to use HTTPS. (See #1690, #1665, #1048)
    * Adding mappings for the TEXNET (see #1852) and the ICGC (see #1902)
      services.
  - obspy.imaging:

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -43,7 +43,7 @@ URL_MAPPINGS = {
     "ETH": "http://eida.ethz.ch",
     "EMSC": "http://www.seismicportal.eu",
     "GEONET": "http://service.geonet.org.nz",
-    "GFZ": "https://geofon.gfz-potsdam.de",
+    "GFZ": "http://geofon.gfz-potsdam.de",
     "ICGC": "http://ws.icgc.cat",
     "INGV": "http://webservices.rm.ingv.it",
     "IPGP": "http://eida.ipgp.fr",
@@ -57,9 +57,9 @@ URL_MAPPINGS = {
     "ODC": "http://www.orfeus-eu.org",
     "ORFEUS": "http://www.orfeus-eu.org",
     "RESIF": "http://ws.resif.fr",
-    "SCEDC": "https://service.scedc.caltech.edu",
+    "SCEDC": "http://service.scedc.caltech.edu",
     "TEXNET": "http://rtserve.beg.utexas.edu",
-    "USGS": "https://earthquake.usgs.gov",
+    "USGS": "http://earthquake.usgs.gov",
     "USP": "http://sismo.iag.usp.br"}
 
 FDSNWS = ("dataselect", "event", "station")


### PR DESCRIPTION
Main reasons are (see #1874):

* The FDSN specifications impose that services are on :80.
* The crypto libraries and certificates in many Python installations are
  outdated making it fail in non-obvious ways to users.

Fixes #1874.