### PR TITLE
fix #1934 header won't be changed in Trace.init

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -70,3 +70,4 @@ Andrew Walker
 Marcus Walther
 Joachim Wassermann
 Mark C. Williams
+Li, Yulin

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -272,6 +272,7 @@ class Trace(object):
         # set some defaults if not set yet
         if header is None:
             header = {}
+        header = header.copy()
         header.setdefault('npts', len(data))
         self.stats = Stats(header)
         # set data without changing npts in stats object (for headonly option)


### PR DESCRIPTION
### What does this PR do?
fix #1934. The header won't be change during Trace.__init__
### Why was it initiated?  Any relevant Issues?
Issue #1934 
### PR Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
