### PR TITLE
io.reftek: switch internal representation of timestamps to integer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).
+ - obspy.io.reftek:
+   * Fix problems reading some Reftek 130 files, presumably due to floating
+     point accuracy issues in comparing timestamps. Internal representation of
+     time stamps is changed to integer nanosecond POSIX timestamp (see #2036,
+     #2038)
  - obspy.io.seiscomp:
    * Fix inventory read when maxClockDrift is unset in SC3ML (see #1993)
  - obspy.io.stationxml

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -17,6 +17,8 @@ import datetime
 import math
 import time
 
+import numpy as np
+
 
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 
@@ -383,6 +385,16 @@ class UTCDateTime(object):
         return self.__ns
 
     def _set_ns(self, value):
+        # allow setting numpy integer types..
+        if isinstance(value, np.integer):
+            value_ = int(value)
+            # ..and be paranoid and check that it's still the same value after
+            # type casting
+            if value_ != value:
+                msg = ('Numpy integer value ({!s}) changed during casting to '
+                       'Python builtin integer ({!s}).').format(value, value_)
+                raise ValueError(msg)
+            value = value_
         if not isinstance(value, int):
             raise TypeError('nanoseconds must be set as int/long type')
         self.__ns = value

--- a/obspy/io/reftek/__init__.py
+++ b/obspy/io/reftek/__init__.py
@@ -56,14 +56,14 @@ Network, location and component codes can be specified during reading:
 <obspy.core.stream.Stream object at 0x...>
 >>> print(st)  # doctest: +ELLIPSIS
 8 Trace(s) in Stream:
-BW.KW1..EHZ | 2015-10-09T22:50:51.000000Z - ... | 200.0 Hz, 3165 samples
-BW.KW1..EHZ | 2015-10-09T22:51:06.215000Z - ... | 200.0 Hz, 892 samples
-BW.KW1..EHZ | 2015-10-09T22:51:11.675000Z - ... | 200.0 Hz, 2743 samples
+BW.KW1..EHE | 2015-10-09T22:50:51.000000Z - ... | 200.0 Hz, 3405 samples
+BW.KW1..EHE | 2015-10-09T22:51:08.415000Z - ... | 200.0 Hz, 3395 samples
 BW.KW1..EHN | 2015-10-09T22:50:51.000000Z - ... | 200.0 Hz, 3107 samples
 BW.KW1..EHN | 2015-10-09T22:51:05.925000Z - ... | 200.0 Hz, 768 samples
 BW.KW1..EHN | 2015-10-09T22:51:10.765000Z - ... | 200.0 Hz, 2925 samples
-BW.KW1..EHE | 2015-10-09T22:50:51.000000Z - ... | 200.0 Hz, 3405 samples
-BW.KW1..EHE | 2015-10-09T22:51:08.415000Z - ... | 200.0 Hz, 3395 samples
+BW.KW1..EHZ | 2015-10-09T22:50:51.000000Z - ... | 200.0 Hz, 3165 samples
+BW.KW1..EHZ | 2015-10-09T22:51:06.215000Z - ... | 200.0 Hz, 892 samples
+BW.KW1..EHZ | 2015-10-09T22:51:11.675000Z - ... | 200.0 Hz, 2743 samples
 
 Reftek 130 specific metadata (from event header packet) is stored
 in ``stats.reftek130``.
@@ -72,12 +72,12 @@ in ``stats.reftek130``.
          network: BW
          station: KW1
         location:
-         channel: EHZ
+         channel: EHE
        starttime: 2015-10-09T22:50:51.000000Z
-         endtime: 2015-10-09T22:51:06.820000Z
+         endtime: 2015-10-09T22:51:08.020000Z
    sampling_rate: 200.0
            delta: 0.005
-            npts: 3165
+            npts: 3405
            calib: 1.0
          _format: REFTEK130
        reftek130: ...

--- a/obspy/io/reftek/core.py
+++ b/obspy/io/reftek/core.py
@@ -152,10 +152,13 @@ class Reftek130(object):
         packets.
         """
         diff = np.diff(self._data['packet_sequence'].astype(np.int16))
-        if np.any(diff < 1):
+        # rollover from 9999 to 0 is not a packet sequence jump..
+        jump = (diff < 1) & (diff != -9999)
+        if np.any(jump):
             msg = ("Detected permuted packet sequence, sorting.")
             warnings.warn(msg)
-            self._data.sort(order=native_str("packet_sequence"))
+            self._data.sort(order=[
+                native_str(key) for key in ("packet_sequence", "time")])
 
     def check_packet_sequence_contiguous(self):
         """

--- a/obspy/io/reftek/core.py
+++ b/obspy/io/reftek/core.py
@@ -100,6 +100,7 @@ def _read_reftek130(filename, network="", location="", component_codes=None,
             network=network, location=location,
             component_codes=component_codes, headonly=headonly,
             verbose=verbose)
+        st.merge(-1)
         return st
     except Reftek130UnpackPacketError:
         msg = ("Unable to read file '{}' as a Reftek130 file. Please contact "

--- a/obspy/io/reftek/core.py
+++ b/obspy/io/reftek/core.py
@@ -108,6 +108,7 @@ def _read_reftek130(filename, network="", location="", component_codes=None,
             verbose=verbose,
             sort_permuted_package_sequence=sort_permuted_package_sequence)
         st.merge(-1)
+        st.sort()
         return st
     except Reftek130UnpackPacketError:
         msg = ("Unable to read file '{}' as a Reftek130 file. Please contact "

--- a/obspy/io/reftek/packet.py
+++ b/obspy/io/reftek/packet.py
@@ -172,8 +172,13 @@ class EHPacket(Packet):
                     value = value.decode()
                 info.append("{}: {}".format(key, value))
             info.append("-" * 20)
-            info += ["{}: {}".format(key, getattr(self, key))
-                     for key in sorted(EH_PAYLOAD.keys())]
+            for key in sorted(EH_PAYLOAD.keys()):
+                value = getattr(self, key)
+                if key in ("trigger_time", "detrigger_time",
+                           "first_sample_time", "last_sample_time"):
+                    if value is not None:
+                        value = UTCDateTime(ns=value)
+                info.append("{}: {}".format(key, value))
             info = "{} Packet\n\t{}".format(self.type.decode(),
                                             "\n\t".join(info))
         return info

--- a/obspy/io/reftek/tests/test_core.py
+++ b/obspy/io/reftek/tests/test_core.py
@@ -135,7 +135,8 @@ class ReftekTestCase(unittest.TestCase):
         """
         st_reftek = _read_reftek130(
             self.reftek_file, network="XX", location="01",
-            component_codes=["1", "2", "3"])
+            component_codes=["1", "2", "3"],
+            sort_permuted_package_sequence=True)
         self._assert_reftek130_test_stream(st_reftek)
 
     def test_read_reftek130_steim2(self):
@@ -147,7 +148,8 @@ class ReftekTestCase(unittest.TestCase):
         """
         st = _read_reftek130(
             self.reftek_file_steim2, network="XX", location="01",
-            component_codes=["1", "2", "3"])
+            component_codes=["1", "2", "3"],
+            sort_permuted_package_sequence=True)
         # note: test data has stream name defined as 'DS 1', so we end up with
         # non-SEED conforming channel codes which is expected
         self.assertEqual(len(st), 3)
@@ -175,7 +177,8 @@ class ReftekTestCase(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             st_reftek = _read_reftek130(
-                self.reftek_file, network="XX", location="01")
+                self.reftek_file, network="XX", location="01",
+                sort_permuted_package_sequence=True)
         self.assertEqual(len(w), 8)
         for w_ in w:
             self.assertEqual(
@@ -220,7 +223,8 @@ class ReftekTestCase(unittest.TestCase):
             self.assertRaises(Reftek130Exception, _read_reftek130, fh.name)
         # try to read mseed file, finding no packets
         self.assertRaises(Reftek130Exception, _read_reftek130,
-                          self.mseed_files[0])
+                          self.mseed_files[0],
+                          sort_permuted_package_sequence=True)
 
     def test_warning_disturbed_packet_sequence(self):
         """
@@ -239,7 +243,8 @@ class ReftekTestCase(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 _read_reftek130(fh.name, network="XX", location="01",
-                                component_codes=["1", "2", "3"])
+                                component_codes=["1", "2", "3"],
+                                sort_permuted_package_sequence=True)
         self.assertEqual(len(w), 1)
         self.assertEqual(str(w[0].message),
                          'Detected a non-contiguous packet sequence!')
@@ -273,7 +278,8 @@ class ReftekTestCase(unittest.TestCase):
                 warnings.simplefilter("always")
                 st_reftek = _read_reftek130(
                     fh.name, network="XX", location="01",
-                    component_codes=["1", "2", "3"])
+                    component_codes=["1", "2", "3"],
+                    sort_permuted_package_sequence=True)
         st_reftek.merge(-1)
         self.assertEqual(len(w), 1)
         self.assertEqual(str(w[0].message),
@@ -307,7 +313,8 @@ class ReftekTestCase(unittest.TestCase):
                 warnings.simplefilter("always")
                 _read_reftek130(
                     fh.name, network="XX", location="01",
-                    component_codes=["1", "2", "3"])
+                    component_codes=["1", "2", "3"],
+                    sort_permuted_package_sequence=True)
         self.assertEqual(len(w), 2)
         self.assertTrue(
             re.match(
@@ -338,7 +345,8 @@ class ReftekTestCase(unittest.TestCase):
                 warnings.simplefilter("always")
                 st_reftek = _read_reftek130(
                     fh.name, network="XX", location="01",
-                    component_codes=["1", "2", "3"])
+                    component_codes=["1", "2", "3"],
+                    sort_permuted_package_sequence=True)
         self.assertEqual(len(w), 1)
         self.assertEqual(
             str(w[0].message),
@@ -363,7 +371,8 @@ class ReftekTestCase(unittest.TestCase):
                 warnings.simplefilter("always")
                 st_reftek = _read_reftek130(
                     fh.name, network="XX", location="01",
-                    component_codes=["1", "2", "3"])
+                    component_codes=["1", "2", "3"],
+                    sort_permuted_package_sequence=True)
         self.assertEqual(len(w), 2)
         # we get two warnings, one about the truncated packet and one about the
         # missing last (ET) packet
@@ -392,7 +401,8 @@ class ReftekTestCase(unittest.TestCase):
             with self.assertRaises(Reftek130Exception) as context:
                 _read_reftek130(
                     fh.name, network="XX", location="01",
-                    component_codes=["1", "2", "3"])
+                    component_codes=["1", "2", "3"],
+                    sort_permuted_package_sequence=True)
         self.assertEqual(
             str(context.exception),
             "Reftek data contains data packets without corresponding header "
@@ -514,7 +524,8 @@ class ReftekTestCase(unittest.TestCase):
         # reading the file should work..
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            st = obspy.read(self.reftek_file_vpu)
+            st = obspy.read(self.reftek_file_vpu,
+                            sort_permuted_package_sequence=True)
         self.assertEqual(len(st), 2)
         self.assertEqual(len(st[0]), 890)
         self.assertEqual(len(st[1]), 890)
@@ -534,7 +545,8 @@ class ReftekTestCase(unittest.TestCase):
         bytes_ = io.BytesIO(data)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            st = obspy.read(bytes_, format='REFTEK130')
+            st = obspy.read(bytes_, format='REFTEK130',
+                            sort_permuted_package_sequence=True)
         self.assertEqual(len(st), 10)
         # we should have data from two different files/stations in there
         for tr in st[:8]:

--- a/obspy/io/reftek/util.py
+++ b/obspy/io/reftek/util.py
@@ -3,9 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import calendar
 import codecs
-import datetime
 
 import numpy as np
 
@@ -31,15 +29,15 @@ def bcd_8bit_hex(_i):
     return np.array(["{:X}".format(int(x)) for x in _i], dtype="|S2")
 
 
-def bcd_julian_day_string_to_seconds_of_year(_i):
+def bcd_julian_day_string_to_nanoseconds_of_year(_i):
     timestrings = bcd_hex(_i)
-    return _timestrings_to_seconds(timestrings)
+    return _timestrings_to_nanoseconds(timestrings)
 
 
 _timegm_cache = {}
 
 
-def _get_timestamp_for_start_of_year(year):
+def _get_nanoseconds_for_start_of_year(year):
     # Reftek 130 data format stores only the last two digits of the year.
     # We currently assume that 00-49 are years 2000-2049 and 50-99 are years
     # 2050-2099. We deliberately raise an exception in the read routine if the
@@ -50,35 +48,37 @@ def _get_timestamp_for_start_of_year(year):
     else:
         year += 1900
     try:
-        t = _timegm_cache[year]
+        ns = _timegm_cache[year]
     except KeyError:
-        t = calendar.timegm(datetime.datetime(year, 1, 1).utctimetuple())
-        _timegm_cache[year] = t
-    return t
+        ns = UTCDateTime(year, 1, 1)._ns
+        _timegm_cache[year] = ns
+    return ns
 
 
-def _timestrings_to_seconds(timestrings):
+def _timestrings_to_nanoseconds(timestrings):
     """
     Helper routine to convert timestrings of form "DDDHHMMSSsss" to array of
-    floating point seconds.
+    integer nanosecond POSIX timestamp.
 
     :param timestring: numpy.ndarray
     :rtype: numpy.ndarray
     """
     # split up the time string into tuple of
     # (day of year, hours, minutes, seconds, milliseconds), still as string
-    seconds = [(string[:3], string[3:5], string[5:7],
-                string[7:9], string[9:]) for string in timestrings]
-    seconds = np.array(seconds, dtype="S3").astype(np.float64)
-    # now scale the columns of the array, so that everything is in seconds
-    seconds[:, 0] -= 1
-    seconds[:, 0] *= 86400
-    seconds[:, 1] *= 3600
-    seconds[:, 2] *= 60
-    seconds[:, 4] *= 1e-3
+    nanoseconds = [(string[:3], string[3:5], string[5:7],
+                    string[7:9], string[9:]) for string in timestrings]
+    nanoseconds = np.array(nanoseconds, dtype="S3").astype(np.int64)
+    # now scale the columns of the array, so that everything is in nanoseconds
+    to_nano = 1000000000
+    nanoseconds[:, 0] -= 1
+    nanoseconds[:, 0] *= 86400 * to_nano
+    nanoseconds[:, 1] *= 3600 * to_nano
+    nanoseconds[:, 2] *= 60 * to_nano
+    nanoseconds[:, 3] *= to_nano
+    nanoseconds[:, 4] *= 1000000
     # sum up days, hours, minutes etc. for every row of the array
-    seconds = seconds.sum(axis=1)
-    return seconds
+    nanoseconds = nanoseconds.sum(axis=1)
+    return nanoseconds
 
 
 def _decode_ascii(chars):
@@ -86,6 +86,9 @@ def _decode_ascii(chars):
 
 
 def _parse_long_time(time_bytestring, decode=True):
+    """
+    :returns: POSIX timestamp as integer nanoseconds
+    """
     if decode:
         time_string = time_bytestring.decode()
     else:
@@ -93,8 +96,10 @@ def _parse_long_time(time_bytestring, decode=True):
     if not time_string.strip():
         return None
     time_string, milliseconds = time_string[:-3], int(time_string[-3:])
-    return (UTCDateTime.strptime(time_string, '%Y%j%H%M%S') +
-            1e-3 * milliseconds)
+    t = UTCDateTime.strptime(time_string, '%Y%j%H%M%S')
+    nanoseconds = t._ns
+    nanoseconds += milliseconds * 1000000
+    return nanoseconds
 
 
 def _16_tuple_ascii(bytestring):


### PR DESCRIPTION
..nanoseconds to avoid any floating point precision issues

### What does this PR do?

Changes internal timestamp representation of Reftek130 packets from floats to integers.

### Why was it initiated?  Any relevant Issues?

Fixes #2036.

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~ only changes low-level objects/private functions
- [x] ~~If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests: should add regression test
- [x] ~~Any new or changed features have are fully documented.~~ no new features
- [ ] Significant changes have been added to `CHANGELOG.txt` .

