### PR TITLE
test runner: Include link to submitted test in printed message on report submission

### DIFF
--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -180,6 +180,10 @@ def _get_suites(verbosity=1, names=[]):
 
 def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
                    ci_url=None, pr_url=None, import_failures=None):
+    """
+    If `server` is specified without URL scheme, 'https://' will be used as a
+    default.
+    """
     # import additional libraries here to speed up normal tests
     from future import standard_library
     with standard_library.hooks():
@@ -356,7 +360,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
                "Accept": "text/plain"}
     url = server
     if not urlparse(url).scheme:
-        url = "http://" + url
+        url = "https://" + url
     response = requests.post(url=url, headers=headers, data=params)
     # get the response
     if response.status_code == 200:

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -360,11 +360,9 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     response = requests.post(url=url, headers=headers, data=params)
     # get the response
     if response.status_code == 200:
-        report_url = response.json().get('url', '')
-        if report_url:
-            report_url = ': {!s}'.format(report_url)
-        print("Test report has been sent to {}{} Thank you!".format(
-            server, report_url or '.'))
+        report_url = response.json().get('url', server)
+        print('Your test results have been reported and are available at: '
+              '{}\nThank you!'.format(report_url))
     # handle errors
     else:
         print("Error: Could not sent a test report to %s." % (server))

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -361,7 +361,8 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     url = server
     if not urlparse(url).scheme:
         url = "https://" + url
-    response = requests.post(url=url, headers=headers, data=params)
+    response = requests.post(url=url, headers=headers,
+                             data=params.encode('UTF-8'))
     # get the response
     if response.status_code == 200:
         report_url = response.json().get('url', server)


### PR DESCRIPTION
tests.obspy.org now sends a json response with a link to the submitted test report, so we should include it in the printed message by `obspy-runtests`.

see obspy/reporter#19