### PR TITLE
fix pyshp version number lookup when shapefile.__version__ is missing

### DIFF
--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -29,7 +29,9 @@ else:
                                  shapefile.__version__.split('.')))
     except AttributeError:
         PYSHP_VERSION = None
-    PYSHP_VERSION_AT_LEAST_1_2_11 = PYSHP_VERSION >= [1, 2, 11]
+        PYSHP_VERSION_AT_LEAST_1_2_11 = False
+    else:
+        PYSHP_VERSION_AT_LEAST_1_2_11 = PYSHP_VERSION >= [1, 2, 11]
 PYSHP_VERSION_WARNING = (
     'pyshp versions < 1.2.11 are buggy, e.g. in writing numerical values to '
     'the dbf table, so e.g. timestamp float values might lack proper '

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -55,7 +55,7 @@ def _write_shapefile(obj, filename, **kwargs):
     """
     if not HAS_PYSHP:
         raise ImportError(IMPORTERROR_MSG)
-    if PYSHP_VERSION < [1, 2, 12]:
+    if not PYSHP_VERSION_AT_LEAST_1_2_11:
         warnings.warn(PYSHP_VERSION_WARNING)
     if not filename.endswith(".shp"):
         filename += ".shp"


### PR DESCRIPTION
older pyshp doesn't have this attribute..

Fixes this problem reported in Debian packaging, which might also hurt people that install pyshp via pip (conda seems to add the missing attribute in older versions during packaging).

```
Traceback (most recent call last):
  File "/usr/bin/obspy3-runtests", line 9, in <module>
    load_entry_point('obspy==1.1.0rc11', 'console_scripts', 'obspy3-runtests')()
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python3/dist-packages/obspy/__init__.py", line 84, in <module>
    numspaces=8)
  File "/usr/lib/python3/dist-packages/obspy/core/util/base.py", line 474, in make_format_plugin_table
    func = buffered_load_entry_point(*ep_list)
  File "/usr/lib/python3/dist-packages/obspy/core/util/misc.py", line 638, in buffered_load_entry_point
    _ENTRY_POINT_CACHE[hash_str] = load_entry_point(dist, group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python3/dist-packages/obspy/io/shapefile/core.py", line 32, in <module>
    PYSHP_VERSION_AT_LEAST_1_2_11 = PYSHP_VERSION >= [1, 2, 11]
TypeError: unorderable types: NoneType() >= list()
```

CC @krischer 