### PR TITLE
Occasional MemoryError in clients.fdsn.tests

### DIFF
--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -255,17 +255,13 @@ class ClientTestCase(unittest.TestCase):
         for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
                     u"", u" ", u"  ", u"--"]:
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
-                try:
-                    self.client.get_stations(0, 0, location=loc)
-                except Exception:
-                    pass
+                self.client.get_stations(0, 0, location=loc,
+                                         filename=mock.Mock())
             self.assertEqual(p.call_count, 1)
             self.assertIn("location=--", p.call_args[0][0])
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
-                try:
-                    self.client.get_waveforms(1, 2, loc, 4, 0, 0)
-                except Exception:
-                    pass
+                self.client.get_waveforms(1, 2, loc, 4, 0, 0,
+                                          filename=mock.Mock())
             self.assertEqual(p.call_count, 1)
             self.assertIn("location=--", p.call_args[0][0])
 


### PR DESCRIPTION
Error on Linux32bit (obspy-runtests needed more than 2GB memory):

```
obspy-runtests -a
Running /home/tom/anaconda/lib/python3.5/site-packages/obspy/scripts/runtests.py, ObsPy version '1.1.0'
..................x.......u............s........................................................................................................T


 raceback (most recent call last):
  File "/home/tom/anaconda/bin/obspy-runtests", line 11, in <module>
  File "/home/tom/anaconda/lib/python3.5/site-packages/obspy/scripts/runtests.py", line 738, in main
  File "/home/tom/anaconda/lib/python3.5/site-packages/obspy/scripts/runtests.py", line 706, in run
  File "/home/tom/anaconda/lib/python3.5/site-packages/obspy/scripts/runtests.py", line 551, in run_tests
  File "/home/tom/anaconda/lib/python3.5/site-packages/obspy/scripts/runtests.py", line 447, in run
  File "/home/tom/anaconda/lib/python3.5/unittest/suite.py", line 84, in __call__
  File "/home/tom/anaconda/lib/python3.5/unittest/suite.py", line 122, in run
  File "/home/tom/anaconda/lib/python3.5/unittest/suite.py", line 84, in __call__
MemoryError
Terminated
```

Assuming alphabetical module order I suspected the FDSN module.
I was able to reproduce on a Linux64bit machine (second run, runtests took 13GB of memory before I aborted):

