### PR TITLE
docs build(bot): add overview page with sphinx build warnings

### DIFF
--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -78,7 +78,7 @@ assets:
 html: assets credits citations
 	if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
 	if [ ! -d $(BUILDDIR)/html ]; then mkdir $(BUILDDIR)/html; fi
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -w $(BUILDDIR)/html/sphinx-build_warnings.txt -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 1> $(BUILDDIR)/html/sphinx-build_stdout.txt 2> $(BUILDDIR)/html/sphinx-build_stderr.txt
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/misc/docs/build-docs.sh
+++ b/misc/docs/build-docs.sh
@@ -125,6 +125,10 @@ if [ ! -f build/html/index.html ] ; then
     SUCCESS=false
 fi
 
+CLEAN_SUCCESS=$SUCCESS
+if [ "$SUCCESS" = true ] ; then
+    grep -i -e Warning -e Error build/html/sphinx-build_warnings.txt && CLEAN_SUCCESS=false
+fi
 
 if [ "$SUCCESS" = true ] ; then
     # perform rest of docs building
@@ -175,8 +179,10 @@ fi
 
 # create github pull request status
 if [ "$BUILD_PR" = true ] ; then
-    if [ "$SUCCESS" = true ] ; then
+    if [ "$CLEAN_SUCCESS" = true ] ; then
         python -c "from obspy_github_api import set_commit_status; set_commit_status(commit='$COMMIT', status='success', context='docs-buildbot', description='Check out Pull Request docs build here:', target_url='http://docs.obspy.org/pull-requests/${PR_NUMBER}/')"
+    elif [ "$SUCCESS" = true ] ; then
+        python -c "from obspy_github_api import set_commit_status; set_commit_status(commit='$COMMIT', status='failure', context='docs-buildbot', description='Build succeeded, but there are warnings/errors:', target_url='http://docs.obspy.org/pull-requests/${PR_NUMBER}/build_status.html')"
     else
         python -c "from obspy_github_api import set_commit_status; set_commit_status(commit='$COMMIT', status='error', context='docs-buildbot', description='Log for failed Pull Request docs build here:', target_url='http://docs.obspy.org/pull-requests/${PR_NUMBER}.log')"
     fi

--- a/misc/docs/source/_templates/build_status.html
+++ b/misc/docs/source/_templates/build_status.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% set title = 'Build overview' %}
+{% block body %}
+  <h1 class="hidden-xs">
+    Build status for this docs build: version {{ release|e }}<br>
+  </h1>
+
+  <a href="sphinx-build_stdout.txt">sphinx-build stdout</a><br/>
+  <a href="sphinx-build_stderr.txt">sphinx-build stderr</a><br/>
+  <a href="sphinx-build_warnings.txt">sphinx-build warnings</a><br/>
+  <a href="index.html">Go to docs build landing page</a><br/>
+
+{% endblock %}

--- a/misc/docs/source/conf.py
+++ b/misc/docs/source/conf.py
@@ -242,7 +242,8 @@ html_sidebars = {
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-html_additional_pages = {'index': 'index.html'}
+html_additional_pages = {'index': 'index.html',
+                         'build_status': 'build_status.html'}
 
 # If false, no module index is generated.
 html_domain_indices = True


### PR DESCRIPTION
.. and set status to "failure" if docs build has warnings or errors.

Right now this will fail with zillions of warnings but eventually if we fix current problems this will help keep docs sane when merging PRs.