### PR TITLE
Allow invalid ids when writing QuakeML files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,9 @@ master:
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)
+ - obspy.io.quakeml:
+   * Allow writing invalid ids but raise a warning
+     (see #2104, #2090, #2093, #1872).
  - obspy.io.shapefile:
    * Add possibility to add custom database columns when writing catalog
      objects to shapefile (see #2012)

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -780,7 +780,7 @@ class ResourceIdentifier(object):
             id = str(uuid4())
 
         regex = r"^(smi|quakeml):[\w\d][\w\d\-\.\*\(\)_~']{2,}/[\w\d\-\." + \
-                r"\*\(\)_~'][\w\d\-\.\*\(\)\+\?_~'=,;#/&amp;]*$"
+                r"\*\(\)_~'][\w\d\-\.\*\(\)\+\?_~'=,;#/&]*$"
         result = re.match(regex, str(id))
         if result is not None:
             return id

--- a/obspy/io/pde/mchedr.py
+++ b/obspy/io/pde/mchedr.py
@@ -1013,7 +1013,8 @@ class Unpickler(object):
     def _deserialize(self):
         catalog = Catalog()
         res_id = '/'.join((res_id_prefix,
-                           self.filename.replace(':', '/'))).replace("//", "/")
+                           self.filename.replace(':', '/')))\
+            .replace('\\', '/').replace('//', '/')
         catalog.resource_id = ResourceIdentifier(id=res_id)
         catalog.description = 'Created from NEIC PDE mchedr format'
         catalog.comments = ''

--- a/obspy/io/pde/mchedr.py
+++ b/obspy/io/pde/mchedr.py
@@ -1012,7 +1012,8 @@ class Unpickler(object):
 
     def _deserialize(self):
         catalog = Catalog()
-        res_id = '/'.join((res_id_prefix, self.filename))
+        res_id = '/'.join((res_id_prefix,
+                           self.filename.replace(':', '/'))).replace("//", "/")
         catalog.resource_id = ResourceIdentifier(id=res_id)
         catalog.description = 'Created from NEIC PDE mchedr format'
         catalog.comments = ''

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1090,7 +1090,7 @@ class Pickler(object):
 
     def _str(self, value, root, tag, always_create=False, attrib=None):
         if isinstance(value, ResourceIdentifier):
-            value = value.get_quakeml_uri()
+            value = self._id(value)
         if always_create is False and value is None:
             return
         etree.SubElement(root, tag, attrib=attrib).text = "%s" % value

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1082,7 +1082,11 @@ class Pickler(object):
         try:
             return obj.get_quakeml_uri()
         except Exception:
-            return ResourceIdentifier().get_quakeml_uri()
+            msg = ("'%s' is not a valid QuakeML URI. It will be in the final "
+                   "file but note that the file will not be a valid QuakeML "
+                   "file.")
+            warnings.warn(msg % obj.id)
+            return obj.id
 
     def _str(self, value, root, tag, always_create=False, attrib=None):
         if isinstance(value, ResourceIdentifier):

--- a/obspy/io/quakeml/tests/data/invalid_id.xml
+++ b/obspy/io/quakeml/tests/data/invalid_id.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<q:quakeml xmlns="http://quakeml.org/xmlns/bed/1.2"
+  xmlns:q="http://quakeml.org/xmlns/quakeml/1.2">
+  <eventParameters publicID="smi:eu.emsc/unid/123456">
+    <event publicID="smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,15)">
+      <magnitude publicID="smi:ch.ethz.sed/magnitude/37465">
+        <mag>
+          <value>5.5</value>
+          <uncertainty>0.1</uncertainty>
+        </mag>
+        <type>MS</type>
+      </magnitude>
+    </event>
+  </eventParameters>
+</q:quakeml>

--- a/obspy/io/quakeml/tests/data/invalid_id.xml
+++ b/obspy/io/quakeml/tests/data/invalid_id.xml
@@ -9,7 +9,83 @@
           <uncertainty>0.1</uncertainty>
         </mag>
         <type>MS</type>
+        <originID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,26)</originID>
+        <methodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,27)</methodID>
       </magnitude>
