### PR TITLE
add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.pyo
 .cache
 .DS_Store
+.idea
 .project
 .pydevproject
 /.settings


### PR DESCRIPTION
### What does this PR do?

Adds the project folder associated with intellij IDE (includes pycharm) to .gitignore file. 

### Why was it initiated?  Any relevant Issues?

Pycharm is a common IDE, we don't want developers accidentally committing their IDE settings. 
 
