### PR TITLE
Add Luca Trani as contributor (QC module)

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -76,6 +76,7 @@ Stange, Stefan
 Sullivan, Benjamin
 Tian, Dongdong
 Trabant, Chad
+Trani, Luca
 Uieda, Leonardo
 Walker, Andrew
 Walther, Marcus


### PR DESCRIPTION
Added Luca Trani as a contributor. Should be included in 1.1.0 for his work on the QC module.