### PR TITLE
HTTP for the examples

### DIFF
--- a/misc/docs/source/tutorial/code_snippets/basemap_plot_with_beachballs.rst
+++ b/misc/docs/source/tutorial/code_snippets/basemap_plot_with_beachballs.rst
@@ -56,7 +56,7 @@ our SRTM data file (from CGIAR_) look like this::
 
 .. _basemap: http://matplotlib.org/basemap/
 .. _download: http://sourceforge.net/projects/matplotlib/files/matplotlib-toolkits/
-.. _here: https://examples.obspy.org/srtm_1240-1300E_4740-4750N.asc.gz
+.. _here: http://examples.obspy.org/srtm_1240-1300E_4740-4750N.asc.gz
 .. _CGIAR: http://srtm.csi.cgiar.org/
 .. _NumPy: http://www.numpy.org/
 .. _GDAL: https://trac.osgeo.org/gdal/wiki/GdalOgrInPython

--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_1.py
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_1.py
@@ -9,7 +9,7 @@ from obspy.signal.array_analysis import array_processing
 
 
 # Load data
-st = obspy.read("https://examples.obspy.org/agfa.mseed")
+st = obspy.read("http://examples.obspy.org/agfa.mseed")
 
 # Set PAZ and coordinates for all 5 channels
 st[0].stats.paz = AttribDict({

--- a/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
+++ b/misc/docs/source/tutorial/code_snippets/beamforming_fk_analysis_2.py
@@ -11,7 +11,7 @@ from obspy.signal.array_analysis import array_processing
 
 
 # Load data
-st = obspy.read("https://examples.obspy.org/agfa.mseed")
+st = obspy.read("http://examples.obspy.org/agfa.mseed")
 
 # Set PAZ and coordinates for all 5 channels
 st[0].stats.paz = AttribDict({

--- a/misc/docs/source/tutorial/code_snippets/clone_dataless_seed.rst
+++ b/misc/docs/source/tutorial/code_snippets/clone_dataless_seed.rst
@@ -14,7 +14,7 @@ DatalessSEED volume (stored on our `examples webserver`_):
     >>> from obspy import UTCDateTime
     >>> from obspy.io.xseed import Parser
     >>>
-    >>> p = Parser("https://examples.obspy.org/dataless.seed.BW_RNON")
+    >>> p = Parser("http://examples.obspy.org/dataless.seed.BW_RNON")
     >>> blk = p.blockettes
 
 Now we can adapt the information only appearing once in the DatalessSEED at the
@@ -75,4 +75,4 @@ At the end we can write the adapted DatalessSEED volume to a new file:
     >>> p.write_seed("dataless.seed.BW_RMOA")
 
 
-.. _`examples webserver`: https://examples.obspy.org
+.. _`examples webserver`: http://examples.obspy.org

--- a/misc/docs/source/tutorial/code_snippets/continuous_wavelet_transform_mlpy.py
+++ b/misc/docs/source/tutorial/code_snippets/continuous_wavelet_transform_mlpy.py
@@ -7,7 +7,7 @@ import obspy
 from obspy.imaging.cm import obspy_sequential
 
 
-tr = obspy.read("https://examples.obspy.org/a02i.2008.240.mseed")[0]
+tr = obspy.read("http://examples.obspy.org/a02i.2008.240.mseed")[0]
 
 omega0 = 8
 wavelet_fct = "morlet"

--- a/misc/docs/source/tutorial/code_snippets/downsampling_seismograms.py
+++ b/misc/docs/source/tutorial/code_snippets/downsampling_seismograms.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import obspy
 
 # Read the seismogram
-st = obspy.read("https://examples.obspy.org/RJOB_061005_072159.ehz.new")
+st = obspy.read("http://examples.obspy.org/RJOB_061005_072159.ehz.new")
 
 # There is only one trace in the Stream object, let's work on that trace...
 tr = st[0]

--- a/misc/docs/source/tutorial/code_snippets/export_seismograms_to_ascii.rst
+++ b/misc/docs/source/tutorial/code_snippets/export_seismograms_to_ascii.rst
@@ -11,7 +11,7 @@ using the :meth:`~obspy.core.stream.Stream.write` method on the generated
 :class:`~obspy.core.stream.Stream` object.
 
     >>> from obspy.core import read
-    >>> stream = read('https://examples.obspy.org/RJOB20090824.ehz')
+    >>> stream = read('http://examples.obspy.org/RJOB20090824.ehz')
     >>> stream.write('outfile.ascii', format='SLIST')
 
 The following ASCII formats are currently supported:

--- a/misc/docs/source/tutorial/code_snippets/export_seismograms_to_matlab.py
+++ b/misc/docs/source/tutorial/code_snippets/export_seismograms_to_matlab.py
@@ -3,7 +3,7 @@ from scipy.io import savemat
 import obspy
 
 
-st = obspy.read("https://examples.obspy.org/BW.BGLD..EH.D.2010.037")
+st = obspy.read("http://examples.obspy.org/BW.BGLD..EH.D.2010.037")
 for i, tr in enumerate(st):
     mdict = {k: str(v) for k, v in tr.stats.iteritems()}
     mdict['data'] = tr.data

--- a/misc/docs/source/tutorial/code_snippets/filtering_seismograms.py
+++ b/misc/docs/source/tutorial/code_snippets/filtering_seismograms.py
@@ -5,7 +5,7 @@ import obspy
 
 
 # Read the seismogram
-st = obspy.read("https://examples.obspy.org/RJOB_061005_072159.ehz.new")
+st = obspy.read("http://examples.obspy.org/RJOB_061005_072159.ehz.new")
 
 # There is only one trace in the Stream object, let's work on that trace...
 tr = st[0]

--- a/misc/docs/source/tutorial/code_snippets/hierarchical_clustering.py
+++ b/misc/docs/source/tutorial/code_snippets/hierarchical_clustering.py
@@ -12,7 +12,7 @@ from scipy.spatial import distance
 from obspy.imaging.cm import obspy_sequential
 
 
-url = "https://examples.obspy.org/dissimilarities.npz"
+url = "http://examples.obspy.org/dissimilarities.npz"
 with io.BytesIO(urlopen(url).read()) as fh, np.load(fh) as data:
     dissimilarity = data['dissimilarity']
 

--- a/misc/docs/source/tutorial/code_snippets/hierarchical_clustering.rst
+++ b/misc/docs/source/tutorial/code_snippets/hierarchical_clustering.rst
@@ -21,7 +21,7 @@ webserver:
     >>> from scipy.cluster import hierarchy
     >>> from scipy.spatial import distance
     >>> 
-    >>> url = "https://examples.obspy.org/dissimilarities.npz"
+    >>> url = "http://examples.obspy.org/dissimilarities.npz"
     >>> with io.BytesIO(urllib.urlopen(url).read()) as fh, np.load(fh) as data:
     ...     dissimilarity = data['dissimilarity']
 
@@ -53,4 +53,4 @@ right-hand subplot:
 
 
 .. _`SciPy`: https://docs.scipy.org/doc/scipy/reference/cluster.html
-.. _`examples webserver`: https://examples.obspy.org
+.. _`examples webserver`: http://examples.obspy.org

--- a/misc/docs/source/tutorial/code_snippets/merging_seismograms.py
+++ b/misc/docs/source/tutorial/code_snippets/merging_seismograms.py
@@ -5,9 +5,9 @@ import obspy
 
 
 # Read in all files starting with dis.
-st = obspy.read("https://examples.obspy.org/dis.G.SCZ.__.BHE")
-st += obspy.read("https://examples.obspy.org/dis.G.SCZ.__.BHE.1")
-st += obspy.read("https://examples.obspy.org/dis.G.SCZ.__.BHE.2")
+st = obspy.read("http://examples.obspy.org/dis.G.SCZ.__.BHE")
+st += obspy.read("http://examples.obspy.org/dis.G.SCZ.__.BHE.1")
+st += obspy.read("http://examples.obspy.org/dis.G.SCZ.__.BHE.2")
 
 # sort
 st.sort(['starttime'])

--- a/misc/docs/source/tutorial/code_snippets/plotting_spectrograms.py
+++ b/misc/docs/source/tutorial/code_snippets/plotting_spectrograms.py
@@ -1,4 +1,4 @@
 import obspy
 
-st = obspy.read("https://examples.obspy.org/RJOB_061005_072159.ehz.new")
+st = obspy.read("http://examples.obspy.org/RJOB_061005_072159.ehz.new")
 st.spectrogram(log=True, title='BW.RJOB ' + str(st[0].stats.starttime))

--- a/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density.py
+++ b/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density.py
@@ -3,12 +3,12 @@ from obspy.signal import PPSD
 from obspy.io.xseed import Parser
 
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
-parser = Parser("https://examples.obspy.org/dataless.seed.BW_KW1")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
+parser = Parser("http://examples.obspy.org/dataless.seed.BW_KW1")
 ppsd = PPSD(st[0].stats, metadata=parser)
 ppsd.add(st)
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
 ppsd.add(st)
 
 ppsd.plot()

--- a/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density.rst
+++ b/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density.rst
@@ -18,7 +18,7 @@ Read data and select a trace with the desired station/channel combination:
 
 .. doctest::
 
-    >>> st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
+    >>> st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
     >>> tr = st.select(id="BW.KW1..EHZ")[0]
 
 Metadata can be provided as an
@@ -32,7 +32,7 @@ probabilistic psd statistics.
 
 .. doctest::
 
-    >>> parser = Parser("https://examples.obspy.org/dataless.seed.BW_KW1")
+    >>> parser = Parser("http://examples.obspy.org/dataless.seed.BW_KW1")
     >>> ppsd = PPSD(tr.stats, metadata=parser)
 
 Now we can add data (either trace or stream objects) to the ppsd estimate. This
@@ -69,7 +69,7 @@ Additional information from other files/sources can be added step by step.
 
 .. doctest::
 
-    >>> st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
+    >>> st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
     >>> ppsd.add(st)
     True
         

--- a/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density2.py
+++ b/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density2.py
@@ -4,12 +4,12 @@ from obspy.imaging.cm import pqlx
 from obspy.io.xseed import Parser
 
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
-parser = Parser("https://examples.obspy.org/dataless.seed.BW_KW1")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
+parser = Parser("http://examples.obspy.org/dataless.seed.BW_KW1")
 ppsd = PPSD(st[0].stats, metadata=parser)
 ppsd.add(st)
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
 ppsd.add(st)
 
 ppsd.plot(cmap=pqlx)

--- a/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density3.py
+++ b/misc/docs/source/tutorial/code_snippets/probabilistic_power_spectral_density3.py
@@ -3,12 +3,12 @@ from obspy.signal import PPSD
 from obspy.io.xseed import Parser
 
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
-parser = Parser("https://examples.obspy.org/dataless.seed.BW_KW1")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
+parser = Parser("http://examples.obspy.org/dataless.seed.BW_KW1")
 ppsd = PPSD(st[0].stats, metadata=parser)
 ppsd.add(st)
 
-st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
+st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
 ppsd.add(st)
 
 ppsd.plot(cumulative=True)

--- a/misc/docs/source/tutorial/code_snippets/reading_seismograms.py
+++ b/misc/docs/source/tutorial/code_snippets/reading_seismograms.py
@@ -1,5 +1,5 @@
 import obspy
 
 
-st = obspy.read('https://examples.obspy.org/RJOB_061005_072159.ehz.new')
+st = obspy.read('http://examples.obspy.org/RJOB_061005_072159.ehz.new')
 st.plot()

--- a/misc/docs/source/tutorial/code_snippets/seismogram_envelopes.py
+++ b/misc/docs/source/tutorial/code_snippets/seismogram_envelopes.py
@@ -5,7 +5,7 @@ import obspy
 import obspy.signal
 
 
-st = obspy.read("https://examples.obspy.org/RJOB_061005_072159.ehz.new")
+st = obspy.read("http://examples.obspy.org/RJOB_061005_072159.ehz.new")
 data = st[0].data
 npts = st[0].stats.npts
 samprate = st[0].stats.sampling_rate

--- a/misc/docs/source/tutorial/code_snippets/seismogram_envelopes.rst
+++ b/misc/docs/source/tutorial/code_snippets/seismogram_envelopes.rst
@@ -9,7 +9,7 @@ This example uses a zero-phase-shift bandpass to filter the data
 with corner frequencies 1 and 3 Hz, using 2 corners (two runs due to zero-phase
 option, thus 4 corners overall). Then we calculate the envelope and plot it
 together with the Trace. Data can be found
-`here <https://examples.obspy.org/RJOB_061005_072159.ehz.new>`_.
+`here <http://examples.obspy.org/RJOB_061005_072159.ehz.new>`_.
 
 .. plot:: tutorial/code_snippets/seismogram_envelopes.py
    :include-source:

--- a/misc/docs/source/tutorial/code_snippets/seismometer_correction_simulation_4.py
+++ b/misc/docs/source/tutorial/code_snippets/seismometer_correction_simulation_4.py
@@ -2,6 +2,6 @@ import obspy
 from obspy.io.xseed import Parser
 
 
-st = obspy.read("https://examples.obspy.org/BW.BGLD..EH.D.2010.037")
-parser = Parser("https://examples.obspy.org/dataless.seed.BW_BGLD")
+st = obspy.read("http://examples.obspy.org/BW.BGLD..EH.D.2010.037")
+parser = Parser("http://examples.obspy.org/dataless.seed.BW_BGLD")
 st.simulate(seedresp={'filename': parser, 'units': "DIS"})

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial.py
@@ -1,6 +1,6 @@
 import obspy
 
-st = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")
+st = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")
 st = st.select(component="Z")
 tr = st[0]
 tr.plot(type="relative")

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
@@ -4,7 +4,7 @@ Trigger/Picker Tutorial
 
 This is a small tutorial that started as a practical for the UNESCO short
 course on triggering. Test data used in this tutorial can be downloaded here:
-`trigger_data.zip <https://examples.obspy.org/trigger_data.zip>`_.
+`trigger_data.zip <http://examples.obspy.org/trigger_data.zip>`_.
 
 The triggers are implemented as described in [Withers1998]_. Information on
 finding the right trigger parameters for STA/LTA type triggers can be found in
@@ -24,7 +24,7 @@ The data files are read into an ObsPy :class:`~obspy.core.trace.Trace` object
 using the :func:`~obspy.core.stream.read()` function.
 
     >>> from obspy.core import read
-    >>> st = read("https://examples.obspy.org/ev0_6.a01.gse2")
+    >>> st = read("http://examples.obspy.org/ev0_6.a01.gse2")
     >>> st = st.select(component="Z")
     >>> tr = st[0]
 
@@ -105,7 +105,7 @@ are the following:
 
     >>> from obspy.core import read
     >>> from obspy.signal.trigger import plot_trigger
-    >>> trace = read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+    >>> trace = read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
     >>> df = trace.stats.sampling_rate
 
 Classic Sta Lta
@@ -175,7 +175,7 @@ example is available from our web server:
     ...          "BW.UH3..SHZ.D.2010.147.cut.slist.gz",
     ...          "BW.UH4..SHZ.D.2010.147.cut.slist.gz"]
     >>> for filename in files:
-    ...     st += read("https://examples.obspy.org/" + filename)
+    ...     st += read("http://examples.obspy.org/" + filename)
 
 After applying a bandpass filter we run the coincidence triggering on all data.
 In the example a recursive STA/LTA is used. The trigger parameters are set to
@@ -277,7 +277,7 @@ network trigger on vertical components only.
     ...          "BW.UH3..SHE.D.2010.147.cut.slist.gz",
     ...          "BW.UH4..SHZ.D.2010.147.cut.slist.gz"]
     >>> for filename in files:
-    ...     st += read("https://examples.obspy.org/" + filename)
+    ...     st += read("http://examples.obspy.org/" + filename)
     >>> st.filter('bandpass', freqmin=10, freqmax=20)  # optional prefiltering
 
 Here we set up a dictionary with template events for one single station. The
@@ -361,7 +361,7 @@ samples.
 
     >>> from obspy.core import read
     >>> from obspy.signal.trigger import pk_baer
-    >>> trace = read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+    >>> trace = read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
     >>> df = trace.stats.sampling_rate
     >>> p_pick, phase_info = pk_baer(trace.data, df,
     ...                             20, 60, 7.0, 12.0, 100, 100)
@@ -382,9 +382,9 @@ For :func:`~obspy.signal.trigger.ar_pick`, input and output are in seconds.
 
     >>> from obspy.core import read
     >>> from obspy.signal.trigger import ar_pick
-    >>> tr1 = read('https://examples.obspy.org/loc_RJOB20050801145719850.z.gse2')[0]
-    >>> tr2 = read('https://examples.obspy.org/loc_RJOB20050801145719850.n.gse2')[0]
-    >>> tr3 = read('https://examples.obspy.org/loc_RJOB20050801145719850.e.gse2')[0]
+    >>> tr1 = read('http://examples.obspy.org/loc_RJOB20050801145719850.z.gse2')[0]
+    >>> tr2 = read('http://examples.obspy.org/loc_RJOB20050801145719850.n.gse2')[0]
+    >>> tr3 = read('http://examples.obspy.org/loc_RJOB20050801145719850.e.gse2')[0]
     >>> df = tr1.stats.sampling_rate
     >>> p_pick, s_pick = ar_pick(tr1.data, tr2.data, tr3.data, df,
     ...                          1.0, 20.0, 1.0, 0.1, 4.0, 1.0, 2, 8, 0.1, 0.2)

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_carl_sta_trig.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_carl_sta_trig.py
@@ -2,7 +2,7 @@ import obspy
 from obspy.signal.trigger import carl_sta_trig, plot_trigger
 
 
-trace = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+trace = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
 df = trace.stats.sampling_rate
 
 cft = carl_sta_trig(trace.data, int(5 * df), int(10 * df), 0.8, 0.8)

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_classic_sta_lta.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_classic_sta_lta.py
@@ -2,7 +2,7 @@ import obspy
 from obspy.signal.trigger import classic_sta_lta, plot_trigger
 
 
-trace = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+trace = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
 df = trace.stats.sampling_rate
 
 cft = classic_sta_lta(trace.data, int(5. * df), int(10. * df))

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_delayed_sta_lta.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_delayed_sta_lta.py
@@ -2,7 +2,7 @@ import obspy
 from obspy.signal.trigger import delayed_sta_lta, plot_trigger
 
 
-trace = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+trace = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
 df = trace.stats.sampling_rate
 
 cft = delayed_sta_lta(trace.data, int(5 * df), int(10 * df))

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_recursive_sta_lta.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_recursive_sta_lta.py
@@ -2,7 +2,7 @@ import obspy
 from obspy.signal.trigger import plot_trigger, recursive_sta_lta
 
 
-trace = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+trace = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
 df = trace.stats.sampling_rate
 
 cft = recursive_sta_lta(trace.data, int(5 * df), int(10 * df))

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_z_detect.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_z_detect.py
@@ -2,7 +2,7 @@ import obspy
 from obspy.signal.trigger import plot_trigger, z_detect
 
 
-trace = obspy.read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+trace = obspy.read("http://examples.obspy.org/ev0_6.a01.gse2")[0]
 df = trace.stats.sampling_rate
 
 cft = z_detect(trace.data, int(10. * df))

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
@@ -11,16 +11,16 @@ contains three channels of a seismograph.
 .. doctest::
 
    >>> from obspy.core import read
-   >>> singlechannel = read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+   >>> singlechannel = read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
    >>> print(singlechannel)
    1 Trace(s) in Stream:
    DK.COP..BHZ | 2009-02-19T00:00:00.025100Z - 2009-02-19T23:59:59.975100Z | 20.0 Hz, 1728000 samples
 
 .. doctest::
 
-   >>> threechannels = read('https://examples.obspy.org/COP.BHE.DK.2009.050')
-   >>> threechannels += read('https://examples.obspy.org/COP.BHN.DK.2009.050')
-   >>> threechannels += read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+   >>> threechannels = read('http://examples.obspy.org/COP.BHE.DK.2009.050')
+   >>> threechannels += read('http://examples.obspy.org/COP.BHN.DK.2009.050')
+   >>> threechannels += read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
    >>> print(threechannels)
    3 Trace(s) in Stream:
    DK.COP..BHE | 2009-02-19T00:00:00.035100Z - 2009-02-19T23:59:59.985100Z | 20.0 Hz, 1728000 samples
@@ -97,7 +97,7 @@ setting the ``type`` parameter to ``'dayplot'``:
 Event information can be included in the plot as well (experimental feature, syntax might change):
 
     >>> from obspy import read
-    >>> st = read("https://examples.obspy.org/GR.BFO..LHZ.2012.108")
+    >>> st = read("http://examples.obspy.org/GR.BFO..LHZ.2012.108")
     >>> st.filter("lowpass", freq=0.1, corners=2)
     >>> st.plot(type="dayplot", interval=60, right_vertical_labels=False,
     ...         vertical_scaling_range=5e3, one_tick_per_line=True,

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_1.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_1.py
@@ -1,5 +1,5 @@
 import obspy
 
 
-singlechannel = obspy.read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+singlechannel = obspy.read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
 singlechannel.plot()

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_2.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_2.py
@@ -1,7 +1,7 @@
 import obspy
 
 
-singlechannel = obspy.read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+singlechannel = obspy.read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
 dt = singlechannel[0].stats.starttime
 singlechannel.plot(color='red', number_of_ticks=7, tick_rotation=5,
                    tick_format='%I:%M %p', starttime=dt + 60 * 60,

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_3.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_3.py
@@ -1,7 +1,7 @@
 import obspy
 
 
-threechannels = obspy.read('https://examples.obspy.org/COP.BHE.DK.2009.050')
-threechannels += obspy.read('https://examples.obspy.org/COP.BHN.DK.2009.050')
-threechannels += obspy.read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+threechannels = obspy.read('http://examples.obspy.org/COP.BHE.DK.2009.050')
+threechannels += obspy.read('http://examples.obspy.org/COP.BHN.DK.2009.050')
+threechannels += obspy.read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
 threechannels.plot(size=(800, 600))

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_4.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_4.py
@@ -1,5 +1,5 @@
 import obspy
 
 
-singlechannel = obspy.read('https://examples.obspy.org/COP.BHZ.DK.2009.050')
+singlechannel = obspy.read('http://examples.obspy.org/COP.BHZ.DK.2009.050')
 singlechannel.plot(type='dayplot')

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_5.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_5.py
@@ -1,7 +1,7 @@
 import obspy
 
 
-st = obspy.read("https://examples.obspy.org/GR.BFO..LHZ.2012.108")
+st = obspy.read("http://examples.obspy.org/GR.BFO..LHZ.2012.108")
 st.filter("lowpass", freq=0.1, corners=2)
 st.plot(type="dayplot", interval=60, right_vertical_labels=False,
         vertical_scaling_range=5e3, one_tick_per_line=True,

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_6.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_6.py
@@ -4,7 +4,7 @@ from obspy import read, Stream
 from obspy.geodetics import gps2dist_azimuth
 
 
-host = 'https://examples.obspy.org/'
+host = 'http://examples.obspy.org/'
 # Files (fmt: SAC)
 files = ['TOK.2011.328.21.10.54.OKR01.HHN.inv',
          'TOK.2011.328.21.10.54.OKR02.HHN.inv',

--- a/misc/docs/source/tutorial/code_snippets/xcorr_pick_correction.py
+++ b/misc/docs/source/tutorial/code_snippets/xcorr_pick_correction.py
@@ -5,7 +5,7 @@ from obspy.signal.cross_correlation import xcorr_pick_correction
 
 
 # read example data of two small earthquakes
-path = "https://examples.obspy.org/BW.UH1..EHZ.D.2010.147.%s.slist.gz"
+path = "http://examples.obspy.org/BW.UH1..EHZ.D.2010.147.%s.slist.gz"
 st1 = obspy.read(path % ("a", ))
 st2 = obspy.read(path % ("b", ))
 # select the single traces to use in correlation.

--- a/obspy/core/__init__.py
+++ b/obspy/core/__init__.py
@@ -55,7 +55,7 @@ Example
 A :class:`~obspy.core.stream.Stream` with an example seismogram can be created
 by calling :func:`~obspy.core.stream.read()` without any arguments.
 Local files can be read by specifying the filename, files stored on http
-servers (e.g. at https://examples.obspy.org) can be read by specifying their
+servers (e.g. at http://examples.obspy.org) can be read by specifying their
 URL. For details and supported formats see the documentation of
 :func:`~obspy.core.stream.read`.
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -127,7 +127,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
 
     .. rubric:: _`Further Examples`
 
-    Example waveform files may be retrieved via https://examples.obspy.org.
+    Example waveform files may be retrieved via http://examples.obspy.org.
 
     (1) Reading multiple local files using wildcards.
 
@@ -156,7 +156,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     (3) Reading a remote file via HTTP protocol.
 
         >>> from obspy import read
-        >>> st = read("https://examples.obspy.org/loc_RJOB20050831023349.z")
+        >>> st = read("http://examples.obspy.org/loc_RJOB20050831023349.z")
         >>> print(st)  # doctest: +ELLIPSIS
         1 Trace(s) in Stream:
         .RJOB..Z | 2005-08-31T02:33:49.850000Z - ... | 200.0 Hz, 12000 samples
@@ -169,7 +169,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         1 Trace(s) in Stream:
         XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - ... | 40.0 Hz, 635 samples
 
-        >>> st = read("https://examples.obspy.org/slist.ascii.bz2")
+        >>> st = read("http://examples.obspy.org/slist.ascii.bz2")
         >>> print(st)  # doctest: +ELLIPSIS
         1 Trace(s) in Stream:
         XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - ... | 40.0 Hz, 635 samples
@@ -178,7 +178,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
 
         >>> import requests
         >>> import io
-        >>> example_url = "https://examples.obspy.org/loc_RJOB20050831023349.z"
+        >>> example_url = "http://examples.obspy.org/loc_RJOB20050831023349.z"
         >>> stringio_obj = io.BytesIO(requests.get(example_url).content)
         >>> st = read(stringio_obj)
         >>> print(st)  # doctest: +ELLIPSIS
@@ -189,7 +189,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
 
         >>> from obspy import read
         >>> dt = UTCDateTime("2005-08-31T02:34:00")
-        >>> st = read("https://examples.obspy.org/loc_RJOB20050831023349.z",
+        >>> st = read("http://examples.obspy.org/loc_RJOB20050831023349.z",
         ...           starttime=dt, endtime=dt+10)
         >>> print(st)  # doctest: +ELLIPSIS
         1 Trace(s) in Stream:

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1836,16 +1836,16 @@ class StreamTestCase(unittest.TestCase):
         """
         # 2 - via http
         # dtype
-        tr = read('https://examples.obspy.org/test.sac', dtype=np.int32)[0]
+        tr = read('http://examples.obspy.org/test.sac', dtype=np.int32)[0]
         self.assertEqual(tr.data.dtype, np.int32)
         # start/end time
-        tr2 = read('https://examples.obspy.org/test.sac',
+        tr2 = read('http://examples.obspy.org/test.sac',
                    starttime=tr.stats.starttime + 1,
                    endtime=tr.stats.endtime - 2)[0]
         self.assertEqual(tr2.stats.starttime, tr.stats.starttime + 1)
         self.assertEqual(tr2.stats.endtime, tr.stats.endtime - 2)
         # headonly
-        tr = read('https://examples.obspy.org/test.sac', headonly=True)[0]
+        tr = read('http://examples.obspy.org/test.sac', headonly=True)[0]
         self.assertFalse(tr.data)
 
     def test_copy(self):

--- a/obspy/imaging/__init__.py
+++ b/obspy/imaging/__init__.py
@@ -23,7 +23,7 @@ arguments to adjust the plot, such as color and tick format changes.
 Additionally the start and end time of the plot can be given as
 :class:`~obspy.core.utcdatetime.UTCDateTime` objects.
 
-Examples files may be retrieved via https://examples.obspy.org.
+Examples files may be retrieved via http://examples.obspy.org.
 
 >>> from obspy import read
 >>> st = read()

--- a/obspy/imaging/cm.py
+++ b/obspy/imaging/cm.py
@@ -347,9 +347,9 @@ def _colormap_plot_ppsd(cmaps):
     from obspy import read
     from obspy.signal import PPSD
     from obspy.io.xseed import Parser
-    st = read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
-    st += read("https://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
-    parser = Parser("https://examples.obspy.org/dataless.seed.BW_KW1")
+    st = read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.037")
+    st += read("http://examples.obspy.org/BW.KW1..EHZ.D.2011.038")
+    parser = Parser("http://examples.obspy.org/dataless.seed.BW_KW1")
     ppsd = PPSD(st[0].stats, metadata=parser)
     ppsd.add(st)
 
@@ -437,7 +437,7 @@ def _colormap_plot_similarity(cmaps):
     import io
     from urllib.request import urlopen
 
-    url = "https://examples.obspy.org/dissimilarities.npz"
+    url = "http://examples.obspy.org/dissimilarities.npz"
     with io.BytesIO(urlopen(url).read()) as fh, np.load(fh) as data:
         dissimilarity = data['dissimilarity']
 
@@ -457,7 +457,7 @@ def _get_beamforming_example_stream():
     from obspy import read
     from obspy.core.util import AttribDict
     from obspy.signal.invsim import corn_freq_2_paz
-    st = read("https://examples.obspy.org/agfa.mseed")
+    st = read("http://examples.obspy.org/agfa.mseed")
     # Set PAZ and coordinates for all 5 channels
     st[0].stats.paz = AttribDict({
         'poles': [(-0.03736 - 0.03617j), (-0.03736 + 0.03617j)],

--- a/obspy/io/seisan/__init__.py
+++ b/obspy/io/seisan/__init__.py
@@ -17,7 +17,7 @@ Reading
 Importing SEISAN files is done similar to reading any other waveform data
 format within ObsPy by using the :func:`~obspy.core.stream.read()` method of
 the :mod:`obspy.core` module. Examples seismograms files may be found at
-https://examples.obspy.org.
+http://examples.obspy.org.
 
 >>> from obspy import read
 >>> st = read("/path/to/2001-01-13-1742-24S.KONO__004")

--- a/obspy/io/sh/__init__.py
+++ b/obspy/io/sh/__init__.py
@@ -17,7 +17,7 @@ Reading
 Importing Q or ASC files is done similar to reading any other waveform data
 format within ObsPy by using the :func:`~obspy.core.stream.read()` method of
 the :mod:`obspy.core` module. Examples seismograms files may be found at
-https://examples.obspy.org.
+http://examples.obspy.org.
 
 >>> from obspy import read
 >>> st = read("/path/to/QFILE-TEST-ASC.ASC")

--- a/obspy/io/wav/__init__.py
+++ b/obspy/io/wav/__init__.py
@@ -16,7 +16,7 @@ Reading
 Importing WAV files is done similar to reading any other waveform data
 format within ObsPy by using the :func:`~obspy.core.stream.read()` method of
 the :mod:`obspy.core` module. Examples seismograms files may be found at
-https://examples.obspy.org.
+http://examples.obspy.org.
 
 >>> from obspy import read
 >>> st = read("/path/to/3cssan.near.8.1.RNON.wav")

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -1430,7 +1430,7 @@ def plot_tfr(st, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6, left=0.1,
     .. rubric:: Example
 
     >>> from obspy import read
-    >>> tr = read("https://examples.obspy.org/a02i.2008.240.mseed")[0]
+    >>> tr = read("http://examples.obspy.org/a02i.2008.240.mseed")[0]
     >>> plot_tfr(tr.data, dt=tr.stats.delta, fmin=.01, # doctest: +SKIP
     ...         fmax=50., w0=8., nf=64, fft_zero_pad_fac=4)
 
@@ -1438,7 +1438,7 @@ def plot_tfr(st, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6, left=0.1,
 
         from obspy.signal.tf_misfit import plot_tfr
         from obspy import read
-        tr = read("https://examples.obspy.org/a02i.2008.240.mseed")[0]
+        tr = read("http://examples.obspy.org/a02i.2008.240.mseed")[0]
         plot_tfr(tr.data, dt=tr.stats.delta, fmin=.01,
                 fmax=50., w0=8., nf=64, fft_zero_pad_fac=4)
     """


### PR DESCRIPTION
As we currently have an expired certificate and this results in most CI failing I changed all the examples to use the HTTP version of our examples server. I don't see any harm in that but maybe I am mistaken.