### PR TITLE
Compatibility for old requests and lxml

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -375,9 +375,14 @@ def get_stationxml_contents(filename):
     channel_tag = "{%s}Channel" % ns
     response_tag = "{%s}Response" % ns
 
-    context = etree.iterparse(filename, events=("start", ),
-                              tag=(network_tag, station_tag, channel_tag,
-                                   response_tag))
+    try:
+        context = etree.iterparse(filename, events=("start", ),
+                                  tag=(network_tag, station_tag, channel_tag,
+                                       response_tag))
+    except TypeError:  # pragma: no cover
+        # Some old lxml version have a way less powerful iterparse()
+        # function. Fall back to parsing with ObsPy.
+        return _get_stationxml_contents_slow(filename)
 
     channels = []
     for event, elem in context:
@@ -405,6 +410,28 @@ def get_stationxml_contents(filename):
         while elem.getprevious() is not None:
             del elem.getparent()[0]
 
+    return channels
+
+
+def _get_stationxml_contents_slow(filename):
+    """
+    Slow variant for get_stationxml_contents() for old lxml versions.
+
+    :param filename: The path to the file.
+    :returns: list of ChannelAvailability objects.
+    """
+    channels = []
+    inv = obspy.read_inventory(filename)
+    for net in inv:
+        for sta in net:
+            for cha in sta:
+                if not cha.response:
+                    continue
+                channels.append(ChannelAvailability(
+                    net.code, sta.code, cha.location_code, cha.code,
+                    cha.start_date, cha.end_date
+                    if cha.end_date else obspy.UTCDateTime(2599, 1, 1),
+                    filename))
     return channels
 
 

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -15,12 +15,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import io
 from multiprocessing.dummy import Pool as ThreadPool
 
 import decorator
 
-from obspy.core.compatibility import urlparse, string_types
+from obspy.core.compatibility import (urlparse, string_types,
+                                      get_reason_from_response)
 import obspy
 
 from ...base import HTTPClient
@@ -268,17 +268,7 @@ class BaseRoutingClient(HTTPClient):
 
         Please overwrite this method in a child class if necessary.
         """
-        if r.content:  # pragma: no cover
-            c = r.content
-        else:
-            c = r.reason
-
-        if hasattr(c, "encode"):
-            c = c.encode()
-
-        with io.BytesIO(c) as f:
-            f.seek(0, 0)
-            raise_on_error(r.status_code, c)
+        raise_on_error(r.status_code, get_reason_from_response(r))
 
     @_assert_filename_not_in_kwargs
     @_assert_attach_response_not_in_kwargs

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -18,6 +18,7 @@ from future.builtins import *  # NOQA
 from multiprocessing.dummy import Pool as ThreadPool
 
 import decorator
+import warnings
 
 from obspy.core.compatibility import (urlparse, string_types,
                                       get_reason_from_response)
@@ -92,8 +93,16 @@ def _download_bulk(r):
     # (2) A global EIDA_TOKEN key. It will be used for all services that
     #     don't have explicit credentials and also support the `/auth` route.
     credentials = r["credentials"].get(urlparse(r["endpoint"]).netloc, {})
-    c = client.Client(r["endpoint"], debug=r["debug"], timeout=r["timeout"],
-                      **credentials)
+    try:
+        c = client.Client(r["endpoint"], debug=r["debug"],
+                          timeout=r["timeout"], **credentials)
+    # This should rarely happen but better safe than sorry.
+    except FDSNException as e:  # pragma: no cover
+        msg = e.args[0]
+        msg += "It will not be used for routing. Try again later?"
+        warnings.warn(msg)
+        return None
+
     if not credentials and "EIDA_TOKEN" in r["credentials"] and \
             c._has_eida_auth:
         c.set_eida_token(r["credentials"]["EIDA_TOKEN"])

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -294,7 +294,7 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         st = self.client.get_waveforms(
             starttime=obspy.UTCDateTime(2017, 1, 1),
             endtime=obspy.UTCDateTime(2017, 1, 1, 0, 1),
-            latitude=35.0, longitude=-120, maxradius=0.2,
+            latitude=35.0, longitude=-110, maxradius=0.3,
             channel="LHZ")
         # This yields 1 channel at the time of writing this test - I assume
         # it is unlikely to every yield less. So this test should be fairly
@@ -305,7 +305,7 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         st2 = self.client.get_waveforms_bulk(
             [["*", "*", "*", "LHZ", obspy.UTCDateTime(2017, 1, 1),
               obspy.UTCDateTime(2017, 1, 1, 0, 1)]],
-            latitude=35.0, longitude=-120, maxradius=0.2)
+            latitude=35.0, longitude=-110, maxradius=0.3)
         self.assertGreaterEqual(len(st2), 1)
 
         self.assertEqual(st, st2)

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -318,7 +318,7 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         inv = self.client.get_stations(
             starttime=obspy.UTCDateTime(2017, 1, 1),
             endtime=obspy.UTCDateTime(2017, 1, 1, 0, 1),
-            latitude=35.0, longitude=-120, maxradius=0.2,
+            latitude=35.0, longitude=-110, maxradius=0.3,
             channel="LHZ", level="network")
         # This yields 1 network at the time of writing this test - I assume
         # it is unlikely to every yield less. So this test should be fairly
@@ -329,7 +329,7 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         inv2 = self.client.get_stations_bulk(
             [["*", "*", "*", "LHZ", obspy.UTCDateTime(2017, 1, 1),
               obspy.UTCDateTime(2017, 1, 1, 0, 1)]],
-            latitude=35.0, longitude=-120, maxradius=0.2,
+            latitude=35.0, longitude=-110, maxradius=0.3,
             level="network")
         self.assertGreaterEqual(len(inv2), 1)
 

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -34,7 +34,8 @@ from obspy.clients.fdsn.mass_downloader import (domain, Restrictions,
 from obspy.clients.fdsn.mass_downloader.utils import (
     filter_channel_priority, get_stationxml_filename, get_mseed_filename,
     get_stationxml_contents, SphericalNearestNeighbour, safe_delete,
-    download_stationxml, download_and_split_mseed_bulk)
+    download_stationxml, download_and_split_mseed_bulk,
+    _get_stationxml_contents_slow)
 from obspy.clients.fdsn.mass_downloader.download_helpers import (
     Channel, TimeInterval, Station, STATUS, ClientDownloadHelper)
 
@@ -1006,6 +1007,17 @@ class DownloadHelpersUtilTestCase(unittest.TestCase):
             [ChannelAvailability(net.code, sta.code, cha.location_code,
                                  cha.code, cha.start_date, cha.end_date,
                                  filename)])
+
+    def test_fast_vs_slow_get_stationxml_contents(self):
+        """
+        Both should of course return the same result.
+
+        For some old lxml versions both will be using the same function,
+        but this is still a useful test.
+        """
+        filename = os.path.join(self.data, "AU.MEEK.xml")
+        self.assertEqual(get_stationxml_contents(filename),
+                         _get_stationxml_contents_slow(filename))
 
     def test_channel_str_representation(self):
         """

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -23,7 +23,7 @@ import warnings
 import requests
 
 import obspy
