### PR TITLE
Ndk bugfix

### DIFF
--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -515,11 +515,15 @@ def _read_lines(line1, line2, line3, line4, line5):
     #         events, the date and time of the analysis. This is useful to
     #         distinguish Quick CMTs ("Q-"), calculated within hours of an
     #         event, from Standard CMTs ("S-"), which are calculated later.
+    if line3[0:9] != "CENTROID:":
+        raise ObsPyNDKException("parse error")
+    numbers = [ line3[10:18], line3[18:22], line3[22:29], line3[29:34], \
+        line3[34:42], line3[42:47], line3[47:53], line3[53:58] ]
     rec["centroid_time"], rec["centroid_time_error"], \
         rec["centroid_latitude"], rec["centroid_latitude_error"], \
         rec["centroid_longitude"], rec["centroid_longitude_error"], \
         rec["centroid_depth_in_km"], rec["centroid_depth_in_km_error"] = \
-        map(float, line3[:58].split()[1:])
+        map(float, numbers)
     type_of_depth = line3[59:63].strip().upper()
 
     if type_of_depth == "FREE":

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -517,8 +517,8 @@ def _read_lines(line1, line2, line3, line4, line5):
     #         event, from Standard CMTs ("S-"), which are calculated later.
     if line3[0:9] != "CENTROID:":
         raise ObsPyNDKException("parse error")
-    numbers = [ line3[10:18], line3[18:22], line3[22:29], line3[29:34], \
-        line3[34:42], line3[42:47], line3[47:53], line3[53:58] ]
+    numbers = [line3[10:18], line3[18:22], line3[22:29], line3[29:34],
+               line3[34:42], line3[42:47], line3[47:53], line3[53:58]]
     rec["centroid_time"], rec["centroid_time_error"], \
         rec["centroid_latitude"], rec["centroid_latitude_error"], \
         rec["centroid_longitude"], rec["centroid_longitude_error"], \


### PR DESCRIPTION
Line 3 must be treated as fixed-width fields because otherwise parsing fails for a few ndk's where there is no space between the centroid time and its error, like e.g. in event C110397G.

To test this:
```
wget 'http://www.ldeo.columbia.edu/~gcmt/projects/CMT/catalog/jan76_dec13.ndk'
python -c 'import obspy; obspy.read_events("jan76_dec13.ndk")'
```
This produced several errors but now works.