### PR TITLE
arclink.Client.get_inventory: useless routing request / fails for StationGroups (virtual networks)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -86,6 +86,8 @@ master: (doi: 10.5281/zenodo.165135)
      vertical, see #1445).
  - obspy.io.arclink:
     * Read support for Arclink Inventory XML (see #1539)
+    * default for `route` parameter in metadata requests is changed to `False`
+      (see #1756)
  - obspy.io.ascii:
     * Custom formatting of sample values when writing SLIST and TSPAIR.
  - obspy.io.datamark:

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -1115,7 +1115,7 @@ class Client(object):
             #  (1) not network id is given,
             #  (2) virtual network (Station group) is requested
             if route:
-                msg = ("Routing was requested but parameter 'netork' is '{}' "
+                msg = ("Routing was requested but parameter 'network' is '{}' "
                        "and therefore routing is disabled.").format(network)
                 warnings.warn(msg)
             result = self._fetch(rtype, rdata, route=False)

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -1103,15 +1103,19 @@ class Client(object):
             rdata.append('lonmin=%f' % min_longitude)
         if max_longitude:
             rdata.append('lonmax=%f' % max_longitude)
+
         # fetch plain XML document
-        if network == '*':
-            # set route to False if not network id is given
+        if network == '*' or network[0] == '_':
+            # To not use routing if
+            #  (1) not network id is given,
+            #  (2) virtual network (Station group) is requested
             result = self._fetch(rtype, rdata, route=False)
         else:
             result = self._fetch(rtype, rdata, route=route)
+
         # parse XML document
         xml_doc = etree.fromstring(result)
-        # get routing version
+        # get inventory version
         if _INVENTORY_NS_1_0 in xml_doc.nsmap.values():
             xml_ns = _INVENTORY_NS_1_0
             stream_ns = 'sensorLocation'

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -1114,6 +1114,10 @@ class Client(object):
             # To not use routing if
             #  (1) not network id is given,
             #  (2) virtual network (Station group) is requested
+            if route:
+                msg = ("Routing was requested but parameter 'netork' is '{}' "
+                       "and therefore routing is disabled.").format(network)
+                warnings.warn(msg)
             result = self._fetch(rtype, rdata, route=False)
         else:
             result = self._fetch(rtype, rdata, route=route)

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -450,7 +450,7 @@ class Client(object):
         # fetching PAZ and coordinates
         if metadata:
             # fetch metadata only once
-            # NOTE: The outing step here is not strictly necessary
+            # NOTE: The routing step here is not strictly necessary
             # TODO: Routing should preferably be done only once
             inv = self.get_inventory(network=network, station=station,
                                      location=location, channel=channel,

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -210,7 +210,7 @@ class Client(object):
         self._write_ln('BYE')
         self._client.close()
 
-    def _fetch(self, request_type, request_data, route=True):
+    def _fetch(self, request_type, request_data, route=False):
         # skip routing on request
         if not route:
             # always use initial node if routing is disabled
@@ -450,6 +450,8 @@ class Client(object):
         # fetching PAZ and coordinates
         if metadata:
             # fetch metadata only once
+            # NOTE: The outing step here is not strictly necessary
+            # TODO: Routing should preferably be done only once
             inv = self.get_inventory(network=network, station=station,
                                      location=location, channel=channel,
                                      starttime=starttime, endtime=endtime,
@@ -616,6 +618,7 @@ class Client(object):
         # request data
         rdata = [starttime, endtime, network, station]
         # fetch plain XML document
+        # TODO: A simpler "routing-less" methods, check _request
         result = self._fetch(rtype, rdata, route=False)
         # parse XML document
         xml_doc = etree.fromstring(result)
@@ -745,7 +748,7 @@ class Client(object):
         return result
 
     def get_metadata(self, network, station, location, channel, time,
-                     route=True):
+                     route=False):
         """
         Returns poles, zeros, normalization factor and sensitivity and station
         coordinates for a single channel at a given time.
@@ -889,7 +892,7 @@ class Client(object):
         return paz
 
     def get_paz(self, network, station, location, channel, time,
-                route=True):
+                route=False):
         """
         Returns poles, zeros, normalization factor and sensitivity for a
         single channel at a given time.
@@ -959,7 +962,7 @@ class Client(object):
             raise ArcLinkException(msg)
 
     def save_response(self, filename, network, station, location, channel,
-                      starttime, endtime, format='SEED'):
+                      starttime, endtime, format='SEED', route=False):
         """
         Writes response information into a file.
 
@@ -980,6 +983,8 @@ class Client(object):
         :type format: str, optional
         :param format: Output format. Currently only Dataless SEED (``'SEED'``)
             is supported.
+        :type route: bool, optional
+        :param route: Enables ArcLink routing (default is ``False``).
         :return: None
 
         .. rubric:: Example
@@ -1000,7 +1005,7 @@ class Client(object):
             # request data
             rdata = [starttime, endtime, network, station, channel, location]
             # fetch dataless
-            data = self._fetch(rtype, rdata)
+            data = self._fetch(rtype, rdata, route=route)
         else:
             raise ValueError("Unsupported format %s" % format)
         if hasattr(filename, "write") and hasattr(filename.write, "__call__"):
@@ -1037,7 +1042,7 @@ class Client(object):
         :type instruments: bool, optional
         :param instruments: Include instrument data (default is ``False``).
         :type route: bool, optional
-        :param route: Enables ArcLink routing (default is ``True``).
+        :param route: Enables ArcLink routing (default is ``False``).
         :type sensortype: str, optional
         :param sensortype: Limit streams to those using specific sensor types:
             ``"VBB"``, ``"BB"``, ``"SM"``, ``"OBS"``, etc. Can be also a
@@ -1329,7 +1334,7 @@ class Client(object):
 
         return data
 
-    def get_networks(self, starttime, endtime, route=True):
+    def get_networks(self, starttime, endtime, route=False):
         """
         Returns a dictionary of available networks within the given time span.
 
@@ -1348,7 +1353,7 @@ class Client(object):
         return self.get_inventory(network='*', starttime=starttime,
                                   endtime=endtime, route=route)
 
-    def get_stations(self, starttime, endtime, network, route=True):
+    def get_stations(self, starttime, endtime, network, route=False):
         """
         Returns a dictionary of available stations in the given network(s).
 
@@ -1364,7 +1369,7 @@ class Client(object):
         :param network: Network code, e.g. ``'BW'``.
         :return: Dictionary of station data.
         :type route: bool, optional
-        :param route: Enables ArcLink routing (default is ``True``).
+        :param route: Enables ArcLink routing (default is ``False``).
         """
         data = self.get_inventory(network=network, starttime=starttime,
                                   endtime=endtime, route=route)

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -1011,7 +1011,7 @@ class Client(object):
 
     def get_inventory(self, network, station='*', location='*', channel='*',
                       starttime=UTCDateTime(), endtime=UTCDateTime(),
-                      instruments=False, route=True, sensortype='',
+                      instruments=False, route=False, sensortype='',
                       min_latitude=None, max_latitude=None,
                       min_longitude=None, max_longitude=None,
                       restricted=None, permanent=None, modified_after=None):

--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -210,7 +210,7 @@ class Client(object):
         self._write_ln('BYE')
         self._client.close()
 
-    def _fetch(self, request_type, request_data, route=False):
+    def _fetch(self, request_type, request_data, route=True):
         # skip routing on request
         if not route:
             # always use initial node if routing is disabled

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -178,8 +178,9 @@ class ClientTestCase(unittest.TestCase):
         self.assertIn('BW.MANZ', result)
         self.assertIn('BW.MANZ..EHE', result)
         # 5 - unknown network 00 via webdc.eu:18002
-        self.assertRaises(ArcLinkException, client.get_inventory, '00', '',
-                          starttime=dt, endtime=dt + 1)
+        result = client.get_inventory('00', '', starttime=dt, endtime=dt + 1)
+        self.assertIsInstance(result, AttribDict)
+        self.assertEqual(result, AttribDict({}))
         # 6 - get channel gain without PAZ
         start = UTCDateTime("1970-01-01 00:00:00")
         end = UTCDateTime("2020-10-19 00:00:00")

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -401,8 +401,50 @@ class ClientTestCase(unittest.TestCase):
                         'restricted': False, 'archive_net': '',
                         'longitude': 12.729887, 'affiliation': 'BayernNetz',
                         'depth': None, 'place': 'Wildenmoos',
-                        'country': ' BW-Net', 'latitude': 47.744171,
+                        'country': 'BW-Net', 'latitude': 47.744171,
                         'end': None}) in result)
