### PR TITLE
Rewrite tests that failed because of line-end chars.

### DIFF
--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -149,8 +149,9 @@ class FutureUsageTestCase(unittest.TestCase):
         for filename in get_all_py_files():
             if _match_exceptions(filename, exceptions):
                 continue
-            with codecs.open(filename, "r", encoding="utf-8") as fh:
-                content = fh.read()
+            with open(filename, "rb") as fh:
+                content = fh.read().decode("utf-8").splitlines()
+                content = "\n".join(content)
 
             if re.search(future_imports_pattern, content) is None:
                 failures.append("File '%s' misses imports: %s" %

--- a/obspy/io/cnv/tests/test_core.py
+++ b/obspy/io/cnv/tests/test_core.py
@@ -33,23 +33,27 @@ class CNVTestCase(unittest.TestCase):
         # read expected OBS file output
         filename = os.path.join(self.datapath, "obspyck_20141020150701.cnv")
         with open(filename, "rb") as fh:
-            expected = fh.read().decode()
+            expected = fh.read().decode().splitlines()
 
         # write via plugin
         with NamedTemporaryFile() as tf:
             cat.write(tf, format="CNV")
             tf.seek(0)
-            got = tf.read().decode()
+            got = tf.read().decode().splitlines()
 
-        self.assertEqual(expected, got)
+        self.assertEqual(len(expected), len(got))
+        for d1, d2 in zip(expected, got):
+            self.assertEqual(d1, d2)
 
         # write manually
         with NamedTemporaryFile() as tf:
             _write_cnv(cat, tf)
             tf.seek(0)
-            got = tf.read().decode()
+            got = tf.read().decode().splitlines()
 
-        self.assertEqual(expected, got)
+        self.assertEqual(len(expected), len(got))
+        for d1, d2 in zip(expected, got):
+            self.assertEqual(d1, d2)
 
 
 def suite():

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -69,7 +69,7 @@ class NLLOCTestCase(unittest.TestCase):
             got = tf.read().decode().splitlines()
 
         self.assertEqual(len(expected), len(got))
-        for d1,d2 in zip(expected, got):
+        for d1, d2 in zip(expected, got):
             self.assertEqual(d1, d2)
 
         # write manually

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -60,23 +60,27 @@ class NLLOCTestCase(unittest.TestCase):
         # read expected OBS file output
         filename = get_example_file("nlloc.obs")
         with open(filename, "rb") as fh:
-            expected = fh.read().decode()
+            expected = fh.read().decode().splitlines()
 
         # write via plugin
         with NamedTemporaryFile() as tf:
             cat.write(tf, format="NLLOC_OBS")
             tf.seek(0)
-            got = tf.read().decode()
+            got = tf.read().decode().splitlines()
 
-        self.assertEqual(expected, got)
+        self.assertEqual(len(expected), len(got))
+        for d1,d2 in zip(expected, got):
+            self.assertEqual(d1, d2)
 
         # write manually
         with NamedTemporaryFile() as tf:
             write_nlloc_obs(cat, tf)
             tf.seek(0)
-            got = tf.read().decode()
+            got = tf.read().decode().splitlines()
 
-        self.assertEqual(expected, got)
+        self.assertEqual(len(expected), len(got))
+        for d1, d2 in zip(expected, got):
+            self.assertEqual(d1, d2)
 
     def test_read_nlloc_hyp(self):
         """

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -58,11 +58,7 @@ class EventTestCase(unittest.TestCase):
             if validate:
                 self.assertTrue(_validate_quakeml(tf.name))
             filepath_cmp = os.path.join(self.path, quakeml_file)
-            tf.seek(0)
-            dat1 = tf.read().decode("utf-8").splitlines()
-            with open(filepath_cmp, 'rb') as f:
-                dat2 = f.read().decode("utf-8").splitlines()
-            self.compare_list_of_lines(dat1, dat2)
+            self._compare(tf, filepath_cmp)
 
     def cmp_write_xslt_file(self, quakeml_file, sc3ml_file, validate=True,
                             path=None):
@@ -82,11 +78,7 @@ class EventTestCase(unittest.TestCase):
             if validate:
                 self.assertTrue(validate_sc3ml(tf.name))
             filepath_cmp = os.path.join(self.path, sc3ml_file)
-            tf.seek(0)
-            dat1 = tf.read().decode("utf-8").splitlines()
-            with open(filepath_cmp, 'rb') as f:
-                dat2 = f.read().decode("utf-8").splitlines()
-            self.compare_list_of_lines(dat1, dat2)
+            self._compare(tf, filepath_cmp)
 
     def test_sc3ml_versions(self):
         """
@@ -300,11 +292,7 @@ class EventTestCase(unittest.TestCase):
             catalog.write(tf, format='SC3ML', validate=True)
             filepath_cmp = \
                 os.path.join(self.path, 'qml-example-1.2-RC3_write.sc3ml')
-            tf.seek(0)
-            dat1 = tf.read().decode("utf-8").splitlines()
-            with open(filepath_cmp, 'rb') as f:
-                dat2 = f.read().decode("utf-8").splitlines()
-            self.compare_list_of_lines(dat1, dat2)
+            self._compare(tf, filepath_cmp)
 
     def test_write_remove_events(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3.xml')
@@ -315,11 +303,7 @@ class EventTestCase(unittest.TestCase):
                           event_removal=True)
             filepath_cmp = \
                 os.path.join(self.path, 'qml-example-1.2-RC3_no_events.sc3ml')
-            tf.seek(0)
-            dat1 = tf.read().decode("utf-8").splitlines()
-            with open(filepath_cmp, 'rb') as f:
-                dat2 = f.read().decode("utf-8").splitlines()
-            self.compare_list_of_lines(dat1, dat2)
+            self._compare(tf, filepath_cmp)
 
     def test_read_and_write(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3_write.sc3ml')
@@ -327,15 +311,15 @@ class EventTestCase(unittest.TestCase):
 
         with NamedTemporaryFile() as tf:
             catalog.write(tf, format='SC3ML', validate=True)
-            tf.seek(0)
-            dat1 = tf.read().decode("utf-8").splitlines()
-            with open(filename, 'rb') as f:
-                dat2 = f.read().decode("utf-8").splitlines()
-            self.compare_list_of_lines(dat1, dat2)
+            self._compare(tf, filename)
 
-    def compare_list_of_lines(self, list1, list2):
-        self.assertEqual(len(list1), len(list2))
-        for d1, d2 in zip(list1, list2):
+    def _compare(self, tf, filename):
+        tf.seek(0)
+        dat1 = tf.read().decode("utf-8").splitlines()
+        with open(filename, 'rb') as f:
+            dat2 = f.read().decode("utf-8").splitlines()
+        self.assertEqual(len(dat1), len(dat2))
+        for d1, d2 in zip(dat1, dat2):
             self.assertEqual(d1, d2)
 
 

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -338,6 +338,7 @@ class EventTestCase(unittest.TestCase):
         for d1, d2 in zip(list1, list2):
             self.assertEqual(d1, d2)
 
+
 def suite():
     return unittest.makeSuite(EventTestCase, "test")
 

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -15,7 +15,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import filecmp
 import os
 import unittest
 
@@ -59,7 +58,13 @@ class EventTestCase(unittest.TestCase):
             if validate:
                 self.assertTrue(_validate_quakeml(tf.name))
             filepath_cmp = os.path.join(self.path, quakeml_file)
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+            tf.seek(0)
+            dat1 = tf.read().decode("utf-8").splitlines()
+            with open(filepath_cmp, 'rb') as f:
+                dat2 = f.read().decode("utf-8").splitlines()
+            self.assertEqual(len(dat1), len(dat2))
+            for d1, d2 in zip(dat1, dat2):
+                self.assertEqual(d1, d2)
 
     def cmp_write_xslt_file(self, quakeml_file, sc3ml_file, validate=True,
                             path=None):
@@ -79,7 +84,14 @@ class EventTestCase(unittest.TestCase):
             if validate:
                 self.assertTrue(validate_sc3ml(tf.name))
             filepath_cmp = os.path.join(self.path, sc3ml_file)
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+            tf.seek(0)
+            dat1 = tf.read().decode("utf-8").splitlines()
+            with open(filepath_cmp, 'rb') as f:
+                dat2 = f.read().decode("utf-8").splitlines()
+            self.assertEqual(len(dat1), len(dat2))
+            for d1, d2 in zip(dat1, dat2):
+                self.assertEqual(d1, d2)
+
 
     def test_sc3ml_versions(self):
         """
@@ -293,7 +305,13 @@ class EventTestCase(unittest.TestCase):
             catalog.write(tf, format='SC3ML', validate=True)
             filepath_cmp = \
                 os.path.join(self.path, 'qml-example-1.2-RC3_write.sc3ml')
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+            tf.seek(0)
+            dat1 = tf.read().decode("utf-8").splitlines()
+            with open(filepath_cmp, 'rb') as f:
+                dat2 = f.read().decode("utf-8").splitlines()
+            self.assertEqual(len(dat1), len(dat2))
+            for d1, d2 in zip(dat1, dat2):
+                self.assertEqual(d1, d2)
 
     def test_write_remove_events(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3.xml')
@@ -304,7 +322,13 @@ class EventTestCase(unittest.TestCase):
                           event_removal=True)
             filepath_cmp = \
                 os.path.join(self.path, 'qml-example-1.2-RC3_no_events.sc3ml')
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+            tf.seek(0)
+            dat1 = tf.read().decode("utf-8").splitlines()
+            with open(filepath_cmp, 'rb') as f:
+                dat2 = f.read().decode("utf-8").splitlines()
+            self.assertEqual(len(dat1), len(dat2))
+            for d1, d2 in zip(dat1, dat2):
+                self.assertEqual(d1, d2)
 
     def test_read_and_write(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3_write.sc3ml')
@@ -312,7 +336,13 @@ class EventTestCase(unittest.TestCase):
 
         with NamedTemporaryFile() as tf:
             catalog.write(tf, format='SC3ML', validate=True)
-            self.assertTrue(filecmp.cmp(filename, tf.name))
+            tf.seek(0)
+            dat1 = tf.read().decode("utf-8").splitlines()
+            with open(filename, 'rb') as f:
+                dat2 = f.read().decode("utf-8").splitlines()
+            self.assertEqual(len(dat1), len(dat2))
+            for d1, d2 in zip(dat1, dat2):
+                self.assertEqual(d1, d2)
 
 
 def suite():

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -62,9 +62,7 @@ class EventTestCase(unittest.TestCase):
             dat1 = tf.read().decode("utf-8").splitlines()
             with open(filepath_cmp, 'rb') as f:
                 dat2 = f.read().decode("utf-8").splitlines()
-            self.assertEqual(len(dat1), len(dat2))
-            for d1, d2 in zip(dat1, dat2):
-                self.assertEqual(d1, d2)
+            self.compare_list_of_lines(dat1, dat2)
 
     def cmp_write_xslt_file(self, quakeml_file, sc3ml_file, validate=True,
                             path=None):
@@ -88,9 +86,7 @@ class EventTestCase(unittest.TestCase):
             dat1 = tf.read().decode("utf-8").splitlines()
             with open(filepath_cmp, 'rb') as f:
                 dat2 = f.read().decode("utf-8").splitlines()
-            self.assertEqual(len(dat1), len(dat2))
-            for d1, d2 in zip(dat1, dat2):
-                self.assertEqual(d1, d2)
+            self.compare_list_of_lines(dat1, dat2)
 
     def test_sc3ml_versions(self):
         """
@@ -308,9 +304,7 @@ class EventTestCase(unittest.TestCase):
             dat1 = tf.read().decode("utf-8").splitlines()
             with open(filepath_cmp, 'rb') as f:
                 dat2 = f.read().decode("utf-8").splitlines()
-            self.assertEqual(len(dat1), len(dat2))
-            for d1, d2 in zip(dat1, dat2):
-                self.assertEqual(d1, d2)
+            self.compare_list_of_lines(dat1, dat2)
 
     def test_write_remove_events(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3.xml')
@@ -325,9 +319,7 @@ class EventTestCase(unittest.TestCase):
             dat1 = tf.read().decode("utf-8").splitlines()
             with open(filepath_cmp, 'rb') as f:
                 dat2 = f.read().decode("utf-8").splitlines()
-            self.assertEqual(len(dat1), len(dat2))
-            for d1, d2 in zip(dat1, dat2):
-                self.assertEqual(d1, d2)
+            self.compare_list_of_lines(dat1, dat2)
 
     def test_read_and_write(self):
         filename = os.path.join(self.path, 'qml-example-1.2-RC3_write.sc3ml')
@@ -339,10 +331,12 @@ class EventTestCase(unittest.TestCase):
             dat1 = tf.read().decode("utf-8").splitlines()
             with open(filename, 'rb') as f:
                 dat2 = f.read().decode("utf-8").splitlines()
-            self.assertEqual(len(dat1), len(dat2))
-            for d1, d2 in zip(dat1, dat2):
-                self.assertEqual(d1, d2)
+            self.compare_list_of_lines(dat1, dat2)
 
+    def compare_list_of_lines(self, list1, list2):
+        self.assertEqual(len(list1), len(list2))
+        for d1, d2 in zip(list1, list2):
+            self.assertEqual(d1, d2)
 
 def suite():
     return unittest.makeSuite(EventTestCase, "test")

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -92,7 +92,6 @@ class EventTestCase(unittest.TestCase):
             for d1, d2 in zip(dat1, dat2):
                 self.assertEqual(d1, d2)
 
-
     def test_sc3ml_versions(self):
         """
         Test multiple schema versions


### PR DESCRIPTION
Thank your for contributing to ObsPy!

### What does this PR do?
Resolves some line-end chars failures in tests. The errors might only arise when git cloning the repo.

### Why was it initiated?  Any relevant Issues?
e.g. http://tests.obspy.org/89313/

### PR Checklist
- [ ] All tests still pass.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .

