### PR TITLE
Avoid clashes in Trace header init: deepcopy provided dictionary

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -45,6 +45,7 @@ Lecocq, Thomas
 Leeman, John
 Legovini, Paride
 Lesage, Philippe
+Li, Yulin
 Lomax, Anthony
 Lopes, Rui L.
 MacCarthy, Jonathan

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2700,8 +2700,14 @@ class TraceTestCase(unittest.TestCase):
         dictionary for multiple Trace inits)
         """
         header = {'station': 'MS', 'starttime': 1}
+        original_header = deepcopy(header)
+
+        # Init two traces and make sure the original header did not change.
         tr1 = Trace(data=np.ones(2), header=header)
+        self.assertEqual(header, original_header)
         tr2 = Trace(data=np.zeros(5), header=header)
+        self.assertEqual(header, original_header)
+
         self.assertEqual(len(tr1), 2)
         self.assertEqual(len(tr2), 5)
         self.assertEqual(tr1.stats.npts, 2)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2694,6 +2694,19 @@ class TraceTestCase(unittest.TestCase):
         self.assertFalse(tr_opt_out.data.flags['C_CONTIGUOUS'])
         self.assertFalse(tr_opt_out.data.flags['F_CONTIGUOUS'])
 
+    def test_header_dict_copied(self):
+        """
+        Regression test for #1934 (collisions when using  the same header
+        dictionary for multiple Trace inits)
+        """
+        header = {'station': 'MS', 'starttime': 1}
+        tr1 = Trace(data=np.ones(2), header=header)
+        tr2 = Trace(data=np.zeros(5), header=header)
+        self.assertEqual(len(tr1), 2)
+        self.assertEqual(len(tr2), 5)
+        self.assertEqual(tr1.stats.npts, 2)
+        self.assertEqual(tr2.stats.npts, 5)
+
 
 def suite():
     return unittest.makeSuite(TraceTestCase, 'test')

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -284,6 +284,7 @@ class Trace(object):
         # set some defaults if not set yet
         if header is None:
             header = {}
+        header = header.copy()
         header.setdefault('npts', len(data))
         self.stats = Stats(header)
         # set data without changing npts in stats object (for headonly option)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -284,7 +284,7 @@ class Trace(object):
         # set some defaults if not set yet
         if header is None:
             header = {}
-        header = header.copy()
+        header = deepcopy(header)
         header.setdefault('npts', len(data))
         self.stats = Stats(header)
         # set data without changing npts in stats object (for headonly option)


### PR DESCRIPTION
Supersedes #1935 and fixes #1934.