### PR TITLE
[MassDownloader] Let the 'channel' and 'location' settings override the priority lists

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -1177,24 +1177,24 @@ class ClientDownloadHelper(object):
                     # Group by locations and apply the channel priority filter
                     # to each.
                     filtered_channels = []
-    
+
                     def get_loc(x):
                         return x.location
-    
+
                     for location, _channels in itertools.groupby(
                             sorted(channels, key=get_loc), get_loc):
                         filtered_channels.extend(utils.filter_channel_priority(
                             list(_channels), key="channel",
                             priorities=self.restrictions.channel_priorities))
                     channels = filtered_channels
-    
+
                 if self.restrictions.location is None:
                     # Filter to remove unwanted locations according to the
                     # priority list.
                     channels = utils.filter_channel_priority(
                         channels, key="location",
                         priorities=self.restrictions.location_priorities)
-    
+
                 if not channels:
                     continue
 

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -1173,26 +1173,28 @@ class ClientDownloadHelper(object):
                         location=channel.location_code, channel=channel.code,
                         intervals=copy.deepcopy(intervals)))
 
-                # Group by locations and apply the channel priority filter to
-                # each.
-                filtered_channels = []
-
-                def get_loc(x):
-                    return x.location
-
-                for location, _channels in itertools.groupby(
-                        sorted(channels, key=get_loc), get_loc):
-                    filtered_channels.extend(utils.filter_channel_priority(
-                        list(_channels), key="channel",
-                        priorities=self.restrictions.channel_priorities))
-                channels = filtered_channels
-
-                # Filter to remove unwanted locations according to the priority
-                # list.
-                channels = utils.filter_channel_priority(
-                    channels, key="location",
-                    priorities=self.restrictions.location_priorities)
-
+                if self.restrictions.channel is None:
+                    # Group by locations and apply the channel priority filter
+                    # to each.
+                    filtered_channels = []
+    
+                    def get_loc(x):
+                        return x.location
+    
+                    for location, _channels in itertools.groupby(
+                            sorted(channels, key=get_loc), get_loc):
+                        filtered_channels.extend(utils.filter_channel_priority(
+                            list(_channels), key="channel",
+                            priorities=self.restrictions.channel_priorities))
+                    channels = filtered_channels
+    
+                if self.restrictions.location is None:
+                    # Filter to remove unwanted locations according to the
+                    # priority list.
+                    channels = utils.filter_channel_priority(
+                        channels, key="location",
+                        priorities=self.restrictions.location_priorities)
+    
                 if not channels:
                     continue
 


### PR DESCRIPTION
### What does this PR do?

This makes the code works as documented, that is: if the `channel` variable is set, then the `channel_priorities` list is ignored. The same goes for the `location` variable and `location_priorities`.

### Why was it initiated?  Any relevant Issues?

Yes: the code was not working as documented (and the documented behavior makes sense).

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
