### PR TITLE
Remove clients.seishub doctests

### DIFF
--- a/obspy/clients/seishub/__init__.py
+++ b/obspy/clients/seishub/__init__.py
@@ -19,10 +19,11 @@ Basic Example
 
 >>> client = Client(timeout=20)
 >>> t = UTCDateTime('2010-01-01T10:00:00')
->>> st = client.waveform.get_waveforms("BW", "MANZ", "", "EH*", t, t+20)
->>> st.sort()  # doctest: +ELLIPSIS
+>>> st = client.waveform.get_waveforms(
+...     "BW", "MANZ", "", "EH*", t, t+20)  # doctest: +SKIP
+>>> st.sort()  # doctest: +ELLIPSIS +SKIP
 <obspy.core.stream.Stream object at ...>
->>> print(st)  # doctest: +ELLIPSIS
+>>> print(st)  # doctest: +ELLIPSIS +SKIP
 3 Trace(s) in Stream:
 BW.MANZ..EHE | 2010-01-01T10:00:00.000000Z - ... | 200.0 Hz, 4001 samples
 BW.MANZ..EHN | 2010-01-01T10:00:00.000000Z - ... | 200.0 Hz, 4001 samples
@@ -31,20 +32,22 @@ BW.MANZ..EHZ | 2010-01-01T10:00:00.000000Z - ... | 200.0 Hz, 4001 samples
 Advanced Examples
 -----------------
 
->>> client.waveform.get_network_ids()     #doctest: +SKIP
+>>> client.waveform.get_network_ids()  #doctest: +SKIP
 ['KT', 'BW', 'NZ', 'GR', ...]
 
->>> sta_ids = client.waveform.get_station_ids(network='BW')
+>>> sta_ids = client.waveform.get_station_ids(network='BW')  # doctest: +SKIP
 >>> sorted(sta_ids)  # doctest: +SKIP
 ['ALTM', 'BGLD', 'BW01',..., 'WETR', 'ZUGS']
 
->>> cha_ids = client.waveform.get_channel_ids(network='BW', station='MANZ')
->>> sorted(cha_ids)  # doctest: +NORMALIZE_WHITESPACE
+>>> cha_ids = client.waveform.get_channel_ids(
+...     network='BW', station='MANZ')  # doctest: +SKIP
+>>> sorted(cha_ids)  # doctest: +NORMALIZE_WHITESPACE +SKIP
 ['AEX', 'AEY', 'BHE', 'BHN', 'BHZ', 'E', 'EHE', 'EHN', 'EHZ', 'HHE', 'HHN',
  'HHZ', 'LOG', 'N', 'SHE', 'SHN', 'SHZ', 'Z']
 
->>> paz = client.station.get_paz('BW.MANZ..EHZ', UTCDateTime('20090808'))
->>> paz = paz.items()
+>>> paz = client.station.get_paz(
+...     'BW.MANZ..EHZ', UTCDateTime('20090808'))  # doctest: +SKIP
+>>> paz = paz.items()  # doctest: +SKIP
 >>> sorted(paz)  # doctest: +SKIP
 [('gain', 60077000.0),
  ('poles', [(-0.037004+0.037016j), (-0.037004-0.037016j), (-251.33+0j),

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -107,8 +107,9 @@ class Client(object):
     >>> t = UTCDateTime("2009-09-03 00:00:00")
     >>> client = Client(timeout=20)
     >>>
-    >>> st = client.waveform.get_waveforms("BW", "RTBE", "", "EHZ", t, t + 20)
-    >>> print(st)  # doctest: +ELLIPSIS
+    >>> st = client.waveform.get_waveforms(
+    ...     "BW", "RTBE", "", "EHZ", t, t + 20)  # doctest: +SKIP
+    >>> print(st)  # doctest: +ELLIPSIS +SKIP
     1 Trace(s) in Stream:
     BW.RTBE..EHZ | 2009-09-03T00:00:00.000000Z - ... | 200.0 Hz, 4001 samples
     """  # noqa
@@ -718,16 +719,17 @@ master/seishub/plugins/seismology/waveform.py
         .. rubric:: Example
 
         >>> c = Client(timeout=20)
-        >>> paz = c.station.get_paz('BW.MANZ..EHZ', '20090707')
-        >>> paz['zeros']
+        >>> paz = c.station.get_paz(
+        ...     'BW.MANZ..EHZ', '20090707')  # doctest: +SKIP
+        >>> paz['zeros']  # doctest: +SKIP
         [0j, 0j]
-        >>> len(paz['poles'])
+        >>> len(paz['poles'])  # doctest: +SKIP
         5
-        >>> print(paz['poles'][0])
+        >>> print(paz['poles'][0])  # doctest: +SKIP
         (-0.037004+0.037016j)
-        >>> paz['gain']
+        >>> paz['gain']  # doctest: +SKIP
         60077000.0
-        >>> paz['sensitivity']
+        >>> paz['sensitivity']  # doctest: +SKIP
         2516800000.0
         """
         # try to read PAZ from previously obtained XSEED data


### PR DESCRIPTION
They currently always cause `obspy-runtests --all` to fail (and they cannot be skipped like the normal seishub unit tests).

Two possible alternatives:

* Move `obspy.clients.seishub` to a separate package and remove it from ObsPy itsself. I feel like this might be an acceptable solution.
* Find a way to conditionally skip the doctests.