### PR TITLE
io.shapefile: enable writing additional fields to shapefile database table

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ master:
  - obspy.core:
    * Casting FDSN identifiers to strings upon setting in the stats dictionary
      (see #1997).
+ - obspy.io.shapefile:
+   * Add possibility to add custom database columns when writing catalog
+     objects to shapefile (see #2012)
 
 1.1.x:
  - obspy.core:

--- a/obspy/io/shapefile/__init__.py
+++ b/obspy/io/shapefile/__init__.py
@@ -6,7 +6,7 @@ This module provides write support for the ESRI shapefile format.
 
 Write support works via the ObsPy plugin structure for
 :class:`~obspy.core.event.Catalog` and
-:class:`~obspy.core.inventory.Inventory`:
+:class:`~obspy.core.inventory.inventory.Inventory`:
 
 >>> from obspy import read_inventory, read_events
 >>> inv = read_inventory()  # load example data

--- a/obspy/io/shapefile/__init__.py
+++ b/obspy/io/shapefile/__init__.py
@@ -14,6 +14,19 @@ Write support works via the ObsPy plugin structure for
 >>> cat = read_events()  # load example data
 >>> cat.write("my_events.shp", format="SHAPEFILE")  # doctest: +SKIP
 
+Additional information for events can be written to the shapefile as custom
+database columns. In this toy example we add the Flinn Engdahl region as a
+database column (see :func:`obspy.io.shapefile.core._write_shapefile()`):
+
+>>> from obspy.geodetics.flinnengdahl import FlinnEngdahl
+>>> fe = FlinnEngdahl()
+>>> regions = [
+...     fe.get_region(event.origins[0].longitude, event.origins[0].latitude)
+...     for event in cat]
+>>> extra_fields = [('Region', 'C', 100, None, regions)]
+>>> cat.write("my_events.shp", format="SHAPEFILE",
+...           extra_fields=extra_fields)  # doctest: +SKIP
+
 .. seealso::
 
     The format definition can be found

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -209,7 +209,7 @@ def _add_inventory_layer(writer, inventory):
     """
     :type writer: :class:`shapefile.Writer`.
     :param writer: pyshp Writer object
-    :type inventory: :class:`~obspy.core.inventory.Inventory`
+    :type inventory: :class:`~obspy.core.inventory.inventory.Inventory`
     :param inventory: Inventory data to add as a new layer.
     """
     # [name, type, width, precision]

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -58,7 +58,7 @@ def _write_shapefile(obj, filename, extra_fields=None, **kwargs):
         the shapefile table. Each item in the list has to be specified as a
         tuple of: field name (i.e. name of database column, ``str``), field
         type (single character as used by ``pyshp``: ``'C'`` for string
-        fields, ``'N'`` for integer/float fields -- use precision ``None`` for
+        fields, ``'N'`` for integer/float fields - use precision ``None`` for
         integer fields, ``'L'`` for boolean fields), field width (``int``),
         field precision (``int``) and field values (``list`` of individual
         values, must have same length as ``catalog``).

--- a/obspy/io/shapefile/core.py
+++ b/obspy/io/shapefile/core.py
@@ -38,7 +38,7 @@ PYSHP_VERSION_WARNING = (
     'precision. You should update to a newer pyshp version.')
 
 
-def _write_shapefile(obj, filename, **kwargs):
+def _write_shapefile(obj, filename, extra_fields=None, **kwargs):
     """
     Write :class:`~obspy.core.inventory.inventory.Inventory` or
     :class:`~obspy.core.event.Catalog` object to a ESRI shapefile.
@@ -52,6 +52,16 @@ def _write_shapefile(obj, filename, **kwargs):
         ".shp", ".shx", ".dbj", ".prj". If filename does not end with ".shp",
         it will be appended. Other files will be created with respective
         suffixes accordingly.
+    :type extra_fields: list
+    :param extra_fields: Currently only implemented for ``obj`` of type
+        :class:`~obspy.core.event.Catalog`. List of extra fields to write to
+        the shapefile table. Each item in the list has to be specified as a
+        tuple of: field name (i.e. name of database column, ``str``), field
+        type (single character as used by ``pyshp``: ``'C'`` for string
+        fields, ``'N'`` for integer/float fields -- use precision ``None`` for
+        integer fields, ``'L'`` for boolean fields), field width (``int``),
+        field precision (``int``) and field values (``list`` of individual
+        values, must have same length as ``catalog``).
     """
     if not HAS_PYSHP:
         raise ImportError(IMPORTERROR_MSG)
@@ -65,7 +75,7 @@ def _write_shapefile(obj, filename, **kwargs):
 
     # create the layer
     if isinstance(obj, Catalog):
-        _add_catalog_layer(writer, obj)
+        _add_catalog_layer(writer, obj, extra_fields=extra_fields)
     elif isinstance(obj, Inventory):
         _add_inventory_layer(writer, obj)
     else:
@@ -77,12 +87,15 @@ def _write_shapefile(obj, filename, **kwargs):
     _save_projection_file(filename.rsplit('.', 1)[0] + '.prj')
 
 
-def _add_catalog_layer(writer, catalog):
+def _add_catalog_layer(writer, catalog, extra_fields=None):
     """
     :type writer: :class:`shapefile.Writer`.
     :param writer: pyshp Writer object
     :type catalog: :class:`~obspy.core.event.Catalog`
     :param catalog: Event data to add as a new layer.
+    :type extra_fields: list
+    :param extra_fields: List of extra fields to write to the shapefile table.
+        For details see :func:`_write_shapefile()`.
     """
     # [name, type, width, precision]
     # field name is 10 chars max
@@ -108,9 +121,16 @@ def _add_catalog_layer(writer, catalog):
         ["Magnitude", 'N', 8, 3],
     ]
 
-    _create_layer(writer, field_definitions)
+    _create_layer(writer, field_definitions, extra_fields)
 
-    for event in catalog:
+    if extra_fields:
+        for name, type_, width, precision, values in extra_fields:
+            if len(values) != len(catalog):
+                msg = ("list of values for each item in 'extra_fields' must "
+                       "have same length as Catalog object")
+                raise ValueError(msg)
+
+    for i, event in enumerate(catalog):
         # try to use preferred origin/magnitude, fall back to first or use
         # empty one with `None` values in it
         origin = (event.preferred_origin() or
@@ -179,6 +199,9 @@ def _add_catalog_layer(writer, catalog):
 
         if origin.latitude is not None and origin.longitude is not None:
             writer.point(origin.longitude, origin.latitude)
+            if extra_fields:
+                for name, _, _, _, values in extra_fields:
+                    feature[name] = values[i]
             _add_record(writer, feature)
 
 
@@ -291,10 +314,18 @@ def _add_field(writer, name, type_, width, precision):
     writer.field(name, **kwargs)
 
 
-def _create_layer(writer, field_definitions):
+def _create_layer(writer, field_definitions, extra_fields=None):
     # Add the fields we're interested in
     for name, type_, width, precision in field_definitions:
         _add_field(writer, name, type_, width, precision)
+    field_names = [name for name, _, _, _ in field_definitions]
+    # add custom fields
+    if extra_fields is not None:
+        for name, type_, width, precision, _ in extra_fields:
+            if name in field_names:
+                msg = "Conflict with existing field named '{}'.".format(name)
+                raise ValueError(msg)
+            _add_field(writer, name, type_, width, precision)
 
 
 def _add_record(writer, feature):

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import copy
 import datetime
 import os
 import unittest
@@ -85,6 +86,12 @@ expected_inventory_records = [
      datetime.date(2007, 12, 17), '.EHZ,.EHN,.EHE'],
     ['BW', 'RJOB', 12.795714, 47.737167, 860.0, datetime.date(2007, 12, 17),
      None, '.EHZ,.EHN,.EHE']]
+# set up expected results with extra 'Region' field
+expected_catalog_fields_with_region = copy.deepcopy(expected_catalog_fields)
+expected_catalog_fields_with_region.append(['Region', 'C', 50, 0])
+expected_catalog_records_with_region = copy.deepcopy(expected_catalog_records)
+expected_catalog_records_with_region[0].append('SOUTHEAST OF HONSHU, JAPAN')
+expected_catalog_records_with_region[1].append('GERMANY')
 
 
 def _assert_records_and_fields(got_fields, got_records, expected_fields,
@@ -194,6 +201,46 @@ class ShapefileTestCase(unittest.TestCase):
                     got_fields=shp.fields, got_records=shp.records(),
                     expected_fields=expected_catalog_fields,
                     expected_records=expected_catalog_records)
+                self.assertEqual(shp.shapeType, shapefile.POINT)
+                _close_shapefile_reader(shp)
+
+    def test_write_catalog_shapefile_with_extra_field(self):
+        """
+        Tests writing a catalog with an additional custom database column
+        """
+        cat = read_events('/path/to/mchedr.dat')
+        cat += read_events('/path/to/nlloc.qml')
+        extra_fields = [('Region', 'C', 50, None,
+                         ['SOUTHEAST OF HONSHU, JAPAN', 'GERMANY'])]
+        with TemporaryWorkingDirectory():
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings('always')
+                _write_shapefile(cat, "catalog.shp", extra_fields=extra_fields)
+            for w_ in w:
+                try:
+                    self.assertEqual(
+                        str(w_.message),
+                        'Encountered an event with origin uncertainty '
+                        'description of type "confidence ellipsoid". This is '
+                        'not yet implemented for output as shapefile. No '
+                        'origin uncertainty will be added to shapefile for '
+                        'such events.')
+                except AssertionError:
+                    continue
+                break
+            else:
+                raise
+            for suffix in SHAPEFILE_SUFFIXES:
+                self.assertTrue(os.path.isfile("catalog" + suffix))
+            with open("catalog.shp", "rb") as fh_shp, \
+                    open("catalog.dbf", "rb") as fh_dbf, \
+                    open("catalog.shx", "rb") as fh_shx:
+                shp = shapefile.Reader(shp=fh_shp, shx=fh_shx, dbf=fh_dbf)
+                # check contents of shapefile that we just wrote
+                _assert_records_and_fields(
+                    got_fields=shp.fields, got_records=shp.records(),
+                    expected_fields=expected_catalog_fields_with_region,
+                    expected_records=expected_catalog_records_with_region)
                 self.assertEqual(shp.shapeType, shapefile.POINT)
                 _close_shapefile_reader(shp)
 

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -211,10 +211,29 @@ class ShapefileTestCase(unittest.TestCase):
         cat = read_events('/path/to/mchedr.dat')
         cat += read_events('/path/to/nlloc.qml')
         extra_fields = [('Region', 'C', 50, None,
-                         ['SOUTHEAST OF HONSHU, JAPAN', 'GERMANY'])]
+                        ['SOUTHEAST OF HONSHU, JAPAN', 'GERMANY'])]
+        bad_extra_fields_wrong_length = [('Region', 'C', 50, None, ['ABC'])]
+        bad_extra_fields_name_clash = [('Magnitude', 'C', 50, None, ['ABC'])]
+
         with TemporaryWorkingDirectory():
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings('always')
+                # test some bad calls that should raise an Exception
+                with self.assertRaises(ValueError) as cm:
+                    _write_shapefile(
+                        cat, "catalog.shp",
+                        extra_fields=bad_extra_fields_wrong_length)
+                self.assertEqual(
+                    str(cm.exception), "list of values for each item in "
+                    "'extra_fields' must have same length as Catalog object")
+                with self.assertRaises(ValueError) as cm:
+                    _write_shapefile(
+                        cat, "catalog.shp",
+                        extra_fields=bad_extra_fields_name_clash)
+                self.assertEqual(
+                    str(cm.exception), "Conflict with existing field named "
+                    "'Magnitude'.")
+                # now test a good call that should work
                 _write_shapefile(cat, "catalog.shp", extra_fields=extra_fields)
             for w_ in w:
                 try:


### PR DESCRIPTION
### What does this PR do?

Makes it possible to pass on additional data for additional database columns in the written shapefile, providing a catalog object.

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .

+DOCS