### PR TITLE
Stream.rotate('->ZNE', components=...): be nice on slightly unexpected input

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3223,6 +3223,16 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             would rotate sets of "BHZ", "BH1", "BH2" (and "HHZ", "HH1", "HH2",
             etc.) channels at the same station.
         """
+        # be nice to users that specify e.g. ``components='ZNE'``..
+        # compare http://lists.swapbytes.de/archives/obspy-users/
+        # 2018-March/002692.html
+        if isinstance(components, (str, native_str)):
+            msg = ("'components' is expected to be a list of one or more "
+                   "component code combinations (e.g. `components=['Z12']` or "
+                   "`components=['Z12', '123']`)")
+            warnings.warn(msg)
+            components = [components]
+
         for component_pair in components:
             st = self.select(component="[{}]".format(component_pair))
             netstaloc = sorted(set(

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3214,23 +3214,21 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type inventory: :class:`~obspy.core.inventory.inventory.Inventory` or
             :class:`~obspy.io.xseed.parser.Parser`
         :param inventory: Inventory or Parser with metadata of channels.
-        :type components: list or tuple
+        :type components: list or tuple or str
         :param components: List of combinations of three (case sensitive)
             component characters. Rotations are executed in this order, so
             order might matter in very strange cases (e.g. if traces with more
             than three component codes are present for the same SEED ID down to
             the component code). For example, specifying components ``"Z12"``
             would rotate sets of "BHZ", "BH1", "BH2" (and "HHZ", "HH1", "HH2",
-            etc.) channels at the same station.
+            etc.) channels at the same station. If only a single set of
+            component codes is used, this option can also be specified as a
+            string (e.g. ``components='Z12'``).
         """
         # be nice to users that specify e.g. ``components='ZNE'``..
         # compare http://lists.swapbytes.de/archives/obspy-users/
         # 2018-March/002692.html
         if isinstance(components, (str, native_str)):
-            msg = ("'components' is expected to be a list of one or more "
-                   "component code combinations (e.g. `components=['Z12']` or "
-                   "`components=['Z12', '123']`)")
-            warnings.warn(msg)
             components = [components]
 
         for component_pair in components:

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2524,6 +2524,8 @@ class StreamTestCase(unittest.TestCase):
         inv = read_inventory("/path/to/ffbx.stationxml", format="STATIONXML")
         parser = Parser("/path/to/ffbx.dataless")
         st_expected = read('/path/to/ffbx_rotated.slist', format='SLIST')
+        st_unrotated = read("/path/to/ffbx_unrotated_gaps.mseed",
+                            format="MSEED")
         for tr in st_expected:
             # ignore format specific keys and processing which also holds
             # version number
@@ -2531,7 +2533,7 @@ class StreamTestCase(unittest.TestCase):
             tr.stats.pop('_format')
         # check rotation using both Inventory and Parser as metadata input
         for metadata in (inv, parser):
-            st = read("/path/to/ffbx_unrotated_gaps.mseed", format="MSEED")
+            st = st_unrotated.copy()
             st.rotate("->ZNE", inventory=metadata)
             # do some checks on results
             self.assertEqual(len(st), 30)
@@ -2547,6 +2549,33 @@ class StreamTestCase(unittest.TestCase):
                 tr_got.stats.pop('_format')
                 tr_got.stats.pop('processing')
                 self.assertEqual(tr_got.stats, tr_expected.stats)
+        # check that using something like `components="Z12"` also works,
+        # although that's not what is expected for input but it might be a too
+        # easy to make mistake that people will likely do it again in the
+        # future anyway..
+        components = 'Z12'
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always')
+            st = st_unrotated.copy()
+            result = st.rotate("->ZNE", inventory=inv,
+                               components=components)
+        # check that rotation to ZNE worked..
+        self.assertEqual(set(tr.stats.channel[-1] for tr in result),
+                         set('ZNE'))
+        # check emitted warning message
+        self.assertTrue(len(w) >= 1)
+        msg = ("'components' is expected to be a list of one or more "
+               "component code combinations (e.g. `components=['Z12']` or "
+               "`components=['Z12', '123']`)")
+        for w_ in w:
+            try:
+                self.assertEqual(str(w_.message), msg)
+            except AssertionError:
+                continue
+            else:
+                break
+        else:
+            self.fail(msg='Expected warning message not shown.')
 
 
 def suite():

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2549,33 +2549,14 @@ class StreamTestCase(unittest.TestCase):
                 tr_got.stats.pop('_format')
                 tr_got.stats.pop('processing')
                 self.assertEqual(tr_got.stats, tr_expected.stats)
+
         # check that using something like `components="Z12"` also works,
-        # although that's not what is expected for input but it might be a too
-        # easy to make mistake that people will likely do it again in the
-        # future anyway..
-        components = 'Z12'
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always')
-            st = st_unrotated.copy()
-            result = st.rotate("->ZNE", inventory=inv,
-                               components=components)
+        st = st_unrotated.copy()
+        result = st.rotate("->ZNE", inventory=inv,
+                           components='Z12')
         # check that rotation to ZNE worked..
         self.assertEqual(set(tr.stats.channel[-1] for tr in result),
                          set('ZNE'))
-        # check emitted warning message
-        self.assertTrue(len(w) >= 1)
-        msg = ("'components' is expected to be a list of one or more "
-               "component code combinations (e.g. `components=['Z12']` or "
-               "`components=['Z12', '123']`)")
-        for w_ in w:
-            try:
-                self.assertEqual(str(w_.message), msg)
-            except AssertionError:
-                continue
-            else:
-                break
-        else:
-            self.fail(msg='Expected warning message not shown.')
 
 
 def suite():


### PR DESCRIPTION
see
http://lists.swapbytes.de/archives/obspy-users/2018-March/002692.html

### What does this PR do?

Make `Stream.rotate('->ZNE', ...)` accept `components` that is a string of component codes (as opposed to a list of strings). Although it's clear from the docstring what is expected, I think the likelihood of people misusing this parameter are high enough that we should work around it. A warning is also shown on invalid input before it is converted. 

### Why was it initiated?  Any relevant Issues?

Report on users mailing list, see http://lists.swapbytes.de/archives/obspy-users/2018-March/002692.html

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~ no docs change
- [x] ~~If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~ no network tests
- [x] All tests still pass.
- [x] ~~Any new features or fixed regressions are be covered via new tests.~~ no new features
- [x] ~~Any new or changed features have are fully documented.~~ no new features
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] ~~First time contributors have added your name to `CONTRIBUTORS.txt` .~~