+        # example 2
+        expected = AttribDict(
+            {'code': 'WDD', 'description': 'Wied Dalam',
+             'affiliation': '', 'country': '', 'place': '', 'remark': '',
+             'restricted': False, 'archive_net': '',
+             'latitude': 35.8373, 'longitude': 14.5242,
+             'elevation': 44.0, 'depth': None,
+             'start': UTCDateTime(1995, 7, 6, 0, 0), 'end': None})
+        # routing default
+        result = client.get_stations(start, end, 'MN')
+        self.assertTrue(expected in result)
+        # w/o routing
+        result = client.get_stations(start, end, 'MN', route=False)
+        self.assertTrue(expected in result)
+        # w/ routing
+        result = client.get_stations(start, end, 'MN', route=True)
+        self.assertTrue(expected in result)
+
+    @unittest.expectedFailure
+    def test_get_stations_inconsistency(self):
+        """
+        """
+        # initialize client
+        client = Client(user='test@obspy.org')
+        # example 1
+        start = UTCDateTime(2008, 1, 1)
+        end = start + 1
+        result_origin = AttribDict(
+            {'remark': '', 'code': 'RWMO', 'elevation': 763.0,
+             'description': 'Wildenmoos, Bavaria, BW-Net',
+             'start': UTCDateTime(2006, 7, 4, 0, 0),
+             'restricted': False, 'archive_net': '',
+             'longitude': 12.729887, 'affiliation': 'BayernNetz',
+             'depth': None, 'place': 'Wildenmoos',
+             'country': ' BW-Net', 'latitude': 47.744171,
+             'end': None})
+        # OK: from origin node
+        result = client.get_stations(start, end, 'BW', route=True)
+        self.assertTrue(result_origin in result)
+        # BUT: this one from a different node was modified and fails
+        result = client.get_stations(start, end, 'BW')
+        self.assertTrue(result_origin in result)
 
     def test_save_waveform(self):
         """

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -9,6 +9,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import io
 import operator
 import unittest
+import warnings
 
 import numpy as np
 
@@ -225,7 +226,13 @@ class ClientTestCase(unittest.TestCase):
         self.assertIn('RO.BISRR', result)
         self.assertIn('RO.VRI', result)
         # 2 - defined @INGV
-        result = client.get_inventory(network="_NFOTABOO", route=True)
+        with warnings.catch_warnings(record=True) as w:
+            result = client.get_inventory(network="_NFOTABOO", route=True)
+        self.assertEqual(len(w), 1)
+        self.assertEqual(
+            str(w[0].message),
+            "Routing was requested but parameter 'network' is '_NFOTABOO' "
+            "and therefore routing is disabled.")
         self.assertIn('IV', result)
         self.assertIn('IV.ATBU', result)
         self.assertIn('IV.SSFR', result)

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -218,18 +218,25 @@ class ClientTestCase(unittest.TestCase):
         """
         Tests get_inventory method for StationGroup, issue #1756.
         """
-        # 1 - defined @NIEP
         client = Client(user='test@obspy.org')
+        # 1 - defined @NIEP
         result = client.get_inventory(network="_NFOVRANC", route=False)
         self.assertIn('RO', result)
         self.assertIn('RO.BISRR', result)
         self.assertIn('RO.VRI', result)
         # 2 - defined @INGV
-        client = Client(user='test@obspy.org')
-        result = client.get_inventory(network="_NFOTABOO")
+        result = client.get_inventory(network="_NFOTABOO", route=True)
         self.assertIn('IV', result)
         self.assertIn('IV.ATBU', result)
         self.assertIn('IV.SSFR', result)
+        # 3 - defined @ETH
+        result = client.get_inventory(network="_NFOVALAIS")
+        self.assertIn('CH', result)
+        self.assertIn('S', result)
+        self.assertIn('7H', result)
+        self.assertIn('CH.AIGLE', result)
+        self.assertIn('CH.VANNI', result)
+        self.assertIn('S.ESION', result)
 
     def test_get_inventory_twice(self):
         """

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -216,14 +216,20 @@ class ClientTestCase(unittest.TestCase):
 
     def test_get_inventory_stationgroup(self):
         """
-        Tests get_inventory method for StationGroup, issue #1756.  
+        Tests get_inventory method for StationGroup, issue #1756.
         """
