### PR TITLE
Adding .gitattributes to force LF line endings in text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This is an alternative to  #1963. It basically forces git to treat all text files with LF line endings. Requires git >= 2.10 to really work but should not do any harm with older gits.

To activate it:

```bash
git rm --cached -r .  # Remove every file from git's index.
git reset --hard      # Rewrite git's index to pick up all the new line endings.
```
