### PR TITLE
fix axes kw in plot_response

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -850,7 +850,7 @@ class Inventory(ComparingObject):
         """
         import matplotlib.pyplot as plt
 
-        if axes:
+        if axes is not None:
             ax1, ax2 = axes
             fig = ax1.figure
         else:
@@ -881,7 +881,7 @@ class Inventory(ComparingObject):
                         msg = "Skipping plot of channel (%s):\n%s"
                         warnings.warn(msg % (str(e), str(cha)), UserWarning)
         # final adjustments to plot if we created the figure in here
-        if not axes:
+        if axes is None:
             from obspy.core.inventory.response import _adjust_bode_plot_figure
             _adjust_bode_plot_figure(fig, plot_degrees, show=False)
         if outfile:


### PR DESCRIPTION
Fixes the following problem:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-bb1fc9308dda> in <module>()
      1 fig, axes = plt.subplots(2, 1, figsize=(12, 12))
----> 2 inv.plot_response(0.01, axes=axes)
      3 plt.show()

~/anaconda/envs/notebooks/lib/python3.6/site-packages/obspy/core/inventory/inventory.py in plot_response(self, min_freq, output, network, station, location, channel, time, starttime, endtime, axes, unwrap_phase, plot_degrees, show, outfile)
    851         import matplotlib.pyplot as plt
    852 
--> 853         if axes:
    854             ax1, ax2 = axes
    855             fig = ax1.figure

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```