### PR TITLE
mseed: Avoid invalid warning when guessing endianness of timestamps / UTCDateTime: proper exceptions on invalid 'julday'

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@
  - General:
    * Tests pass with numpy 1.14 (see #2044).
  - obspy.core:
+   * UTCDateTime now raises a meaningful exceptions when passing
+     invalid or out-of-bounds 'julday' during initialization (see #1988)
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
    * read_inventory() used with non-existing file path (e.g. typo in filename)
      now shows a proper "No such file or directory" error message (see #2062)
@@ -28,6 +30,8 @@
      (see #1981, #2057).
    * Fix util.get_start_and_end_time returning sample rate = 0 when
      sample rate = 1 (see #2069)
+   * Avoid showing invalid warnings when guessing endian during parsing
+     timestamps (see #1988)
  - obspy.io.nordic
    * Bug-fix for amplitudes without magnitude_hint (see #2021)
    * Bug-fix for wavefiles with full path stripping (see #2021)

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -463,7 +463,7 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, UTCDateTime, 2010, 9, 31)
         self.assertRaises(ValueError, UTCDateTime, '2010-09-31')
         # invalid julday
-        self.assertRaises(TypeError, UTCDateTime, year=2010, julday=999)
+        self.assertRaises(ValueError, UTCDateTime, year=2010, julday=999)
         # testing some strange patterns
         self.assertRaises(TypeError, UTCDateTime, "ABC")
         self.assertRaises(TypeError, UTCDateTime, "12X3T")

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -339,6 +339,15 @@ class UTCDateTime(object):
                 return
         # check for ordinal/julian date kwargs
         if 'julday' in kwargs:
+            try:
+                int(kwargs['julday'])
+            except (ValueError, TypeError):
+                msg = "Failed to convert 'julday' to int: {!s}".format(
+                    kwargs['julday'])
+                raise TypeError(msg)
+            if not (0 <= int(kwargs['julday']) <= 366):
+                msg = "'julday' out of bounds: {!s}".format(kwargs['julday'])
+                raise ValueError(msg)
             if 'year' in kwargs:
                 # year given as kwargs
                 year = kwargs['year']

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -345,7 +345,7 @@ class UTCDateTime(object):
                 msg = "Failed to convert 'julday' to int: {!s}".format(
                     kwargs['julday'])
                 raise TypeError(msg)
-            if not (0 <= int(kwargs['julday']) <= 366):
+            if not (1 <= int(kwargs['julday']) <= 366):
                 msg = "'julday' out of bounds: {!s}".format(kwargs['julday'])
                 raise ValueError(msg)
             if 'year' in kwargs:

--- a/obspy/io/mseed/__init__.py
+++ b/obspy/io/mseed/__init__.py
@@ -160,6 +160,10 @@ class InternalMSEEDError(ObsPyMSEEDError):
     pass
 
 
+class InternalMSEEDParseTimeError(InternalMSEEDError):
+    pass
+
+
 class InternalMSEEDWarning(UserWarning):
     pass
 

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -642,7 +642,7 @@ def _get_record_information(file_object, offset=0, endian=None):
         return native_str('%sHHBBBxHHhhBBBxlxxH' % s)
 
     def _parse_time(values):
-        if not (0 <= values[1] <= 366):
+        if not (1 <= values[1] <= 366):
             msg = 'julday out of bounds (wrong endian?): {!s}'.format(
                 values[1])
             raise InternalMSEEDParseTimeError(msg)

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -658,10 +658,15 @@ def _get_record_information(file_object, offset=0, endian=None):
                 "the maximum strictly allowed value is 9999. It will be "
                 "interpreted as one or more additional seconds." % values[5],
                 category=UserWarning)
-        return UTCDateTime(
-            year=values[0], julday=values[1],
-            hour=values[2], minute=values[3], second=values[4],
-            microsecond=msec % 1000000) + offset
+        try:
+            t = UTCDateTime(
+                year=values[0], julday=values[1],
+                hour=values[2], minute=values[3], second=values[4],
+                microsecond=msec % 1000000) + offset
+        except TypeError:
+            msg = 'Problem decoding time (wrong endian?)'
+            raise InternalMSEEDParseTimeError(msg)
+        return t
 
     if endian is None:
         try:

--- a/obspy/io/seisan/tests/test_core.py
+++ b/obspy/io/seisan/tests/test_core.py
@@ -8,7 +8,6 @@ from future.builtins import *  # NOQA
 
 import os
 import unittest
-import warnings
 
 import numpy as np
 
@@ -195,13 +194,8 @@ class CoreTestCase(unittest.TestCase):
         # 1 - little endian, 32 bit, version 7
         st1 = read(os.path.join(self.path,
                                 '2011-09-06-1311-36S.A1032_001BH_Z'))
-        # raises "UserWarning: Record contains a fractional seconds" - ignore
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', UserWarning)
-            st2 = read(os.path.join(self.path,
-                                    '2011-09-06-1311-36S.A1032_001BH_Z.mseed'))
-            self.assertEqual(len(w), 1)
-            self.assertEqual(w[0].category, UserWarning)
+        st2 = read(os.path.join(self.path,
+                                '2011-09-06-1311-36S.A1032_001BH_Z.mseed'))
         self.assertEqual(len(st1), len(st2))
         self.assertTrue(np.allclose(st1[0].data, st2[0].data))
 


### PR DESCRIPTION
    mseed: avoid showing invalid warnings when guessing endian during
    parsing time stamps
    
    so far, if during parsing a timestamp the endian is not known beforehand
    and if the wrong endian is tried first, a warning message about
    invalid fractional seconds gets shown which is a bogus warning
    
    also, internally we simply rely on UTCDateTime.__init__() raising any
    exception whatsoever for endian detection. this adds some sanity by
    checking if the julday is in between 1-366 (which is the range accepted
    by UTCDateTime.__init__)

---

    utcdatetime: add proper sanity checks for UTCDateTime(..., julday=..)
    
    right now passing invalid juldays can result in misleading error messages, because
    julday is silently discarded when encountering out-of-bounds values that
    internally in datetime.datetime.strptime(..., '%Y%j') raise "ValueError:
    unconverted data remains:"
    
    In [1]: UTCDateTime(year=2017, julday=367)
    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call last)
    <ipython-input-1-0e1465633d82> in <module>()
    ----> 1 UTCDateTime(year=2017, julday=367)
    
    /home/megies/git/obspy-master/obspy/core/utcdatetime.py in __init__(self, *args, **kwargs)
        357             kwargs['microsecond'] = int(round(_frac * 1e6))
        358             args = args[0:5]
    --> 359         dt = datetime.datetime(*args, **kwargs)
        360         self._from_datetime(dt)
        361
    
    TypeError: Required argument 'month' (pos 2) not found
    
This changes this to:
    
    In [1]: UTCDateTime(year=2017, julday=367)
    ---------------------------------------------------------------------------
    ValueError                                Traceback (most recent call last)
    <ipython-input-1-0e1465633d82> in <module>()
    ----> 1 UTCDateTime(year=2017, julday=367)
    
    /home/megies/git/obspy-master/obspy/core/utcdatetime.py in __init__(self, *args, **kwargs)
        342             if not (0 <= int(kwargs['julday']) <= 366):
        343                 msg = "'julday' out of bounds: {!s}".format(kwargs['julday'])
    --> 344                 raise ValueError(msg)
        345             if 'year' in kwargs:
        346                 # year given as kwargs
    
    ValueError: 'julday' out of bounds: 367


no time to add tests right now, sorry..