### PR TITLE
Allowing singular COUNT unit in evalresp

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
  -obspy.io.seiscomp:
    * Fix inventory read when maxClockDrift is unset in SC3ML (see #1993)
+ -obspy.signal:
+   * Allow singular COUNT units in evalresp (see #2003, #2011).
 
 1.1.0: (doi: 10.5281/zenodo.165135)
  - General:

--- a/obspy/signal/src/evalresp/string_fctns.c
+++ b/obspy/signal/src/evalresp/string_fctns.c
@@ -607,7 +607,7 @@ int check_units(char *line) {
       unitScaleFact = 1.0e2;
     return(DIS);
   }
-  else if(string_match(line,"^COUNTS[^A-Z]?","-r") || string_match(line,"^DIGITAL[^A-Z]?","-r")) {
+  else if(string_match(line,"^COUNTS?[^A-Z]?","-r") || string_match(line,"^DIGITAL[^A-Z]?","-r")) {
     return(COUNTS);
   }
   else if(string_match(line,"^V[^A-Z]?","-r") || string_match(line,"^VOLTS[^A-Z]?","-r")) {


### PR DESCRIPTION
Fixes #2003 

Small thing and I did not add a test because we don't really use this internally but it might help some people.