### PR TITLE
fix read_inventory() with invalid filename showing strange error message

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@
    * Tests pass with numpy 1.14 (see #2044).
  - obspy.core:
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
+ - obspy.core:
+   * read_inventory() used with non-existing file path (e.g. typo in filename)
+     now shows a proper "No such file or directory" error message (see #2062)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -13,9 +13,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 from future.utils import python_2_unicode_compatible, native_str
-from future.utils import PY2
 
-import builtins
 import copy
 import fnmatch
 import os
@@ -37,10 +35,6 @@ from .util import _unified_content_strings, _textwrap
 # from there results in hard to resolve cyclic imports.
 SOFTWARE_MODULE = "ObsPy %s" % obspy.__version__
 SOFTWARE_URI = "https://www.obspy.org"
-
-
-if PY2:
-    FileNotFoundError = getattr(builtins, 'IOError')
 
 
 def _create_example_inventory():
@@ -100,10 +94,6 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=path_or_file_object, filename_or_buffer=fh)
             return read_inventory(fh.name, format=format)
-    if not os.path.exists(path_or_file_object):
-        msg = "[Errno 2] No such file or directory: '{}'".format(
-            path_or_file_object)
-        raise FileNotFoundError(msg)
     return _read_from_plugin("inventory", path_or_file_object,
                              format=format, *args, **kwargs)[0]
 

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -13,7 +13,9 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 from future.utils import python_2_unicode_compatible, native_str
+from future.utils import PY2
 
+import builtins
 import copy
 import fnmatch
 import os
@@ -35,6 +37,10 @@ from .util import _unified_content_strings, _textwrap
 # from there results in hard to resolve cyclic imports.
 SOFTWARE_MODULE = "ObsPy %s" % obspy.__version__
 SOFTWARE_URI = "https://www.obspy.org"
+
+
+if PY2:
+    FileNotFoundError = getattr(builtins, 'IOError')
 
 
 def _create_example_inventory():
@@ -94,6 +100,10 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=path_or_file_object, filename_or_buffer=fh)
             return read_inventory(fh.name, format=format)
+    if not os.path.exists(path_or_file_object):
+        msg = "[Errno 2] No such file or directory: '{}'".format(
+            path_or_file_object)
+        raise FileNotFoundError(msg)
     return _read_from_plugin("inventory", path_or_file_object,
                              format=format, *args, **kwargs)[0]
 

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -2,7 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
+from future.utils import PY2, native_str
 
+import builtins
 import copy
 import os
 import sys
@@ -19,6 +21,7 @@ from obspy.core.event import (Catalog, Comment, CreationInfo, Event, Origin,
 from obspy.core.event.source import farfield
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import BASEMAP_VERSION, CARTOPY_VERSION
+from obspy.core.util.base import _get_entry_points
 from obspy.core.util.testing import ImageComparison
 from obspy.core.event.base import QuantityError
 
@@ -252,6 +255,38 @@ class CatalogTestCase(unittest.TestCase):
         ResourceIdentifier._ResourceIdentifier__resource_id_weak_dict.clear()
         # Also clear the tracker.
         ResourceIdentifier._ResourceIdentifier__resource_id_tracker.clear()
+
+    def test_read_invalid_filename(self):
+        """
+        Tests that we get a sane error message when calling read_events()
+        with a filename that doesn't exist
+        """
+        doesnt_exist = 'dsfhjkfs'
+        for i in range(10):
+            if os.path.exists(doesnt_exist):
+                doesnt_exist += doesnt_exist
+                continue
+            break
+        else:
+            self.fail('unable to get invalid file path')
+        doesnt_exist = native_str(doesnt_exist)
+
+        if PY2:
+            exception_type = getattr(builtins, 'IOError')
+        else:
+            exception_type = getattr(builtins, 'FileNotFoundError')
+        exception_msg = "[Errno 2] No such file or directory: '{}'"
+
+        formats = _get_entry_points(
+            'obspy.plugin.catalog', 'readFormat').keys()
+        # try read_inventory() with invalid filename for all registered read
+        # plugins and also for filetype autodiscovery
+        formats = [None] + list(formats)
+        for format in formats:
+            with self.assertRaises(exception_type) as e:
+                read_events(doesnt_exist, format=format)
+            self.assertEqual(
+                str(e.exception), exception_msg.format(doesnt_exist))
 
     def test_creation_info(self):
         cat = Catalog()

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -12,7 +12,7 @@ Test suite for the inventory class.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2
+from future.utils import PY2, native_str
 
 import builtins
 import os
@@ -447,6 +447,7 @@ class InventoryTestCase(unittest.TestCase):
             break
         else:
             self.fail('unable to get invalid file path')
+        doesnt_exist = native_str(doesnt_exist)
 
         if PY2:
             exception_type = getattr(builtins, 'IOError')
@@ -458,12 +459,12 @@ class InventoryTestCase(unittest.TestCase):
             'obspy.plugin.inventory', 'readFormat').keys()
         # try read_inventory() with invalid filename for all registered read
         # plugins and also for filetype autodiscovery