-from obspy.core.compatibility import configparser
+from obspy.core.compatibility import configparser, get_text_from_response
 from obspy.core.inventory.util import _textwrap
 
 
@@ -289,8 +289,8 @@ class RemoteNRL(NRL):
         Download service with basic cache.
         """
         if url not in _remote_nrl_cache:
-            response = requests.get(url)
-            _remote_nrl_cache[url] = response.text
+            r = requests.get(url)
+            _remote_nrl_cache[url] = get_text_from_response(r)
         return _remote_nrl_cache[url]
 
     def _join(self, *paths):

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -5,6 +5,7 @@ Py3k compatibility module
 from future.utils import PY2
 
 import io
+import json
 
 import numpy as np
 
@@ -127,3 +128,42 @@ def round_away(number):
         return int(int(number) + int(np.sign(number)))
     else:
         return int(np.round(number))
+
+
+def get_json_from_response(r):
+    """
+    Get a JSON response in a way that also works for very old request
+    versions.
+
+    :type r: :class:`requests.Response
+    :param r: The server's response.
+    """
+    if hasattr(r, "json"):
+        if isinstance(r.json, dict):
+            return r.json
+        return r.json()
+
+    c = r.content
+    try:
+        c = c.decode()
+    except Exception:
+        pass
+    return json.loads(c)
+
+
+def get_text_from_response(r):
+    """
+    Get a text response in a way that also works for very old request versions.
+
+    :type r: :class:`requests.Response
+    :param r: The server's response.
+    """
+    if hasattr(r, "text"):
+        return r.text
+
+    c = r.content
+    try:
+        c = c.decode()
+    except Exception:
+        pass
+    return c

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -169,3 +169,22 @@ def get_text_from_response(r):
     except Exception:
         pass
     return c
+
+
+def get_reason_from_response(r):
+    """
+    Get the status text.
+
+    :type r: :class:`requests.Response
+    :param r: The server's response.
+    """
+    # Very old requests version might not have the reason attribute.
+    if hasattr(r, "reason"):
+        c = r.reason
+    else:  # pragma: no cover
+        c = r.raw.reason
+
+    if hasattr(c, "encode"):
+        c = c.encode()
+
+    return c

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Py3k compatibility module
+ObsPy's compatibility layer.
+
+Includes things to easy dealing with Py2/Py3 differences as well as making
+it work with various versions of our dependencies.
 """
 from future.utils import PY2
 
@@ -121,7 +124,6 @@ def round_away(number):
     >>> round_away(-11.0)
     -11
     """
-
     floor = np.floor(number)
     ceil = np.ceil(number)
     if (floor != ceil) and (abs(number - floor) == abs(ceil - number)):


### PR DESCRIPTION
This PR fixes a couple of problems with very old versions of the `requests` and `lxml` packages. Mainly Debian Wheezy is affected.