### PR TITLE
Read blank miniSEED records

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,9 @@
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).
+ - obspy.io.mseed:
+   * Ability to read files that have embedded chunks filled with zero bytes
+     (see #1981, #2057).
  - obspy.io.reftek:
    * Fix problems reading some Reftek 130 files, presumably due to floating
      point accuracy issues in comparing timestamps. Internal representation of

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,7 @@
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).
  - obspy.io.mseed:
-   * Ability to read files that have embedded chunks filled with zero bytes
+   * Ability to read files that have embedded chunks of non SEED data.
      (see #1981, #2057).
  - obspy.io.reftek:
    * Fix problems reading some Reftek 130 files, presumably due to floating

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -706,5 +706,51 @@ def get_all_py_files():
     return sorted(py_files)
 
 
+class WarningsCapture(object):
+    """
+    Try hard to capture all warnings.
+
+    Aims to be a reliable drop-in replacement for built-in
+    warnings.catch_warnings() context manager.
+
+    Based on pytest's _DeprecatedCallContext context manager.
+    """
+    def __enter__(self):
+        self.captured_warnings = []
+        self._old_warn = warnings.warn
+        self._old_warn_explicit = warnings.warn_explicit
+        warnings.warn_explicit = self._warn_explicit
+        warnings.warn = self._warn
+        return self
+
+    def _warn_explicit(self, message, category, *args, **kwargs):
+        self.captured_warnings.append(
+            warnings.WarningMessage(message=category(message),
+                                    category=category,
+                                    filename="", lineno=0))
+
+    def _warn(self, message, category=None, *args, **kwargs):
+        if isinstance(message, Warning):
+            self.captured_warnings.append(
+                warnings.WarningMessage(
+                    message=category(message), category=category or Warning,
+                    filename="", lineno=0))
+        else:
+            self.captured_warnings.append(
+                warnings.WarningMessage(
+                    message=category(message), category=category,
+                    filename="", lineno=0))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        warnings.warn_explicit = self._old_warn_explicit
+        warnings.warn = self._old_warn
+
+    def __len__(self):
+        return len(self.captured_warnings)
+
+    def __getitem__(self, key):
+        return self.captured_warnings[key]
+
+
 if __name__ == '__main__':
     doctest.testmod(exclude_empty=True)

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -311,6 +311,7 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
     LinkedRecordList *recordCurrent = NULL;
     int datasize;
     int record_count = 0;
+    int byte_num;
 
     if (header_byteorder >= 0) {
         // Enforce little endian.
@@ -368,7 +369,7 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
         // Skip fully empty chunks that could make up a full record. This
         // (rarely but sometimes) happens for example when the digitizer
         // crashes unexpectedly.
-        int byte_num = 0;
+        byte_num = 0;
         while (byte_num < MINRECLEN) {
             // Break at first non-zero byte.
             if (*(mseed + offset + byte_num)) {

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -365,6 +365,22 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
             continue;
         }
 
+        // Skip fully empty chunks that could make up a full record. This
+        // (rarely but sometimes) happens for example when the digitizer
+        // crashes unexpectedly.
+        int byte_num = 0;
+        while (byte_num < MINRECLEN) {
+            // Break at first non-zero byte.
+            if (*(mseed + offset + byte_num)) {
+                break;
+            }
+            byte_num += 1;
+        }
+        if (byte_num == MINRECLEN) {
+            offset += MINRECLEN;
+            continue;
+        }
+
         // Pass (buflen - offset) because msr_parse() expects only a single record. This
         // way libmseed can take care to not overstep bounds.
         // Return values:

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1198,6 +1198,9 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 "readMSEEDBuffer(): Not a SEED record. Will skip bytes "
                 "4096 to 4223.")
 
+            # Should always be two records.
+            self.assertEqual(st[0].stats.mseed.number_of_records, 2)
+
             # Remove things like file-size and what not.
             del st[0].stats.mseed
             self.assertEqual(reference, st)
@@ -1216,6 +1219,9 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 with WarningsCapture() as w:
                     st = _read_mseed(buf)
                 self.assertEqual(len(w), length // 128)
+
+            # Should always be two records.
+            self.assertEqual(st[0].stats.mseed.number_of_records, 2)
 
             # Remove things like file-size and what not.
             del st[0].stats.mseed

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -21,6 +21,7 @@ from obspy import Stream, Trace, UTCDateTime, read
 from obspy.core.compatibility import from_buffer, mock
 from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.attribdict import AttribDict
+from obspy.core.util.testing import WarningsCapture
 from obspy.io.mseed import (InternalMSEEDError, InternalMSEEDWarning,
                             ObsPyMSEEDFilesizeTooSmallError,
                             ObsPyMSEEDFilesizeTooLargeError)
@@ -139,8 +140,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                                     verbose=0)
 
         # test readMSTraces. Will raise an internal warning.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with WarningsCapture() as w:
             data_record = _read_mseed(file)[0].data
 
         # This will raise 18 (!) warnings. It will skip 17 * 128 bytes due
@@ -1187,8 +1187,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 buf.write(rec2)
                 buf.seek(0, 0)
                 # This will raise 1 warning per 128 bytes.
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
+                with WarningsCapture() as w:
                     st = _read_mseed(buf)
                 self.assertEqual(len(w), length // 128)
 
@@ -1214,8 +1213,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
                 buf.write(rec2)
                 buf.seek(0, 0)
                 # This will raise 1 warning per 128 bytes.
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
+                with WarningsCapture() as w:
                     st = _read_mseed(buf)
                 self.assertEqual(len(w), length // 128)
 

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -1237,6 +1237,7 @@ class MSEEDUtilTestCase(unittest.TestCase):
         filename = os.path.join(self.path, "data",
                                 "record_with_invalid_word_order.mseed")
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             info = util.get_record_information(filename)
 
         self.assertEqual(len(w), 1)


### PR DESCRIPTION
As discussed in #1981 this PR enables ObsPy to read MiniSEED files that have chunks (at some multiple of the minimal record size) filled with zero bytes. This can go in maintenance as it does not really change behavior (it just reads some files it previously did not).

Also contains an unrelated fix to make the test cases more independent.