-        formats = [None] + formats
-        for format in formats:
+        formats = [None] + list(formats)
+        for format in formats[:1]:
             with self.assertRaises(exception_type) as e:
                 read_inventory(doesnt_exist, format=format)
             self.assertEqual(
-                e.exception.args[0], exception_msg.format(doesnt_exist))
+                str(e.exception), exception_msg.format(doesnt_exist))
 
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -12,7 +12,9 @@ Test suite for the inventory class.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
+import builtins
 import os
 import unittest
 import warnings
@@ -25,6 +27,7 @@ from obspy import UTCDateTime, read_inventory, read_events
 from obspy.core.compatibility import mock
 from obspy.core.util import (
     BASEMAP_VERSION, CARTOPY_VERSION, MATPLOTLIB_VERSION)
+from obspy.core.util.base import _get_entry_points
 from obspy.core.util.testing import ImageComparison
 from obspy.core.inventory import (Channel, Inventory, Network, Response,
                                   Station)
@@ -430,6 +433,37 @@ class InventoryTestCase(unittest.TestCase):
         )
         for contents_, expected_ in zip(contents, expected):
             self.assertEqual(expected_, _unified_content_strings(contents_))
+
+    def test_read_invalid_filename(self):
+        """
+        Tests that we get a sane error message when calling read_inventory()
+        with a filename that doesn't exist
+        """
+        doesnt_exist = 'dsfhjkfs'
+        for i in range(10):
+            if os.path.exists(doesnt_exist):
+                doesnt_exist += doesnt_exist
+                continue
+            break
+        else:
+            self.fail('unable to get invalid file path')
+
+        if PY2:
+            exception_type = getattr(builtins, 'IOError')
+        else:
+            exception_type = getattr(builtins, 'FileNotFoundError')
+        exception_msg = "[Errno 2] No such file or directory: '{}'"
+
+        formats = _get_entry_points(
+            'obspy.plugin.inventory', 'readFormat').keys()
+        # try read_inventory() with invalid filename for all registered read
+        # plugins and also for filetype autodiscovery
+        formats = [None] + formats
+        for format in formats:
+            with self.assertRaises(exception_type) as e:
+                read_inventory(doesnt_exist, format=format)
+            self.assertEqual(
+                e.exception.args[0], exception_msg.format(doesnt_exist))
 
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -2,7 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2, native_str
 
+import builtins
 import io
 import os
 import threading
