### PR TITLE
Normalize MT components in mopad prior to plotting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,9 @@
      and/or `location` are set (see #1810, #2031, #2047).
    * A few fixes and stability improvements for the mass downloader
      (see #2081).
+ - obspy.imaging:
+   * Normalize moment tensors prior to plotting in the mopad wrapper to
+     stabilize the algorithm (see #2114, #2125).
  - obspy.io.mseed:
    * Ability to read files that have embedded chunks of non SEED data.
      (see #1981, #2057).

--- a/obspy/imaging/mopad_wrapper.py
+++ b/obspy/imaging/mopad_wrapper.py
@@ -52,6 +52,19 @@ KWARG_MAP = {
 }
 
 
+def _normalize_focmec(fm):
+    """
+    Improve stability of plots by normalizing the moment tensors. The scale
+    does not matter for the beachballs.
+    """
+    # Only normalize 6 component tensors.
+    if len(fm) != 6:
+        return fm
+    fm = np.array(fm, dtype=np.float64)
+    fm /= np.linalg.norm(fm)
+    return fm
+
+
 def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
           alpha=1.0, xy=(0, 0), width=200, size=100, nofill=False,
           zorder=100, mopad_basis='USE', axes=None):
@@ -113,6 +126,7 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     ``'NWU'`` North, West, Up     Stein and Wysession 2003
     ========= =================== =============================================
     """
+    fm = _normalize_focmec(fm)
     # initialize beachball
     mt = mopad_MomentTensor(fm, system=mopad_basis)
     bb = mopad_BeachBall(mt, npoints=size)
@@ -279,6 +293,7 @@ def beachball(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
             mt = [1, 2, 3, -4, -5, -10]
             beachball(mt, mopad_basis='NED')
     """
+    fm = _normalize_focmec(fm)
     mopad_kwargs = {}
     loc = locals()
     # map to kwargs used in mopad


### PR DESCRIPTION
Normalizes the MT components prior to plotting. This stabilizes the plots and the scale does not matter for the radiation pattern.

Fixes #2114.

Already covered through the existing tests.