### PR TITLE
PPSD: change internal representation of timestamps to integer nanosecond

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,10 @@ master:
      objects to shapefile (see #2012)
  - obspy.signal.PPSD:
    * Fixed exact trace cutting for PSD segments (see #2040).
+   * Timestamp representations internally and in npz I/O were changed to use
+     integer nanosecond POSIX timestamps to avoid any potential floating point
+     inaccuracies and since this is also what UTCDateTime is based on nowadays
+     (see #2045)
  - obspy.signal.cross_correlation:
    * Add new `correlate_template()` function with 'full' normalization option,
      required for correlations in template-matching
@@ -14,6 +18,7 @@ master:
    * 'domain' parameter in correlate function is deprecated in favour of new
      'method' parameter to be consistent with recent SciPy versions
      (see #2042).
+
 
 1.1.x:
  - General:

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -326,7 +326,7 @@ class PPSD(object):
             raise ValueError(msg)
 
         # save version numbers
-        self.ppsd_version = 1
+        self.ppsd_version = 2
         self.obspy_version = __version__
         self.matplotlib_version = ".".join(map(str, MATPLOTLIB_VERSION))
         self.numpy_version = np.__version__
@@ -495,16 +495,16 @@ class PPSD(object):
 
     @property
     def times_processed(self):
-        return list(map(UTCDateTime, self._times_processed))
+        return [UTCDateTime(ns=ns) for ns in self._times_processed]
 
     @property
     def times_data(self):
-        return [(UTCDateTime(t1), UTCDateTime(t2))
+        return [(UTCDateTime(ns=t1), UTCDateTime(ns=t2))
                 for t1, t2 in self._times_data]
 
     @property
     def times_gaps(self):
-        return [(UTCDateTime(t1), UTCDateTime(t2))
+        return [(UTCDateTime(ns=t1), UTCDateTime(ns=t2))
                 for t1, t2 in self._times_gaps]
 
     @property
@@ -525,7 +525,7 @@ class PPSD(object):
     @property
     def current_times_used(self):
         self.__check_histogram()
-        return list(map(UTCDateTime, self._current_times_used))
+        return [UTCDateTime(ns=ns) for ns in self._current_times_used]
 
     def _setup_period_binning(self, period_smoothing_width_octaves,
                               period_step_octaves, period_limits):
@@ -608,8 +608,9 @@ class PPSD(object):
         :type utcdatetime: :class:`~obspy.core.utcdatetime.UTCDateTime`
         :type spectrum: :class:`numpy.ndarray`
         """
-        ind = bisect.bisect(self._times_processed, utcdatetime.timestamp)
-        self._times_processed.insert(ind, utcdatetime.timestamp)
+        t = utcdatetime._ns
+        ind = bisect.bisect(self._times_processed, t)
+        self._times_processed.insert(ind, t)
         self._binned_psds.insert(ind, spectrum)
 
     def __insert_gap_times(self, stream):
@@ -619,7 +620,7 @@ class PPSD(object):
 
         :type stream: :class:`~obspy.core.stream.Stream`
         """
-        self._times_gaps += [[gap[4].timestamp, gap[5].timestamp]
+        self._times_gaps += [[gap[4]._ns, gap[5]._ns]
                              for gap in stream.get_gaps()]
 
     def __insert_data_times(self, stream):
@@ -630,7 +631,7 @@ class PPSD(object):
         :type stream: :class:`~obspy.core.stream.Stream`
         """
         self._times_data += \
-            [[tr.stats.starttime.timestamp, tr.stats.endtime.timestamp]
+            [[tr.stats.starttime._ns, tr.stats.endtime._ns]
              for tr in stream]
 
     def __check_time_present(self, utcdatetime):
@@ -643,9 +644,9 @@ class PPSD(object):
         insert this piece of data.
         """
         index1 = bisect.bisect_left(self._times_processed,
-                                    utcdatetime.timestamp)
+                                    utcdatetime._ns)
         index2 = bisect.bisect_right(self._times_processed,
-                                     utcdatetime.timestamp + self.ppsd_length)
+                                     utcdatetime._ns + self.ppsd_length * 1e9)
         if index1 != index2:
             return True
         else:
@@ -860,7 +861,7 @@ class PPSD(object):
                               (native_str('month'), np.int8)])
             times_all_details = np.empty(shape=len(self._times_processed),
                                          dtype=dtype)
-            utc_times_all = [UTCDateTime(t) for t in self._times_processed]
+            utc_times_all = [UTCDateTime(ns=t) for t in self._times_processed]
             times_all_details['time_of_day'][:] = \
                 [t._get_hours_after_midnight() for t in utc_times_all]
             times_all_details['iso_weekday'][:] = \
@@ -886,9 +887,9 @@ class PPSD(object):
         times_all = np.array(self._times_processed)
         selected = np.ones(len(times_all), dtype=np.bool)
         if starttime is not None:
-            selected &= times_all > starttime.timestamp
+            selected &= times_all > starttime._ns
         if endtime is not None:
-            selected &= times_all < endtime.timestamp
+            selected &= times_all < endtime._ns
         if time_of_weekday is not None:
             times_all_details = self._get_times_all_details()
             # we need to do a logical OR over all different user specified time
@@ -1237,9 +1238,8 @@ class PPSD(object):
             _check_npz_ppsd_version(ppsd, data)
             for key in ppsd.NPZ_STORE_KEYS:
                 # data is stored as arrays in the npz.
-                # we have to convert those back to lists (or simple types), so
-                # that additionally processed data can be appended/inserted
-                # later.
+                # we have to convert those back to lists (or simple types), so that
+                # additionally processed data can be appended/inserted later.
                 data_ = data[key]
                 if key in ppsd.NPZ_STORE_KEYS_LIST_TYPES:
                     if key in ['_times_data', '_times_gaps']:
@@ -1249,7 +1249,18 @@ class PPSD(object):
                 elif key in (ppsd.NPZ_STORE_KEYS_SIMPLE_TYPES +
                              ppsd.NPZ_STORE_KEYS_VERSION_NUMBERS):
                     data_ = data_.item()
+                # convert floating point POSIX second timestamps from older npz
+                # files
+                if (key in ppsd.NPZ_STORE_KEYS_LIST_TYPES and
+                        data['ppsd_version'].item() == 1):
+                    if key in ['_times_data', '_times_gaps']:
+                        data_ = [[UTCDateTime(start)._ns, UTCDateTime(end)._ns]
+                                 for start, end in data_]
+                    elif key == '_times_processed':
+                        data_ = [UTCDateTime(t)._ns for t in data_]
                 setattr(ppsd, key, data_)
+            # we converted all data, so update ppsd version
+            ppsd.ppsd_version = 2
             return ppsd
 
         # XXX get rid of if/else again when bumping minimal numpy to 1.7
@@ -1315,17 +1326,24 @@ class PPSD(object):
             _times_gaps = data["_times_gaps"].tolist()
             _times_processed = [d_ for d_ in data["_times_processed"]]
             _binned_psds = [d_ for d_ in data["_binned_psds"]]
+            # convert floating point POSIX second timestamps from older npz
+            # files
+            if data['ppsd_version'].item() == 1:
+                _times_data = [[UTCDateTime(start)._ns, UTCDateTime(end)._ns]
+                               for start, end in _times_data]
+                _times_gaps = [[UTCDateTime(start)._ns, UTCDateTime(end)._ns]
+                               for start, end in _times_gaps]
+                _times_processed = [UTCDateTime(t)._ns for t in _times_processed]
             # add new data
             self._times_data.extend(_times_data)
             self._times_gaps.extend(_times_gaps)
             duplicates = 0
             for t, psd in zip(_times_processed, _binned_psds):
-                t = UTCDateTime(t)
+                t = UTCDateTime(ns=t)
                 if self.__check_time_present(t):
                     duplicates += 1
                     continue
                 self.__insert_processed_data(t, psd)
-
             # warn if some segments were omitted
             if duplicates:
                 msg = ("%d/%d segments omitted in file '%s' "
@@ -1347,7 +1365,7 @@ class PPSD(object):
     def _split_lists(self, times, psds):
         """
         """
-        t_diff_gapless = self.step
+        t_diff_gapless = self.step * 1e9
         gap_indices = np.argwhere(np.diff(times) - t_diff_gapless)
         gap_indices = (gap_indices.flatten() + 1).tolist()
 
@@ -1574,7 +1592,7 @@ class PPSD(object):
                         color_kwargs = {'color': cur_color}
                 else:
                     color_kwargs = {'color': color}
-                times_ = [UTCDateTime(t).matplotlib_date for t in times_]
+                times_ = [UTCDateTime(ns=t).matplotlib_date for t in times_]
                 line = ax.plot(times_, psd_values, label=label, ls=linestyle,
                                marker=marker, **color_kwargs)[0]
                 # plot the next lines with the same color (we can't easily
@@ -1854,8 +1872,8 @@ class PPSD(object):
     def _get_plot_title(self):
         title = "%s   %s -- %s  (%i/%i segments)"
         title = title % (self.id,
-                         UTCDateTime(self._times_processed[0]).date,
-                         UTCDateTime(self._times_processed[-1]).date,
+                         UTCDateTime(ns=self._times_processed[0]).date,
+                         UTCDateTime(ns=self._times_processed[-1]).date,
                          self.current_histogram_count,
                          len(self._times_processed))
         return title
@@ -1893,9 +1911,9 @@ class PPSD(object):
         ax.set_yticks([])
 
         # plot data used in histogram stack
-        used_times = [UTCDateTime(t) for t in self._times_processed
+        used_times = [UTCDateTime(ns=t) for t in self._times_processed
                       if t in self._current_times_used]
-        unused_times = [UTCDateTime(t) for t in self._times_processed
+        unused_times = [UTCDateTime(ns=t) for t in self._times_processed
                         if t not in self._current_times_used]
         for times, color in zip((used_times, unused_times), ("b", "0.6")):
             # skip on empty lists (i.e. all data used, or none used in stack)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -1238,8 +1238,9 @@ class PPSD(object):
             _check_npz_ppsd_version(ppsd, data)
             for key in ppsd.NPZ_STORE_KEYS:
                 # data is stored as arrays in the npz.
-                # we have to convert those back to lists (or simple types), so that
-                # additionally processed data can be appended/inserted later.
+                # we have to convert those back to lists (or simple types), so
+                # that additionally processed data can be appended/inserted
+                # later.
                 data_ = data[key]
                 if key in ppsd.NPZ_STORE_KEYS_LIST_TYPES:
                     if key in ['_times_data', '_times_gaps']:
@@ -1333,7 +1334,8 @@ class PPSD(object):
                                for start, end in _times_data]
                 _times_gaps = [[UTCDateTime(start)._ns, UTCDateTime(end)._ns]
                                for start, end in _times_gaps]
-                _times_processed = [UTCDateTime(t)._ns for t in _times_processed]
+                _times_processed = [
+                    UTCDateTime(t)._ns for t in _times_processed]
             # add new data
             self._times_data.extend(_times_data)
             self._times_gaps.extend(_times_gaps)

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -426,8 +426,10 @@ class PsdTestCase(unittest.TestCase):
         # of psd pieces, to facilitate testing the stack selection.
         ppsd = PPSD(stats=Stats(dict(sampling_rate=150)), metadata=None,
                     db_bins=(-200, -50, 20.), period_step_octaves=1.4)
-        ppsd._times_processed = np.load(
-            os.path.join(self.path, "ppsd_times_processed.npy")).tolist()
+        # change data to nowadays used nanoseconds POSIX timestamp
+        ppsd._times_processed = [
+            UTCDateTime(t)._ns for t in np.load(
+                os.path.join(self.path, "ppsd_times_processed.npy")).tolist()]
         np.random.seed(1234)
         ppsd._binned_psds = [
             arr for arr in np.random.uniform(
@@ -436,11 +438,11 @@ class PsdTestCase(unittest.TestCase):
 
         # Test callback function that selects a fixed random set of the
         # timestamps.  Also checks that we get passed the type we expect,
-        # which is 1D numpy ndarray of float type.
+        # which is 1D numpy ndarray of int type.
         def callback(t_array):
             self.assertIsInstance(t_array, np.ndarray)
             self.assertEqual(t_array.shape, (len(ppsd._times_processed),))
-            self.assertEqual(t_array.dtype, np.float64)
+            self.assertTrue(np.issubdtype(t_array.dtype, np.integer))
             np.random.seed(1234)
             res = np.random.randint(0, 2, len(t_array)).astype(np.bool)
             return res
@@ -540,6 +542,8 @@ class PsdTestCase(unittest.TestCase):
                     db_bins=(-200, -50, 20.), period_step_octaves=1.4)
         _times_processed = np.load(
             os.path.join(self.path, "ppsd_times_processed.npy")).tolist()
+        # change data to nowadays used nanoseconds POSIX timestamp
+        _times_processed = [UTCDateTime(t)._ns for t in _times_processed]
         np.random.seed(1234)
         _binned_psds = [
             arr for arr in np.random.uniform(

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -683,30 +683,24 @@ class PsdTestCase(unittest.TestCase):
                                **restrictions)
 
     def test_exclude_last_sample(self):
-
+        start = UTCDateTime("2017-01-01T00:00:00")
         header = {
-            "starttime":  UTCDateTime("2017-01-01T00:00:00"),
+            "starttime": start,
             "network": "GR",
             "station": "FUR",
             "channel": "BHZ"
         }
-
         # 49 segments of 30 minutes to allow 30 minutes overlap in next day
         tr = Trace(data=np.arange(30 * 60 * 4, dtype=np.int32), header=header)
 
-        ppsd = PPSD(
-            tr.stats,
-            read_inventory()
-        )
-
+        ppsd = PPSD(tr.stats, read_inventory())
         ppsd.add(tr)
 
         self.assertEqual(3, len(ppsd._times_processed))
         self.assertEqual(3600, ppsd.len)
-
         for i, time in enumerate(ppsd._times_processed):
-            current = UTCDateTime("2017-01-01T00:00:00") + (i * 30 * 60)
-            self.assertTrue(UTCDateTime(time) == current)
+            current = start.ns + (i * 30 * 60) * 1e9
+            self.assertTrue(time == current)
 
     def test_ppsd_spectrogram_plot(self):
         """


### PR DESCRIPTION
This changes all internally used timestamps in PPSD to POSIX timestamps as integer nanoseconds, eliminating all potential floating point inaccuracies when e.g. comparing time stamps etc.

The only drawback is that npz files written on newer obspy versions will result in exceptions when reading on older obspy versions (the other way around should work fine). But I think the positive effect outweighs this drawback.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~
- [x] ~~If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [x] ~~Any new features or fixed regressions are be covered via new tests.~~ no new features
- [x] ~~Any new or changed features have are fully documented.~~ no new features
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] ~~First time contributors have added your name to `CONTRIBUTORS.txt` .~~