@@ -514,6 +516,38 @@ class WaveformPluginsTestCase(unittest.TestCase):
         """
         st = read("/path/to/tarfile_impostor.mseed")
         self.assertEqual(st[0].id, "10.864.1B.004")
+
+    def test_read_invalid_filename(self):
+        """
+        Tests that we get a sane error message when calling read()
+        with a filename that doesn't exist
+        """
+        doesnt_exist = 'dsfhjkfs'
+        for i in range(10):
+            if os.path.exists(doesnt_exist):
+                doesnt_exist += doesnt_exist
+                continue
+            break
+        else:
+            self.fail('unable to get invalid file path')
+        doesnt_exist = native_str(doesnt_exist)
+
+        if PY2:
+            exception_type = getattr(builtins, 'IOError')
+        else:
+            exception_type = getattr(builtins, 'FileNotFoundError')
+        exception_msg = "[Errno 2] No such file or directory: '{}'"
+
+        formats = _get_entry_points(
+            'obspy.plugin.catalog', 'readFormat').keys()
+        # try read_inventory() with invalid filename for all registered read
+        # plugins and also for filetype autodiscovery
+        formats = [None] + list(formats)
+        for format in formats:
+            with self.assertRaises(exception_type) as e:
+                read(doesnt_exist, format=format)
+            self.assertEqual(
+                str(e.exception), exception_msg.format(doesnt_exist))
 
 
 def suite():

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -11,7 +11,9 @@ Base utilities and constants for ObsPy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
+import builtins
 import doctest
 import inspect
 import io
@@ -357,10 +359,19 @@ BASEMAP_VERSION = get_dependency_version('basemap')
 CARTOPY_VERSION = get_dependency_version('cartopy')
 
 
+if PY2:
+    FileNotFoundError = getattr(builtins, 'IOError')
+
+
 def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
     """
     Reads a single file from a plug-in's readFormat function.
     """
+    if isinstance(filename, (str, native_str)):
+        if not os.path.exists(filename):
+            msg = "[Errno 2] No such file or directory: '{}'".format(
+                filename)
+            raise FileNotFoundError(msg)
     eps = ENTRY_POINTS[plugin_type]
     # get format entry point
     format_ep = None


### PR DESCRIPTION
`read_inventory()` with invalid filename shows strange error message by lxml..

We should show the usual error messages on Python2/3 instead.

```python
read_inventory("bladfdfdfdfdfd")
```

```
IOError                                   Traceback (most recent call last)
<ipython-input-7-35b65229f0b3> in <module>()
----> 1 read_inventory("bladfdfdfdfdfd")

<decorator-gen-158> in read_inventory(path_or_file_object, format, *args, **kwargs)

/home/megies/anaconda/envs/1.1.0py2/lib/python2.7/site-packages/obspy/core/util/decorator.pyc in _map_example_filename(func, *args, **kwargs)
    299                         except IOError:
    300                             pass
--> 301         return func(*args, **kwargs)
    302     return _map_example_filename
    303 

/home/megies/anaconda/envs/1.1.0py2/lib/python2.7/site-packages/obspy/core/inventory/inventory.pyc in read_inventory(path_or_file_object, format, *args, **kwargs)
     96             return read_inventory(fh.name, format=format)
     97     return _read_from_plugin("inventory", path_or_file_object,
---> 98                              format=format, *args, **kwargs)[0]
     99 
    100 

/home/megies/anaconda/envs/1.1.0py2/lib/python2.7/site-packages/obspy/core/util/base.pyc in _read_from_plugin(plugin_type, filename, format, **kwargs)
    384                 position = None
    385             # check format
--> 386             is_format = is_format(filename)
    387             if position is not None:
    388                 filename.seek(0, 0)

/home/megies/anaconda/envs/1.1.0py2/lib/python2.7/site-packages/obspy/io/stationxml/core.pyc in _is_stationxml(path_or_file_object)
     66         else:
     67             try:
---> 68                 xmldoc = etree.parse(path_or_file_object)
     69             except etree.XMLSyntaxError:
     70                 return False

src/lxml/etree.pyx in lxml.etree.parse (src/lxml/etree.c:83185)()

src/lxml/parser.pxi in lxml.etree._parseDocument (src/lxml/etree.c:120757)()

src/lxml/parser.pxi in lxml.etree._parseDocumentFromURL (src/lxml/etree.c:121104)()

src/lxml/parser.pxi in lxml.etree._parseDocFromFile (src/lxml/etree.c:120012)()

src/lxml/parser.pxi in lxml.etree._BaseParser._parseDocFromFile (src/lxml/etree.c:114561)()

src/lxml/parser.pxi in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/etree.c:107738)()

src/lxml/parser.pxi in lxml.etree._handleParseResult (src/lxml/etree.c:109447)()

src/lxml/parser.pxi in lxml.etree._raiseParseError (src/lxml/etree.c:108258)()

IOError: Error reading file 'bladfdfdfdfdfd': failed to load external entity "bladfdfdfdfdfd"

```