### PR TITLE
Add event support to SC3ML 0.10 schema

### DIFF
--- a/obspy/io/seiscomp/core.py
+++ b/obspy/io/seiscomp/core.py
@@ -24,7 +24,7 @@ from obspy.io.quakeml.core import _xml_doc_from_anything
 
 
 # SC3ML version for which an XSD file is available
-SUPPORTED_XSD_VERSION = ['0.3', '0.5', '0.6', '0.7', '0.8', '0.9']
+SUPPORTED_XSD_VERSION = ['0.3', '0.5', '0.6', '0.7', '0.8', '0.9', '0.10']
 
 
 def _is_sc3ml(path_or_file_object):
@@ -73,7 +73,7 @@ def _is_sc3ml(path_or_file_object):
     return match is not None
 
 
-def validate(path_or_object, version='0.9', verbose=False):
+def validate(path_or_object, version=None, verbose=False):
     """
     Check if the given file is a valid SC3ML file.
 
@@ -87,6 +87,9 @@ def validate(path_or_object, version='0.9', verbose=False):
     :rtype: bool
     :return: `True` if SC3ML file is valid.
     """
+    if version is None:
+        version = SUPPORTED_XSD_VERSION[-1]
+
     if version not in SUPPORTED_XSD_VERSION:
         raise ValueError('%s is not a supported version. Use one of these '
                          'versions: [%s].'

--- a/obspy/io/seiscomp/data/sc3ml_0.10.xsd
+++ b/obspy/io/seiscomp/data/sc3ml_0.10.xsd
@@ -1,0 +1,1167 @@
+<?xml version="1.0"?>
+<!-- Generated from Seiscomp Schema, do not edit -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" targetNamespace="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:simpleType name="ResourceIdentifier">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="FloatArrayType">
+    <xs:list itemType="xs:double"/>
+  </xs:simpleType>
+  <xs:simpleType name="ComplexArrayType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\s*\(\s*[+\-]?[0-9]+(\.[0-9]+)?([Ee][+\-][0-9]+)?\s*,\s*[+\-]?[0-9]+(\.[0-9]+)?([Ee][+\-][0-9]+)?\s*\)\s*)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TimeArrayType">
+    <xs:list itemType="xs:dateTime"/>
+  </xs:simpleType>
+  <xs:simpleType name="OriginUncertaintyDescription">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="horizontal uncertainty"/>
+      <xs:enumeration value="uncertainty ellipse"/>
+      <xs:enumeration value="confidence ellipsoid"/>
+      <xs:enumeration value="probability density function"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard CMT solution"/>
+      <xs:enumeration value="quick CMT solution"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginDepthType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="from location"/>
+      <xs:enumeration value="from moment tensor inversion"/>
+      <xs:enumeration value="from modeling of broad-band P waveforms"/>
+      <xs:enumeration value="constrained by depth phases"/>
+      <xs:enumeration value="constrained by direct phases"/>
+      <xs:enumeration value="operator assigned"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OriginType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="hypocenter"/>
+      <xs:enumeration value="centroid"/>
+      <xs:enumeration value="amplitude"/>
+      <xs:enumeration value="macroseismic"/>
+      <xs:enumeration value="rupture start"/>
+      <xs:enumeration value="rupture end"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="automatic"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EvaluationStatus">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="preliminary"/>
+      <xs:enumeration value="confirmed"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+      <xs:enumeration value="rejected"/>
+      <xs:enumeration value="reported"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickOnset">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="emergent"/>
+      <xs:enumeration value="impulsive"/>
+      <xs:enumeration value="questionable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MomentTensorMethod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CMT - general moment tensor"/>
+      <xs:enumeration value="CMT - moment tensor with zero trace"/>
+      <xs:enumeration value="CMT - double-couple source"/>
+      <xs:enumeration value="teleseismic"/>
+      <xs:enumeration value="regional"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DataUsedWaveType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="body waves"/>
+      <xs:enumeration value="P body waves"/>
+      <xs:enumeration value="long-period body waves"/>
+      <xs:enumeration value="surface waves"/>
+      <xs:enumeration value="intermediate-period surface waves"/>
+      <xs:enumeration value="long-period mantle waves"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventDescriptionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="felt report"/>
+      <xs:enumeration value="Flinn-Engdahl region"/>
+      <xs:enumeration value="local time"/>
+      <xs:enumeration value="tectonic summary"/>
+      <xs:enumeration value="nearest cities"/>
+      <xs:enumeration value="earthquake name"/>
+      <xs:enumeration value="region name"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="not existing"/>
+      <xs:enumeration value="not locatable"/>
+      <xs:enumeration value="outside of network interest"/>
+      <xs:enumeration value="earthquake"/>
+      <xs:enumeration value="induced earthquake"/>
+      <xs:enumeration value="quarry blast"/>
+      <xs:enumeration value="explosion"/>
+      <xs:enumeration value="chemical explosion"/>
+      <xs:enumeration value="nuclear explosion"/>
+      <xs:enumeration value="landslide"/>
+      <xs:enumeration value="rockslide"/>
+      <xs:enumeration value="snow avalanche"/>
+      <xs:enumeration value="debris avalanche"/>
+      <xs:enumeration value="mine collapse"/>
+      <xs:enumeration value="building collapse"/>
+      <xs:enumeration value="volcanic eruption"/>
+      <xs:enumeration value="meteor impact"/>
+      <xs:enumeration value="plane crash"/>
+      <xs:enumeration value="sonic boom"/>
+      <xs:enumeration value="duplicate"/>
+      <xs:enumeration value="other"/>
+      <xs:enumeration value="not reported"/>
+      <xs:enumeration value="anthropogenic event"/>
+      <xs:enumeration value="collapse"/>
+      <xs:enumeration value="cavity collapse"/>
+      <xs:enumeration value="accidental explosion"/>
+      <xs:enumeration value="controlled explosion"/>
+      <xs:enumeration value="experimental explosion"/>
+      <xs:enumeration value="industrial explosion"/>
+      <xs:enumeration value="mining explosion"/>
+      <xs:enumeration value="road cut"/>
+      <xs:enumeration value="blasting levee"/>
+      <xs:enumeration value="induced or triggered event"/>
+      <xs:enumeration value="rock burst"/>
+      <xs:enumeration value="reservoir loading"/>
+      <xs:enumeration value="fluid injection"/>
+      <xs:enumeration value="fluid extraction"/>
+      <xs:enumeration value="crash"/>
+      <xs:enumeration value="train crash"/>
+      <xs:enumeration value="boat crash"/>
+      <xs:enumeration value="atmospheric event"/>
+      <xs:enumeration value="sonic blast"/>
+      <xs:enumeration value="acoustic noise"/>
+      <xs:enumeration value="thunder"/>
+      <xs:enumeration value="avalanche"/>
+      <xs:enumeration value="hydroacoustic event"/>
+      <xs:enumeration value="ice quake"/>
+      <xs:enumeration value="slide"/>
+      <xs:enumeration value="meteorite"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EventTypeCertainty">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="known"/>
+      <xs:enumeration value="suspected"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SourceTimeFunctionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="box car"/>
+      <xs:enumeration value="triangle"/>
+      <xs:enumeration value="trapezoid"/>
+      <xs:enumeration value="unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PickPolarity">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="positive"/>
+      <xs:enumeration value="negative"/>
+      <xs:enumeration value="undecidable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StationGroupType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="deployment"/>
+      <xs:enumeration value="array"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TimePDF1D">
+    <xs:sequence>
+      <xs:element name="variable" type="scs:TimeArray" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="probability" type="scs:RealArray" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TimeQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pdf" type="scs:TimePDF1D" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CreationInfo">
+    <xs:sequence>
+      <xs:element name="agencyID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="agencyURI" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="authorURI" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="modificationTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EventDescription">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventDescriptionType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Phase">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Comment">
+    <xs:sequence>
+      <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="id" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RealArray">
+    <xs:simpleContent>
+      <xs:extension base="scs:FloatArrayType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="ComplexArray">
+    <xs:simpleContent>
+      <xs:extension base="scs:ComplexArrayType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="TimeArray">
+    <xs:simpleContent>
+      <xs:extension base="scs:TimeArrayType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RealPDF1D">
+    <xs:sequence>
+      <xs:element name="variable" type="scs:RealArray" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="probability" type="scs:RealArray" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RealQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pdf" type="scs:RealPDF1D" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="IntegerQuantity">
+    <xs:sequence>
+      <xs:element name="value" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceLevel" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Axis">
+    <xs:sequence>
+      <xs:element name="azimuth" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="plunge" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="length" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PrincipalAxes">
+    <xs:sequence>
+      <xs:element name="tAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="pAxis" type="scs:Axis" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="nAxis" type="scs:Axis" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DataUsed">
+    <xs:sequence>
+      <xs:element name="waveType" type="scs:DataUsedWaveType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="componentCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="shortestPeriod" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CompositeTime">
+    <xs:sequence>
+      <xs:element name="year" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="month" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="day" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="hour" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minute" type="scs:IntegerQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="second" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Tensor">
+    <xs:sequence>
+      <xs:element name="Mrr" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mpp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrt" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mrp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Mtp" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OriginQuality">
+    <xs:sequence>
+      <xs:element name="associatedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="associatedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="usedStationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthPhaseCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="standardError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="secondaryAzimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="groundTruthLevel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maximumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minimumDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="medianDistance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlane">
+    <xs:sequence>
+      <xs:element name="strike" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dip" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="rake" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TimeWindow">
+    <xs:sequence>
+      <xs:element name="reference" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="begin" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="WaveformStreamID">
+    <xs:sequence>
+      <xs:element name="resourceURI" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string"/>
+    <xs:attribute name="channelCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="SourceTimeFunction">
+    <xs:sequence>
+      <xs:element name="type" type="scs:SourceTimeFunctionType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="duration" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="riseTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decayTime" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NodalPlanes">
+    <xs:sequence>
+      <xs:element name="nodalPlane1" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlane2" type="scs:NodalPlane" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preferredPlane" type="xs:integer"/>
+  </xs:complexType>
+  <xs:complexType name="ConfidenceEllipsoid">
+    <xs:sequence>
+      <xs:element name="semiMajorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiMinorAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="semiIntermediateAxisLength" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisPlunge" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisAzimuth" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="majorAxisRotation" type="xs:double" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PickReference">
+    <xs:simpleContent>
+      <xs:extension base="scs:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AmplitudeReference">
+    <xs:simpleContent>
+      <xs:extension base="scs:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Reading">
+    <xs:sequence>
+      <xs:element name="pickReference" type="scs:PickReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitudeReference" type="scs:AmplitudeReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorComponentContribution">
+    <xs:sequence>
+      <xs:element name="weight" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeShift" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="dataTimeWindow" type="scs:FloatArrayType" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="phaseCode" type="xs:string" use="required"/>
+    <xs:attribute name="component" type="xs:integer" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorStationContribution">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="component" type="scs:MomentTensorComponentContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="active" type="xs:boolean" use="required"/>
+    <xs:attribute name="weight" type="xs:double"/>
+    <xs:attribute name="timeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensorPhaseSetting">
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="lowerPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="upperPeriod" type="xs:double" use="required"/>
+    <xs:attribute name="minimumSNR" type="xs:double"/>
+    <xs:attribute name="maximumTimeShift" type="xs:double"/>
+  </xs:complexType>
+  <xs:complexType name="MomentTensor">
+    <xs:sequence>
+      <xs:element name="derivedOriginID" type="scs:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="momentMagnitudeID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalarMoment" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="tensor" type="scs:Tensor" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="variance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="varianceReduction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="doubleCouple" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clvd" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="iso" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="greensFunctionID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceTimeFunction" type="scs:SourceTimeFunction" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="method" type="scs:MomentTensorMethod" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:MomentTensorStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="cmtVersion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="dataUsed" type="scs:DataUsed" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="phaseSetting" type="scs:MomentTensorPhaseSetting" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMomentTensorContribution" type="scs:MomentTensorStationContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanism">
+    <xs:sequence>
+      <xs:element name="triggeringOriginID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="nodalPlanes" type="scs:NodalPlanes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="principalAxes" type="scs:PrincipalAxes" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationPolarityCount" type="xs:int" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="misfit" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationDistributionRatio" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="momentTensor" type="scs:MomentTensor" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Amplitude">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="amplitude" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeWindow" type="scs:TimeWindow" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="period" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="snr" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="pickID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filterID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="scalingTime" type="scs:TimeQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitudeHint" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitudeContribution">
+    <xs:sequence>
+      <xs:element name="stationMagnitudeID" type="scs:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="residual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Magnitude">
+    <xs:sequence>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="originID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationCount" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthalGap" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitudeContribution" type="scs:StationMagnitudeContribution" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="StationMagnitude">
+    <xs:sequence>
+      <xs:element name="originID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="magnitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="amplitudeID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Pick">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="filterID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlowness" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="slownessMethodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="onset" type="scs:PickOnset" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="phaseHint" type="scs:Phase" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="polarity" type="scs:PickPolarity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginReference">
+    <xs:simpleContent>
+      <xs:extension base="scs:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="FocalMechanismReference">
+    <xs:simpleContent>
+      <xs:extension base="scs:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Event">
+    <xs:sequence>
+      <xs:element name="preferredOriginID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredMagnitudeID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredFocalMechanismID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:EventType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="typeCertainty" type="scs:EventTypeCertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="scs:EventDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="originReference" type="scs:OriginReference" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanismReference" type="scs:FocalMechanismReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OriginUncertainty">
+    <xs:sequence>
+      <xs:element name="horizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuthMaxHorizontalUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="confidenceEllipsoid" type="scs:ConfidenceEllipsoid" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="preferredDescription" type="scs:OriginUncertaintyDescription" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Arrival">
+    <xs:sequence>
+      <xs:element name="pickID" type="scs:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="phase" type="scs:Phase" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="timeCorrection" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="distance" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="takeOffAngle" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthResidual" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="horizontalSlownessUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="backazimuthUsed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="weight" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="preliminary" type="xs:boolean"/>
+  </xs:complexType>
+  <xs:complexType name="Origin">
+    <xs:sequence>
+      <xs:element name="time" type="scs:TimeQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="latitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="longitude" type="scs:RealQuantity" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="depth" type="scs:RealQuantity" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depthType" type="scs:OriginDepthType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="timeFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="epicenterFixed" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="referenceSystemID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="methodID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="earthModelID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="quality" type="scs:OriginQuality" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="uncertainty" type="scs:OriginUncertainty" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="scs:OriginType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationMode" type="scs:EvaluationMode" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="evaluationStatus" type="scs:EvaluationStatus" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="compositeTime" type="scs:CompositeTime" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arrival" type="scs:Arrival" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stationMagnitude" type="scs:StationMagnitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="magnitude" type="scs:Magnitude" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="EventParameters">
+    <xs:sequence>
+      <xs:element name="pick" type="scs:Pick" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="amplitude" type="scs:Amplitude" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="reading" type="scs:Reading" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="origin" type="scs:Origin" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="focalMechanism" type="scs:FocalMechanism" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="event" type="scs:Event" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Parameter">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ParameterSet">
+    <xs:sequence>
+      <xs:element name="baseID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="moduleID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="parameter" type="scs:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime"/>
+  </xs:complexType>
+  <xs:complexType name="Setup">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigStation">
+    <xs:sequence>
+      <xs:element name="creationInfo" type="scs:CreationInfo" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="setup" type="scs:Setup" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ConfigModule">
+    <xs:sequence>
+      <xs:element name="parameterSetID" type="scs:ResourceIdentifier" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="station" type="scs:ConfigStation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Config">
+    <xs:sequence>
+      <xs:element name="parameterSet" type="scs:ParameterSet" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="module" type="scs:ConfigModule" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="QCLog">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+    <xs:attribute name="creatorID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="WaveformQuality">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="parameter" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:double" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="lowerUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="upperUncertainty" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="windowLength" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="xs:string" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Outage">
+    <xs:sequence>
+      <xs:element name="waveformID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="creatorID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="created" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="QualityControl">
+    <xs:sequence>
+      <xs:element name="log" type="scs:QCLog" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="waveformQuality" type="scs:WaveformQuality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="outage" type="scs:Outage" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Blob">
+    <xs:simpleContent>
+      <xs:extension base="xs:string"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationReference">
+    <xs:simpleContent>
+      <xs:extension base="scs:ResourceIdentifier"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="StationGroup">
+    <xs:sequence>
+      <xs:element name="type" type="scs:StationGroupType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="stationReference" type="scs:StationReference" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxSource">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="conversion" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="AuxDevice">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="scs:AuxSource" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="SensorCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Sensor">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="model" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lowFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="highFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:SensorCalibration" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="response" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePAZ">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFactor" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="normalizationFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfZeros" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfPoles" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="zeros" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="poles" type="scs:ComplexArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponsePolynomial">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="frequencyUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationLowerBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationUpperBound" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="approximationError" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseFAP">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfTuples" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="tuples" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseFIR">
+    <xs:sequence>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfCoefficients" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="symmetry" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="coefficients" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="ResponseIIR">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="decimationFactor" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="delay" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="correction" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfNumerators" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numberOfDenominators" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="numerators" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="denominators" type="scs:RealArray" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="DataloggerCalibration">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="serialNumber" type="xs:string" use="required"/>
+    <xs:attribute name="channel" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Decimation">
+    <xs:sequence>
+      <xs:element name="analogueFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitalFilterChain" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="sampleRateNumerator" type="xs:integer" use="required"/>
+    <xs:attribute name="sampleRateDenominator" type="xs:integer" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Datalogger">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="digitizerManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="recorderManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockModel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockManufacturer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxClockDrift" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="calibration" type="scs:DataloggerCalibration" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="decimation" type="scs:Decimation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="AuxStream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="deviceSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="source" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="device" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="Stream">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dataloggerChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorChannel" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clockSerialNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateNumerator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sampleRateDenominator" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="depth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="azimuth" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="dip" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gain" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainFrequency" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="gainUnit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="flags" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="datalogger" type="scs:ResourceIdentifier"/>
+    <xs:attribute name="sensor" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="SensorLocation">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="auxStream" type="scs:AuxStream" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="stream" type="scs:Stream" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Station">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="latitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="longitude" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="elevation" type="xs:double" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="place" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="affiliation" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="sensorLocation" type="scs:SensorLocation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+    <xs:attribute name="archiveNetworkCode" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Network">
+    <xs:sequence>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="institutions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="remark" type="scs:Blob" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="comment" type="scs:Comment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="station" type="scs:Station" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="code" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Inventory">
+    <xs:sequence>
+      <xs:element name="stationGroup" type="scs:StationGroup" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="auxDevice" type="scs:AuxDevice" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="sensor" type="scs:Sensor" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="datalogger" type="scs:Datalogger" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePAZ" type="scs:ResponsePAZ" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseFIR" type="scs:ResponseFIR" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseIIR" type="scs:ResponseIIR" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responsePolynomial" type="scs:ResponsePolynomial" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="responseFAP" type="scs:ResponseFAP" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="network" type="scs:Network" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="RouteArclink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="RouteSeedlink">
+    <xs:sequence>
+      <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Route">
+    <xs:sequence>
+      <xs:element name="arclink" type="scs:RouteArclink" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="seedlink" type="scs:RouteSeedlink" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Access">
+    <xs:sequence>
+      <xs:element name="user" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="start" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="end" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="networkCode" type="xs:string" use="required"/>
+    <xs:attribute name="stationCode" type="xs:string" use="required"/>
+    <xs:attribute name="locationCode" type="xs:string" use="required"/>
+    <xs:attribute name="streamCode" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Routing">
+    <xs:sequence>
+      <xs:element name="route" type="scs:Route" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="access" type="scs:Access" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="JournalEntry">
+    <xs:sequence>
+      <xs:element name="objectID" type="scs:ResourceIdentifier" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="created" type="xs:dateTime"/>
+    <xs:attribute name="sender" type="xs:string" use="required"/>
+    <xs:attribute name="action" type="xs:string" use="required"/>
+    <xs:attribute name="parameters" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="Journaling">
+    <xs:sequence>
+      <xs:element name="entry" type="scs:JournalEntry" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkUser">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="email" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkStatusLine">
+    <xs:sequence>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="volumeID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestLine">
+    <xs:sequence>
+      <xs:element name="end" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="streamID" type="scs:WaveformStreamID" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="restricted" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="shared" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="netClass" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="constraints" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="status" type="scs:ArclinkStatusLine" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="start" type="xs:dateTime" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequestSummary">
+    <xs:sequence>
+      <xs:element name="okLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="totalLineCount" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="averageTimeWindow" type="xs:integer" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ArclinkRequest">
+    <xs:sequence>
+      <xs:element name="requestID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="userIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientID" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="clientIP" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="created" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="status" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="message" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="header" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="summary" type="scs:ArclinkRequestSummary" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="statusLine" type="scs:ArclinkStatusLine" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="requestLine" type="scs:ArclinkRequestLine" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ArclinkLog">
+    <xs:sequence>
+      <xs:element name="arclinkRequest" type="scs:ArclinkRequest" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="arclinkUser" type="scs:ArclinkUser" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="publicID" type="scs:ResourceIdentifier"/>
+  </xs:complexType>
+  <xs:element name="seiscomp">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="EventParameters" type="scs:EventParameters" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Config" type="scs:Config" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="QualityControl" type="scs:QualityControl" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Inventory" type="scs:Inventory" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Routing" type="scs:Routing" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="Journaling" type="scs:Journaling" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="ArclinkLog" type="scs:ArclinkLog" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="version" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/obspy/io/seiscomp/data/sc3ml_0.10__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.10__quakeml_1.2.xsl
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- * SC3ML 0.9 to QuakeML 1.2 stylesheet converter
+ * SC3ML 0.10 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
  * Version : 2017.342.01
@@ -27,14 +27,14 @@
  * This stylesheet converts a SC3ML to a QuakeML document. It may be invoked
  * e.g. using xalan or xsltproc:
  *
- *   xalan -in sc3ml.xml -xsl sc3ml_0.9__quakeml_1.2.xsl -out quakeml.xml
- *   xsltproc -o quakeml.xml sc3ml_0.9__quakeml_1.2.xsl sc3ml.xml
+ *   xalan -in sc3ml.xml -xsl sc3ml_0.10__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -o quakeml.xml sc3ml_0.10__quakeml_1.2.xsl sc3ml.xml
  *
  * You can also modify the default ID prefix with the reverse DNS name of your
  * institute by setting the ID_PREFIX param:
  *
- *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.9__quakeml_1.2.xsl -out quakeml.xml
- *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.9__quakeml_1.2.xsl sc3ml.xml
+ *   xalan -param ID_PREFIX "'smi:org.gfz-potsdam.de/geofon/'" -in sc3ml.xml -xsl sc3ml_0.10__quakeml_1.2.xsl -out quakeml.xml
+ *   xsltproc -stringparam ID_PREFIX smi:org.gfz-potsdam.de/geofon/ -o quakeml.xml sc3ml_0.10__quakeml_1.2.xsl sc3ml.xml
  *
  * ================
  * Transformation
@@ -171,7 +171,7 @@
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"
+        xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10"
         xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
         xmlns="http://quakeml.org/xmlns/bed/1.2"
         xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"

--- a/obspy/io/seiscomp/data/sc3ml_0.5__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.5__quakeml_1.2.xsl
@@ -18,6 +18,7 @@
  * SC3ML 0.5 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -70,18 +71,21 @@
  *  - Renaming of nodes: The following table lists the mapping of names between
  *    both schema:
  *
- *    Parent (SC3)        SC3 name           QuakeML name
- *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
- *    seiscomp            EventParameters    eventParameters
- *    arrival             weight             timeWeight
- *                        takeOffAngle       takeoffAngle
- *    magnitude           magnitude          mag
- *    stationMagnitude    magnitude          mag
- *    amplitude           amplitude          genericAmplitude
- *    origin              uncertainty        originUncertainty
- *    momentTensor        method             category
- *    waveformID          resourceURI        CDATA
- *    comment             id                 id (attribute)
+ *    Parent (SC3)     SC3 name                 QuakeML name
+ *    """""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp         EventParameters          eventParameters
+ *    arrival          weight [copied to following fields if true]
+ *                       timeUsed               timeWeight
+ *                       horizontalSlownessUsed horizontalSlownessWeight
+ *                       backazimuthUsed        backazimuthWeight
+ *                     takeOffAngle             takeoffAngle
+ *    magnitude        magnitude                mag
+ *    stationMagnitude magnitude                mag
+ *    amplitude        amplitude                genericAmplitude
+ *    origin           uncertainty              originUncertainty
+ *    momentTensor     method                   category
+ *    waveformID       resourceURI              CDATA
+ *    comment          id                       id (attribute)
  *
  *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
  *
@@ -94,9 +98,6 @@
  *    Parent          Element lost
  *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
  *    creationInfo    modificationTime
- *    arrival         timeUsed
- *                    horizontalSlownessUsed
- *                    backazimuthUsed
  *    momentTensor    method
  *                    stationMomentTensorContribution
  *                    status
@@ -104,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -152,6 +157,16 @@
  *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
  *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
  *    - Fix Arrival publicID generation
+ *
+ *  * 27.09.2017:
+ *    - Use '_' instead of '#' in arrival publicID generation
+ *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
+ *      backazimuthWeight depending on timeUsed, horizontalUsed and
+ *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -257,6 +272,9 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
+    <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
     <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
@@ -268,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -382,15 +401,54 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <!-- origin arrival -->
     <xsl:template match="scs:arrival">
         <xsl:element name="{local-name()}">
+            <!-- since SC3ML does not include a publicID it is generated from pick and origin id -->
             <xsl:attribute name="{$PID}">
                 <xsl:call-template name="convertID">
-                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                    <xsl:with-param name="id" select="concat(scs:pickID, '_', translate(../@publicID, ' :', '__'))"/>
                 </xsl:call-template>
             </xsl:attribute>
-            <!--comment/-->
+            <!-- mapping of weight to timeWeight, horizontalSlownessWeight and backazimuthWeight
+                 depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
+            <xsl:choose>
+                <xsl:when test="scs:weight">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:otherwise>
+            </xsl:choose>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
@@ -401,13 +459,6 @@
             <xsl:apply-templates select="@*"/>
             <xsl:call-template name="valueOfIDNode"/>
         </xsl:element>
-    </xsl:template>
-
-    <!-- arrival/weight -> arrival/timeWeight-->
-    <xsl:template match="scs:arrival/scs:weight">
-        <xsl:call-template name="genericNode">
-            <xsl:with-param name="name" select="'timeWeight'"/>
-        </xsl:call-template>
     </xsl:template>
 
     <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->

--- a/obspy/io/seiscomp/data/sc3ml_0.6__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.6__quakeml_1.2.xsl
@@ -18,6 +18,7 @@
  * SC3ML 0.6 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -70,18 +71,21 @@
  *  - Renaming of nodes: The following table lists the mapping of names between
  *    both schema:
  *
- *    Parent (SC3)        SC3 name           QuakeML name
- *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
- *    seiscomp            EventParameters    eventParameters
- *    arrival             weight             timeWeight
- *                        takeOffAngle       takeoffAngle
- *    magnitude           magnitude          mag
- *    stationMagnitude    magnitude          mag
- *    amplitude           amplitude          genericAmplitude
- *    origin              uncertainty        originUncertainty
- *    momentTensor        method             category
- *    waveformID          resourceURI        CDATA
- *    comment             id                 id (attribute)
+ *    Parent (SC3)     SC3 name                 QuakeML name
+ *    """""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp         EventParameters          eventParameters
+ *    arrival          weight [copied to following fields if true]
+ *                       timeUsed               timeWeight
+ *                       horizontalSlownessUsed horizontalSlownessWeight
+ *                       backazimuthUsed        backazimuthWeight
+ *                     takeOffAngle             takeoffAngle
+ *    magnitude        magnitude                mag
+ *    stationMagnitude magnitude                mag
+ *    amplitude        amplitude                genericAmplitude
+ *    origin           uncertainty              originUncertainty
+ *    momentTensor     method                   category
+ *    waveformID       resourceURI              CDATA
+ *    comment          id                       id (attribute)
  *
  *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
  *
@@ -94,9 +98,6 @@
  *    Parent          Element lost
  *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
  *    creationInfo    modificationTime
- *    arrival         timeUsed
- *                    horizontalSlownessUsed
- *                    backazimuthUsed
  *    momentTensor    method
  *                    stationMomentTensorContribution
  *                    status
@@ -104,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -152,6 +157,16 @@
  *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
  *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
  *    - Fix Arrival publicID generation
+ *
+ *  * 27.09.2017:
+ *    - Use '_' instead of '#' in arrival publicID generation
+ *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
+ *      backazimuthWeight depending on timeUsed, horizontalUsed and
+ *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -257,6 +272,9 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
+    <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
     <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
@@ -268,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -382,15 +401,54 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <!-- origin arrival -->
     <xsl:template match="scs:arrival">
         <xsl:element name="{local-name()}">
+            <!-- since SC3ML does not include a publicID it is generated from pick and origin id -->
             <xsl:attribute name="{$PID}">
                 <xsl:call-template name="convertID">
-                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                    <xsl:with-param name="id" select="concat(scs:pickID, '_', translate(../@publicID, ' :', '__'))"/>
                 </xsl:call-template>
             </xsl:attribute>
-            <!--comment/-->
+            <!-- mapping of weight to timeWeight, horizontalSlownessWeight and backazimuthWeight
+                 depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
+            <xsl:choose>
+                <xsl:when test="scs:weight">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:otherwise>
+            </xsl:choose>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
@@ -401,13 +459,6 @@
             <xsl:apply-templates select="@*"/>
             <xsl:call-template name="valueOfIDNode"/>
         </xsl:element>
-    </xsl:template>
-
-    <!-- arrival/weight -> arrival/timeWeight-->
-    <xsl:template match="scs:arrival/scs:weight">
-        <xsl:call-template name="genericNode">
-            <xsl:with-param name="name" select="'timeWeight'"/>
-        </xsl:call-template>
     </xsl:template>
 
     <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->

--- a/obspy/io/seiscomp/data/sc3ml_0.8__quakeml_1.2.xsl
+++ b/obspy/io/seiscomp/data/sc3ml_0.8__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.8 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2016.161.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -71,18 +71,21 @@
  *  - Renaming of nodes: The following table lists the mapping of names between
  *    both schema:
  *
- *    Parent (SC3)        SC3 name           QuakeML name
- *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
- *    seiscomp            EventParameters    eventParameters
- *    arrival             weight             timeWeight
- *                        takeOffAngle       takeoffAngle
- *    magnitude           magnitude          mag
- *    stationMagnitude    magnitude          mag
- *    amplitude           amplitude          genericAmplitude
- *    origin              uncertainty        originUncertainty
- *    momentTensor        method             category
- *    waveformID          resourceURI        CDATA
- *    comment             id                 id (attribute)
+ *    Parent (SC3)     SC3 name                 QuakeML name
+ *    """""""""""""""""""""""""""""""""""""""""""""""""""""""
+ *    seiscomp         EventParameters          eventParameters
+ *    arrival          weight [copied to following fields if true]
+ *                       timeUsed               timeWeight
+ *                       horizontalSlownessUsed horizontalSlownessWeight
+ *                       backazimuthUsed        backazimuthWeight
+ *                     takeOffAngle             takeoffAngle
+ *    magnitude        magnitude                mag
+ *    stationMagnitude magnitude                mag
+ *    amplitude        amplitude                genericAmplitude
+ *    origin           uncertainty              originUncertainty
+ *    momentTensor     method                   category
+ *    waveformID       resourceURI              CDATA
+ *    comment          id                       id (attribute)
  *
  *  - Enumerations: Both schema use enumerations. Numerous mappings are applied.
  *
@@ -95,9 +98,6 @@
  *    Parent          Element lost
  *    """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
  *    creationInfo    modificationTime
- *    arrival         timeUsed
- *                    horizontalSlownessUsed
- *                    backazimuthUsed
  *    momentTensor    method
  *                    stationMomentTensorContribution
  *                    status
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -153,6 +157,16 @@
  *    - Fix amplitude/unit (enumeration in QuakeML, not in SC3ML)
  *    - Don't modify id if it starts with 'smi:' or 'quakeml:'
  *    - Fix Arrival publicID generation
+ *
+ *  * 27.09.2017:
+ *    - Use '_' instead of '#' in arrival publicID generation
+ *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
+ *      backazimuthWeight depending on timeUsed, horizontalUsed and
+ *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -258,6 +272,9 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
+    <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
     <xsl:template match="scs:arrival/scs:backazimuthUsed"/>
@@ -269,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -383,15 +401,54 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- origin arrival, since SC3ML does not include a publicID it is generated from pick and origin id -->
+    <!-- origin arrival -->
     <xsl:template match="scs:arrival">
         <xsl:element name="{local-name()}">
+            <!-- since SC3ML does not include a publicID it is generated from pick and origin id -->
             <xsl:attribute name="{$PID}">
                 <xsl:call-template name="convertID">
-                    <xsl:with-param name="id" select="concat(scs:pickID, '#', translate(../@publicID, ' :', '__'))"/>
+                    <xsl:with-param name="id" select="concat(scs:pickID, '_', translate(../@publicID, ' :', '__'))"/>
                 </xsl:call-template>
             </xsl:attribute>
-            <!--comment/-->
+            <!-- mapping of weight to timeWeight, horizontalSlownessWeight and backazimuthWeight
+                 depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
+            <xsl:choose>
+                <xsl:when test="scs:weight">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="scs:weight"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))">
+                        <xsl:element name="timeWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:horizontalSlownessUsed='true') or (scs:horizontalSlownessUsed='1'))">
+                        <xsl:element name="horizontalSlownessWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:if test="((scs:backazimuthUsed='true') or (scs:backazimuthUsed='1'))">
+                        <xsl:element name="backazimuthWeight">
+                            <xsl:value-of select="'1'"/>
+                        </xsl:element>
+                    </xsl:if>
+                </xsl:otherwise>
+            </xsl:choose>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
@@ -402,13 +459,6 @@
             <xsl:apply-templates select="@*"/>
             <xsl:call-template name="valueOfIDNode"/>
         </xsl:element>
-    </xsl:template>
-
-    <!-- arrival/weight -> arrival/timeWeight-->
-    <xsl:template match="scs:arrival/scs:weight">
-        <xsl:call-template name="genericNode">
-            <xsl:with-param name="name" select="'timeWeight'"/>
-        </xsl:call-template>
     </xsl:template>
 
     <!-- arrival/takeOffAngle -> arrival/takeoffAngle -->

--- a/obspy/io/seiscomp/event.py
+++ b/obspy/io/seiscomp/event.py
@@ -25,12 +25,12 @@ from obspy.io.quakeml.core import Pickler, Unpickler, _xml_doc_from_anything
 from obspy.io.seiscomp.core import validate as validate_sc3ml
 
 
-SCHEMA_VERSION = ['0.5', '0.6', '0.7', '0.8', '0.9']
+SCHEMA_VERSION = ['0.5', '0.6', '0.7', '0.8', '0.9', '0.10']
 
 
 def _read_sc3ml(filename, id_prefix='smi:org.gfz-potsdam.de/geofon/'):
     """
-    Read a 0.9 SC3ML file and returns a :class:`~obspy.core.event.Catalog`.
+    Read a SC3ML file and returns a :class:`~obspy.core.event.Catalog`.
 
     An XSLT file is used to convert the SC3ML file to a QuakeML file. The
     catalog is then generated using the QuakeML module.
@@ -89,8 +89,8 @@ def _read_sc3ml(filename, id_prefix='smi:org.gfz-potsdam.de/geofon/'):
 def _write_sc3ml(catalog, filename, validate=False, verbose=False,
                  event_removal=False, **kwargs):  # @UnusedVariable
     """
-    Write a SC3ML file. Since a XSLT file is used to write the SC3ML file from
-    a QuakeML file, the catalog is first converted in QuakeML.
+    Write a SC3ML 0.10 file. Since a XSLT file is used to write the SC3ML file
+    from a QuakeML file, the catalog is first converted in QuakeML.
 
     .. warning::
         This function should NOT be called directly, it registers via the
@@ -116,7 +116,7 @@ def _write_sc3ml(catalog, filename, validate=False, verbose=False,
     nsmap_ = getattr(catalog, "nsmap", {})
     quakeml_doc = Pickler(nsmap=nsmap_).dumps(catalog)
     xslt_filename = os.path.join(os.path.dirname(__file__), 'data',
-                                 'quakeml_1.2__sc3ml_0.9.xsl')
+                                 'quakeml_1.2__sc3ml_0.10.xsl')
     transform = etree.XSLT(etree.parse(xslt_filename))
     sc3ml_doc = transform(etree.parse(io.BytesIO(quakeml_doc)))
 

--- a/obspy/io/seiscomp/tests/data/field_sc3ml0.10.sc3ml
+++ b/obspy/io/seiscomp/tests/data/field_sc3ml0.10.sc3ml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
+  <EventParameters publicID="smi:eu.emsc/unid">
+    <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
+      <time>
+        <value>2011-03-11T05:46:24.120000Z</value>
+        <pdf>
+          <variable>2002-05-30T09:00:00 2003-05-30T09:00:00 2004-05-30T09:00:00</variable>
+          <probability>0.5 1.3 2.8</probability>
+        </pdf>
+      </time>
+      <latitude>
+        <value>38.297</value>
+      </latitude>
+      <longitude>
+        <value>142.373</value>
+      </longitude>
+      <comment>
+        <text>comment</text>
+        <start>2002-05-30T09:00:00</start>
+        <end>2003-05-30T09:00:00</end>
+      </comment>
+    </origin>
+    <event publicID="smi:ch.ethz.sed/event/historical/1165">
+      <originReference>smi:www.iris.edu/ws/event/query?originId=7680412</originReference>
+    </event>
+  </EventParameters>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/data/field_sc3ml0.10_res.xml
+++ b/obspy/io/seiscomp/tests/data/field_sc3ml0.10_res.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
+  <eventParameters publicID="smi:eu.emsc/unid">
+    <event publicID="smi:ch.ethz.sed/event/historical/1165">
+      <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
+        <time>
+          <value>2011-03-11T05:46:24.120000Z</value>
+        </time>
+        <latitude>
+          <value>38.297</value>
+        </latitude>
+        <longitude>
+          <value>142.373</value>
+        </longitude>
+        <comment>
+          <text>comment</text>
+        </comment>
+      </origin>
+    </event>
+  </eventParameters>
+</q:quakeml>

--- a/obspy/io/seiscomp/tests/data/iris_events.sc3ml
+++ b/obspy/io/seiscomp/tests/data/iris_events.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:www.iris.edu/ws/event/query">
     <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
       <time>

--- a/obspy/io/seiscomp/tests/data/no_version_attribute.sc3ml
+++ b/obspy/io/seiscomp/tests/data/no_version_attribute.sc3ml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9"/>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10"/>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_no_events.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_no_events.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_write.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_write.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_wrong_id.sc3ml
+++ b/obspy/io/seiscomp/tests/data/qml-example-1.2-RC3_wrong_id.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:nz.org.geonet/catalog/1">
     <amplitude publicID="test_amplitude_id">
       <type>A</type>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival.xml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival.xml
@@ -12,7 +12,8 @@
         <longitude>
           <value>142.373</value>
         </longitude>
-        <arrival publicID="smi:ch.ethz.sed/pick/117634#smi_www.iris.edu/ws/event/query?originId=7680412">
+        <arrival publicID="smi:ch.ethz.sed/pick/117634_smi_www.iris.edu/ws/event/query?originId=7680412">
+          <timeWeight>0.48</timeWeight>
           <pickID>smi:ch.ethz.sed/pick/117634</pickID>
           <phase>Pn</phase>
           <azimuth>12.0</azimuth>
@@ -23,7 +24,6 @@
           <timeResidual>1.6</timeResidual>
           <horizontalSlownessResidual>1.7</horizontalSlownessResidual>
           <backazimuthResidual>1.8</backazimuthResidual>
-          <timeWeight>0.48</timeWeight>
           <earthModelID>smi:ch.ethz.sed/earthmodel/U21</earthModelID>
           <creationInfo>
             <agencyID>EMSC</agencyID>
@@ -34,13 +34,22 @@
             <version>1.0.1</version>
           </creationInfo>
         </arrival>
-        <arrival publicID="smi:geonet.org.nz/pick/4965459#smi_www.iris.edu/ws/event/query?originId=7680412">
+        <arrival publicID="smi:geonet.org.nz/pick/4965459_smi_www.iris.edu/ws/event/query?originId=7680412">
+          <horizontalSlownessWeight>0.48</horizontalSlownessWeight>
           <pickID>smi:geonet.org.nz/pick/4965459</pickID>
           <phase>P*</phase>
-          <azimuth>356.0</azimuth>
-          <distance>45.036</distance>
-          <horizontalSlownessResidual>-0.736</horizontalSlownessResidual>
+        </arrival>
+        <arrival publicID="smi:geonet.org.nz/pick/4965460_smi_www.iris.edu/ws/event/query?originId=7680412">
+          <backazimuthWeight>0.48</backazimuthWeight>
+          <pickID>smi:geonet.org.nz/pick/4965460</pickID>
+          <phase>P*</phase>
+        </arrival>
+        <arrival publicID="smi:geonet.org.nz/pick/4965461_smi_www.iris.edu/ws/event/query?originId=7680412">
           <timeWeight>0.48</timeWeight>
+          <horizontalSlownessWeight>0.48</horizontalSlownessWeight>
+          <backazimuthWeight>0.48</backazimuthWeight>
+          <pickID>smi:geonet.org.nz/pick/4965461</pickID>
+          <phase>P*</phase>
         </arrival>
       </origin>
     </event>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival_res.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_arrival_res.sc3ml
@@ -48,8 +48,6 @@
         <pickID>smi:geonet.org.nz/pick/4965461</pickID>
         <phase>P*</phase>
         <timeUsed>true</timeUsed>
-        <horizontalSlownessUsed>true</horizontalSlownessUsed>
-        <backazimuthUsed>true</backazimuthUsed>
         <weight>0.48</weight>
       </arrival>
     </origin>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_data_used.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_data_used.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:ISC/bulletin">
     <focalMechanism publicID="smi:ISC/fmid=292310">
       <momentTensor publicID="smi:ISC/mtid=123456">

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_event.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_event.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <event publicID="smi:ch.ethz.sed/event/historical/1165">
       <preferredOriginID>smi:ch.ethz.sed/origin/2054</preferredOriginID>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_focalmechanism.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_focalmechanism.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:ISC/bulletin">
     <focalMechanism publicID="smi:ISC/fmid=292309">
       <triggeringOriginID>smi:local/originId=7680412</triggeringOriginID>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_magnitude.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_magnitude.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_origin.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <pick publicID="smi:ch.ethz.sed/pick/117634">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.xml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_pick.xml
@@ -57,11 +57,11 @@
         <longitude>
           <value>142.373</value>
         </longitude>
-        <arrival publicID="smi:ch.ethz.sed/pick/117634#smi_ch.ethz.sed/event/historical/1165/origin/1">
+        <arrival publicID="smi:ch.ethz.sed/pick/117634_smi_ch.ethz.sed/event/historical/1165/origin/1">
           <pickID>smi:ch.ethz.sed/pick/117634</pickID>
           <phase>Pn</phase>
         </arrival>
-        <arrival publicID="smi:geonet.org.nz/pick/4965421#smi_ch.ethz.sed/event/historical/1165/origin/1">
+        <arrival publicID="smi:geonet.org.nz/pick/4965421_smi_ch.ethz.sed/event/historical/1165/origin/1">
           <pickID>smi:geonet.org.nz/pick/4965421</pickID>
           <phase>Pn</phase>
         </arrival>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitude.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitude.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitudecontributions.sc3ml
+++ b/obspy/io/seiscomp/tests/data/quakeml_1.2_stationmagnitudecontributions.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="smi:eu.emsc/unid">
     <origin publicID="smi:ch.ethz.sed/event/historical/1165/origin/1">
       <time>

--- a/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
+++ b/obspy/io/seiscomp/tests/data/usgs_event.sc3ml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10" version="0.10">
   <EventParameters publicID="quakeml:comcat.cr.usgs.gov/fdsnws/event/1/query">
     <origin publicID="quakeml:earthquake.usgs.gov/product/ci/origin/ci37285320/1415311367340">
       <time>

--- a/obspy/io/seiscomp/tests/data/version0.11
+++ b/obspy/io/seiscomp/tests/data/version0.11
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.11" version="0.11">
+    <EventParameters />
+    <Inventory />
+</seiscomp>

--- a/obspy/io/seiscomp/tests/test_core.py
+++ b/obspy/io/seiscomp/tests/test_core.py
@@ -46,10 +46,10 @@ class CoreTestCase(unittest.TestCase):
         self.assertFalse(validate(filename, version='0.8'))
 
         with self.assertRaises(ValueError) as e:
-            validate(filename, version='0.10')
+            validate(filename, version='0.11')
 
-        expected_error = ("0.10 is not a supported version. Use one of these "
-                          "versions: [0.3, 0.5, 0.6, 0.7, 0.8, 0.9].")
+        expected_error = ("0.11 is not a supported version. Use one of these "
+                          "versions: [0.3, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10].")
         self.assertEqual(e.exception.args[0], expected_error)
 
 

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -41,9 +41,9 @@ class EventTestCase(unittest.TestCase):
             os.path.join(io_directory, 'quakeml', 'tests', 'data')
         self.path = os.path.join(os.path.dirname(__file__), 'data')
         self.read_xslt_filename = os.path.join(
-            io_directory, 'seiscomp', 'data', 'sc3ml_0.9__quakeml_1.2.xsl')
+            io_directory, 'seiscomp', 'data', 'sc3ml_0.10__quakeml_1.2.xsl')
         self.write_xslt_filename = os.path.join(
-            io_directory, 'seiscomp', 'data', 'quakeml_1.2__sc3ml_0.9.xsl')
+            io_directory, 'seiscomp', 'data', 'quakeml_1.2__sc3ml_0.10.xsl')
 
     def cmp_read_xslt_file(self, sc3ml_file, quakeml_file, validate=True):
         """
@@ -85,7 +85,7 @@ class EventTestCase(unittest.TestCase):
         """
         Test multiple schema versions
         """
-        for version in ['0.5', '0.6', '0.7', '0.8', '0.9']:
+        for version in ['0.5', '0.6', '0.7', '0.8', '0.10']:
             filename = os.path.join(self.path, 'version%s' % version)
             read_events(filename)
 
@@ -94,15 +94,15 @@ class EventTestCase(unittest.TestCase):
             read_events(filename)
 
         expected_message = ("Can't read SC3ML version 0.3, ObsPy can deal "
-                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
+                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9, 0.10].")
         self.assertEqual(e.exception.args[0], expected_message)
 
-        filename = os.path.join(self.path, 'version0.10')
+        filename = os.path.join(self.path, 'version0.11')
         with self.assertRaises(ValueError) as e:
             read_events(filename)
 
-        expected_message = ("Can't read SC3ML version 0.10, ObsPy can deal "
-                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9].")
+        expected_message = ("Can't read SC3ML version 0.11, ObsPy can deal "
+                            "with versions [0.5, 0.6, 0.7, 0.8, 0.9, 0.10].")
         self.assertEqual(e.exception.args[0], expected_message)
 
     def test_read_xslt_event(self):
@@ -132,7 +132,7 @@ class EventTestCase(unittest.TestCase):
 
     def test_read_xslt_arrival(self):
         self.cmp_read_xslt_file('quakeml_1.2_arrival.sc3ml',
-                                'quakeml_1.2_arrival_res.xml')
+                                'quakeml_1.2_arrival.xml')
 
     def test_read_xslt_pick(self):
         self.cmp_read_xslt_file('quakeml_1.2_pick.sc3ml',
@@ -211,6 +211,13 @@ class EventTestCase(unittest.TestCase):
         expected_message = "Not a SC3ML compatible file or string."
         self.assertEqual(e.exception.args[0], expected_message)
 
+    def test_read_field_sc3ml0_10(self):
+        """
+        Test new fields in SC3ML 0.10 which are not in the QuakeML 1.2.
+        """
+        self.cmp_read_xslt_file('field_sc3ml0.10.sc3ml',
+                                'field_sc3ml0.10_res.xml')
+
     def test_write_xslt_event(self):
         self.cmp_write_xslt_file('quakeml_1.2_event.xml',
                                  'quakeml_1.2_event.sc3ml',
@@ -243,8 +250,7 @@ class EventTestCase(unittest.TestCase):
 
     def test_write_xslt_arrival(self):
         self.cmp_write_xslt_file('quakeml_1.2_arrival.xml',
-                                 'quakeml_1.2_arrival.sc3ml',
-                                 path=self.quakeml_path)
+                                 'quakeml_1.2_arrival_res.sc3ml')
 
     def test_write_xslt_pick(self):
         self.cmp_write_xslt_file('quakeml_1.2_pick.xml',

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -61,6 +61,39 @@ class EventTestCase(unittest.TestCase):
             filepath_cmp = os.path.join(self.path, quakeml_file)
             self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
 
+    def cmp_read_xslt_file_old_version(self, sc3ml_file, quakeml_file, version,
+                                       validate=True):
+        """
+        Change the version of the sc3ml_file and check if the generated file
+        is the same than the QuakeML file.
+        """
+        xslt_filename = self.read_xslt_filename.replace(
+            'sc3ml_0.10__quakeml_1.2.xsl',
+            'sc3ml_%s__quakeml_1.2.xsl' % version,
+        )
+        transform = etree.XSLT(etree.parse(xslt_filename))
+        filename = os.path.join(self.path, sc3ml_file)
+
+        with open(filename, 'r') as f:
+            data = f.read()
+            # Remove encoding declaration otherwise lxml will not be
+            # able to read the file.
+            data = data.replace('<?xml version="1.0" encoding="UTF-8"?>\n', '')
+            data = data.replace(
+                'http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10',
+                'http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/%s'
+                % version)
+            sc3ml_doc = etree.fromstring(data)
+
+        quakeml_doc = transform(sc3ml_doc)
+
+        with NamedTemporaryFile() as tf:
+            tf.write(quakeml_doc)
+            if validate:
+                self.assertTrue(_validate_quakeml(tf.name))
+            filepath_cmp = os.path.join(self.path, quakeml_file)
+            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+
     def cmp_write_xslt_file(self, quakeml_file, sc3ml_file, validate=True,
                             path=None):
         """
@@ -217,6 +250,46 @@ class EventTestCase(unittest.TestCase):
         """
         self.cmp_read_xslt_file('field_sc3ml0.10.sc3ml',
                                 'field_sc3ml0.10_res.xml')
+
+    def test_read_0_5_file(self):
+        """
+        Test reading a file in version 0.5.
+        """
+        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
+                                            'qml-example-1.2-RC3.xml',
+                                            '0.5')
+
+    def test_read_0_6_file(self):
+        """
+        Test reading a file in version 0.6.
+        """
+        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
+                                            'qml-example-1.2-RC3.xml',
+                                            '0.6')
+
+    def test_read_0_7_file(self):
+        """
+        Test reading a file in version 0.7.
+        """
+        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
+                                            'qml-example-1.2-RC3.xml',
+                                            '0.7')
+
+    def test_read_0_8_file(self):
+        """
+        Test reading a file in version 0.8.
+        """
+        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
+                                            'qml-example-1.2-RC3.xml',
+                                            '0.8')
+
+    def test_read_0_9_file(self):
+        """
+        Test reading a file in version 0.9.
+        """
+        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
+                                            'qml-example-1.2-RC3.xml',
+                                            '0.9')
 
     def test_write_xslt_event(self):
         self.cmp_write_xslt_file('quakeml_1.2_event.xml',

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -26,7 +26,7 @@ from obspy.core.util.base import NamedTemporaryFile
 from obspy.io.quakeml.core import _read_quakeml
 from obspy.io.quakeml.core import _validate as _validate_quakeml
 from obspy.io.seiscomp.core import validate as validate_sc3ml
-from obspy.io.seiscomp.event import _read_sc3ml
+from obspy.io.seiscomp.event import SCHEMA_VERSION, _read_sc3ml
 
 
 class EventTestCase(unittest.TestCase):
@@ -35,45 +35,20 @@ class EventTestCase(unittest.TestCase):
     """
     def setUp(self):
         # directory where the test files are located
-        io_directory = \
+        self.io_directory = \
             os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         self.quakeml_path = \
-            os.path.join(io_directory, 'quakeml', 'tests', 'data')
+            os.path.join(self.io_directory, 'quakeml', 'tests', 'data')
         self.path = os.path.join(os.path.dirname(__file__), 'data')
-        self.read_xslt_filename = os.path.join(
-            io_directory, 'seiscomp', 'data', 'sc3ml_0.10__quakeml_1.2.xsl')
         self.write_xslt_filename = os.path.join(
-            io_directory, 'seiscomp', 'data', 'quakeml_1.2__sc3ml_0.10.xsl')
+            self.io_directory, 'seiscomp', 'data',
+            'quakeml_1.2__sc3ml_0.10.xsl')
 
-    def cmp_read_xslt_file(self, sc3ml_file, quakeml_file, validate=True):
+    def change_version(self, filename, version):
         """
-        Check if the QuakeML file generated with the XSLT file is the
-        same than the one in the data folder.
+        Change the version number of a SC3ML file and return an etree
+        document.
         """
-        transform = etree.XSLT(etree.parse(self.read_xslt_filename))
-        filename = os.path.join(self.path, sc3ml_file)
-        quakeml_doc = transform(etree.parse(filename))
-
-        with NamedTemporaryFile() as tf:
-            tf.write(quakeml_doc)
-            if validate:
-                self.assertTrue(_validate_quakeml(tf.name))
-            filepath_cmp = os.path.join(self.path, quakeml_file)
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
-
-    def cmp_read_xslt_file_old_version(self, sc3ml_file, quakeml_file, version,
-                                       validate=True):
-        """
-        Change the version of the sc3ml_file and check if the generated file
-        is the same than the QuakeML file.
-        """
-        xslt_filename = self.read_xslt_filename.replace(
-            'sc3ml_0.10__quakeml_1.2.xsl',
-            'sc3ml_%s__quakeml_1.2.xsl' % version,
-        )
-        transform = etree.XSLT(etree.parse(xslt_filename))
-        filename = os.path.join(self.path, sc3ml_file)
-
         with open(filename, 'r') as f:
             data = f.read()
             # Remove encoding declaration otherwise lxml will not be
@@ -83,16 +58,37 @@ class EventTestCase(unittest.TestCase):
                 'http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.10',
                 'http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/%s'
                 % version)
-            sc3ml_doc = etree.fromstring(data)
+            return etree.fromstring(data)
 
-        quakeml_doc = transform(sc3ml_doc)
+    def cmp_read_xslt_file(self, sc3ml_file, quakeml_file, validate=True):
+        """
+        Check if the QuakeML file generated with the XSLT file is the
+        same than the one in the data folder. Every available SC3ML
+        versions are tested except those for which the file is not
+        valid.
+        """
+        for version in SCHEMA_VERSION:
+            read_xslt_filename = os.path.join(
+                self.io_directory, 'seiscomp', 'data',
+                'sc3ml_%s__quakeml_1.2.xsl' % version,
+            )
 
-        with NamedTemporaryFile() as tf:
-            tf.write(quakeml_doc)
-            if validate:
-                self.assertTrue(_validate_quakeml(tf.name))
-            filepath_cmp = os.path.join(self.path, quakeml_file)
-            self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
+            transform = etree.XSLT(etree.parse(read_xslt_filename))
+            filename = os.path.join(self.path, sc3ml_file)
+            sc3ml_doc = self.change_version(filename, version)
+
+            # Only test valid SC3ML file
+            if not validate_sc3ml(sc3ml_doc):
+                continue
+
+            quakeml_doc = transform(sc3ml_doc)
+
+            with NamedTemporaryFile() as tf:
+                tf.write(quakeml_doc)
+                if validate:
+                    self.assertTrue(_validate_quakeml(tf.name))
+                filepath_cmp = os.path.join(self.path, quakeml_file)
+                self.assertTrue(filecmp.cmp(filepath_cmp, tf.name))
 
     def cmp_write_xslt_file(self, quakeml_file, sc3ml_file, validate=True,
                             path=None):
@@ -250,46 +246,6 @@ class EventTestCase(unittest.TestCase):
         """
         self.cmp_read_xslt_file('field_sc3ml0.10.sc3ml',
                                 'field_sc3ml0.10_res.xml')
-
-    def test_read_0_5_file(self):
-        """
-        Test reading a file in version 0.5.
-        """
-        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
-                                            'qml-example-1.2-RC3.xml',
-                                            '0.5')
-
-    def test_read_0_6_file(self):
-        """
-        Test reading a file in version 0.6.
-        """
-        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
-                                            'qml-example-1.2-RC3.xml',
-                                            '0.6')
-
-    def test_read_0_7_file(self):
-        """
-        Test reading a file in version 0.7.
-        """
-        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
-                                            'qml-example-1.2-RC3.xml',
-                                            '0.7')
-
-    def test_read_0_8_file(self):
-        """
-        Test reading a file in version 0.8.
-        """
-        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
-                                            'qml-example-1.2-RC3.xml',
-                                            '0.8')
-
-    def test_read_0_9_file(self):
-        """
-        Test reading a file in version 0.9.
-        """
-        self.cmp_read_xslt_file_old_version('qml-example-1.2-RC3.sc3ml',
-                                            'qml-example-1.2-RC3.xml',
-                                            '0.9')
 
     def test_write_xslt_event(self):
         self.cmp_write_xslt_file('quakeml_1.2_event.xml',


### PR DESCRIPTION
Hey! I looked a bit to the SC3ML 0.10 event support (see https://github.com/obspy/obspy/issues/2004) and it should be pretty good. There are some changes on the `Arrival/weight` mapping and some fields have been added. Event types have also been added to better match QuakeML. The rest concerns the inventory part that I didn't touch.

I made some changes to the XSLT files provided by SeisComP3 and as they added them to their [Github repository](https://github.com/SeisComP3/seiscomp3/tree/master/src/trunk/libs/xml), I did a [pull request](https://github.com/SeisComP3/seiscomp3/pull/158). It is still open so changes can still be made to this PR.

Morevover, the SC3ML files are always written in SC3ML 0.10. I didn't let the possibility to write files in SC3ML 0.9. What do you think about that? Is it worth to keep the choice of the version at the cost of a slightly greater complexity? I do not know if many people want to write in an old SC3ML version.