### PR TITLE
MD: Let 'channel' and 'location' override the priority lists

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,9 @@
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).
+ - obspy.clients.fdsn:
+   * Mass downloader: Priority lists are now correctly overwritten if `channel`
+     and/or `location` are set (see #1810, #2031, #2047).
  - obspy.io.mseed:
    * Ability to read files that have embedded chunks of non SEED data.
      (see #1981, #2057).

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -1173,25 +1173,27 @@ class ClientDownloadHelper(object):
                         location=channel.location_code, channel=channel.code,
                         intervals=copy.deepcopy(intervals)))
 
-                # Group by locations and apply the channel priority filter to
-                # each.
-                filtered_channels = []
+                if self.restrictions.channel is None:
+                    # Group by locations and apply the channel priority filter
+                    # to each.
+                    filtered_channels = []
 
-                def get_loc(x):
-                    return x.location
+                    def get_loc(x):
+                        return x.location
 
-                for location, _channels in itertools.groupby(
-                        sorted(channels, key=get_loc), get_loc):
-                    filtered_channels.extend(utils.filter_channel_priority(
-                        list(_channels), key="channel",
-                        priorities=self.restrictions.channel_priorities))
-                channels = filtered_channels
+                    for location, _channels in itertools.groupby(
+                            sorted(channels, key=get_loc), get_loc):
+                        filtered_channels.extend(utils.filter_channel_priority(
+                            list(_channels), key="channel",
+                            priorities=self.restrictions.channel_priorities))
+                    channels = filtered_channels
 
-                # Filter to remove unwanted locations according to the priority
-                # list.
-                channels = utils.filter_channel_priority(
-                    channels, key="location",
-                    priorities=self.restrictions.location_priorities)
+                if self.restrictions.location is None:
+                    # Filter to remove unwanted locations according to the
+                    # priority list.
+                    channels = utils.filter_channel_priority(
+                        channels, key="location",
+                        priorities=self.restrictions.location_priorities)
 
                 if not channels:
                     continue

--- a/obspy/clients/fdsn/tests/data/uncommon_channel_location.txt
+++ b/obspy/clients/fdsn/tests/data/uncommon_channel_location.txt
@@ -1,2 +1,5 @@
 #Network | Station | Location | Channel | Latitude | Longitude | Elevation | Depth | Azimuth | Dip | SensorDescription | Scale | ScaleFreq | ScaleUnits |  SampleRate | StartTime | EndTime
-AK|BAGL|31|RST|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59
+AK|BAGLA|31|RST|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59
+AK|BAGLB||RST|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59
+AK|BAGLC|31|EHE|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59
+AK|BAGLD||EHE|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59

--- a/obspy/clients/fdsn/tests/data/uncommon_channel_location.txt
+++ b/obspy/clients/fdsn/tests/data/uncommon_channel_location.txt
@@ -1,0 +1,2 @@
+#Network | Station | Location | Channel | Latitude | Longitude | Elevation | Depth | Azimuth | Dip | SensorDescription | Scale | ScaleFreq | ScaleUnits |  SampleRate | StartTime | EndTime
+AK|BAGL|31|RST|60.4896|-142.0915|1470.0|0.0|0.0|-90.0|Nanometrics Trillium 240 Sec Response sn 400 and a|4.88233E8|0.02|M/S|1.0|2013-01-01T00:00:00|2599-12-31T23:59:59

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2249,6 +2249,24 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
         self.assertEqual([("AK", "BAGL"), ("AK", "BWN"), ("AZ", "BZN")],
                          sorted(c.stations.keys()))
 
