### PR TITLE
docker: Some changes for Deb packaging

### DIFF
--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -222,6 +222,16 @@ $ docker login  # docker hub user needs write access to "obspy/base-images" of o
 $ docker push obspy/base-images:${DISTRO_FULL}
 ```
 
+To run ``armhf`` docker images/containers built this way on non-ARM Linux machines,
+it seems that it's necessary to install ``qemu``, ``qemu-user-static`` and
+``qemu-system-arm`` packages (Debian/Ubuntu).
+Furthermore, qemu multiarch support has to be registered with docker (see
+https://hub.docker.com/r/multiarch/qemu-user-static/):
+
+```bash
+$ docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+
 ### Setting up `docker-testbot` to automatically test PRs and branches and send commit statuses
 
 ##### Install docker

--- a/misc/docker/obspy_images
+++ b/misc/docker/obspy_images
@@ -12,7 +12,6 @@ obspy/base-images:debian_9_stretch_armhf
 obspy/base-images:debian_9_stretch_32bit
 obspy/base-images:ubuntu_14_04_trusty_32bit
 obspy/base-images:ubuntu_16_04_xenial_32bit
-obspy/base-images:ubuntu_17_04_zesty_32bit
 obspy/base-images:ubuntu_17_10_artful_32bit
 obspy:centos_7
 obspy:debian_7_wheezy
@@ -32,8 +31,6 @@ obspy:ubuntu_14_04_trusty
 obspy:ubuntu_14_04_trusty_32bit
 obspy:ubuntu_16_04_xenial
 obspy:ubuntu_16_04_xenial_32bit
-obspy:ubuntu_17_04_zesty
-obspy:ubuntu_17_04_zesty_32bit
 obspy:ubuntu_17_10_artful
 obspy:ubuntu_17_10_artful_32bit
 opensuse:42.2

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -6,7 +6,7 @@ LOG_DIR_ROOT=logs/package_debs
 LOG_DIR_BASE=$LOG_DIR_ROOT/$DATETIME
 mkdir -p $LOG_DIR_BASE
 
-DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_7_wheezy_armhf debian_8_jessie debian_8_jessie_32bit debian_8_jessie_armhf debian_9_stretch debian_9_stretch_32bit debian_9_stretch_armhf ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_17_04_zesty ubuntu_17_04_zesty_32bit ubuntu_17_10_artful ubuntu_17_10_artful_32bit"
+DOCKER_IMAGES="debian_7_wheezy debian_7_wheezy_32bit debian_7_wheezy_armhf debian_8_jessie debian_8_jessie_32bit debian_8_jessie_armhf debian_9_stretch debian_9_stretch_32bit debian_9_stretch_armhf ubuntu_14_04_trusty ubuntu_14_04_trusty_32bit ubuntu_16_04_xenial ubuntu_16_04_xenial_32bit ubuntu_17_10_artful ubuntu_17_10_artful_32bit"
 
 # Parse the target for deb package building (e.g. "-tmegies:deb_1.0.2")
 SET_COMMIT_STATUS=false

--- a/misc/docker/package_debs.sh
+++ b/misc/docker/package_debs.sh
@@ -43,9 +43,6 @@ DOCKER=`which docker.io || which docker`
 rm -rf $TEMP_PATH
 mkdir -p $TEMP_PATH
 
-# Deb packaging is always performed using the deb build script from misc/debian
-# from the current state of the local repository.
-cp -a $OBSPY_PATH/misc/debian/deb__build_debs.sh $TEMP_PATH/
 # but we need to find out the SHA of the git target (e.g. if a branch name was
 # specified..)
 git clone git://github.com/$REPO/obspy $TEMP_PATH/obspy
@@ -53,11 +50,14 @@ cd $TEMP_PATH/obspy
 git checkout $GITTARGET
 SHA=`git log -1 --pretty=format:'%H'`
 cd $CURDIR
+# Deb packaging is always performed using the deb build script from misc/debian
+# of the target branch
+cp -a $TEMP_PATH/obspy/misc/debian/deb__build_debs.sh $TEMP_PATH/
 rm -rf $TEMP_PATH/obspy
 
 cd $CURDIR
 
-# Copy the install script.
+# Copy the install script. Use current version (on master)
 cp scripts/package_debs.sh $TEMP_PATH/package_debs.sh
 
 


### PR DESCRIPTION
- add infos about qemu use for ARM
- remove one EOL Ubuntu
- use `deb__build_debs.sh` from target branch instead of current local repo version, that way it's cleaner to set the `DEBVERSION` and overall version of the package in the deb building branch, as opposed to just locally