### PR TITLE
Improve LocalNRL/RemoteNRL check in NRL

### DIFF
--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -23,7 +23,8 @@ import warnings
 import requests
 
 import obspy
-from obspy.core.compatibility import configparser, get_text_from_response
+from obspy.core.compatibility import (
+    configparser, get_text_from_response, urlparse)
 from obspy.core.inventory.util import _textwrap
 
 
@@ -45,7 +46,8 @@ class NRL(object):
     def __new__(cls, root=None):
         # root provided and it's no web URL
         if root:
-            if root.startwith('http://') or root.startwith('https://'):
+            scheme = urlparse(root).scheme
+            if scheme in ('http', 'https'):
                 return super(NRL, cls).__new__(RemoteNRL)
             # Check if it's really a folder on the file-system.
             if not os.path.isdir(root):

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -52,7 +52,7 @@ class NRL(object):
             # Check if it's really a folder on the file-system.
             if not os.path.isdir(root):
                 msg = ("Provided path '{}' seems to be a local file path "
-                       "but directory does not exist.").format(
+                       "but the directory does not exist.").format(
                             root)
                 raise ValueError(msg)
             return super(NRL, cls).__new__(LocalNRL)

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -23,8 +23,7 @@ import warnings
 import requests
 
 import obspy
-from obspy.core.compatibility import (
-    configparser, get_text_from_response, urlparse)
+from obspy.core.compatibility import configparser, get_text_from_response
 from obspy.core.inventory.util import _textwrap
 
 
@@ -46,15 +45,15 @@ class NRL(object):
     def __new__(cls, root=None):
         # root provided and it's no web URL
         if root:
-            scheme = urlparse(root).scheme
-            if not scheme or scheme == 'file':
-                # Check if it's really a folder on the file-system.
-                if not os.path.isdir(root):
-                    msg = ("Provided path '{}' seems to be a local file path "
-                           "but directory does not exist.").format(
-                                root)
-                    raise OSError(msg)
-                return super(NRL, cls).__new__(LocalNRL)
+            if root.startwith('http://') or root.startwith('https://'):
+                return super(NRL, cls).__new__(RemoteNRL)
+            # Check if it's really a folder on the file-system.
+            if not os.path.isdir(root):
+                msg = ("Provided path '{}' seems to be a local file path "
+                       "but directory does not exist.").format(
+                            root)
+                raise OSError(msg)
+            return super(NRL, cls).__new__(LocalNRL)
         # Otherwise delegate to the remote NRL client to deal with all kinds
         # of remote resources (currently only HTTP).
         return super(NRL, cls).__new__(RemoteNRL)

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -54,7 +54,7 @@ class NRL(object):
                 msg = ("Provided path '{}' seems to be a local file path "
                        "but directory does not exist.").format(
                             root)
-                raise OSError(msg)
+                raise ValueError(msg)
             return super(NRL, cls).__new__(LocalNRL)
         # Otherwise delegate to the remote NRL client to deal with all kinds
         # of remote resources (currently only HTTP).

--- a/obspy/clients/nrl/tests/test_nrl.py
+++ b/obspy/clients/nrl/tests/test_nrl.py
@@ -107,6 +107,14 @@ Select the sensor manufacturer (20 items):
   'REF TEK', 'Sercel/Mark Products', 'SolGeo',
   'Sprengnether (now Eentec)', 'Streckeisen'""".strip())
 
+    def test_error_handling_invalid_path(self):
+        with self.assertRaises(ValueError) as err:
+            NRL("/some/really/random/path")
+        self.assertEqual(
+            err.exception.args[0],
+            "Provided path '/some/really/random/path' seems to be a local "
+            "file path but the directory does not exist.")
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(NRLTestCase, 'test')


### PR DESCRIPTION
Looks like we might have an issue with `LocalNRL`:

No time to double check right now..

```python
In [1]: from obspy.clients.nrl import LocalNRL
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-6c64f9413b71> in <module>()
----> 1 from obspy.clients.nrl import LocalNRL

ImportError: cannot import name 'LocalNRL'

In [2]: from obspy.clients.nrl.client import LocalNRL

In [3]: nrl = LocalNRL('/home/megies/Documents/work/2017_baku/downloads/IRIS-NRL')

In [4]: nrl.get_response( # doctest: +SKIP
   ...:     sensor_keys=['Streckeisen', 'STS-1', '360 seconds'],
   ...:     datalogger_keys=['REF TEK', 'RT 130 & 130-SMA', '1', '200'])
   ...:     
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-af6b46893846> in <module>()
      1 nrl.get_response( # doctest: +SKIP
      2     sensor_keys=['Streckeisen', 'STS-1', '360 seconds'],
----> 3     datalogger_keys=['REF TEK', 'RT 130 & 130-SMA', '1', '200'])
      4 

~/anaconda/envs/1.1.0py3/lib/python3.6/site-packages/obspy/clients/nrl/client.py in get_response(self, datalogger_keys, sensor_keys)
    201             Stage 10: Coefficients... from COUNTS to COUNTS, gain: 1
    202         """
--> 203         dl_resp = self.get_datalogger_response(datalogger_keys)
    204         sensor_resp = self.get_sensor_response(sensor_keys)
    205 

~/anaconda/envs/1.1.0py3/lib/python3.6/site-packages/obspy/clients/nrl/client.py in get_datalogger_response(self, datalogger_keys)
    146         :rtype: :class:`~obspy.core.inventory.response.Response`
    147         """
--> 148         datalogger = self.dataloggers
    149         for key in datalogger_keys:
    150             datalogger = datalogger[key]

AttributeError: 'RemoteNRL' object has no attribute 'dataloggers'

In [5]: import obspy

In [6]: obspy.__version__
Out[6]: '1.1.0rc7.post0+27.g04bbbf2540.obspy.read.isf'
```

Also, I think that either..
 - `NRL` should have a kwarg to access a local folder for convenience, or
 - `LocalNRL` should be added to `clients/nrl/__init__.py`