+        # When 'channel' or 'location' are set they should override
+        # 'channel_priorities' and 'location_priorities'. If this isn't
+        # happening this test will fail, as we're requesting data
+        # with a channel and location what are not covered by the default
+        # priorities lists.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            station_starttime=obspy.UTCDateTime(2000, 1, 1),
+            station_endtime=obspy.UTCDateTime(2015, 1, 1),
+            channel="RST",
+            location="31")
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "uncommon_channel_location.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGL")], sorted(c.stations.keys()))
+
         # Excluding things that don't exists does not do anything.
         self.restrictions = Restrictions(
             starttime=obspy.UTCDateTime(2001, 1, 1),

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2249,24 +2249,6 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
         self.assertEqual([("AK", "BAGL"), ("AK", "BWN"), ("AZ", "BZN")],
                          sorted(c.stations.keys()))
 
-        # When 'channel' or 'location' are set they should override
-        # 'channel_priorities' and 'location_priorities'. If this isn't
-        # happening this test will fail, as we're requesting data
-        # with a channel and location what are not covered by the default
-        # priorities lists.
-        self.restrictions = Restrictions(
-            starttime=obspy.UTCDateTime(2001, 1, 1),
-            endtime=obspy.UTCDateTime(2015, 1, 1),
-            station_starttime=obspy.UTCDateTime(2000, 1, 1),
-            station_endtime=obspy.UTCDateTime(2015, 1, 1),
-            channel="RST",
-            location="31")
-        c = self._init_client()
-        c.client.get_stations.return_value = obspy.read_inventory(
-            os.path.join(self.data, "uncommon_channel_location.txt"))
-        c.get_availability()
-        self.assertEqual([("AK", "BAGL")], sorted(c.stations.keys()))
-
         # Excluding things that don't exists does not do anything.
         self.restrictions = Restrictions(
             starttime=obspy.UTCDateTime(2001, 1, 1),
@@ -2367,6 +2349,76 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
             os.path.join(self.data, "channel_level_fdsn.txt"))
         c.get_availability()
         self.assertEqual([("AK", "BAGL")],
+                         sorted(c.stations.keys()))
+
+        # When 'channel' or 'location' are set they should override
+        # 'channel_priorities' and 'location_priorities'. If this isn't
+        # happening this test will fail, as we're requesting data
+        # with a channel and location what are not covered by the default
+        # priorities lists.
+        #
+        # The tests are a bit strange in the way that the availability
+        # filtering does not enforce the set "location" + "channel" but only
+        # the priority lists. Location + channel are already set at the queries
+        # to the datacenters so they can be assumed to be correct.
+        #
+        # The availability information contains uncommon channel + location
+        # combinations and only one station will be selected first.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            # This will be ignored as soon as channel and location are being
+            # set.
+            channel_priorities=["EH*", "BH*"],
+            location_priorities=["", "01"])
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "uncommon_channel_location.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGLD")], sorted(c.stations.keys()))
+
+        # With a set location, the channel priorities are still active.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            channel_priorities=["EH*", "BH*"],
+            location_priorities=["", "01"],
+            location="31")
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "uncommon_channel_location.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGLC"), ("AK", "BAGLD")],
+                         sorted(c.stations.keys()))
+
+        # Same with the set channel.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            channel_priorities=["EH*", "BH*"],
+            location_priorities=["", "01"],
+            channel="RST")
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "uncommon_channel_location.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGLB"), ("AK", "BAGLD")],
+                         sorted(c.stations.keys()))
+
+        # If both are set, the priorities are properly ignored.
+        self.restrictions = Restrictions(
+            starttime=obspy.UTCDateTime(2001, 1, 1),
+            endtime=obspy.UTCDateTime(2015, 1, 1),
+            channel_priorities=["EH*", "BH*"],
+            location_priorities=["", "01"],
+            location="31",
+            channel="RST")
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data, "uncommon_channel_location.txt"))
+        c.get_availability()
+        self.assertEqual([("AK", "BAGLA"), ("AK", "BAGLB"), ("AK", "BAGLC"),
+                          ("AK", "BAGLD")],
                          sorted(c.stations.keys()))
 
     def test_excluding_networks_and_stations_with_an_inventory_object(self):


### PR DESCRIPTION
### What does this PR do?

This makes the code works as documented, that is: if the `channel` variable is set, then the `channel_priorities` list is ignored. The same goes for the `location` variable and `location_priorities`.

### Why was it initiated?  Any relevant Issues?

Fixes #1810.
Fixes #2031.

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.fdsn"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .