### PR TITLE
fix docker Linux32 conda package builder

### DIFF
--- a/misc/installer/anaconda/LinuxCondaBuilder_32bit/Dockerfile
+++ b/misc/installer/anaconda/LinuxCondaBuilder_32bit/Dockerfile
@@ -5,13 +5,25 @@ MAINTAINER Lion Krischer
 RUN yum -y update || true
 RUN yum install curl gcc bzip2 tar
 
+# see below comment, conda>=4.3.27 does not work with CentOS 5 / glibc 2.5, so
+# use last conda version that works. Eventually CentOS 5 can be dropped, it is
+# already end-of-life. But currently the build still seems to work, so it
+# probably doesn't hurt to be nice to ancient Linux 32 bit boxes that might
+# still be encountered very sporadically.
 #RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -o miniconda.sh
-RUN curl https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86.sh -o miniconda.sh
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86.sh -o miniconda.sh
 
 ## Force installation.
 RUN yes yes | bash miniconda.sh -b -p /miniconda
 
-RUN /miniconda/bin/conda update --yes conda
+# Starting with conda==4.3.27, Anaconda drops support for CentOS 5 / glibc 2.5
+# and instead uses CentOS 6 / glibc 2.12 as minimum baseline.
+# So, to build against glibc 2.5 we need to fix the conda version to use.
+# See https://github.com/conda/conda/issues/6041#issuecomment-333215057
+RUN /miniconda/bin/conda install --yes 'conda<4.3.27'
+# Avoid accidentally updating to conda>=4.3.27 later on
+RUN /miniconda/bin/conda config --set auto_update_conda False
+RUN /miniconda/bin/conda config --set always_yes True
 RUN /miniconda/bin/conda install --yes conda-build anaconda-client jinja2
 
 RUN mkdir -p /temporary/obspy
@@ -19,9 +31,6 @@ COPY meta.yaml /temporary/obspy/meta.yaml
 
 # Tests can fail on occasion. We still want the image to be created.
 RUN /miniconda/bin/conda build --py 27 /temporary/obspy
-# 3.3 has some dependency conflicts. Maybe they get resolved in the future but
-# not that important otherwise.
-# RUN /miniconda/bin/conda build --py 33 /temporary/obspy
 RUN /miniconda/bin/conda build --py 34 /temporary/obspy
 RUN /miniconda/bin/conda build --py 35 /temporary/obspy
 RUN /miniconda/bin/conda build --py 36 /temporary/obspy

--- a/misc/installer/anaconda/LinuxCondaBuilder_32bit/Dockerfile
+++ b/misc/installer/anaconda/LinuxCondaBuilder_32bit/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Lion Krischer
 RUN yum -y update || true
 RUN yum install curl gcc bzip2 tar
 
-RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -o miniconda.sh
+#RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -o miniconda.sh
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86.sh -o miniconda.sh
 
 ## Force installation.
 RUN yes yes | bash miniconda.sh -b -p /miniconda

--- a/misc/installer/anaconda/LinuxCondaBuilder_64bit/Dockerfile
+++ b/misc/installer/anaconda/LinuxCondaBuilder_64bit/Dockerfile
@@ -6,12 +6,25 @@ MAINTAINER Lion Krischer
 RUN yum -y upgrade || true
 RUN yum install -y gcc tar bzip2
 
-RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+# see below comment, conda>=4.3.27 does not work with CentOS 5 / glibc 2.5, so
+# use last conda version that works. Eventually CentOS 5 can be dropped, it is
+# already end-of-life. But currently the build still seems to work, so it
+# probably doesn't hurt to be nice to ancient Linux 32 bit boxes that might
+# still be encountered very sporadically.
+#RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -o miniconda.sh
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86.sh -o miniconda.sh
 RUN chmod +x miniconda.sh
 
 RUN ./miniconda.sh -b -p /miniconda
 
-RUN /miniconda/bin/conda update --yes conda
+# Starting with conda==4.3.27, Anaconda drops support for CentOS 5 / glibc 2.5
+# and instead uses CentOS 6 / glibc 2.12 as minimum baseline.
+# So, to build against glibc 2.5 we need to fix the conda version to use.
+# See https://github.com/conda/conda/issues/6041#issuecomment-333215057
+RUN /miniconda/bin/conda install --yes 'conda<4.3.27'
+# Avoid accidentally updating to conda>=4.3.27 later on
+RUN /miniconda/bin/conda config --set auto_update_conda False
+RUN /miniconda/bin/conda config --set always_yes True
 RUN /miniconda/bin/conda install --yes conda-build anaconda-client jinja2
 
 RUN mkdir -p /temporary/obspy
