### PR TITLE
Horizontal record section using figure handle

### DIFF
--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1112,10 +1112,17 @@ class WaveformPlotting(object):
             ax.legend(legend_lines, legend_labels)
 
         # Setting up plot axes
-        if self.sect_offset_min is not None:
-            self.set_offset_lim(left=self._offset_min)
-        if self.sect_offset_max is not None:
-            self.set_offset_lim(right=self._offset_max)
+        if self.sect_orientation == 'vertical':
+            if self.sect_offset_min is not None:
+                self.set_offset_lim(left=self._offset_min)
+            if self.sect_offset_max is not None:
+                self.set_offset_lim(right=self._offset_max)
+        elif self.sect_orientation == 'horizontal':
+            if self.sect_offset_min is not None:
+                self.set_offset_lim(bottom=self._offset_min)
+            if self.sect_offset_max is not None:
+                self.set_offset_lim(top=self._offset_max)
+
         # Set up offset ticks
         tick_min, tick_max = np.array(self.get_offset_lim())
         if tick_min != 0.0 and self.sect_plot_dx is not None:


### PR DESCRIPTION
When using a figure handle for plotting a record section (type='section', fig=fig), I was getting the following error:

>   File "/Users/sph1r17/programs/obspy/obspy/core/stream.py", line 1146, in plot
>     return waveform.plot_waveform(*args, **kwargs)
>   File "/Users/sph1r17/programs/obspy/obspy/imaging/waveform.py", line 276, in plot_waveform
>     self.plot_section(*args, **kwargs)
>   File "/Users/sph1r17/programs/obspy/obspy/imaging/waveform.py", line 1116, in plot_section
>     self.set_offset_lim(left=self._offset_min)
>   File "/Users/sph1r17/anaconda/envs/obspy_dev/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 3019, in set_ylim
>     list(six.iterkeys(kw)))
> ValueError: unrecognized kwargs: ['left']
> 

It seems the vertical vs horizontal - left/right vs bottom/top switch was not working when a fig handle was defined. 

My proposed change works fine but maybe there is a more elegant way...?
