### PR TITLE
Mass downloader fixes

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -599,7 +599,7 @@ class ClientDownloadHelper(object):
                 if st not in rejected_stations:
                     rejected_stations.append(st)
 
-        # Otherwise it will add new stations approximating a Poisson disk
+            # Otherwise it will add new stations approximating a Poisson disk
         # distribution.
         else:
             while stations:
@@ -1192,9 +1192,12 @@ class ClientDownloadHelper(object):
                     if (channel.start_date > self.restrictions.endtime) or \
                             (channel.end_date < self.restrictions.starttime):
                         continue
-                    channels.append(Channel(
+                    new_channel = Channel(
                         location=channel.location_code, channel=channel.code,
-                        intervals=copy.deepcopy(intervals)))
+                        intervals=copy.deepcopy(intervals))
+                    # Get rid of duplicated entries in the availability.
+                    if new_channel not in channels:
+                        channels.append(new_channel)
 
                 if self.restrictions.channel is None:
                     # Group by locations and apply the channel priority filter

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -1195,7 +1195,9 @@ class ClientDownloadHelper(object):
                     new_channel = Channel(
                         location=channel.location_code, channel=channel.code,
                         intervals=copy.deepcopy(intervals))
-                    # Get rid of duplicated entries in the availability.
+                    # Multiple channel epochs would result in duplicate
+                    # channels which we don't want. Bit of a silly logic here
+                    # to get rid of them.
                     if new_channel not in channels:
                         channels.append(new_channel)
 

--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -46,7 +46,21 @@ STATUS = Enum(["none", "needs_downloading", "downloaded", "ignore", "exists",
                "download_partially_failed"])
 
 
-class Station(object):
+class _SlotsEqualityComparisionObject(object):
+    """
+    Helper object with an equality comparision method simply comparing all
+    slotted attributes.
+    """
+    __slots__ = []
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+        return all([getattr(self, _i) == getattr(other, _i)
+                    for _i in self.__slots__])
+
+
+class Station(_SlotsEqualityComparisionObject):
     """
     Object representing a seismic station within the download helper classes.
 
@@ -386,7 +400,7 @@ class Station(object):
                         time_interval.status = STATUS.DOWNLOAD_REJECTED
 
 
-class Channel(object):
+class Channel(_SlotsEqualityComparisionObject):
     """
     Object representing a Channel. Each time interval should end up in one
     MiniSEED file.
@@ -427,7 +441,7 @@ class Channel(object):
             intervals="\n\t".join([str(i) for i in self.intervals]))
 
 