-        # 1 - w/o routing okay 
+        # 1 - defined @NIEP
         client = Client(user='test@obspy.org')
-        client.get_inventory(network="_NFOVRANC", route=False)
-        # 2 - w/ routing, issue #1756
+        result = client.get_inventory(network="_NFOVRANC", route=False)
+        self.assertIn('RO', result)
+        self.assertIn('RO.BISRR', result)
+        self.assertIn('RO.VRI', result)
+        # 2 - defined @INGV
         client = Client(user='test@obspy.org')
-        client.get_inventory(network="_NFOTABOO")
+        result = client.get_inventory(network="_NFOTABOO")
+        self.assertIn('IV', result)
+        self.assertIn('IV.ATBU', result)
+        self.assertIn('IV.SSFR', result)
 
     def test_get_inventory_twice(self):
         """

--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -213,6 +213,17 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(channel[2].endtime, UTCDateTime(2011, 1, 15, 9, 56))
         self.assertEqual(channel[2].gain, 588000000.0)
 
+    def test_get_inventory_stationgroup(self):
+        """
+        Tests get_inventory method for StationGroup, issue #1756.  
+        """
+        # 1 - w/o routing okay 
+        client = Client(user='test@obspy.org')
+        client.get_inventory(network="_NFOVRANC", route=False)
+        # 2 - w/ routing, issue #1756
+        client = Client(user='test@obspy.org')
+        client.get_inventory(network="_NFOTABOO")
+
     def test_get_inventory_twice(self):
         """
         Requesting inventory data twice should not fail.


