### PR TITLE
Travis: try to reenable 32bit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,8 @@ matrix:
       env: PYTHON_VERSION=3.5
     - os: linux
       env: PYTHON_VERSION=3.6
-    # - os: linux
-    #   env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
-    #   addons:
-    #     apt:
-    #       packages:
-    #         # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
-    #         - libstdc++6:i386
-    #         - gcc-multilib
+    - os: linux
+      env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
     - os: osx
       env: PYTHON_VERSION=2.7
     - os: osx
@@ -41,6 +35,18 @@ before_install:
   - if [ `uname` = "Darwin" ]; then brew update; brew install -v jq; fi
   - curl "https://raw.githubusercontent.com/JuliaLang/julia/master/contrib/travis_fastfail.sh" -o "/tmp/fastfail.sh" || echo "Failed to fetch travis_fastfail.sh"
   - if [ -f /tmp/fastfail.sh ]; then chmod u+x /tmp/fastfail.sh; /tmp/fastfail.sh || exit 1; fi
+  # it seems Travis is now ignoring addons/apt/packages when nested into
+  # matrix/includes, so manually install those packages:
+  # $ travis lint .travis.yml
+  # Warnings for .travis.yml:
+  # [x] in matrix.include section: unexpected key addons, dropping
+  # See also
+  # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+  - |
+      if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
+        sudo apt-get -qq update;
+        sudo apt-get install -y libstdc++6:i386 gcc-multilib;
+      fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -48,23 +54,22 @@ install:
     else
       export OS="Linux";
     fi
-  # - |
-  # -   if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
-  # -     export ARCH=""
-  # -     # OPT is used by setuptools patches contained in newer numpy versions
-  # -     # used by obspy when running pip install --no-deps .
-  # -     export OPT="-m32"
-  # -     # workaround for sudo dpkg --add-architecture i386
-  # -     # be sure multiarch is the only file in this directory
-  # -     ls /etc/dpkg/dpkg.cfg.d/
-  # -     # multiarch must contain foreign-architecture i386. If not it will
-  # -     # error later and you need to do the following and add sudo: true
-  # -     #sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
-  # -     cat /etc/dpkg/dpkg.cfg.d/multiarch
-  # -   else
-  # -     export ARCH="_64"
-  # -   fi
-  - export ARCH="_64"
+  - |
+      if [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
+        export ARCH=""
+        # OPT is used by setuptools patches contained in newer numpy versions
+        # used by obspy when running pip install --no-deps .
+        export OPT="-m32"
+        # workaround for sudo dpkg --add-architecture i386
+        # be sure multiarch is the only file in this directory
+        ls /etc/dpkg/dpkg.cfg.d/
+        # multiarch must contain foreign-architecture i386. If not it will
+        # error later and you need to do the following and add sudo: true
+        #sudo sh -c "echo 'foreign-architecture i386' > /etc/dpkg/dpkg.cfg.d/multiarch"
+        cat /etc/dpkg/dpkg.cfg.d/multiarch
+      else
+        export ARCH="_64"
+      fi
   - if [[ "${PYTHON_VERSION:0:1}" == '2' ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-${OS}-x86${ARCH}.sh -O miniconda.sh;
     else
@@ -98,14 +103,14 @@ install:
         MATPLOTLIB="matplotlib"
         BASEMAP="basemap"
         PYPROJ="pyproj"
-      # elif [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
-      #   # Special packages for 32bit. Also let conda resolve to the latest
-      #   # versions.
-      #   NUMPY="numpy"
-      #   SCIPY="scipy"
-      #   MATPLOTLIB="matplotlib"
-      #   BASEMAP="basemap"
-      #   PYPROJ="pyproj"
+      elif [[ "$ARCHITECTURE_32BIT" == "True" ]]; then
+        # Special packages for 32bit. Also let conda resolve to the latest
+        # versions.
+        NUMPY="numpy"
+        SCIPY="scipy"
+        MATPLOTLIB="matplotlib"
+        BASEMAP="basemap"
+        PYPROJ="pyproj"
       # For anything else also let conda resolve, but force matplotlib 2.
       else
         NUMPY="numpy"


### PR DESCRIPTION
Maybe it  was broken earlier only due to syntax changes in Travis yml, looks like specifying apt package addons in build matrix was once supported but it's now ignored.