### PR TITLE
reftek: fix reading file with no data in first channel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,7 +21,9 @@
    * Fix problems reading some Reftek 130 files, presumably due to floating
      point accuracy issues in comparing timestamps. Internal representation of
      time stamps is changed to integer nanosecond POSIX timestamp (see #2036,
-     #2038)
+     #2038, #2105)
+   * Fix a bug that prevents reading files that have no data in first channel
+     (see #2101)
  - obspy.io.seiscomp:
    * Fix inventory read when maxClockDrift is unset in SC3ML (see #1993)
  - obspy.io.stationxml

--- a/obspy/io/reftek/core.py
+++ b/obspy/io/reftek/core.py
@@ -272,7 +272,9 @@ class Reftek130(object):
                 "reftek130": eh._to_dict()}
             delta = 1.0 / eh.sampling_rate
             delta_nanoseconds = int(delta * 1e9)
-            for channel_number in np.unique(data['channel_number']):
+            inds_dt = data['packet_type'] == b"DT"
+            data_channels = np.unique(data[inds_dt]['channel_number'])
+            for channel_number in data_channels:
                 inds = data['channel_number'] == channel_number
                 # channel number of EH/ET packets also equals zero (one of the
                 # three unused bytes in the extended header of EH/ET packets)

--- a/obspy/io/reftek/tests/test_core.py
+++ b/obspy/io/reftek/tests/test_core.py
@@ -554,6 +554,29 @@ class ReftekTestCase(unittest.TestCase):
         for tr in st[8:]:
             self.assertEqual(tr.stats.station, 'TL02')
 
+    def test_reading_file_with_no_data_in_channel_zero(self):
+        """
+        Test reading a file that has no data packets in channel zero (e.g.
+        6-channel Reftek and only recording on channels 4-6)
+
+        Simply reuse the existing test data omitting the data packet that has
+        channel zero.
+        """
+        with open(self.reftek_file_vpu, 'rb') as fh:
+            data = fh.read()
+        # only use first packet (the EH packet) and last packet (a DT packet
+        # for channel number 1, i.e. channel 2)
+        data = data[:1024] + data[-1024:]
+        bio = io.BytesIO(data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            st = obspy.read(bio, format='REFTEK130')
+        self.assertEqual(len(st), 1)
+        # just a few basic checks, reading data is covered in other tests
+        tr = st[0]
+        self.assertEqual(tr.id, ".TL02..DS 11")
+        self.assertEqual(len(tr), 890)
+
 
 def suite():
     return unittest.makeSuite(ReftekTestCase, "test")


### PR DESCRIPTION
### What does this PR do?

Fixes #2101 


### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
