### PR TITLE
Allow "&", ">" and "<" in ResourceID

### DIFF
--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -779,8 +779,10 @@ class ResourceIdentifier(object):
         if str(id).strip() == "":
             id = str(uuid4())
 
+        # Note: the characters "&", ">" and "<" are allowed here since
+        # they are HTML-escaped when serializing to XML
         regex = r"^(smi|quakeml):[\w\d][\w\d\-\.\*\(\)_~']{2,}/[\w\d\-\." + \
-                r"\*\(\)_~'][\w\d\-\.\*\(\)\+\?_~'=,;#/&amp;]*$"
+                r"\*\(\)_~'][\w\d\-\.\*\(\)\+\?_~'=,;#/&><]*$"
         result = re.match(regex, str(id))
         if result is not None:
             return id


### PR DESCRIPTION
This PR is a possible fix for #2090.

The characters `&`, `>` and `<` can IMHO be accepted for Resource ID, since they are HTML-escaped when serializing to XML, i.e. they become on writing `&amp;`, `&gt;` and `&lt;`, respectively.

I validated a QuakeML file resulting from this PR using `jing` and it is valid QuakeML.

Note that I changed `&amp;` (as reported on the QuakeML documentation) with simply `&`, since it has no sense in a regex string (matching `&amp;` means separately matching `&`,  `a`, `m`, `p` and `;`).
