### PR TITLE
Fix Trace.times(type='matplotlib') being slow

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@
  - obspy.core:
    * read_inventory() used with non-existing file path (e.g. typo in filename)
      now shows a proper "No such file or directory" error message (see #2062)
+ - obspy.core:
+   * Speed up Trace.times() for type="matplotlib" (see #2112)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,7 @@
    * read_inventory() used with non-existing file path (e.g. typo in filename)
      now shows a proper "No such file or directory" error message (see #2062)
  - obspy.core:
-   * Speed up Trace.times() for type="matplotlib" (see #2112)
+   * Fix Trace.times(type='matplotlib') being slow (see #2112)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Bonaimé, Sébastien
 Carothers, Lloyd
 Chamberlain, Calum
 Chambers, Derrick
+Chen, Zhao
 Clark, Adam
 Danecek, Peter
 van Driel, Martin

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2497,7 +2497,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         elif type == "matplotlib":
             from matplotlib.dates import date2num
             time_array = (date2num(self.stats.starttime.datetime)
-                          + time_array / 86400)
+                          + time_array / 86400.0)
         else:
             msg = "Invalid `type`: {}".format(type)
             raise ValueError(msg)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2496,11 +2496,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 [self.stats.starttime + t_ for t_ in time_array])
         elif type == "matplotlib":
             from matplotlib.dates import date2num
-            SECONDSPERDAY = 86400
-            time_array = (
-                date2num(self.stats.starttime.datetime) 
-                + time_array / SECONDSPERDAY
-            )
+            time_array = (date2num(self.stats.starttime.datetime)
+                          + time_array / 86400)
         else:
             msg = "Invalid `type`: {}".format(type)
             raise ValueError(msg)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2496,8 +2496,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 [self.stats.starttime + t_ for t_ in time_array])
         elif type == "matplotlib":
             from matplotlib.dates import date2num
-            time_array = date2num([(self.stats.starttime + t_).datetime
-                                   for t_ in time_array])
+            SECONDSPERDAY = 86400
+            time_array = (
+                date2num(self.stats.starttime.datetime) 
+                + time_array / SECONDSPERDAY
+            )
         else:
             msg = "Invalid `type`: {}".format(type)
             raise ValueError(msg)


### PR DESCRIPTION

### What does this PR do?

The current version of obspy.core.trace.Trace.times is very slow for type="matplotlib". This PR speeds it up by ~1000 times.

### Why was it initiated?  Any relevant Issues?

I don't see relevant issues.

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
