### PR TITLE
Fix bug setting stats.delta to zero. Tests. Pickling tests.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+1.1.x:
+ -obspy.core:
+   * Allow pickling of traces with sr=0 / setting delta =0 (see #1990)
+
 1.1.0: (doi: 10.5281/zenodo.165135)
  - General:
    * Read support for Guralp Compressed Format (GCF) waveform data,

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 1.1.x:
  -obspy.core:
-   * Allow pickling of traces with sr=0 / setting delta =0 (see #1990)
+   * Fix pickling of traces with a sampling rate of 0 (see #1990)
 
 1.1.0: (doi: 10.5281/zenodo.165135)
  - General:

--- a/obspy/core/tests/test_stats.py
+++ b/obspy/core/tests/test_stats.py
@@ -196,6 +196,11 @@ class StatsTestCase(unittest.TestCase):
         temp = pickle.dumps(stats, protocol=2)
         stats2 = pickle.loads(temp)
         self.assertEqual(stats, stats2)
+        # SOH channels sampling_rate & delta == 0. for #1989
+        stats.sampling_rate = 0
+        pickle.loads(pickle.dumps(stats, protocol=0))
+        pickle.loads(pickle.dumps(stats, protocol=1))
+        pickle.loads(pickle.dumps(stats, protocol=2))
 
     def test_set_calib(self):
         """
@@ -227,6 +232,13 @@ class StatsTestCase(unittest.TestCase):
         ad = Stats(adict)
         self.assertEqual(ad, adict)
         self.assertEqual(adict, ad)
+
+    def test_delta_zero(self):
+        """
+        Make sure you can set delta = 0. for #1989
+        """
+        stat = Stats()
+        stat.delta = 0
 
 
 def suite():

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2716,8 +2716,7 @@ class TraceTestCase(unittest.TestCase):
 
     def test_pickle(self):
         """
-        Test that  Trace can be pickled
-        #1989
+        Test that  Trace can be pickled #1989
         """
         tr_orig = Trace()
         tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=0))
@@ -2727,10 +2726,9 @@ class TraceTestCase(unittest.TestCase):
         tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=2))
         self.assertEqual(tr_orig, tr_pickled)
 
-    def test_pickle_SOH(self):
+    def test_pickle_soh(self):
         """
-        Test that trace can be pickled with samplerate = 0
-        #1989
+        Test that trace can be pickled with samplerate = 0 #1989
         """
         tr_orig = Trace()
         tr_orig.stats.sampling_rate = 0

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -5,6 +5,7 @@ from future.builtins import *  # NOQA
 
 import math
 import os
+import pickle
 import unittest
 from copy import deepcopy
 import warnings
@@ -2712,6 +2713,33 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(len(tr2), 5)
         self.assertEqual(tr1.stats.npts, 2)
         self.assertEqual(tr2.stats.npts, 5)
+
+    def test_pickle(self):
+        """
+        Test that  Trace can be pickled
+        #1989
+        """
+        tr_orig = Trace()
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=0))
+        self.assertEqual(tr_orig, tr_pickled)
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=1))
+        self.assertEqual(tr_orig, tr_pickled)
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=2))
+        self.assertEqual(tr_orig, tr_pickled)
+
+    def test_pickle_SOH(self):
+        """
+        Test that trace can be pickled with samplerate = 0
+        #1989
+        """
+        tr_orig = Trace()
+        tr_orig.stats.sampling_rate = 0
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=0))
+        self.assertEqual(tr_orig, tr_pickled)
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=1))
+        self.assertEqual(tr_orig, tr_pickled)
+        tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=2))
+        self.assertEqual(tr_orig, tr_pickled)
 
 
 def suite():

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -158,9 +158,9 @@ class Stats(AttribDict):
             # ensure correct data type
             if key == 'delta':
                 key = 'sampling_rate'
-                if value > 0.0:
+                try:
                     value = 1.0 / float(value)
-                else:
+                except ZeroDivisionError:
                     value = 0.0
             elif key == 'sampling_rate':
                 value = float(value)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -158,7 +158,10 @@ class Stats(AttribDict):
             # ensure correct data type
             if key == 'delta':
                 key = 'sampling_rate'
-                value = 1.0 / float(value)
+                if value > 0.0:
+                    value = 1.0 / float(value)
+                else:
+                    value = 0.0
             elif key == 'sampling_rate':
                 value = float(value)
             elif key == 'starttime':


### PR DESCRIPTION
Addresses bug #1989
This bug prevented pickling of SOH channels with SR = 0.