### PR TITLE
UTCDateTime: add public property to access nanosecond integer POSIX timestamp

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1123,6 +1123,20 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertFalse(a == e)
         self.assertFalse(e == a)
 
+    def test_ns_public_attribute(self):
+        """
+        Basic test for public ns interface to UTCDateTime
+        """
+        t = UTCDateTime('2018-01-17T12:34:56.789012Z')
+        # test getter
+        self.assertEqual(t.ns, 1516192496789012000)
+        # test setter
+        x = 1516426162899012123
+        t.ns = x
+        self.assertEqual(t.ns, x)
+        self.assertEqual(t.day, 20)
+        self.assertEqual(t.microsecond, 899012)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -404,6 +404,7 @@ class UTCDateTime(object):
         self.__ns = value
 
     _ns = property(_get_ns, _set_ns)
+    ns = property(_get_ns, _set_ns)
 
     def _from_datetime(self, dt):
         """

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -23,10 +23,6 @@ import numpy as np
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 
 
-ns_doc = ("POSIX timestamp as integer nanoseconds. This is the internal "
-          "representation of UTCDateTime objects.")
-
-
 class UTCDateTime(object):
     """
     A UTC-based datetime object.
@@ -390,9 +386,23 @@ class UTCDateTime(object):
                                    second, microsecond)._ns
 
     def _get_ns(self):
+        """
+        Returns POSIX timestamp as integer nanoseconds.
+
+        This is the internal representation of UTCDateTime objects.
+
+        :rtype: int
+        :returns: POSIX timestamp as integer nanoseconds
+        """
         return self.__ns
 
     def _set_ns(self, value):
+        """
+        Set UTCDateTime object from POSIX timestamp as integer nanoseconds.
+
+        :type value: int
+        :param value: POSIX timestamp as integer nanoseconds
+        """
         # allow setting numpy integer types..
         if isinstance(value, np.integer):
             value_ = int(value)
@@ -407,8 +417,8 @@ class UTCDateTime(object):
             raise TypeError('nanoseconds must be set as int/long type')
         self.__ns = value
 
-    _ns = property(_get_ns, _set_ns, doc=ns_doc)
-    ns = property(_get_ns, _set_ns, doc=ns_doc)
+    _ns = property(_get_ns, _set_ns)
+    ns = property(_get_ns, _set_ns)
 
     def _from_datetime(self, dt):
         """

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -23,6 +23,10 @@ import numpy as np
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 
 
+ns_doc = ("POSIX timestamp as integer nanoseconds. This is the internal "
+          "representation of UTCDateTime objects.")
+
+
 class UTCDateTime(object):
     """
     A UTC-based datetime object.
@@ -403,8 +407,8 @@ class UTCDateTime(object):
             raise TypeError('nanoseconds must be set as int/long type')
         self.__ns = value
 
-    _ns = property(_get_ns, _set_ns)
-    ns = property(_get_ns, _set_ns)
+    _ns = property(_get_ns, _set_ns, doc=ns_doc)
+    ns = property(_get_ns, _set_ns, doc=ns_doc)
 
     def _from_datetime(self, dt):
         """


### PR DESCRIPTION
Since this is now the internal representation of UTCDateTime, I think it makes sense for user code to use that to serialize UTCDateTime objects, and we should therefore offer a public property to access this. Also implementing `__int__` for this would be handy, but I fear that might be way too confusing alongside the existing `__float__` which returns the timestamp in seconds..


### Why was it initiated?  Any relevant Issues?

e.g. #2045, #2036

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] ~~First time contributors have added your name to `CONTRIBUTORS.txt` .~~
- [x] maybe should add `doc` to new property