### PR TITLE
Fix URLs with invalid symbols

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -55,6 +55,8 @@ master: (doi: 10.5281/zenodo.165135)
    * Bode plots can now optionally plot the phase in degrees (see #1763).
    * `Stream.select()` now also works on the component level if channels only
      have one letter (see #1847).
+   * Now strips all invalid characters from the temporary filenames used for
+     downloading data using the `read_X()` methods (see #1958).
  - obspy.clients.earthworm:
    * Much faster trace unpacking (see #1762).
  - obspy.clients.fdsn:

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -32,7 +32,8 @@ import numpy as np
 
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, _read_from_plugin
-from obspy.core.util.base import ENTRY_POINTS, download_to_file
+from obspy.core.util.base import (ENTRY_POINTS, download_to_file,
+                                  sanitize_filename)
 from obspy.core.util.decorator import (map_example_filename, rlock,
                                        uncompress_file)
 from obspy.core.util.misc import buffered_load_entry_point
@@ -825,7 +826,7 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
         # URL
         # extract extension if any
         suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
-        with NamedTemporaryFile(suffix=suffix) as fh:
+        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=pathname_or_url, filename_or_buffer=fh)
             catalog = _read(fh.name, format, **kwargs)
         return catalog

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -23,7 +23,7 @@ import warnings
 import obspy
 from obspy.core.util.base import (ENTRY_POINTS, ComparingObject,
                                   _read_from_plugin, NamedTemporaryFile,
-                                  download_to_file)
+                                  download_to_file, sanitize_filename)
 from obspy.core.util.decorator import map_example_filename
 from obspy.core.util.misc import buffered_load_entry_point
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
@@ -91,7 +91,7 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         # extract extension if any
         suffix = \
             os.path.basename(path_or_file_object).partition('.')[2] or '.tmp'
-        with NamedTemporaryFile(suffix=suffix) as fh:
+        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=path_or_file_object, filename_or_buffer=fh)
             return read_inventory(fh.name, format=format)
     return _read_from_plugin("inventory", path_or_file_object,

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -29,7 +29,8 @@ from obspy.core.trace import Trace
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
-                                  _read_from_plugin, download_to_file)
+                                  _read_from_plugin, download_to_file,
+                                  sanitize_filename)
 from obspy.core.util.decorator import (map_example_filename,
                                        raise_if_masked, uncompress_file)
 from obspy.core.util.misc import get_window_times, buffered_load_entry_point
@@ -224,7 +225,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
         # some URL
         # extract extension if any
         suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
-        with NamedTemporaryFile(suffix=suffix) as fh:
+        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=pathname_or_url, filename_or_buffer=fh)
             st.extend(_read(fh.name, format, headonly, **kwargs).traces)
     else:

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -9,7 +9,7 @@ import unittest
 
 from obspy.core.compatibility import mock
 from obspy.core.util.base import (NamedTemporaryFile, get_dependency_version,
-                                  download_to_file)
+                                  download_to_file, sanitize_filename)
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
 from requests import HTTPError
@@ -108,6 +108,16 @@ class UtilBaseTestCase(unittest.TestCase):
                 self.assertEqual(e.exception.args[0],
                                  "%s HTTP Error: %s for url: %s" %
                                  (code, reason, url))
+
+    def test_sanitize_filename(self):
+        self.assertEqual(sanitize_filename("example.mseed"),
+                         "example.mseed")
+        self.assertEqual(sanitize_filename("Example.mseed"),
+                         "Example.mseed")
+        self.assertEqual(sanitize_filename("example.mseed?raw=True"),
+                         "example.mseedrawTrue")
+        self.assertEqual(sanitize_filename("Example.mseed?raw=true"),
+                         "Example.mseedrawtrue")
 
 
 def suite():

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -536,7 +536,7 @@ def _get_deprecated_argument_action(old_name, new_name, real_action='store'):
 
 def sanitize_filename(filename):
     """
-    Modified by Django's slugify functions.
+    Adapted from Django's slugify functions.
 
     :param filename: The filename.
     """

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -16,8 +16,10 @@ import doctest
 import inspect
 import io
 import os
+import re
 import sys
 import tempfile
+import unicodedata
 from collections import OrderedDict
 
 import numpy as np
@@ -530,6 +532,24 @@ def _get_deprecated_argument_action(old_name, new_name, real_action='store'):
                 setattr(namespace, self.dest, False)
 
     return _Action
+
+
+def sanitize_filename(filename):
+    """
+    Modified by Django's slugify functions.
+
+    :param filename: The filename.
+    """
+    try:
+        filename = filename.decode()
+    except:
+        pass
+
+    value = unicodedata.normalize('NFKD', filename).encode(
+        'ascii', 'ignore').decode('ascii')
+    # In constrast to django we allow dots and don't lowercase.
+    value = re.sub(r'[^\w\.\s-]', '', value).strip()
+    return re.sub(r'[-\s]+', '-', value)
 
 
 def download_to_file(url, filename_or_buffer, chunk_size=1024):


### PR DESCRIPTION
We used the URLs to download files with the `read_X()` methods to determine the suffix of the temporary files. This could result in invalid characters being part of the filenames. This should be fixed with this PR.