### PR TITLE
PPSD: raise exception when trying to load/add a npz that was written with a higher 'ppsd_version'

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,10 @@
    * Write the UTC time zone specifier to all times (see #2015).
  - obspy.signal:
    * Allow singular COUNT units in evalresp (see #2003, #2011).
+   * PPSD: for safety reasons, raise an ObsPyException if trying to read a PPSD
+     npz file that was written with a newer version of the npz representation
+     than is used by current ObsPy version (see #2051)
+
 
 1.1.0: (doi: 10.5281/zenodo.165135)
  - General:

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -1232,19 +1232,8 @@ class PPSD(object):
         data = np.load(filename)
         # the information regarding stats is set from the npz
         ppsd = PPSD(Stats(), metadata=metadata)
-        # add some future-proofing and show a warning if older obspy
-        # versions should read a more recent ppsd npz file, since this is very
-        # like problematic
-        if data['ppsd_version'].item() > ppsd.ppsd_version:
-            msg = ("Trying to read a PPSD npz with 'ppsd_version={}'. This "
-                   "file was written on a more recent ObsPy version that very "
-                   "likely has incompatible changes in PPSD internal "
-                   "structure and npz serialization. It can not safely be "
-                   "read with this ObsPy version (current 'ppsd_version' is "
-                   "{}). Please consider updating your ObsPy "
-                   "installation.").format(data['ppsd_version'].item(),
-                                           ppsd.ppsd_version)
-            raise ObsPyException(msg)
+        # check ppsd_version version and raise if higher than current
+        _check_npz_ppsd_version(ppsd, data)
         for key in ppsd.NPZ_STORE_KEYS:
             # data is stored as arrays in the npz.
             # we have to convert those back to lists (or simple types), so that
@@ -1926,6 +1915,22 @@ def get_nhnm():
     periods = data['model_periods']
     nlnm = data['high_noise']
     return (periods, nlnm)
+
+
+def _check_npz_ppsd_version(ppsd, npzfile):
+    # add some future-proofing and show a warning if older obspy
+    # versions should read a more recent ppsd npz file, since this is very
+    # like problematic
+    if npzfile['ppsd_version'].item() > ppsd.ppsd_version:
+        msg = ("Trying to read/add a PPSD npz with 'ppsd_version={}'. This "
+               "file was written on a more recent ObsPy version that very "
+               "likely has incompatible changes in PPSD internal "
+               "structure and npz serialization. It can not safely be "
+               "read with this ObsPy version (current 'ppsd_version' is "
+               "{}). Please consider updating your ObsPy "
+               "installation.").format(npzfile['ppsd_version'].item(),
+                                       ppsd.ppsd_version)
+        raise ObsPyException(msg)
 
 
 if __name__ == '__main__':

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -1275,6 +1275,8 @@ class PPSD(object):
         See :meth:`PPSD.add_npz()`.
         """
         data = np.load(filename)
+        # check ppsd_version version and raise if higher than current
+        _check_npz_ppsd_version(self, data)
         # check if all metadata agree
         for key in self.NPZ_STORE_KEYS_SIMPLE_TYPES:
             if getattr(self, key) != data[key].item():

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -39,6 +39,7 @@ from obspy.imaging.scripts.scan import compress_start_end
 from obspy.core.inventory import Inventory
 from obspy.core.util import AttribDict
 from obspy.core.util.base import MATPLOTLIB_VERSION
+from obspy.core.util.obspy_types import ObsPyException
 from obspy.imaging.cm import obspy_sequential
 from obspy.imaging.util import _set_xaxis_obspy_dates
 from obspy.io.xseed import Parser
@@ -1231,6 +1232,19 @@ class PPSD(object):
         data = np.load(filename)
         # the information regarding stats is set from the npz
         ppsd = PPSD(Stats(), metadata=metadata)
+        # add some future-proofing and show a warning if older obspy
+        # versions should read a more recent ppsd npz file, since this is very
+        # like problematic
+        if data['ppsd_version'].item() > ppsd.ppsd_version:
+            msg = ("Trying to read a PPSD npz with 'ppsd_version={}'. This "
+                   "file was written on a more recent ObsPy version that very "
+                   "likely has incompatible changes in PPSD internal "
+                   "structure and npz serialization. It can not safely be "
+                   "read with this ObsPy version (current 'ppsd_version' is "
+                   "{}). Please consider updating your ObsPy "
+                   "installation.").format(data['ppsd_version'].item(),
+                                           ppsd.ppsd_version)
+            raise ObsPyException(msg)
         for key in ppsd.NPZ_STORE_KEYS:
             # data is stored as arrays in the npz.
             # we have to convert those back to lists (or simple types), so that

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -726,6 +726,12 @@ class PsdTestCase(unittest.TestCase):
             with self.assertRaises(ObsPyException) as e:
                 PPSD.load_npz(filename)
             self.assertEqual(str(e.exception), msg)
+            # 2 - adding a npz
+            ppsd = PPSD.load_npz(self.example_ppsd_npz)
+            for method in (ppsd.add_npz, ppsd._add_npz):
+                with self.assertRaises(ObsPyException) as e:
+                    method(filename)
+                self.assertEqual(str(e.exception), msg)
 
 
 def suite():

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -725,10 +725,14 @@ class PsdTestCase(unittest.TestCase):
                 np.savez(fh, **items)
             with self.assertRaises(ObsPyException) as e:
                 PPSD.load_npz(filename)
-            self.assertEqual(str(e.exception), msg)
-            # 2 - adding a npz
-            ppsd = PPSD.load_npz(self.example_ppsd_npz)
-            for method in (ppsd.add_npz, ppsd._add_npz):
+        self.assertEqual(str(e.exception), msg)
+        # 2 - adding a npz
+        ppsd = PPSD.load_npz(self.example_ppsd_npz)
+        for method in (ppsd.add_npz, ppsd._add_npz):
+            with NamedTemporaryFile() as tf:
+                filename = tf.name
+                with open(filename, 'wb') as fh:
+                    np.savez(fh, **items)
                 with self.assertRaises(ObsPyException) as e:
                     method(filename)
                 self.assertEqual(str(e.exception), msg)

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -704,6 +704,14 @@ class PsdTestCase(unittest.TestCase):
         a higher 'ppsd_version' number which is used to keep track of changes
         in PPSD and the npz file used for serialization).
         """
+        msg = ("Trying to read/add a PPSD npz with 'ppsd_version=100'. This "
+               "file was written on a more recent ObsPy version that very "
+               "likely has incompatible changes in PPSD internal structure "
+               "and npz serialization. It can not safely be read with this "
+               "ObsPy version (current 'ppsd_version' is {!s}). Please "
+               "consider updating your ObsPy installation.".format(
+                   PPSD(stats=Stats(), metadata=None).ppsd_version))
+        # 1 - loading a npz
         data = np.load(self.example_ppsd_npz)
         # we have to load, modify 'ppsd_version' and save the npz file for the
         # test..
@@ -717,15 +725,7 @@ class PsdTestCase(unittest.TestCase):
                 np.savez(fh, **items)
             with self.assertRaises(ObsPyException) as e:
                 PPSD.load_npz(filename)
-            self.assertEqual(
-                str(e.exception),
-                "Trying to read a PPSD npz with 'ppsd_version=100'. This "
-                "file was written on a more recent ObsPy version that very "
-                "likely has incompatible changes in PPSD internal structure "
-                "and npz serialization. It can not safely be read with this "
-                "ObsPy version (current 'ppsd_version' is {!s}). Please "
-                "consider updating your ObsPy installation.".format(
-                    PPSD(stats=Stats(), metadata=None).ppsd_version))
+            self.assertEqual(str(e.exception), msg)
 
 
 def suite():

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -19,6 +19,7 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime, read, read_inventory
 from obspy.core import Stats
 from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.obspy_types import ObsPyException
 from obspy.core.util.testing import (
     ImageComparison, ImageComparisonException, MATPLOTLIB_VERSION)
 from obspy.io.xseed import Parser
@@ -695,6 +696,36 @@ class PsdTestCase(unittest.TestCase):
         with ImageComparison(self.path_images, 'ppsd_spectrogram.png',
                              reltol=1.5) as ic:
             ppsd.plot_spectrogram(filename=ic.name, show=False)
+
+    def test_exception_reading_newer_npz(self):
+        """
+        Checks that an exception is properly raised when trying to read a npz
+        that was written on a more recent ObsPy version (specifically that has
+        a higher 'ppsd_version' number which is used to keep track of changes
+        in PPSD and the npz file used for serialization).
+        """
+        data = np.load(self.example_ppsd_npz)
+        # we have to load, modify 'ppsd_version' and save the npz file for the
+        # test..
+        items = {key: data[key] for key in data.files}
+        # deliberately set a higher ppsd_version number
+        items['ppsd_version'] = items['ppsd_version'].copy()
+        items['ppsd_version'].fill(100)
+        with NamedTemporaryFile() as tf:
+            filename = tf.name
+            with open(filename, 'wb') as fh:
+                np.savez(fh, **items)
+            with self.assertRaises(ObsPyException) as e:
+                PPSD.load_npz(filename)
+            self.assertEqual(
+                str(e.exception),
+                "Trying to read a PPSD npz with 'ppsd_version=100'. This "
+                "file was written on a more recent ObsPy version that very "
+                "likely has incompatible changes in PPSD internal structure "
+                "and npz serialization. It can not safely be read with this "
+                "ObsPy version (current 'ppsd_version' is {!s}). Please "
+                "consider updating your ObsPy installation.".format(
+                    PPSD(stats=Stats(), metadata=None).ppsd_version))
 
 
 def suite():

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ KEYWORDS = [
     'web service', 'Winston', 'XML-SEED', 'XSEED']
 
 # when bumping to numpy 1.9.0: replace bytes() in io.reftek with np.tobytes()
+# when bumping to numpy 1.7.0: get rid of if/else when loading npz file to PPSD
 INSTALL_REQUIRES = [
     'future>=0.12.4',
     'numpy>=1.6.1',


### PR DESCRIPTION
.. than is currently used (to be more precise, raise
when reading a npz file that has a higher 'ppsd_version' which is used
for tracking changes in PPSD internal structure and serialization)

also has a test

with obspy >=1.2.0 this will be upgraded to an exception



### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~
- [x] ~~If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] ~~Any new or changed features have are fully documented.~~
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] ~~First time contributors have added your name to `CONTRIBUTORS.txt`~~