```
(workhorse) eule@kiste:~/dev/obspy$ obspy-runtests -v clients.fdsn

Running /home/eule/dev/obspy/obspy/scripts/runtests.py, ObsPy version '1.1.0.post0+1.g45d52199d8.obspy.lanczos.doc'
__init__ (obspy.clients.fdsn)
Doctest: obspy.clients.fdsn.__init__ ... ok
__init__ (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.__init__ ... ok
get_events (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.get_events ... ok
get_stations (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.get_stations ... ok
get_stations_bulk (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.get_stations_bulk ... ok
get_waveforms (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.get_waveforms ... ok
get_waveforms_bulk (obspy.clients.fdsn.client.Client)
Doctest: obspy.clients.fdsn.client.Client.get_waveforms_bulk ... ok
build_url (obspy.clients.fdsn.client)
Doctest: obspy.clients.fdsn.client.build_url ... ok
convert_to_string (obspy.clients.fdsn.client)
Doctest: obspy.clients.fdsn.client.convert_to_string ... ok
_convert_boolean (obspy.clients.fdsn.wadl_parser.WADLParser)
Doctest: obspy.clients.fdsn.wadl_parser.WADLParser._convert_boolean ... ok
RoutingClient (obspy.clients.fdsn.routing.routing_client)
Doctest: obspy.clients.fdsn.routing.routing_client.RoutingClient ... ok
__init__ (obspy.clients.fdsn.mass_downloader)
Doctest: obspy.clients.fdsn.mass_downloader.__init__ ... ok
Restrictions (obspy.clients.fdsn.mass_downloader.restrictions)
Doctest: obspy.clients.fdsn.mass_downloader.restrictions.Restrictions ... ok
CircularDomain (obspy.clients.fdsn.mass_downloader.domain)
Doctest: obspy.clients.fdsn.mass_downloader.domain.CircularDomain ... ok
GlobalDomain (obspy.clients.fdsn.mass_downloader.domain)
Doctest: obspy.clients.fdsn.mass_downloader.domain.GlobalDomain ... ok
RectangularDomain (obspy.clients.fdsn.mass_downloader.domain)
Doctest: obspy.clients.fdsn.mass_downloader.domain.RectangularDomain ... ok
test_error_handling (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_service_version (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_stations (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_stations_bulk (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_stations_integration_test (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_waveforms (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_waveforms_bulk (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_waveforms_integration_test (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_non_allowed_parameters (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_response_splitting (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_response_splitting_fdsnws_subdomain (obspy.clients.fdsn.tests.test_eidaws_routing_client.EIDAWSRoutingClientTestCase) ... ok
test_get_service_version (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_stations (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_stations_bulk (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_stations_error_handling (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_stations_integration_test (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_waveforms (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_waveforms_bulk (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_waveforms_error_handling (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_get_waveforms_integration_test (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_response_splitting (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_response_splitting_fdsnws_subdomain (obspy.clients.fdsn.tests.test_federator_routing_client.FederatorRoutingClientTestCase) ... ok
test_circular_domain (obspy.clients.fdsn.tests.test_mass_downloader.DomainTestCase) ... ok
test_global_domain (obspy.clients.fdsn.tests.test_mass_downloader.DomainTestCase) ... ok
test_instantiating_root_domain_object_fails (obspy.clients.fdsn.tests.test_mass_downloader.DomainTestCase) ... ok
test_rectangular_domain (obspy.clients.fdsn.tests.test_mass_downloader.DomainTestCase) ... ok
test_subclassing_without_abstract_method (obspy.clients.fdsn.tests.test_mass_downloader.DomainTestCase) ... ok
test_channel_priority_filtering (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_channel_str_representation (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_download_and_split_mseed (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_download_stationxml (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_fast_vs_slow_get_stationxml_contents (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_get_stationxml_contents (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_location_priority_filtering (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_mseed_filename_helper (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_safe_delete (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_spherical_nearest_neighbour (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_stationxml_filename_helper (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelpersUtilTestCase) ... ok
test_repr (obspy.clients.fdsn.tests.test_mass_downloader.TimeIntervalTestCase) ... ok
test_temporal_bounds (obspy.clients.fdsn.tests.test_mass_downloader.ChannelTestCase) ... ok
test_wants_station_information (obspy.clients.fdsn.tests.test_mass_downloader.ChannelTestCase) ... ok
test_has_existing_or_downloaded_time_intervals (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_has_existing_time_intervals (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_prepare_mseed_download (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_prepare_stationxml_download_dictionary_case (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_prepare_stationxml_download_simple_cases (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_remove_files (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_sanitize_downloads (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_str_method (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_temporal_bounds (obspy.clients.fdsn.tests.test_mass_downloader.StationTestCase) ... ok
test_download_method (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelperTestCase) ... ok
test_initialization (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelperTestCase) ... ok
test_initialization_detailed (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelperTestCase) ... ok
test_initialization_with_existing_clients (obspy.clients.fdsn.tests.test_mass_downloader.DownloadHelperTestCase) ... ok
test_basic_object_methods (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_download_mseed (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_download_stationxml (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_excluding_networks_and_stations (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_excluding_networks_and_stations_with_an_inventory_object (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_get_availability (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_looped_methods (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_parse_miniseed_filenames (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_station_list_nearest_neighbour_filter (obspy.clients.fdsn.tests.test_mass_downloader.ClientDownloadHelperTestCase) ... ok
test_inventory_parsing (obspy.clients.fdsn.tests.test_mass_downloader.RestrictionsTestCase) ... ok
test_passing_string_as_priority_list_raises (obspy.clients.fdsn.tests.test_mass_downloader.RestrictionsTestCase) ... ok
test_restrictions_object (obspy.clients.fdsn.tests.test_mass_downloader.RestrictionsTestCase) ... ok
test_authentication (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_conflicting_params (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_dataselect_bulk (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_default_requested_urls (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_download_urls_for_custom_mapping (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_eida_token_resolution (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_get_waveform_attach_response (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_get_waveforms_empty_seed_codes (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_help_function_with_iris (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_iris_event_catalog_availability (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_iris_event_contributors_availability (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_iris_example_queries_dataselect (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_iris_example_queries_event (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_iris_example_queries_station (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ok
test_location_parameters (obspy.clients.fdsn.tests.test_client.ClientTestCase) ... ^C^C^C^C^C^C^C^CTraceback (most recent call last):
  File "/home/eule/anaconda/envs/workhorse/bin/obspy-runtests", line 11, in <module>
    load_entry_point('obspy', 'console_scripts', 'obspy-runtests')()
  File "/home/eule/dev/obspy/obspy/scripts/runtests.py", line 738, in main
    errors = run(argv, interactive)
  File "/home/eule/dev/obspy/obspy/scripts/runtests.py", line 706, in run
    pr_url=args.pr_url)
  File "/home/eule/dev/obspy/obspy/scripts/runtests.py", line 551, in run_tests
    timeit=timeit).run(suites)
  File "/home/eule/dev/obspy/obspy/scripts/runtests.py", line 447, in run
    test(result)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 122, in run
    test(result)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 122, in run
    test(result)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/suite.py", line 122, in run
    test(result)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/case.py", line 653, in __call__
    return self.run(*args, **kwds)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/case.py", line 605, in run
    testMethod()
  File "/home/eule/dev/obspy/obspy/clients/fdsn/tests/test_client.py", line 259, in test_location_parameters
    self.client.get_stations(0, 0, location=loc)
  File "/home/eule/dev/obspy/obspy/clients/fdsn/client.py", line 718, in get_stations
    inventory = read_inventory(data_stream)
  File "<decorator-gen-45>", line 2, in read_inventory
  File "/home/eule/dev/obspy/obspy/core/util/decorator.py", line 301, in _map_example_filename
    return func(*args, **kwargs)
  File "/home/eule/dev/obspy/obspy/core/inventory/inventory.py", line 98, in read_inventory
    format=format, *args, **kwargs)[0]
  File "/home/eule/dev/obspy/obspy/core/util/base.py", line 386, in _read_from_plugin
    is_format = is_format(filename)
  File "/home/eule/dev/obspy/obspy/io/xseed/core.py", line 90, in _is_resp
    return _internal_is_resp(filename)
  File "/home/eule/dev/obspy/obspy/io/xseed/core.py", line 104, in _internal_is_resp
    lines = fh.readline().splitlines()
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/mock.py", line 919, in __call__
    return _mock_self._mock_call(*args, **kwargs)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/mock.py", line 930, in _mock_call
    self.call_args = _call
  File "/home/eule/anaconda/envs/workhorse/lib/python3.5/unittest/mock.py", line 679, in __setattr__
    def __setattr__(self, name, value):
KeyboardInterrupt
^C^C
```