### PR TITLE
"Supported Formats" table missing in docs for Inventory.write()

### DIFF
--- a/misc/docs/source/packages/obspy.io.xseed.rst
+++ b/misc/docs/source/packages/obspy.io.xseed.rst
@@ -19,6 +19,7 @@
        :toctree: autogen
        :nosignatures:
 
+       core
        fields
        parser
        utils

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -43,8 +43,8 @@ from obspy.core.trace import Trace  # NOQA
 from obspy.core.stream import Stream, read
 from obspy.core.event import read_events, Catalog
 from obspy.core.inventory import read_inventory, Inventory  # NOQA
-from obspy.core.util.obspy_types import (
-    ObsPyException, ObsPyReadingError)  # NOQA
+from obspy.core.util.obspy_types import (  # NOQA
+    ObsPyException, ObsPyReadingError)
 
 
 __all__ = ["UTCDateTime", "Trace", "__version__", "Stream", "read",
@@ -60,6 +60,9 @@ read.__doc__ = \
 read_events.__doc__ = \
     read_events.__doc__ % make_format_plugin_table("event", "read",
                                                    numspaces=4)
+read_inventory.__doc__ = \
+    read_inventory.__doc__ % make_format_plugin_table("inventory", "read",
+                                                      numspaces=4)
 
 
 if PY2:
@@ -69,6 +72,9 @@ if PY2:
     Catalog.write.im_func.func_doc = \
         Catalog.write.__doc__ % make_format_plugin_table("event", "write",
                                                          numspaces=8)
+    Inventory.write.im_func.func_doc = \
+        Inventory.write.__doc__ % make_format_plugin_table(
+            "inventory", "write", numspaces=8)
 else:
     Stream.write.__doc__ = \
         Stream.write.__doc__ % make_format_plugin_table("waveform", "write",
@@ -76,6 +82,9 @@ else:
     Catalog.write.__doc__ = \
         Catalog.write.__doc__ % make_format_plugin_table("event", "write",
                                                          numspaces=8)
+    Inventory.write.__doc__ = \
+        Inventory.write.__doc__ % make_format_plugin_table(
+            "inventory", "write", numspaces=8)
 
 
 if requests.__version__ in ('2.12.0', '2.12.1', '2.12.2'):

--- a/obspy/core/__init__.py
+++ b/obspy/core/__init__.py
@@ -56,7 +56,8 @@ A :class:`~obspy.core.stream.Stream` with an example seismogram can be created
 by calling :func:`~obspy.core.stream.read()` without any arguments.
 Local files can be read by specifying the filename, files stored on http
 servers (e.g. at https://examples.obspy.org) can be read by specifying their
-URL. For details see the documentation of :func:`~obspy.core.stream.read`.
+URL. For details and supported formats see the documentation of
+:func:`~obspy.core.stream.read`.
 
 >>> from obspy import read
 >>> st = read()
@@ -92,7 +93,10 @@ Event Metadata
 Event metadata are handled in a hierarchy of classes closely modelled after the
 de-facto standard format `QuakeML <https://quake.ethz.ch/quakeml/>`_.
 See the IPython notebooks mentioned in the :ref:`ObsPy Tutorial <tutorial>` for
-more detailed usage examples.
+more detailed usage examples. See
+:func:`~obspy.core.event.catalog.read_events()` and
+:meth:`Catalog.write() <obspy.core.event.catalog.Catalog.write>` for supported
+formats.
 
 .. figure:: /_images/Event.png
 
@@ -103,7 +107,10 @@ Station metadata are handled in a hierarchy of classes closely modelled after
 the de-facto standard format
 `FDSN StationXML <https://www.fdsn.org/xml/station/>`_ which was developed as a
 human readable XML replacement for Dataless SEED.
-See :mod:`obspy.core.inventory` for more details.
+See :mod:`obspy.core.inventory` for more details. See
+:func:`~obspy.core.inventory.inventory.read_inventory()` and
+:meth:`Inventory.write() <obspy.core.inventory.inventory.Inventory.write>` for
+supported formats.
 
 .. figure:: /_images/Inventory.png
 
@@ -114,11 +121,11 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 # don't change order
-from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util.attribdict import AttribDict
-from obspy.core.trace import Stats, Trace
-from obspy.core.stream import Stream, read
-from obspy.scripts.runtests import run_tests
+from obspy.core.utcdatetime import UTCDateTime  # NOQA
+from obspy.core.util.attribdict import AttribDict  # NOQA
+from obspy.core.trace import Stats, Trace  # NOQA
+from obspy.core.stream import Stream, read  # NOQA
+from obspy.scripts.runtests import run_tests  # NOQA
 
 
 if __name__ == '__main__':

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -466,9 +466,9 @@ class Catalog(object):
 
         .. rubric:: Example
 
-        >>> from obspy.core.event import read_events
-        >>> catalog = read_events() # doctest: +SKIP
-        >>> catalog.write("example.xml", format="QUAKEML") # doctest: +SKIP
+        >>> from obspy import read_events
+        >>> catalog = read_events()
+        >>> catalog.write("example.xml", format="QUAKEML")  # doctest: +SKIP
 
         Writing single events into files with meaningful filenames can be done
         e.g. using event.id
@@ -481,7 +481,8 @@ class Catalog(object):
 
         Additional ObsPy modules extend the parameters of the
         :meth:`~obspy.core.event.Catalog.write` method. The following
-        table summarizes all known formats currently available for ObsPy.
+        table summarizes all known formats with write capability currently
+        available for ObsPy.
 
         Please refer to the `Linked Function Call`_ of each module for any
         extra options available.
@@ -496,10 +497,11 @@ class Catalog(object):
             write_format = buffered_load_entry_point(
                 format_ep.dist.key, 'obspy.plugin.event.%s' % (format_ep.name),
                 'writeFormat')
-        except (IndexError, ImportError):
-            msg = "Format \"%s\" is not supported. Supported types: %s"
-            raise TypeError(msg % (format, ', '.join(EVENT_ENTRY_POINTS)))
-        write_format(self, filename, **kwargs)
+        except (IndexError, ImportError, KeyError):
+            msg = "Writing format \"%s\" is not supported. Supported types: %s"
+            raise ValueError(msg % (format,
+                                    ', '.join(EVENT_ENTRY_POINTS_WRITE)))
+        return write_format(self, filename, **kwargs)
 
     def plot(self, projection='global', resolution='l',
              continent_fill_color='0.9', water_fill_color='1.0',
@@ -772,15 +774,16 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
     multiple event files given via file name or URL using the
     ``pathname_or_url`` attribute.
 
-    :type pathname_or_url: str or StringIO.StringIO, optional
+    :type pathname_or_url: str or StringIO.StringIO
     :param pathname_or_url: String containing a file name or a URL or a open
         file-like object. Wildcards are allowed for a file name. If this
         attribute is omitted, an example :class:`~obspy.core.event.Catalog`
         object will be returned.
-    :type format: str, optional
+    :type format: str
     :param format: Format of the file to read (e.g. ``"QUAKEML"``). See the
         `Supported Formats`_ section below for a list of supported formats.
-    :return: A ObsPy :class:`~obspy.core.event.Catalog` object.
+    :rtype: :class:`~obspy.core.event.Catalog`
+    :return: An ObsPy :class:`~obspy.core.event.Catalog` object.
 
     .. rubric:: _`Supported Formats`
 

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -54,11 +54,27 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
     :param path_or_file_object: File name or file like object. If this
         attribute is omitted, an example :class:`Inventory`
         object will be returned.
-    :type format: str, optional
-    :param format: Format of the file to read (e.g. ``"STATIONXML"``).
+    :type format: str
+    :param format: Format of the file to read (e.g. ``"STATIONXML"``). See the
+        `Supported Formats`_ section below for a list of supported formats.
+    :rtype: :class:`~obspy.core.inventory.inventory.Inventory`
+    :return: An ObsPy :class:`~obspy.core.inventory.inventory.Inventory`
+        object.
 
     Additional args and kwargs are passed on to the underlying ``_read_X()``
     methods of the inventory plugins.
+
+    .. rubric:: _`Supported Formats`
+
+    Additional ObsPy modules extend the functionality of the
+    :func:`~obspy.core.inventory.inventory.read_inventory` function. The
+    following table summarizes all known file formats currently supported by
+    ObsPy.
+
+    Please refer to the `Linked Function Call`_ of each module for any extra
+    options available at the import stage.
+
+    %s
 
     .. note::
 
@@ -263,7 +279,30 @@ class Inventory(ComparingObject):
 
         :param path_or_file_object: File name or file-like object to be written
             to.
-        :param format: The format of the written file.
+        :type format: str
+        :param format: The file format to use (e.g. ``"STATIONXML"``). See the
+            `Supported Formats`_ section below for a list of supported formats.
+        :param kwargs: Additional keyword arguments passed to the underlying
+            plugin's writer method.
+
+        .. rubric:: Example
+
+        >>> from obspy import read_inventory
+        >>> inventory = read_inventory()
+        >>> inventory.write("example.xml",
+        ...                 format="STATIONXML")  # doctest: +SKIP
+
+        .. rubric:: _`Supported Formats`
+
+        Additional ObsPy modules extend the parameters of the
+        :meth:`~obspy.core.inventory.inventory.Inventory.write()` method. The
+        following table summarizes all known formats with write capability
+        currently available for ObsPy.
+
+        Please refer to the `Linked Function Call`_ of each module for any
+        extra options available.
+
+        %s
         """
         format = format.upper()
         try:
@@ -274,9 +313,10 @@ class Inventory(ComparingObject):
                 format_ep.dist.key,
                 'obspy.plugin.inventory.%s' % (format_ep.name), 'writeFormat')
         except (IndexError, ImportError, KeyError):
-            msg = "Writing format \"%s\" is not supported. Supported types: %s"
-            raise TypeError(msg % (format,
-                                   ', '.join(ENTRY_POINTS['inventory_write'])))
+            msg = "Writing format '{}' is not supported. Supported types: {}"
+            msg = msg.format(format,
+                             ', '.join(ENTRY_POINTS['inventory_write']))
+            raise ValueError(msg)
         return write_format(self, path_or_file_object, **kwargs)
 
     @property

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1437,8 +1437,8 @@ class Stream(object):
                 'obspy.plugin.waveform.%s' % (format_ep.name), 'writeFormat')
         except (IndexError, ImportError, KeyError):
             msg = "Writing format \"%s\" is not supported. Supported types: %s"
-            raise TypeError(msg % (format,
-                                   ', '.join(ENTRY_POINTS['waveform_write'])))
+            raise ValueError(msg % (format,
+                                    ', '.join(ENTRY_POINTS['waveform_write'])))
         write_format(self, filename, **kwargs)
 
     def trim(self, starttime=None, endtime=None, pad=False,

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1980,9 +1980,9 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(ct[0].stats.mseed.dataquality, 'A')
 
     def test_write(self):
-        # writing in unknown format raises TypeError
+        # writing in unknown format raises ValueError
         st = read()
-        self.assertRaises(TypeError, st.write, 'file.ext', format="UNKNOWN")
+        self.assertRaises(ValueError, st.write, 'file.ext', format="UNKNOWN")
 
     def test_detrend(self):
         """

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -498,7 +498,7 @@ class WaveformPluginsTestCase(unittest.TestCase):
                     self.assertEqual(mocked_func.call_count, 1)
 
         # An unknown suffix should raise.
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             for obj in stream_trace:
                 obj.write("temp.random_suffix")
 

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -428,9 +428,9 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
 
     >>> table = make_format_plugin_table("event", "write", 4, True)
     >>> print(table)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    ======... ===============... ========================================...
-    Format    Required Module    _`Linked Function Call`
-    ======... ===============... ========================================...
+    ======... ===========... ========================================...
+    Format    Used Module    _`Linked Function Call`
+    ======... ===========... ========================================...
     CMTSOLUTION  :mod:`...io.cmtsolution` :func:`..._write_cmtsolution`
     CNV       :mod:`...io.cnv`   :func:`obspy.io.cnv.core._write_cnv`
     JSON      :mod:`...io.json`  :func:`obspy.io.json.core._write_json`
@@ -444,7 +444,7 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     SHAPEFILE :mod:`obspy.io.shapefile`
                              :func:`obspy.io.shapefile.core._write_shapefile`
     ZMAP      :mod:`...io.zmap`  :func:`obspy.io.zmap.core._write_zmap`
-    ======... ===============... ========================================...
+    ======... ===========... ========================================...
 
     :type group: str
     :param group: Plugin group to search (e.g. "waveform" or "event").
@@ -474,7 +474,7 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
         mod_list.append((name, module_short, func_str))
 
     mod_list = sorted(mod_list)
-    headers = ["Format", "Required Module", "_`Linked Function Call`"]
+    headers = ["Format", "Used Module", "_`Linked Function Call`"]
     maxlens = [max([len(x[0]) for x in mod_list] + [len(headers[0])]),
                max([len(x[1]) for x in mod_list] + [len(headers[1])]),
                max([len(x[2]) for x in mod_list] + [len(headers[2])])]


### PR DESCRIPTION
Should be done same as for `Catalog.write()`

+DOCS