+      <pick publicID="smi:org.gfz-potsdam.de/geofon/Pick#20160627194457.143264.18834">
+        <phaseHint>P</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <creationInfo>
+          <agencyID>OVSM</agencyID>
+          <author>clouard</author>
+          <creationTime>2016-06-27T19:44:57.14344Z</creationTime>
+        </creationInfo>
+        <time>
+          <value>2016-01-04T01:48:01.560346Z</value>
+          <lowerUncertainty>0.05000000075</lowerUncertainty>
+          <upperUncertainty>0.05000000075</upperUncertainty>
+        </time>
+        <waveformID networkCode="MQ" stationCode="CPM" locationCode="91" channelCode="EHZ"/>
+        <filterID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,16)</filterID>
+        <methodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,28)</methodID>
+        <slownessMethodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,29)</slownessMethodID>
+      </pick>
+      <amplitude publicID="smi:nz.org.geonet/event/2806038g/amplitude/1/modified">
+        <genericAmplitude>
+          <value>1.0e-08</value>
+        </genericAmplitude>
+        <filterID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,20)</filterID>
+        <methodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,17)</methodID>
+        <pickID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,18)</pickID>
+        <creationInfo>
+          <agencyID>EMSC</agencyID>
+          <agencyURI>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,30)</agencyURI>
+          <author>Erika Mustermann</author>
+          <authorURI>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,31)</authorURI>
+          <creationTime>2012-04-04T16:40:50.000000Z</creationTime>
+          <version>1.0.1</version>
+        </creationInfo>
+      </amplitude>
+      <stationMagnitude publicID="smi:ch.ethz.sed/magnitude/station/881342">
+        <originID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,21)</originID>
+        <amplitudeID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,22)</amplitudeID>
+        <methodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,23)</methodID>
+        <mag>
+          <value>6.5</value>
+          <uncertainty>0.2</uncertainty>
+        </mag>
+      </stationMagnitude>
+      <origin publicID="smi:www.iris.edu/ws/event/query?originId=7680412">
+        <time>
+          <value>2011-03-11T05:46:24.120000Z</value>
+        </time>
+        <latitude>
+          <value>38.297</value>
+        </latitude>
+        <longitude>
+          <value>142.373</value>
+        </longitude>
+        <arrival publicID="smi:some/arrival/id">
+          <pickID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,32)</pickID>
+          <phase>Pn</phase>
+          <azimuth>12.0</azimuth>
+          <distance>0.5</distance>
+          <takeoffAngle>
+            <value>11.0</value>
+            <uncertainty>0.2</uncertainty>
+          </takeoffAngle>
+          <timeResidual>1.6</timeResidual>
+          <horizontalSlownessResidual>1.7</horizontalSlownessResidual>
+          <backazimuthResidual>1.8</backazimuthResidual>
+          <timeWeight>0.48</timeWeight>
+          <horizontalSlownessWeight>0.49</horizontalSlownessWeight>
+          <backazimuthWeight>0.5</backazimuthWeight>
+          <earthModelID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,33)</earthModelID>
+        </arrival>
+        <referenceSystemID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,34)</referenceSystemID>
+        <methodID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,35)</methodID>
+        <earthModelID>smi:org.gfz-potsdam.de/geofon/RMHP(60)&gt;&gt;ITAPER(3)&gt;&gt;BW(4,5,36)</earthModelID>
+      </origin>
     </event>
   </eventParameters>
 </q:quakeml>

--- a/obspy/io/quakeml/tests/data/neries_events.xml
+++ b/obspy/io/quakeml/tests/data/neries_events.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <quakeml xmlns="http://quakeml.org/xmlns/quakeml/1.0">
-  <eventParameters publicID="smi://eu.emsc/unid">
+  <eventParameters publicID="smi:eu.emsc/unid">
     <event publicID="quakeml:eu.emsc/event/20120404_0000041">
       <preferredOriginID>quakeml:eu.emsc/origin/rts/261020/782484</preferredOriginID>
       <preferredMagnitudeID>quakeml:eu.emsc/NetworkMagnitude/rts/261020/782484/796646</preferredMagnitudeID>

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1062,6 +1062,32 @@ class QuakeMLTestCase(unittest.TestCase):
         self.assertEqual(cat[0].focal_mechanisms[0].nodal_planes, None)
         self.assertEqual(cat[0].focal_mechanisms[0].principal_axes, None)
 
+    def test_writing_invalid_quakeml_id(self):
+        """
+        Some ids might be invalid. We still want to write them to not mess
+        with any external tools relying on the ids. But we also raise a
+        warning of course.
+        """
+        filename = os.path.join(self.path, 'invalid_id.xml')
+        cat = read_events(filename)
+        self.assertEqual(
+            cat[0].resource_id.id,
+            "smi:org.gfz-potsdam.de/geofon/RMHP(60)>>ITAPER(3)>>BW(4,5,15)")
+        with NamedTemporaryFile() as tf:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                cat.write(tf.name, format="quakeml")
+                cat2 = read_events(tf.name)
+        self.assertEqual(len(w), 1)
+        self.assertEqual(
+            w[0].message.args[0],
+            "'smi:org.gfz-potsdam.de/geofon/RMHP(60)>>ITAPER(3)>>BW(4,5,15)' "
+            "is not a valid QuakeML URI. It will be in the final file but "
+            "note that the file will not be a valid QuakeML file.")
+        self.assertEqual(
+            cat2[0].resource_id.id,
+            "smi:org.gfz-potsdam.de/geofon/RMHP(60)>>ITAPER(3)>>BW(4,5,15)")
+
 
 def suite():
     return unittest.makeSuite(QuakeMLTestCase, 'test')

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1078,7 +1078,7 @@ class QuakeMLTestCase(unittest.TestCase):
                 warnings.simplefilter("always")
                 cat.write(tf.name, format="quakeml")
                 cat2 = read_events(tf.name)
-        self.assertEqual(len(w), 1)
+        self.assertEqual(len(w), 19)
         self.assertEqual(
             w[0].message.args[0],
             "'smi:org.gfz-potsdam.de/geofon/RMHP(60)>>ITAPER(3)>>BW(4,5,15)' "


### PR DESCRIPTION
Fixes #2090, #2093, and also #1872 I think. It least it fixes the problem from ObsPy's side.

This PR allows writing invalid QuakeML resource ids and can thus round-trip these ids. The rational for this is that external systems might depend on these ids so we don't want to mess with them. It does raise a warning though. I think that is the best way to handle this issue.

Before this PR ObsPy created a random (but valid) resource id for each element's `publicID` attribute. For all cross-referential ids it failed (see e.g. #2090). Now it will always work, but raise a warning.

CC: @claudiodsf @megies @gempa-jabe @andres-h @Brtle