-class TimeInterval(object):
+class TimeInterval(_SlotsEqualityComparisionObject):
     """
     Simple object representing a time interval of a channel.
 
@@ -570,12 +584,21 @@ class ClientDownloadHelper(object):
 
             # Remove these indices this results in a set of stations we wish to
             # keep.
-            remaining_stations.extend(set(
-                _i[1] for _i in enumerate(stations)
-                if _i[0] not in indexes_to_remove))
-            rejected_stations.extend(set(
-                _i[1] for _i in enumerate(stations)
-                if _i[0] in indexes_to_remove))
+            new_remaining_stations = [_i[1] for _i in enumerate(stations)
+                                      if _i[0] not in indexes_to_remove]
+            new_rejected_stations = [_i[1] for _i in enumerate(stations)
+                                     if _i[0] in indexes_to_remove]
+
+            # Station objects are not hashable thus we have to go the long
+            # route.
+            for st in new_remaining_stations:
+                if st not in remaining_stations:
+                    remaining_stations.append(st)
+
+            for st in new_rejected_stations:
+                if st not in rejected_stations:
+                    rejected_stations.append(st)
+
         # Otherwise it will add new stations approximating a Poisson disk
         # distribution.
         else:

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -102,12 +102,17 @@ def download_and_split_mseed_bulk(client, client_name, chunks, logger):
     # intervals, each of which will end up in a separate file.
     filenames = collections.defaultdict(list)
     for chunk in chunks:
-        filenames[tuple(chunk[:4])].append({
+        candidate = {
             "starttime": chunk[4],
             "endtime": chunk[5],
             "filename": chunk[6],
             "current_latest_endtime": None,
-            "sequence_number": None})
+            "sequence_number": None}
+        # Should not be necessary if chunks have been deduplicated before but
+        # better safe than sorry.
+        if candidate in filenames[tuple(chunk[:4])]:
+            continue
+        filenames[tuple(chunk[:4])].append(candidate)
 
     sequence_number = [0]
 

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -176,7 +176,9 @@ def download_and_split_mseed_bulk(client, client_name, chunks, logger):
                 else:
                     candidates = [second]
         elif len(candidates) >= 2:
-            raise NotImplementedError
+            raise NotImplementedError(
+                "Please contact the developers. candidates: %s" %
+                str(candidates))
 
         # Finally found the correct chunk
         ret_val = candidates[0]

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -36,8 +36,17 @@ from obspy.io.mseed.util import get_record_information
 
 # Different types of errors that can happen when downloading data via the
 # FDSN clients.
-ERRORS = (FDSNException, HTTPError, URLError, socket_timeout)
+ERRORS = [FDSNException, HTTPError, URLError, socket_timeout]
 
+# Python 2 does have special classes for connection errors.
+if sys.version_info.major == 2:
+    # Use the base OS error on Python 2.
+    ERRORS.append(OSError)
+else:
+    # All other connection errors inherit from it.
+    ERRORS.append(ConnectionError)
+
+ERRORS = tuple(ERRORS)
 
 # mean earth radius in meter as defined by the International Union of
 # Geodesy and Geophysics. Used for the spherical kd-tree.

--- a/obspy/clients/fdsn/tests/data/channel_level_fdsn_with_multiple_epochs.txt
+++ b/obspy/clients/fdsn/tests/data/channel_level_fdsn_with_multiple_epochs.txt
@@ -1,0 +1,4 @@
+#Network | Station | Location | Channel | Latitude | Longitude | Elevation | Depth | Azimuth | Dip | SensorDescription | Scale | ScaleFreq | ScaleUnits | SampleRate | StartTime | EndTime
+TA|857A||LHZ|28.267|-82.229103|50.0|0.0|0.0|-90.0|Streckeisen STS-2 G3/Quanterra 330 Linear Phase Co|6.2520198E8|0.03|M/S|1.0|2012-02-17T00:00:00|2012-07-19T18:00:00
+TA|857A||LHZ|28.267|-82.229103|50.0|0.0|0.0|-90.0|Streckeisen STS-2 G3/Quanterra 330 Linear Phase Co|6.2520198E8|0.03|M/S|1.0|2012-07-19T18:00:00|2012-07-21T18:00:00
+TA|857A||LHZ|28.267|-82.229103|50.0|0.0|0.0|-90.0|Streckeisen STS-2 G3/Quanterra 330 Linear Phase Co|6.2520198E8|0.03|M/S|1.0|2012-07-21T18:00:00|2012-07-25T17:59:59

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2237,6 +2237,21 @@ class ClientDownloadHelperTestCase(unittest.TestCase):
             os.path.join(self.data, "channel_level_fdsn.txt"))
         c.get_availability()
 
+    def test_get_availability_with_multiple_channel_epochs(self):
+        """
+        Make sure to get rid of du
+        """
+        c = self._init_client()
+        c.client.get_stations.return_value = obspy.read_inventory(
+            os.path.join(self.data,
+                         "channel_level_fdsn_with_multiple_epochs.txt"))
+        c.get_availability()
+        self.assertEqual(list(c.stations.keys()), [("TA", "857A")])
+        self.assertEqual(len(c.stations[("TA", "857A")].channels), 1)
+        chan = c.stations[("TA", "857A")].channels[0]
+        self.assertEqual(chan.intervals[0].start, c.restrictions.starttime)
+        self.assertEqual(chan.intervals[0].end, c.restrictions.endtime)
+
     def test_excluding_networks_and_stations(self):
         """
         Tests the excluding of networks and stations.


### PR DESCRIPTION
This fixes a couple of issues with the mass downloader. Most of them originated when channels had a number of short epochs which it did not cleanly handle. Additionally it catches another error class as discovered in #2079 .

It includes a version of #1870 but also fixes the root cause of the whole thing so it should no longer be necessary. But better safe than sorry.

Fixes #2079 and #1870.