### PR TITLE
Id of waveform

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ master:
      different precisions (see #2077).
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).
+   * Added id property to WaveformStreamID (see #2131).
  - obspy.io.nordic:
    * Add ability to read and write focal mechanisms and moment tensor
      information.

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -1221,12 +1221,7 @@ class WaveformStreamID(__WaveformStreamID):
             self.location_code if self.location_code else "",
             self.channel_code if self.channel_code else "")
 
-    @property
-    def id(self):
-        """
-        Return the seed string representation.
-        """
-        return self.get_seed_string()
+    id = property(get_seed_string)
 
 
 __ConfidenceEllipsoid = _event_type_class_factory(

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -1209,11 +1209,24 @@ class WaveformStreamID(__WaveformStreamID):
                                                resource_uri=resource_uri)
 
     def get_seed_string(self):
+        """
+        Return the seed string representation.
+
+        The seed string is of the form:
+            network.station.location.channel
+        """
         return "%s.%s.%s.%s" % (
             self.network_code if self.network_code else "",
             self.station_code if self.station_code else "",
             self.location_code if self.location_code else "",
             self.channel_code if self.channel_code else "")
+
+    @property
+    def id(self):
+        """
+        Return the seed string representation.
+        """
+        return self.get_seed_string()
 
 
 __ConfidenceEllipsoid = _event_type_class_factory(

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -739,6 +739,14 @@ class WaveformStreamIDTestCase(unittest.TestCase):
             self.assertEqual(waveform_id.location_code, None)
             self.assertEqual(waveform_id.channel_code, None)
 
+    def test_id_property(self):
+        """
+        Enure the `id` property of WaveformStreamID returns the same as
+        `get_seed_string`"
+        """
+        waveform_id = WaveformStreamID(seed_string="BW.FUR.01.EHZ")
+        self.assertEqual(waveform_id.id, waveform_id.get_seed_string())
+
 
 class ResourceIdentifierTestCase(unittest.TestCase):
     """


### PR DESCRIPTION

### What does this PR do?

This PR adds a `id` attribute to the `WaveformStreamID` class, which does the same as the `get_seed_string` method. Apart from enabling more concise code, this addition will make `WaveformStreamID` consistent with `Trace` which has an `id` attribute. 

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
