### PR TITLE
fix linalg warning in rotate (determinant)

### DIFF
--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -21,6 +21,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import warnings
 from math import cos, sin, radians
 
 import numpy as np
@@ -216,10 +217,14 @@ def rotate2zne(data_1, azimuth_1, dip_1, data_2, azimuth_2, dip_2, data_3,
     # Determinant gives the volume change of a unit cube going from one
     # basis to the next. It should neither be too small nor to large. These
     # here are arbitrary limits.
-    if not (1E-6 < abs(np.linalg.det(m)) < 1E6):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore',
+                                '.*invalid value encountered in det.*')
+        det = np.linalg.det(m)
+    if not (1E-6 < abs(det) < 1E6):
         raise ValueError("The given directions are not linearly independent, "
                          "at least within numerical precision. Determinant "
-                         "of the base change matrix: %g" % np.linalg.det(m))
+                         "of the base change matrix: %g" % det)
 
     if not inverse:
         m = np.linalg.inv(m)


### PR DESCRIPTION
Just suppresses a linalg warning in test run (and also when using that functionality in real world).