### PR TITLE
Raise Arclink EOL message

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 1.1.x:
  - obspy.core:
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
+ - obspy.clients.arclink:
+   * Raise a warning at import time that the ArcLink protocol will be
+     deprecated soon (see #1987).
  - obspy.io.seiscomp:
    * Fix inventory read when maxClockDrift is unset in SC3ML (see #1993)
  - obspy.io.stationxml

--- a/obspy/clients/arclink/__init__.py
+++ b/obspy/clients/arclink/__init__.py
@@ -161,6 +161,19 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import warnings
+
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
+
+# Raise a deprecation warning. This has been requested by the EIDA management
+# board.
+msg = (
+    "The ArcLink protocol will be deprecated in the near future. Please, use "
+    "the client contacting the routing service provided by EIDA: "
+    "https://docs.obspy.org/packages/obspy.clients.fdsn.html#"
+    "basic-routing-clients-usage")
+warnings.warn(msg, category=ObsPyDeprecationWarning)
+
 from .client import Client  # NOQA
 
 


### PR DESCRIPTION
Arclink will "soon" be EOL. The EIDA management board asked us to raise a warning message when users are importing the Arclink client.

They'll come back to us with a concrete suggestion for this warning message.

Including this in the next bugfix release should be fine as it does not change behavior.