### PR TITLE
fix writing QuakeML when a quantities' error is None and not of type QuantityError

### DIFF
--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1107,10 +1107,11 @@ class Pickler(object):
             return
         subelement = etree.Element(tag)
         self._str(quantity, subelement, 'value')
-        self._str(error.uncertainty, subelement, 'uncertainty')
-        self._str(error.lower_uncertainty, subelement, 'lowerUncertainty')
-        self._str(error.upper_uncertainty, subelement, 'upperUncertainty')
-        self._str(error.confidence_level, subelement, 'confidenceLevel')
+        if error is not None:
+            self._str(error.uncertainty, subelement, 'uncertainty')
+            self._str(error.lower_uncertainty, subelement, 'lowerUncertainty')
+            self._str(error.upper_uncertainty, subelement, 'upperUncertainty')
+            self._str(error.confidence_level, subelement, 'confidenceLevel')
         element.append(subelement)
 
     def _waveform_id(self, obj, element, required=False):


### PR DESCRIPTION
Avoids errors like this:
```python
/home/megies/git/obspy-master/obspy/io/quakeml/core.pyc in dumps(self, catalog)
   1077         :returns: QuakeML formatted string.
   1078         """
-> 1079         return self._serialize(catalog)
   1080 
   1081     def _id(self, obj):

/home/megies/git/obspy-master/obspy/io/quakeml/core.pyc in _serialize(self, catalog, pretty_print)
   1747             # origins
   1748             for origin in event.origins:
-> 1749                 event_el.append(self._origin(origin))
   1750             # magnitudes
   1751             for magnitude in event.magnitudes:

/home/megies/git/obspy-master/obspy/io/quakeml/core.pyc in _origin(self, origin)
   1357         element = etree.Element(
   1358             'origin', attrib={'publicID': self._id(origin.resource_id)})
-> 1359         self._value(origin.time, origin.time_errors, element, 'time', True)
   1360         self._value(origin.latitude, origin.latitude_errors, element,
   1361                     'latitude', True)

/home/megies/git/obspy-master/obspy/io/quakeml/core.pyc in _value(self, quantity, error, element, tag, always_create)
   1108         subelement = etree.Element(tag)
   1109         self._str(quantity, subelement, 'value')
-> 1110         self._str(error.uncertainty, subelement, 'uncertainty')
   1111         self._str(error.lower_uncertainty, subelement, 'lowerUncertainty')
   1112         self._str(error.upper_uncertainty, subelement, 'upperUncertainty')

AttributeError: 'NoneType' object has no attribute 'uncertainty'
```