### PR TITLE
fix: use preferred order in read_events and read_inventory

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,11 +49,12 @@ master:
    * Tests pass with numpy 1.14 (see #2044).
  - obspy.core:
    * Fix pickling of traces with a sampling rate of 0 (see #1990)
- - obspy.core:
    * read_inventory() used with non-existing file path (e.g. typo in filename)
      now shows a proper "No such file or directory" error message (see #2062)
- - obspy.core:
    * Fix Trace.times(type='matplotlib') being slow (see #2112)
+   * read_events() now actually honors the preferred event plugin order, i.e.
+     trying for QuakeML first when file type was not explicitly specified
+     (see #2113)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,9 +52,9 @@ master:
    * read_inventory() used with non-existing file path (e.g. typo in filename)
      now shows a proper "No such file or directory" error message (see #2062)
    * Fix Trace.times(type='matplotlib') being slow (see #2112)
-   * read_events() now actually honors the preferred event plugin order, i.e.
-     trying for QuakeML first when file type was not explicitly specified
-     (see #2113)
+   * read_events() and read_inventory() now trial most common plugins first
+     (QuakeML/StationXML, ...) in case of automatic file format detection (i.e.
+     when file type was not explicitly specified, see #2113)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -56,6 +56,7 @@ WAVEFORM_PREFERRED_ORDER = ['MSEED', 'SAC', 'GSE2', 'SEISAN', 'SACXY', 'GSE1',
                             'NNSA_KB_CORE', 'AH', 'PDAS', 'KINEMETRICS_EVT',
                             'GCF']
 EVENT_PREFERRED_ORDER = ['QUAKEML', 'NLLOC_HYP']
+INVENTORY_PREFERRED_ORDER = ['STATIONXML', 'SEED', 'RESP']
 # waveform plugins accepting a byteorder keyword
 WAVEFORM_ACCEPT_BYTEORDER = ['MSEED', 'Q', 'SAC', 'SEGY', 'SU']
 
@@ -276,7 +277,8 @@ ENTRY_POINTS = {
                                        EVENT_PREFERRED_ORDER),
     'event_write': _get_entry_points('obspy.plugin.event', 'writeFormat'),
     'taper': _get_entry_points('obspy.plugin.taper'),
-    'inventory': _get_entry_points('obspy.plugin.inventory', 'readFormat'),
+    'inventory': _get_ordered_entry_points(
+        'obspy.plugin.inventory', 'readFormat', INVENTORY_PREFERRED_ORDER),
     'inventory_write': _get_entry_points(
         'obspy.plugin.inventory', 'writeFormat'),
 }

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -272,7 +272,8 @@ ENTRY_POINTS = {
         'obspy.plugin.waveform', 'readFormat', WAVEFORM_PREFERRED_ORDER),
     'waveform_write': _get_ordered_entry_points(
         'obspy.plugin.waveform', 'writeFormat', WAVEFORM_PREFERRED_ORDER),
-    'event': _get_entry_points('obspy.plugin.event', 'readFormat'),
+    'event': _get_ordered_entry_points('obspy.plugin.event', 'readFormat',
+                                       EVENT_PREFERRED_ORDER),
     'event_write': _get_entry_points('obspy.plugin.event', 'writeFormat'),
     'taper': _get_entry_points('obspy.plugin.taper'),
     'inventory': _get_entry_points('obspy.plugin.inventory', 'readFormat'),


### PR DESCRIPTION
### What does this PR do?

Make `read_events()` and `read_inventory()` use preferred plugin  order in automatic file type checks.

### Why was it initiated?  Any relevant Issues?

Most read operations will be on QuakeML/StationXML, so we don't want to run through
a lot of other `_is_xxx()` checks before trying that one..

### PR Checklist
- [x] Correct base branch selected? `master` for new fetures, `maintenance_...` for bug fixes
- [x] All tests still pass.
- [x] Significant changes have been added to `CHANGELOG.txt` .
