### PR TITLE
Support for numpy 1.14

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 1.1.x:
+ - General:
+   * Tests pass with numpy 1.14 (see #2044).
  - obspy.core:
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
  - obspy.clients.arclink:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Make sure the doctests run across numpy versions when using pytest.
+"""
+import numpy as np
+
+try:
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass

--- a/obspy/clients/earthworm/waveserver.py
+++ b/obspy/clients/earthworm/waveserver.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
+from obspy.core.compatibility import from_buffer
 
 
 RETURNFLAG_KEY = {
@@ -102,7 +103,7 @@ class TraceBuf2(object):
         """
         Parse tracebuf char array data into self.data
         """
-        self.data = np.fromstring(dat, self.inputType)
+        self.data = from_buffer(dat, self.inputType)
         ndat = len(self.data)
         if self.ndata != ndat:
             msg = 'data count in header (%d) != data count (%d)'
@@ -298,7 +299,7 @@ def read_wave_server_v(server, port, scnl, start, end, timeout=None,
         if current_tb is not None:
             if cleanup and new_tb.start - current_tb.end == period:
                 buf = dat[p:p + nbytes]
-                bufs.append(np.fromstring(buf, current_tb.inputType))
+                bufs.append(from_buffer(buf, current_tb.inputType))
                 current_tb.end = new_tb.end
 
             else:
@@ -314,7 +315,7 @@ def read_wave_server_v(server, port, scnl, start, end, timeout=None,
             current_tb = new_tb
             tbl.append(current_tb)
             period = 1 / current_tb.rate
-            bufs = [np.fromstring(dat[p:p + nbytes], current_tb.inputType)]
+            bufs = [from_buffer(dat[p:p + nbytes], current_tb.inputType)]
 
         p += nbytes
 

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -44,12 +44,20 @@ if PY2:
         if isinstance(dtype, unicode):  # noqa
             dtype = str(dtype)
         if data:
+            try:
+                data = data.encode()
+            except AttributeError:
+                pass
             return np.frombuffer(data, dtype=dtype).copy()
         else:
             return np.array([], dtype=dtype)
     import ConfigParser as configparser  # NOQA
 else:
     def from_buffer(data, dtype):
+        try:
+            data = data.encode()
+        except AttributeError:
+            pass
         return np.array(memoryview(data)).view(dtype).copy()  # NOQA
     import configparser  # NOQA
 

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -46,7 +46,7 @@ if PY2:
         if data:
             try:
                 data = data.encode()
-            except AttributeError:
+            except Exception:
                 pass
             return np.frombuffer(data, dtype=dtype).copy()
         else:
@@ -56,7 +56,7 @@ else:
     def from_buffer(data, dtype):
         try:
             data = data.encode()
-        except AttributeError:
+        except Exception:
             pass
         return np.array(memoryview(data)).view(dtype).copy()  # NOQA
     import configparser  # NOQA

--- a/obspy/core/preview.py
+++ b/obspy/core/preview.py
@@ -66,7 +66,7 @@ def create_preview(trace, delta=60):
         # skip tailing samples
         last_diff = []
     # Fill NaN value with -1.
-    if np.isnan(last_diff):
+    if len(last_diff) and np.isnan(last_diff)[0]:
         last_diff = -1
     # reshape matrix
     data = trace.data[start:end].reshape([number_of_slices, samples_per_slice])

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -9,9 +9,11 @@ import unittest
 
 from obspy.core.compatibility import mock
 from obspy.core.util.base import (NamedTemporaryFile, get_dependency_version,
-                                  download_to_file, sanitize_filename)
+                                  download_to_file, sanitize_filename,
+                                  create_empty_data_chunk)
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
+import numpy as np
 from requests import HTTPError
 
 
@@ -118,6 +120,23 @@ class UtilBaseTestCase(unittest.TestCase):
                          "example.mseedrawTrue")
         self.assertEqual(sanitize_filename("Example.mseed?raw=true"),
                          "Example.mseedrawtrue")
+
+    def test_create_empty_data_chunk(self):
+        out = create_empty_data_chunk(3, 'int', 10)
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.dtype, np.int64)
+        np.testing.assert_allclose(out, [10, 10, 10])
+
+        out = create_empty_data_chunk(6, np.complex128, 0)
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.dtype, np.complex128)
+        np.testing.assert_allclose(out, np.zeros(6, dtype=np.complex128))
+
+        # Fully masked output.
+        out = create_empty_data_chunk(3, 'f')
+        self.assertIsInstance(out, np.ma.MaskedArray)
+        self.assertEqual(out.dtype, np.float32)
+        np.testing.assert_allclose(out.mask, [True, True, True])
 
 
 def suite():

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -124,7 +124,9 @@ class UtilBaseTestCase(unittest.TestCase):
     def test_create_empty_data_chunk(self):
         out = create_empty_data_chunk(3, 'int', 10)
         self.assertIsInstance(out, np.ndarray)
-        self.assertEqual(out.dtype, np.int64)
+        # The default dtype for an integer (np.int_) is a `C long` which is
+        # only 32 bits on windows. Thus we have to allow both.
+        self.assertIn(out.dtype, (np.int32, np.int64))
         np.testing.assert_allclose(out, [10, 10, 10])
 
         out = create_empty_data_chunk(6, np.complex128, 0)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2111,7 +2111,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                                taper_sides[len(taper_sides) - wlen:]))
 
         # Convert data if it's not a floating point type.
-        if not np.issubdtype(self.data.dtype, float):
+        if not np.issubdtype(self.data.dtype, np.floating):
             self.data = np.require(self.data, dtype=np.float64)
 
         self.data *= taper
@@ -2176,7 +2176,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             return self
 
         # Convert data if it's not a floating point type.
-        if not np.issubdtype(self.data.dtype, float):
+        if not np.issubdtype(self.data.dtype, np.floating):
             self.data = np.require(self.data, dtype=np.float64)
 
         self.data /= abs(norm)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2446,7 +2446,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         >>> from obspy import read, UTCDateTime
         >>> tr = read()[0]
 
-        >>> tr.times()
+        >>> tr.times()  # doctest: +NORMALIZE_WHITESPACE
         array([  0.00000000e+00,   1.00000000e-02,   2.00000000e-02, ...,
                  2.99700000e+01,   2.99800000e+01,   2.99900000e+01])
 

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -253,12 +253,16 @@ class UTCDateTime(object):
                     self._from_datetime(dt_)
                 return
             # check types
-            try:
-                # got a timestamp
-                self._from_timestamp(value.__float__())
-                return
-            except Exception:
-                pass
+            # The string instance check is mainly needed to not convert
+            # numpy strings as these can be converted to floats on
+            # numpy >= 1.14.
+            if not isinstance(value, (str, bytes)):
+                try:
+                    # got a timestamp
+                    self._from_timestamp(value.__float__())
+                    return
+                except Exception:
+                    pass
             if isinstance(value, datetime.datetime):
                 # got a Python datetime.datetime object
                 self._from_datetime(value)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -141,9 +141,6 @@ def create_empty_data_chunk(delta, dtype, fill_value=None):
     >>> create_empty_data_chunk(3, 'int', 10)
     array([10, 10, 10])
 
-    >>> create_empty_data_chunk(6, np.complex128, 0)
-    array([ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j])
-
     >>> create_empty_data_chunk(
     ...     3, 'f')  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     masked_array(data = [-- -- --],

--- a/obspy/io/cmtsolution/__init__.py
+++ b/obspy/io/cmtsolution/__init__.py
@@ -26,7 +26,7 @@ It works by utilizing ObsPy's :func:`~obspy.core.event.read_events` function.
 
 The event will contain a couple of origins and magnitudes.
 
->>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACES +ELLIPSIS
+>>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
 Event:  2003-12-26T01:56:58.129999Z | +29.100,  +58.240 | 6.54 mw
             resource_id: ResourceIdentifier(id="...")
              event_type: 'earthquake'

--- a/obspy/io/cmtsolution/__init__.py
+++ b/obspy/io/cmtsolution/__init__.py
@@ -22,19 +22,24 @@ It works by utilizing ObsPy's :func:`~obspy.core.event.read_events` function.
 >>> cat = obspy.read_events("/path/to/CMTSOLUTION")
 >>> print(cat)
 1 Event(s) in Catalog:
-2003-12-26T01:56:58.129999Z | +29.100,  +58.240 | 6.54 mw
+2003-12-26T01:56:58.130000Z | +29.100,  +58.240 | 6.54 mw
 
 The event will contain a couple of origins and magnitudes.
 
 >>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-Event:  2003-12-26T01:56:58.129999Z | +29.100,  +58.240 | 6.54 mw
-            resource_id: ResourceIdentifier(id="...")
-             event_type: 'earthquake'
-    ---------
-     event_descriptions: 1 Elements
-       focal_mechanisms: 1 Elements
-                origins: 2 Elements
-             magnitudes: 3 Elements
+Event:     2003-12-26T01:56:58.130000Z | +29.100,  +58.240 | 6.54 mw
+<BLANKLINE>
+                     resource_id: ResourceIdentifier(id="...")
+                      event_type: 'earthquake'
+             preferred_origin_id: ResourceIdentifier(id="...")
+          preferred_magnitude_id: ResourceIdentifier(id="...")
+    preferred_focal_mechanism_id: ResourceIdentifier(id="...")
+                            ---------
+              event_descriptions: 1 Elements
+                        comments: 1 Elements
+                focal_mechanisms: 1 Elements
+                         origins: 2 Elements
+                      magnitudes: 3 Elements
 
 This module also offers write support for the CMTSOLUTION format.
 

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -16,6 +16,7 @@ from struct import pack
 import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
+from obspy.core.compatibility import from_buffer
 from obspy.core.util import NATIVE_BYTEORDER
 from . import (util, InternalMSEEDError, ObsPyMSEEDFilesizeTooSmallError,
                ObsPyMSEEDFilesizeTooLargeError)
@@ -309,7 +310,7 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
         # Read to NumPy array which is used as a buffer.
         bfr_np = np.fromfile(mseed_object, dtype=np.int8)
     elif hasattr(mseed_object, 'read'):
-        bfr_np = np.fromstring(mseed_object.read(), dtype=np.int8)
+        bfr_np = from_buffer(mseed_object.read(), dtype=np.int8)
 
     # Search for data records and pass only the data part to the underlying C
     # routine.

--- a/obspy/io/mseed/msstruct.py
+++ b/obspy/io/mseed/msstruct.py
@@ -12,6 +12,7 @@ import os
 import numpy as np
 
 from obspy import UTCDateTime
+from obspy.core.compatibility import from_buffer
 from .headers import HPTMODULUS, MS_NOERROR, MSFileParam, MSRecord, clibmseed
 
 
@@ -32,7 +33,7 @@ def _get_ms_file_info(f, real_name):
     info = {'filesize': os.path.getsize(real_name)}
     pos = f.tell()
     f.seek(0)
-    rec_buffer = np.fromstring(f.read(512), dtype=np.int8)
+    rec_buffer = from_buffer(f.read(512), dtype=np.int8)
     info['record_length'] = clibmseed.ms_detect(rec_buffer, 512)
     # Calculate Number of Records
     info['number_of_records'] = int(info['filesize'] //

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core import AttribDict
+from obspy.core.compatibility import from_buffer
 from obspy.core.util import CatchOutput, NamedTemporaryFile
 from obspy.io.mseed import (util, InternalMSEEDWarning,
                             InternalMSEEDError)
@@ -756,8 +757,8 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
                     # ObsPy
                     with open(tempfile, "rb") as fp:
                         s = fp.read()
-                    data = np.fromstring(s[56:256],
-                                         dtype=native_str(btype + dtype))
+                    data = from_buffer(s[56:256],
+                                       dtype=native_str(btype + dtype))
                     np.testing.assert_array_equal(data, st[0].data[:len(data)])
                     # Read the binary chunk of data with ObsPy
                     st2 = read(tempfile)
@@ -768,7 +769,7 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         Tests writing small ASCII strings.
         """
         st = Stream()
-        st.append(Trace(data=np.fromstring("A" * 8, native_str("|S1"))))
+        st.append(Trace(data=from_buffer("A" * 8, native_str("|S1"))))
         with NamedTemporaryFile() as tf:
             tempfile = tf.name
             st.write(tempfile, format="MSEED")
@@ -829,10 +830,10 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         files = {
             os.path.join(path, "smallASCII.mseed"):
             (native_str('|S1'), 'a', 0,
-             np.fromstring('ABCDEFGH', dtype=native_str('|S1'))),
+             from_buffer('ABCDEFGH', dtype=native_str('|S1'))),
             # Tests all ASCII letters.
             os.path.join(path, "fullASCII.mseed"):
-            (native_str('|S1'), 'a', 0, np.fromstring(
+            (native_str('|S1'), 'a', 0, from_buffer(
                 """ !"#$%&'()*+,-./""" +
                 """0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`""" +
                 """abcdefghijklmnopqrstuvwxyz{|}~""",

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -18,6 +18,7 @@ from struct import pack, unpack
 import numpy as np
 
 from obspy import UTCDateTime
+from obspy.core.compatibility import from_buffer
 from obspy.core.util.decorator import ObsPyDeprecationWarning
 from .headers import (ENCODINGS, ENDIAN, FIXED_HEADER_ACTIVITY_FLAGS,
                       FIXED_HEADER_DATA_QUAL_FLAGS,
@@ -234,7 +235,7 @@ def get_flags(files, starttime=None, endtime=None,
             # Read to NumPy array which is used as a buffer.
             bfr_np = np.fromfile(file, dtype=np.int8)
         elif hasattr(file, 'read'):
-            bfr_np = np.fromstring(file.read(), dtype=np.int8)
+            bfr_np = from_buffer(file.read(), dtype=np.int8)
 
         offset = 0
 
@@ -738,7 +739,7 @@ def _get_record_information(file_object, offset=0, endian=None):
     if "record_length" not in info:
         file_object.seek(record_start, 0)
         # Read 16 kb - should be a safe maximal record length.
-        buf = np.fromstring(file_object.read(2 ** 14), dtype=np.int8)
+        buf = from_buffer(file_object.read(2 ** 14), dtype=np.int8)
         # This is a messy check - we just delegate to libmseed.
         reclen = clibmseed.ms_detect(buf, len(buf))
         if reclen < 0:

--- a/obspy/io/pdas/core.py
+++ b/obspy/io/pdas/core.py
@@ -15,6 +15,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import numpy as np
 
 from obspy.core import Stream, Trace, UTCDateTime
+from obspy.core.compatibility import from_buffer
 
 
 def _is_pdas(filename):
@@ -83,9 +84,9 @@ def _read_pdas(filename, **kwargs):
     sampling_rate = 1.0 / float(items[6][1].decode())
     dtype = items[1][1].decode()
     if dtype.upper() == "LONG":
-        data = np.fromstring(data, dtype=np.int16)
+        data = from_buffer(data, dtype=np.int16)
     elif dtype.upper() == "SHORT":
-        data = np.fromstring(data, dtype=np.int8)
+        data = from_buffer(data, dtype=np.int8)
     else:
         raise NotImplementedError()
 

--- a/obspy/io/reftek/packet.py
+++ b/obspy/io/reftek/packet.py
@@ -17,6 +17,7 @@ import warnings
 import numpy as np
 
 from obspy import UTCDateTime
+from obspy.core.compatibility import from_buffer
 from obspy.io.mseed.headers import clibmseed
 
 from .util import (
@@ -232,7 +233,7 @@ def _initial_unpack_packets(bytestring):
         msg = ("Length of data not a multiple of 1024. Data might be "
                "truncated. Dropping {:d} byte(s) at the end.").format(tail)
         warnings.warn(msg)
-    data = np.fromstring(
+    data = from_buffer(
         bytestring, dtype=PACKET_INITIAL_UNPACK_DTYPE)
     result = np.empty_like(data, dtype=PACKET_FINAL_DTYPE)
 

--- a/obspy/io/reftek/util.py
+++ b/obspy/io/reftek/util.py
@@ -10,6 +10,7 @@ import datetime
 import numpy as np
 
 from obspy import UTCDateTime
+from obspy.core.compatibility import from_buffer
 
 
 def bcd(_i):
@@ -24,7 +25,11 @@ def bcd_16bit_int(_i):
 def bcd_hex(_i):
     m = _i.shape[1]
     _bcd = codecs.encode(_i.ravel(), "hex_codec").decode("ASCII").upper()
-    return np.fromstring(_bcd, dtype="|S%d" % (m * 2))
+    try:
+        _bcd = _bcd.encode()
+    except AttributeError:
+        pass
+    return from_buffer(_bcd, dtype="|S%d" % (m * 2))
 
 
 def bcd_8bit_hex(_i):

--- a/obspy/io/reftek/util.py
+++ b/obspy/io/reftek/util.py
@@ -25,10 +25,6 @@ def bcd_16bit_int(_i):
 def bcd_hex(_i):
     m = _i.shape[1]
     _bcd = codecs.encode(_i.ravel(), "hex_codec").decode("ASCII").upper()
-    try:
-        _bcd = _bcd.encode()
-    except AttributeError:
-        pass
     return from_buffer(_bcd, dtype="|S%d" % (m * 2))
 
 

--- a/obspy/io/sac/arrayio.py
+++ b/obspy/io/sac/arrayio.py
@@ -251,7 +251,7 @@ def read_sac_ascii(source, headonly=False):
     hs, = init_header_arrays(arrays=('str',))
     for i, j in enumerate(range(0, 24, 3)):
         line = contents[14 + 8 + i]
-        hs[j:j + 3] = np.fromstring(line, dtype=native_str('|S8'), count=3)
+        hs[j:j + 3] = from_buffer(line[:24], dtype=native_str('|S8'))
     # --------------------------------------------------------------
     # read in the seismogram points
     # --------------------------------------------------------------

--- a/obspy/io/scardec/__init__.py
+++ b/obspy/io/scardec/__init__.py
@@ -26,7 +26,7 @@ It works by utilizing ObsPy's :func:`~obspy.core.event.read_events` function.
 
 The event will contain one origins with a moment rate function.
 
->>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACES +ELLIPSIS
+>>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
 Event:  2014-01-25T05:14:18.000000Z |  -7.985, +109.265 | 6.202 mw
 
                resource_id: ResourceIdentifier(id='...')

--- a/obspy/io/scardec/__init__.py
+++ b/obspy/io/scardec/__init__.py
@@ -19,25 +19,27 @@ Example
 It works by utilizing ObsPy's :func:`~obspy.core.event.read_events` function.
 
 >>> import obspy
->>> cat = obspy.read_events("/path/to/SCARDEC_file")
+>>> cat = obspy.read_events("/path/to/test.scardec")
 >>> print(cat)
 1 Event(s) in Catalog:
-2003-12-26T01:56:58.129999Z | +29.100,  +58.240 | 6.54 mw
+2014-01-25T05:14:18.000000Z |  -7.985, +109.265 | 6.202 mw
 
 The event will contain one origins with a moment rate function.
 
 >>> print(cat[0])  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
 Event:  2014-01-25T05:14:18.000000Z |  -7.985, +109.265 | 6.202 mw
-
-               resource_id: ResourceIdentifier(id='...')
-                event_type: 'earthquake'
-    ---------
-        event_descriptions: 1 Elements
-                  comments: 1 Elements
-          focal_mechanisms: 1 Elements
-                   origins: 1 Elements
-                magnitudes: 1 Elements
-     source_time_functions: 1 Elements
+<BLANKLINE>
+                     resource_id: ResourceIdentifier(id="...")
+                      event_type: 'earthquake'
+             preferred_origin_id: ResourceIdentifier(id="...")
+          preferred_magnitude_id: ResourceIdentifier(id="...")
+    preferred_focal_mechanism_id: ResourceIdentifier(id="...")
+                            ---------
+              event_descriptions: 1 Elements
+                        comments: 1 Elements
+                focal_mechanisms: 1 Elements
+                         origins: 1 Elements
+                      magnitudes: 1 Elements
 
 
 This module also offers write support for the SCARDEC format.

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import AttribDict
+from obspy.core.compatibility import from_buffer
 from .header import MONTHS
 
 
@@ -246,7 +247,7 @@ class SEG2(object):
             header['calib'] = float(header['seg2']['DESCALING_FACTOR'])
 
         # Unpack the data.
-        data = np.fromstring(
+        data = from_buffer(
             self.file_pointer.read(number_of_samples_in_data_block *
                                    sample_size),
             dtype=dtype)

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -14,6 +14,7 @@ import warnings
 import numpy as np
 
 import obspy
+from obspy.core.compatibility import from_buffer
 from obspy.core.util import NamedTemporaryFile, AttribDict
 from obspy.io.segy.header import (DATA_SAMPLE_FORMAT_PACK_FUNCTIONS,
                                   DATA_SAMPLE_FORMAT_UNPACK_FUNCTIONS)
@@ -107,9 +108,9 @@ class SEGYTestCase(unittest.TestCase):
                 # Read the data as uint8 to be able to directly access the
                 # different bytes.
                 # Original data.
-                packed_data = np.fromstring(packed_data, np.uint8)
+                packed_data = from_buffer(packed_data, np.uint8)
                 # Newly written.
-                new_packed_data = np.fromstring(new_packed_data, np.uint8)
+                new_packed_data = from_buffer(new_packed_data, np.uint8)
 
                 # Figure out the non normalized fractions in the original data
                 # because these cannot be compared directly.
@@ -372,8 +373,8 @@ class SEGYTestCase(unittest.TestCase):
             # tested again here.
             if len(non_normalized_samples) != 0:
                 # Convert to 4 byte integers. Any 4 byte numbers work.
-                org_data = np.fromstring(org_data, np.int32)
-                new_data = np.fromstring(new_data, np.int32)
+                org_data = from_buffer(org_data, np.int32)
+                new_data = from_buffer(new_data, np.int32)
                 # Skip the header (4*960 bytes) and replace the non normalized
                 # data samples.
                 org_data[960:][non_normalized_samples] = \

--- a/obspy/io/segy/unpack.py
+++ b/obspy/io/segy/unpack.py
@@ -23,6 +23,7 @@ import warnings
 
 import numpy as np
 
+from obspy.core.compatibility import from_buffer
 from .util import clibsegy
 
 
@@ -46,7 +47,7 @@ def unpack_4byte_ibm(file, count, endian='>'):
     Unpacks 4 byte IBM floating points.
     """
     # Read as 4 byte integer so bit shifting works.
-    data = np.fromstring(file.read(count * 4), dtype=np.float32)
+    data = from_buffer(file.read(count * 4), dtype=np.float32)
     # Swap the byte order if necessary.
     if BYTEORDER != endian:
         data = data.byteswap()
@@ -92,7 +93,7 @@ def unpack_4byte_integer(file, count, endian='>'):
     Unpacks 4 byte integers.
     """
     # Read as 4 byte integer so bit shifting works.
-    data = np.fromstring(file.read(count * 4), dtype=np.int32)
+    data = from_buffer(file.read(count * 4), dtype=np.int32)
     # Swap the byte order if necessary.
     if BYTEORDER != endian:
         data = data.byteswap()
@@ -104,7 +105,7 @@ def unpack_2byte_integer(file, count, endian='>'):
     Unpacks 2 byte integers.
     """
     # Read as 4 byte integer so bit shifting works.
-    data = np.fromstring(file.read(count * 2), dtype=np.int16)
+    data = from_buffer(file.read(count * 2), dtype=np.int16)
     # Swap the byte order if necessary.
     if BYTEORDER != endian:
         data = data.byteswap()
@@ -120,7 +121,7 @@ def unpack_4byte_ieee(file, count, endian='>'):
     Unpacks 4 byte IEEE floating points.
     """
     # Read as 4 byte integer so bit shifting works.
-    data = np.fromstring(file.read(count * 4), dtype=np.float32)
+    data = from_buffer(file.read(count * 4), dtype=np.float32)
     # Swap the byte order if necessary.
     if BYTEORDER != endian:
         data = data.byteswap()

--- a/obspy/io/seisan/core.py
+++ b/obspy/io/seisan/core.py
@@ -157,7 +157,7 @@ def _read_seisan(filename, headonly=False, **kwargs):  # @UnusedVariable
             # written.
             start_bytes = fh.read(dtype.itemsize)
             # convert to int32/int64
-            length = np.fromstring(start_bytes, dtype=dtype)[0]
+            length = from_buffer(start_bytes, dtype=dtype)[0]
             data = fh.read(length)
             end_bytes = fh.read(dtype.itemsize)
             assert start_bytes == end_bytes
@@ -175,7 +175,7 @@ def _read_seisan(filename, headonly=False, **kwargs):  # @UnusedVariable
                     # end of file
                     break
                 # convert to unsigned int8
-                length = np.fromstring(start_byte, np.uint8)[0]
+                length = from_buffer(start_byte, np.uint8)[0]
                 data += fh.read(length)
                 end_byte = fh.read(1)
                 assert start_byte == end_byte

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
+from obspy.core.compatibility import from_buffer
 from obspy.core.util import loadtxt
 
 
@@ -464,7 +465,7 @@ def _read_q(filename, headonly=False, data_directory=None, byteorder='=',
             # read data
             data = fh_data.read(npts * 4)
             dtype = native_str(byteorder + 'f4')
-            data = np.fromstring(data, dtype=dtype)
+            data = from_buffer(data, dtype=dtype)
             # convert to system byte order
             data = np.require(data, native_str('=f4'))
             stream.append(Trace(data=data, header=header))

--- a/obspy/io/wav/core.py
+++ b/obspy/io/wav/core.py
@@ -27,6 +27,7 @@ import wave
 import numpy as np
 
 from obspy import Stream, Trace
+from obspy.core.compatibility import from_buffer
 
 
 # WAVE data format is unsigned char up to 8bit, and signed int
@@ -102,7 +103,7 @@ def _read_wav(filename, headonly=False, **kwargs):  # @UnusedVariable
         if width not in WIDTH2DTYPE.keys():
             msg = "Unsupported Format Type, word width %dbytes" % width
             raise TypeError(msg)
-        data = np.fromstring(fh.readframes(length), dtype=WIDTH2DTYPE[width])
+        data = from_buffer(fh.readframes(length), dtype=WIDTH2DTYPE[width])
     finally:
         fh.close()
     return Stream([Trace(header=header, data=data)])

--- a/obspy/io/win/core.py
+++ b/obspy/io/win/core.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
+from obspy.core.compatibility import from_buffer
 
 
 def _is_win(filename, century="20"):  # @UnusedVariable
@@ -46,7 +47,7 @@ def _is_win(filename, century="20"):  # @UnusedVariable
             int('%x' % (ord(buff[2:3]) >> 4))
             ord(buff[3:4])
             idata00 = fpin.read(4)
-            np.fromstring(idata00, native_str('>i'))[0]
+            from_buffer(idata00, native_str('>i'))[0]
     except Exception:
         return False
     return True
@@ -83,7 +84,7 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
             if len(pklen) < 4:
                 break
             leng = 4
-            truelen = np.fromstring(pklen, native_str('>i'))[0]
+            truelen = from_buffer(pklen, native_str('>i'))[0]
             if truelen == 0:
                 break
             buff = fpin.read(6)
@@ -117,7 +118,7 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
 
                 idata00 = fpin.read(4)
                 leng += 4
-                idata22 = np.fromstring(idata00, native_str('>i'))[0]
+                idata22 = from_buffer(idata00, native_str('>i'))[0]
 
                 if chanum in output:
                     output[chanum].append(idata22)
@@ -136,34 +137,34 @@ def _read_win(filename, century="20", **kwargs):  # @UnusedVariable
                 if datawide == 0.5:
                     for i in range(xlen):
                         idata2 = output[chanum][-1] + \
-                            np.fromstring(sdata[i:i + 1], np.int8)[0] >> 4
+                            from_buffer(sdata[i:i + 1], np.int8)[0] >> 4
                         output[chanum].append(idata2)
                         idata2 = idata2 +\
-                            (np.fromstring(sdata[i:i + 1],
-                                           np.int8)[0] << 4) >> 4
+                            (from_buffer(sdata[i:i + 1],
+                                         np.int8)[0] << 4) >> 4
                         output[chanum].append(idata2)
                 elif datawide == 1:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[i:i + 1], np.int8)[0]
+                            from_buffer(sdata[i:i + 1], np.int8)[0]
                         output[chanum].append(idata2)
                 elif datawide == 2:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[2 * i:2 * (i + 1)],
-                                          native_str('>h'))[0]
+                            from_buffer(sdata[2 * i:2 * (i + 1)],
+                                        native_str('>h'))[0]
                         output[chanum].append(idata2)
                 elif datawide == 3:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[3 * i:3 * (i + 1)] + b' ',
-                                          native_str('>i'))[0] >> 8
+                            from_buffer(sdata[3 * i:3 * (i + 1)] + b' ',
+                                        native_str('>i'))[0] >> 8
                         output[chanum].append(idata2)
                 elif datawide == 4:
                     for i in range((xlen // datawide)):
                         idata2 = output[chanum][-1] +\
-                            np.fromstring(sdata[4 * i:4 * (i + 1)],
-                                          native_str('>i'))[0]
+                            from_buffer(sdata[4 * i:4 * (i + 1)],
+                                        native_str('>i'))[0]
                         output[chanum].append(idata2)
                 else:
                     msg = "DATAWIDE is %s " % datawide + \

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -129,6 +129,14 @@ The following commands will produce the same output as shown above:
 Type "help" to see all available options.
 """
 
+# Set legacy printing for numpy so the doctests work regardless of the numpy
+# version.
+try:
+    np.set_printoptions(legacy='1.13')
+except TypeError:
+    pass
+
+
 HOSTNAME = platform.node().split('.', 1)[0]
 
 

--- a/obspy/signal/_sosfilt.py
+++ b/obspy/signal/_sosfilt.py
@@ -66,8 +66,10 @@ def _cplxreal(z, tol=None):
     --------
     >>> a = [4, 3, 1, 2-2j, 2+2j, 2-1j, 2+1j, 2-1j, 2+1j, 1+1j, 1-1j]
     >>> zc, zr = _cplxreal(a)
-    >>> print(zc)
-    [ 1.+1.j  2.+1.j  2.+1.j  2.+2.j]
+    >>> print(zc.real)
+    [ 1.  2.  2.  2.]
+    >>> print(zc.imag)
+    [ 1.  1.  1.  2.]
     >>> print(zr)
     [ 1.  3.  4.]
     """

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -770,7 +770,13 @@ def array_transff_wavenumber(coords, klim, kstep, coordsys='lonlat'):
     ks = np.transpose(np.vstack((kxgrid.flatten(), kygrid.flatten())))
 
     # z coordinate is not used
-    k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2])
+    # Bug with numpy 1.14.0 (https://github.com/numpy/numpy/issues/10343)
+    # Nothing we can do.
+    if np.__version__ == "1.14.0":  # pragma: no cover
+        k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2], optimize=False)
+    else:
+        k_dot_r = np.einsum('ni,mi->nm', ks, coords[:, :2])
+
     transff = np.abs(np.sum(np.exp(1j * k_dot_r), axis=1))**2 / len(coords)**2
 
     return transff.reshape(nkx, nky)

--- a/obspy/signal/detrend.py
+++ b/obspy/signal/detrend.py
@@ -28,7 +28,7 @@ def simple(data):
         case the dtype has to be changed.
     """
     # Convert data if it's not a floating point type.
-    if not np.issubdtype(data.dtype, float):
+    if not np.issubdtype(data.dtype, np.floating):
         data = np.require(data, dtype=np.float64)
     ndat = len(data)
     x1, x2 = data[0], data[-1]
@@ -107,7 +107,7 @@ def polynomial(data, order, plot=False):
         polynomial(tr.data, order=3, plot=True)
     """
     # Convert data if it's not a floating point type.
-    if not np.issubdtype(data.dtype, float):
+    if not np.issubdtype(data.dtype, np.floating):
         data = np.require(data, dtype=np.float64)
 
     x = np.arange(len(data))
@@ -170,7 +170,7 @@ def spline(data, order, dspline, plot=False):
         spline(tr.data, order=2, dspline=1000, plot=True)
     """
     # Convert data if it's not a floating point type.
-    if not np.issubdtype(data.dtype, float):
+    if not np.issubdtype(data.dtype, np.floating):
         data = np.require(data, dtype=np.float64)
 
     x = np.arange(len(data))

--- a/obspy/taup/tests/test_plotting.py
+++ b/obspy/taup/tests/test_plotting.py
@@ -248,7 +248,7 @@ class TauPyPlottingTestCase(unittest.TestCase):
         arrivals = self.model.get_ray_paths(500, 20, phase_list=['P'])
         # polar plot attempted in cartesian axes
         expected_msg = "Plot type 'spam' is not a valid option."
-        with self.assertRaisesRegexp(ValueError, expected_msg):
+        with self.assertRaises(ValueError, msg=expected_msg):
             arrivals.plot_rays(plot_type="spam")
 
 

--- a/obspy/taup/velocity_model.py
+++ b/obspy/taup/velocity_model.py
@@ -283,7 +283,7 @@ class VelocityModel(object):
         # Check for gaps
         gaps = self.layers[:-1]['bot_depth'] != self.layers[1:]['top_depth']
         gaps = np.where(gaps)[0]
-        if gaps:
+        if gaps.size:
             msg = ("There is a gap in the velocity model between layer(s) %s "
                    "and %s.\n%s" % (gaps, gaps + 1, self.layers[gaps]))
             raise ValueError(msg)
@@ -291,7 +291,7 @@ class VelocityModel(object):
         # Check for zero thickness
         probs = self.layers['bot_depth'] == self.layers['top_depth']
         probs = np.where(probs)[0]
-        if probs:
+        if probs.size:
             msg = ("There is a zero thickness layer in the velocity model at "
                    "layer(s) %s\n%s" % (probs, self.layers[probs]))
             raise ValueError(msg)
@@ -300,7 +300,7 @@ class VelocityModel(object):
         probs = np.logical_or(self.layers['top_p_velocity'] <= 0.0,
                               self.layers['bot_p_velocity'] <= 0.0)
         probs = np.where(probs)[0]
-        if probs:
+        if probs.size:
             msg = ("There is a negative P velocity layer in the velocity "
                    "model at layer(s) %s\n%s" % (probs, self.layers[probs]))
             raise ValueError(msg)
@@ -309,7 +309,7 @@ class VelocityModel(object):
         probs = np.logical_or(self.layers['top_s_velocity'] < 0.0,
                               self.layers['bot_s_velocity'] < 0.0)
         probs = np.where(probs)[0]
-        if probs:
+        if probs.size:
             msg = ("There is a negative S velocity layer in the velocity "
                    "model at layer(s) %s\n%s" % (probs, self.layers[probs]))
             raise ValueError(msg)
@@ -321,7 +321,7 @@ class VelocityModel(object):
             np.logical_and(self.layers['top_p_velocity'] == 0.0,
                            self.layers['bot_p_velocity'] != 0.0))
         probs = np.where(probs)[0]
-        if probs:
+        if probs.size:
             msg = ("There is a layer that goes to zero P velocity (top or "
                    "bottom) without a discontinuity in the velocity model at "
                    "layer(s) %s\nThis would cause a divide by zero within "
@@ -339,7 +339,7 @@ class VelocityModel(object):
         #  in IASP91, therefore ignore it.
         probs = np.logical_and(probs, self.layers['top_depth'] != 0)
         probs = np.where(probs)[0]
-        if probs:
+        if probs.size:
             msg = ("There is a layer that goes to zero S velocity (top or "
                    "bottom) without a discontinuity in the velocity model at "
                    "layer(s) %s\nThis would cause a divide by zero within "

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+test_option=conftest.py


### PR DESCRIPTION
This PR makes the test pass with numpy 1.14 and also mostly gets rid of newly introduced deprecation warnings.

The main issue is that numpy 1.14 changed the way arrays are printed - but they do offer a legacy printing setting so the doctests don't have to be changed. This setup is performed in the main obspy-runtests routine as well as for pytest. Thus some doctests currently cannot be directly executed on numpy 1.14 but I'm not sure if anyone does this and we can fix it as we encounter it.