### PR TITLE
avoid a wrong numpy cast to `object` which raises a deprecation warning

### DIFF
--- a/obspy/taup/taup_geo.py
+++ b/obspy/taup/taup_geo.py
@@ -197,7 +197,7 @@ def add_geo_to_arrivals(arrivals, source_latitude_in_deg,
                     radii = rplanet - arrival.path['depth']
                     rmean = np.sqrt(radii[1:] * radii[:-1])
                     diff_dists = rmean * np.diff(arrival.path['dist'])
-                    npts_extra = np.floor(diff_dists / mindist).astype(int)
+                    npts_extra = np.floor(diff_dists / mindist).astype(np.int)
 
                     # count number of extra points and initialize array
                     npts_old = len(arrival.path)


### PR DESCRIPTION
in later indexing and might raise an exception on newer numpy in the
future

See https://ci.appveyor.com/project/obspy/obspy/build/1.0.5436-master/job/2i8f0qtuciuttf1a#L506

```
obspy\taup\taup_geo.py:230: DeprecationWarning: object of type <type 'float'> cannot be safely interpreted as an integer.
  npts_new + 2)[1: -1]
```