### PR TITLE
Return empty inventory if read_inventory on http:// returns 204

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -76,8 +76,12 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         suffix = \
             os.path.basename(path_or_file_object).partition('.')[2] or '.tmp'
         with NamedTemporaryFile(suffix=suffix) as fh:
-            download_to_file(url=path_or_file_object, filename_or_buffer=fh)
-            return read_inventory(fh.name, format=format)
+            status_code = download_to_file(url=path_or_file_object,
+                                           filename_or_buffer=fh)
+            if status_code == 204:
+                return Inventory([], "")
+            else:
+                return read_inventory(fh.name, format=format)
     return _read_from_plugin("inventory", path_or_file_object,
                              format=format, *args, **kwargs)[0]
 

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -76,12 +76,8 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         suffix = \
             os.path.basename(path_or_file_object).partition('.')[2] or '.tmp'
         with NamedTemporaryFile(suffix=suffix) as fh:
-            status_code = download_to_file(url=path_or_file_object,
-                                           filename_or_buffer=fh)
-            if status_code == 204:
-                return Inventory([], "")
-            else:
-                return read_inventory(fh.name, format=format)
+            download_to_file(url=path_or_file_object, filename_or_buffer=fh)
+            return read_inventory(fh.name, format=format)
     return _read_from_plugin("inventory", path_or_file_object,
                              format=format, *args, **kwargs)[0]
 

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -9,7 +9,7 @@ import unittest
 
 from obspy.core.compatibility import mock
 from obspy.core.util.base import (NamedTemporaryFile, get_dependency_version,
-                                 download_to_file)
+                                  download_to_file)
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
 from requests import HTTPError

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -8,7 +8,8 @@ import shutil
 import unittest
 
 from obspy.core.compatibility import mock
-from obspy.core.util.base import NamedTemporaryFile, get_dependency_version, download_to_file
+from obspy.core.util.base import (NamedTemporaryFile, get_dependency_version,
+                                 download_to_file)
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
 from requests import HTTPError

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -107,9 +107,9 @@ class UtilBaseTestCase(unittest.TestCase):
                 mocked_get.return_value.reason = reason
                 with self.assertRaises(HTTPError) as e:
                     download_to_file(url, None)
-                    self.assertEqual(e.exception.args[0],
-                                     "%s HTTP Error: %s for url: %s" %
-                                     (code, reason, url))
+                self.assertEqual(e.exception.args[0],
+                                 "%s HTTP Error: %s for url: %s" %
+                                 (code, reason, url))
 
 
 def suite():

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -99,16 +99,16 @@ class UtilBaseTestCase(unittest.TestCase):
         url = "http://obspy.org"
         for response_tuple in [("204", "No Content"), ("400", "Bad Request"),
                                ("500", "Internal Server Error")]:
-          code = response_tuple[0]
-          reason = response_tuple[1]
-          with mock.patch("requests.get") as mocked_get:
-            mocked_get.return_value.status_code = code
-            mocked_get.return_value.reason = reason
-            with self.assertRaises(HTTPError) as e:
-              download_to_file(url, None)
-            self.assertEqual(e.exception.args[0],
-                             "%s HTTP Error: %s for url: %s" % (code,
-                                                                reason, url))
+            code = response_tuple[0]
+            reason = response_tuple[1]
+            with mock.patch("requests.get") as mocked_get:
+                mocked_get.return_value.status_code = code
+                mocked_get.return_value.reason = reason
+                with self.assertRaises(HTTPError) as e:
+                    download_to_file(url, None)
+                    self.assertEqual(e.exception.args[0],
+                                     "%s HTTP Error: %s for url: %s" %
+                                     (code, reason, url))
 
 
 def suite():

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -8,8 +8,10 @@ import shutil
 import unittest
 
 from obspy.core.compatibility import mock