@@ -19,7 +32,6 @@ COPY meta.yaml /temporary/obspy/meta.yaml
 
 # Tests can fail on occasion. We still want the image to be created.
 RUN /miniconda/bin/conda build --py 27 /temporary/obspy
-RUN /miniconda/bin/conda build --py 33 /temporary/obspy
 RUN /miniconda/bin/conda build --py 34 /temporary/obspy
 RUN /miniconda/bin/conda build --py 35 /temporary/obspy
 RUN /miniconda/bin/conda build --py 36 /temporary/obspy

--- a/misc/installer/anaconda/README.md
+++ b/misc/installer/anaconda/README.md
@@ -23,7 +23,11 @@ Once in a while its also a good idea to clean the `conda-bld` directory in the r
 
 ## For Linux Using Docker
 
-This must be done on a Linux with a fairly old `libc` version. We currently do it for `libc 2.12`, thus it is done in Docker containers.
+**NOTE:** Linux 64 bit conda packages are now in general built via conda-forge:
+https://github.com/conda-forge/obspy-feedstock/
+
+This must be done on a Linux with a fairly old `libc` version. We currently do
+it for `libc 2.5`, thus it is done in Docker containers (Centos5).
 
 Make sure Docker is installed and running (also that some space is left on your disc or boot2docker's VM!). Execute
 
@@ -31,7 +35,10 @@ Make sure Docker is installed and running (also that some space is left on your 
 $ ./build_conda_packages_linux.sh
 ```
 
-This will take a while but it will build packages for all Python versions on 64 and 32 bit. It will copy the final packages to `conda_builds` so as a last step you have to upload them from your local machine.
+This will take a while but it will build packages for all Python versions on 32
+bit (uncomment 64 bit section in build script if needed). It will copy the
+final packages to `conda_builds` so as a last step you have to upload them from
+your local machine.
 
 ```bash
 $ cd conda_builds
@@ -40,6 +47,9 @@ $ anaconda upload -u obspy linux-64/obspy*
 ```
 
 ## For OSX
+
+**NOTE:** OSX conda packages are now in general built via conda-forge:
+https://github.com/conda-forge/obspy-feedstock/
 
 On OSX just execute (from this directory)
 
@@ -56,4 +66,5 @@ $ anaconda upload -u obspy --channel docker --channel main obspy*
 
 ## For Windows
 
-Currently performed on AppVeyor using this: https://github.com/obspy/conda-builder
+**NOTE:** OSX conda packages are now in general built via conda-forge:
+https://github.com/conda-forge/obspy-feedstock/

--- a/misc/installer/anaconda/build_conda_packages_linux.sh
+++ b/misc/installer/anaconda/build_conda_packages_linux.sh
@@ -29,26 +29,26 @@ $DOCKER rmi obspy_conda_builder_32bit
 rm -f LinuxCondaBuilder_32bit/meta.yaml
 
 
-################################################################################
-### 64 bit
-
-# Dockerfiles only work with files in their directory structure
-cp obspy/meta.yaml LinuxCondaBuilder_64bit/meta.yaml
-
-ID=$RANDOM-$RANDOM-$RANDOM
-$DOCKER build -t obspy_conda_builder_64bit LinuxCondaBuilder_64bit
-
-sleep 10
-echo "Done building container!"
-
-# Cleanup potentially existing runs.
-$DOCKER kill conda_build_container || true
-$DOCKER rm conda_build_container || true
-# Ugly way to ensure a container is running to be able to copy something.
-$DOCKER run --name=conda_build_container -d obspy_conda_builder_64bit sleep 60
-$DOCKER cp conda_build_container:/miniconda/conda-bld/linux-64 $BUILD_DIR
-$DOCKER kill conda_build_container
-$DOCKER rm conda_build_container
-$DOCKER rmi obspy_conda_builder_64bit
-
-rm -f LinuxCondaBuilder_64bit/meta.yaml
+# ################################################################################
+# ### 64 bit
+#
+# # Dockerfiles only work with files in their directory structure
+# cp obspy/meta.yaml LinuxCondaBuilder_64bit/meta.yaml
+#
+# ID=$RANDOM-$RANDOM-$RANDOM
+# $DOCKER build -t obspy_conda_builder_64bit LinuxCondaBuilder_64bit
+#
+# sleep 10
+# echo "Done building container!"
+#
+# # Cleanup potentially existing runs.
+# $DOCKER kill conda_build_container || true
+# $DOCKER rm conda_build_container || true
+# # Ugly way to ensure a container is running to be able to copy something.
+# $DOCKER run --name=conda_build_container -d obspy_conda_builder_64bit sleep 60
+# $DOCKER cp conda_build_container:/miniconda/conda-bld/linux-64 $BUILD_DIR
+# $DOCKER kill conda_build_container
+# $DOCKER rm conda_build_container
+# $DOCKER rmi obspy_conda_builder_64bit
+#
+# rm -f LinuxCondaBuilder_64bit/meta.yaml

--- a/misc/installer/anaconda/obspy/meta.yaml
+++ b/misc/installer/anaconda/obspy/meta.yaml
@@ -1,5 +1,7 @@
-{% set version = "1.0.3" %}
-{% set sha256 = "7170c7427471f978f7a7b0fe61c2bfb7094c59b3859cd8d5d5bbae6380cc20a5" %}
+{% set version = "1.1.0rc6" %}
+{% set sha256 = "0a09a198bd48b32b445d9a307202a26d12f8f057a67ee836f483c6a88b423b4e" %}
+#{% set version = "1.1.0rc7.post0+27.g04bbbf2540.obspy.read.isf" %}
+#{% set sha256 = "25e6f44e9e13cf194a3010f1792702ad8a13cfc9b07fe0219bb0daa1a12df36d" %}
 
 package:
   name: obspy
@@ -7,8 +9,9 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  url: https://pypi.io/packages/source/o/obspy/obspy-1.0.3.zip
-  # url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
+  # url: https://pypi.io/packages/source/o/obspy/obspy-1.0.3.zip
+  #url: https://www.geophysik.uni-muenchen.de/~megies/obspy-1.1.0rc7.post0+27.g04bbbf2540.obspy.read.isf.zip
+  url: https://github.com/obspy/obspy/files/1391402/obspy-1.1.0rc6.zip
   sha256: {{ sha256 }}
 
 
@@ -27,7 +30,7 @@ requirements:
     - scipy
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     - lxml
     - sqlalchemy
     - requests
@@ -42,7 +45,7 @@ requirements:
     - scipy
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     - lxml
     - sqlalchemy
     - requests
@@ -56,7 +59,7 @@ test:
     - flake8
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     # there's a packaging problem with icu, see obspy/obspy#1677
     #- icu 58.*
   imports:

--- a/misc/installer/anaconda/obspy/meta.yaml
+++ b/misc/installer/anaconda/obspy/meta.yaml
@@ -1,7 +1,5 @@
-{% set version = "1.1.0rc6" %}
-{% set sha256 = "0a09a198bd48b32b445d9a307202a26d12f8f057a67ee836f483c6a88b423b4e" %}
-#{% set version = "1.1.0rc7.post0+27.g04bbbf2540.obspy.read.isf" %}
-#{% set sha256 = "25e6f44e9e13cf194a3010f1792702ad8a13cfc9b07fe0219bb0daa1a12df36d" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "ef48b4e52a8166c35c46775b523899ffaa00658018822103e1ad9f5008050d61" %}
 
 package:
   name: obspy
@@ -9,9 +7,7 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  # url: https://pypi.io/packages/source/o/obspy/obspy-1.0.3.zip
-  #url: https://www.geophysik.uni-muenchen.de/~megies/obspy-1.1.0rc7.post0+27.g04bbbf2540.obspy.read.isf.zip
-  url: https://github.com/obspy/obspy/files/1391402/obspy-1.1.0rc6.zip
+  url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
   sha256: {{ sha256 }}
 
 


### PR DESCRIPTION
One problem seems to be current Miniconda3, it ends up in GLIBC version errors. But even with this change, inside the build container, conda-build errors out.