### PR TITLE
Routing to fdsnws sub domains

### DIFF
--- a/obspy/clients/fdsn/routing/eidaws_routing_client.py
+++ b/obspy/clients/fdsn/routing/eidaws_routing_client.py
@@ -191,7 +191,7 @@ class EIDAWSRoutingClient(BaseRoutingClient):
             if not line:
                 continue
             if "http" in line and "fdsnws" in line:
-                current_key = line[:line.find("/fdsnws")]
+                current_key = line[:line.rfind("/fdsnws")]
                 continue
             split[current_key].append(line)
 

--- a/obspy/clients/fdsn/routing/federator_routing_client.py
+++ b/obspy/clients/fdsn/routing/federator_routing_client.py
@@ -172,7 +172,7 @@ class FederatorRoutingClient(BaseRoutingClient):
             if "http://" in line:
                 if key not in line:
                     continue
-                current_key = line[len(key) + 1:line.find("/fdsnws")]
+                current_key = line[len(key) + 1:line.rfind("/fdsnws")]
                 continue
             # Anything before the first data center can be ignored.
             if current_key is None:

--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -97,9 +97,9 @@ AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59
         self.assertEqual(
             EIDAWSRoutingClient._split_routing_response(data),
             {"http://eida.gein.noa.gr":
-                 "HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59",
+                "HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59",
              "http://fdsnws.raspberryshakedata.com":
-                 "AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59"})
+                "AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59"})
 
     def test_non_allowed_parameters(self):
         with self.assertRaises(ValueError) as e:

--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -86,6 +86,21 @@ NU * * * 2017-01-01T00:00:00 2017-01-01T00:10:00
                 "http://geofon.gfz-potsdam.de": (
                     "NU * * * 2017-01-01T00:00:00 2017-01-01T00:10:00")})
 
+    def test_response_splitting_fdsnws_subdomain(self):
+        data = """
+http://eida.gein.noa.gr/fdsnws/station/1/
+HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59
+
+http://fdsnws.raspberryshakedata.com/fdsnws/station/1/
+AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59
+        """
+        self.assertEqual(
+            EIDAWSRoutingClient._split_routing_response(data),
+            {"http://eida.gein.noa.gr":
+                 "HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59",
+             "http://fdsnws.raspberryshakedata.com":
+                 "AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59"})
+
     def test_non_allowed_parameters(self):
         with self.assertRaises(ValueError) as e:
             self.client.get_waveforms(

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -77,6 +77,26 @@ AC PUK -- HHE 2009-05-29T00:00:00 2009-12-22T00:00:00
         self.assertEqual(e.exception.args[0],
                          "Service must be 'dataselect' or 'station'.")
 
+    def test_response_splitting_fdsnws_subdomain(self):
+        data = """
+DATACENTER=NOA,http://bbnet.gein.noa.gr/HL/
+DATASELECTSERVICE=http://eida.gein.noa.gr/fdsnws/dataselect/1/
+STATIONSERVICE=http://eida.gein.noa.gr/fdsnws/station/1/
+HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59
+
+DATACENTER=RASPISHAKE,http://raspberryshake.net/
+DATASELECTSERVICE=http://fdsnws.raspberryshakedata.com/fdsnws/dataselect/1/
+STATIONSERVICE=http://fdsnws.raspberryshakedata.com/fdsnws/station/1/
+EVENTSERVICE=http://fdsnws.raspberryshakedata.com/fdsnws/event/1/
+AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59
+        """
+        self.assertEqual(
+            FederatorRoutingClient._split_routing_response(data, "station"),
+            {"http://eida.gein.noa.gr":
+                "HP LTHK * * 2017-10-20T00:00:00 2599-12-31T23:59:59",
+             "http://fdsnws.raspberryshakedata.com":
+                 "AM RA14E * * 2017-10-20T00:00:00 2599-12-31T23:59:59"})
+
     def test_get_waveforms(self):
         """
         This just dispatches to the get_waveforms_bulk() method - so no need


### PR DESCRIPTION
Fixes #1954.

Discovered as at least the IRIS federator now also routes to the raspberryshake fdsnws service. I also applied the same fix to the eida router as it was wrong in both.