-from obspy.core.util.base import NamedTemporaryFile, get_dependency_version
+from obspy.core.util.base import NamedTemporaryFile, get_dependency_version, download_to_file
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
+
+from requests import HTTPError
 
 
 class UtilBaseTestCase(unittest.TestCase):
@@ -89,6 +91,24 @@ class UtilBaseTestCase(unittest.TestCase):
 
         # check that temp file is deleted
         self.assertFalse(os.path.exists(ic.name))
+
+    def test_mock_read_inventory_http_errors(self):
+        """
+        Tests HTTP Error on 204, 400, and 500
+        """
+        url = "http://obspy.org"
+        for response_tuple in [("204", "No Content"), ("400", "Bad Request"),
+                               ("500", "Internal Server Error")]:
+          code = response_tuple[0]
+          reason = response_tuple[1]
+          with mock.patch("requests.get") as mocked_get:
+            mocked_get.return_value.status_code = code
+            mocked_get.return_value.reason = reason
+            with self.assertRaises(HTTPError) as e:
+              download_to_file(url, None)
+            self.assertEqual(e.exception.args[0],
+                             "%s HTTP Error: %s for url: %s" % (code,
+                                                                reason, url))
 
 
 def suite():

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -575,8 +575,8 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
 
     # Raise anything except for 200
     if r.status_code != 200:
-      raise requests.HTTPError(u'%s HTTP Error: %s for url: %s'
-                                % (r.status_code, r.reason, url))
+        raise requests.HTTPError(u'%s HTTP Error: %s for url: %s'
+                                 % (r.status_code, r.reason, url))
 
     if hasattr(filename_or_buffer, "write"):
         for chunk in r.iter_content(chunk_size=chunk_size):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -575,7 +575,8 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
 
     # Raise anything except for 200
     if r.status_code != 200:
-      raise requests.HTTPError(u'%s HTTP Error: %s for url: %s' % (r.status_code, r.reason, url))
+      raise requests.HTTPError(u'%s HTTP Error: %s for url: %s'
+                               % (r.status_code, r.reason, url))
 
     if hasattr(filename_or_buffer, "write"):
         for chunk in r.iter_content(chunk_size=chunk_size):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -573,7 +573,9 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
     except TypeError:
         r = requests.get(url)
 
-    r.raise_for_status()
+    # Raise anything except for 200
+    if r.status_code != 200:
+      raise requests.HTTPError(u'%s HTTP Error: %s for url: %s' % (r.status_code, r.reason, url))
 
     if hasattr(filename_or_buffer, "write"):
         for chunk in r.iter_content(chunk_size=chunk_size):
@@ -586,8 +588,6 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
                 if not chunk:
                     continue
                 fh.write(chunk)
-
-    return r.status_code
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -587,6 +587,8 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
                     continue
                 fh.write(chunk)
 
+    return r.status_code
+
 
 if __name__ == '__main__':
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -575,7 +575,7 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
 
     # Raise anything except for 200
     if r.status_code != 200:
-        raise requests.HTTPError(u'%s HTTP Error: %s for url: %s'
+        raise requests.HTTPError('%s HTTP Error: %s for url: %s'
                                  % (r.status_code, r.reason, url))
 
     if hasattr(filename_or_buffer, "write"):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -576,7 +576,7 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
     # Raise anything except for 200
     if r.status_code != 200:
       raise requests.HTTPError(u'%s HTTP Error: %s for url: %s'
-                               % (r.status_code, r.reason, url))
+                                % (r.status_code, r.reason, url))
 
     if hasattr(filename_or_buffer, "write"):
         for chunk in r.iter_content(chunk_size=chunk_size):


### PR DESCRIPTION
ObsPy throws when `read_inventory` is called with a 204 response. I think it would be good to return an empty inventory instead a `TypeError`.

    TypeError: Unknown format for file /tmp/obspy-cg1Kog.tmp

Can add a test using our webservice, but what is the best place to put it? And is it OK to include tests over http?

    www.orfeus-eu.org/fdsnws/station/1/query?network=BOGUS