### PR DESCRIPTION
Obspy version 1.0.2 (no change for module .clients.arclink documented)
Python version 3.5.3
Platform: macOX 10.10.5 (14F2315)
Package manager: MacPorts

I realized this because I tried to get an inventory for a Virtual network (Station Group in Seiscomp3 terminology). 

Apparently, the `get_inventory` method requests routing information first, before it requests the inventory itself. (1) To my understanding the routing request is useless, because in an Arclink federation (EIDA) the Inventory of all nodes should have been synchronized. If synchronization fails, it also does for the routing information. (2) For Station Groups no routing information is available so this step fails completely.

I therefore suggest to eliminate the routing request completely. It is useful only for data requests (`get_waveforms`), while `get_inventory` and `get_routing` are at the same level. 

If someone really thinks routing for `get_inventory` might be somehow useful, we should set the default to `route=False`. But honestly, I'd rather opt for complete removal because do not see any utility.

Example:
```
from obspy.clients.arclink import Client

client = Client(user="peter.danecek", institution="INGV", debug=True)
client.get_inventory(network="_NFOVRANC")
```

Error:
```
ArcLinkException: Could not find route to _NFOVRANC.*. If you think the data should be there, you might want to retry with manually connecting to a different ArcLink node (see docstring of Client) to see if there is a problem with a routing table at a specific ArcLink node (and contact the ArcLink node operators).
```

Fix:
```
client.get_inventory(network="_NFOVRANC", route=False)

