### PR TITLE
fix io.shapefile for pyshp version 1.2.11

### DIFF
--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -18,7 +18,7 @@ try:
 except ImportError as e:
     HAS_PYSHP = False
     PYSHP_VERSION = None
-    PYSHP_VERSION_AT_LEAST_1_2_12 = False
+    PYSHP_VERSION_AT_LEAST_1_2_11 = False
     IMPORTERROR_MSG = str(e) + (
         ". ObsPy's write support for shapefiles requires the 'pyshp' module "
         "to be installed in addition to the general ObsPy dependencies.")
@@ -29,9 +29,9 @@ else:
                                  shapefile.__version__.split('.')))
     except AttributeError:
         PYSHP_VERSION = None
-    PYSHP_VERSION_AT_LEAST_1_2_12 = PYSHP_VERSION >= [1, 2, 12]
+    PYSHP_VERSION_AT_LEAST_1_2_11 = PYSHP_VERSION >= [1, 2, 11]
 PYSHP_VERSION_WARNING = (
-    'pyshp versions < 1.2.12 are buggy, e.g. in writing numerical values to '
+    'pyshp versions < 1.2.11 are buggy, e.g. in writing numerical values to '
     'the dbf table, so e.g. timestamp float values might lack proper '
     'precision. You should update to a newer pyshp version.')
 
@@ -295,8 +295,8 @@ def _add_record(writer, feature):
     values = []
     for key, type_, width, precision in writer.fields:
         value = feature.get(key)
-        # various hacks for old pyshp < 1.2.12
-        if not PYSHP_VERSION_AT_LEAST_1_2_12:
+        # various hacks for old pyshp < 1.2.11
+        if not PYSHP_VERSION_AT_LEAST_1_2_11:
             if type_ == 'C':
                 # mimick pyshp 1.2.12 behavior of putting 'None' in string
                 # fields for value of `None`

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -11,7 +11,7 @@ import warnings
 from obspy import read_events, read_inventory
 from obspy.core.util.misc import TemporaryWorkingDirectory
 from obspy.io.shapefile.core import (
-    _write_shapefile, HAS_PYSHP, PYSHP_VERSION_AT_LEAST_1_2_12,
+    _write_shapefile, HAS_PYSHP, PYSHP_VERSION_AT_LEAST_1_2_11,
     PYSHP_VERSION_WARNING)
 
 if HAS_PYSHP:
@@ -104,7 +104,7 @@ def _assert_records_and_fields(got_fields, got_records, expected_fields,
             # on older pyshp <=1.2.10 date fields don't get cast to
             # datetime.date on reading..
             field_type = field[1]
-            if not PYSHP_VERSION_AT_LEAST_1_2_12:
+            if not PYSHP_VERSION_AT_LEAST_1_2_11:
                 if field_type == 'D':
                     if got == 'None':
                         got = None
@@ -249,7 +249,7 @@ class ShapefileTestCase(unittest.TestCase):
                     continue
                 break
             else:
-                if not PYSHP_VERSION_AT_LEAST_1_2_12:
+                if not PYSHP_VERSION_AT_LEAST_1_2_11:
                     raise AssertionError('pyshape version warning not shown')
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("inventory" + suffix))
@@ -279,7 +279,7 @@ class ShapefileTestCase(unittest.TestCase):
                     continue
                 break
             else:
-                if not PYSHP_VERSION_AT_LEAST_1_2_12:
+                if not PYSHP_VERSION_AT_LEAST_1_2_11:
                     raise AssertionError('pyshape version warning not shown')
             for suffix in SHAPEFILE_SUFFIXES:
                 self.assertTrue(os.path.isfile("inventory" + suffix))


### PR DESCRIPTION
Should fix io.shapefile for pyshp version 1.2.11, at least works locally now for 1.2.10, 1.2.11 and current 1.2.12