### PR TITLE
String representation for empty origin objects

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,9 @@
    * read_events() and read_inventory() now trial most common plugins first
      (QuakeML/StationXML, ...) in case of automatic file format detection (i.e.
      when file type was not explicitly specified, see #2113)
+   * Event instances with Origin instances that have do not have defined
+     latitude/longitude attributes will no longer raise a TypeError when
+     creating a string representation (see #2119 and #2127).
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -114,9 +114,11 @@ class Event(__Event):
         origin = None
         if self.origins:
             origin = self.preferred_origin() or self.origins[0]
-            out += '%s | %+7.3f, %+8.3f' % (origin.time,
-                                            origin.latitude,
-                                            origin.longitude)
+            # get lat, lon, time and handle if any are None (#2119)
+            lat, lon, time = origin.latitude, origin.longitude, origin.time
+            lat_str = '%+7.3f' % lat if lat is not None else ''
+            lon_str = '%+8.3f' % lon if lon is not None else ''
+            out += '%s | %s, %s' % (time, lat_str, lon_str)
         if self.magnitudes:
             magnitude = self.preferred_magnitude() or self.magnitudes[0]
             out += ' | %s %-2s' % (magnitude.mag,

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -116,8 +116,8 @@ class Event(__Event):
             origin = self.preferred_origin() or self.origins[0]
             # get lat, lon, time and handle if any are None (#2119)
             lat, lon, time = origin.latitude, origin.longitude, origin.time
-            lat_str = '%+7.3f' % lat if lat is not None else ''
-            lon_str = '%+8.3f' % lon if lon is not None else ''
+            lat_str = '%+7.3f' % lat if lat is not None else 'None'
+            lon_str = '%+8.3f' % lon if lon is not None else 'None'
             out += '%s | %s, %s' % (time, lat_str, lon_str)
         if self.magnitudes:
             magnitude = self.preferred_magnitude() or self.magnitudes[0]

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -61,8 +61,10 @@ class EventTestCase(unittest.TestCase):
         Ensure an event with an empty origin returns a str without raising a
         TypeError (#2119).
         """
-        out = str(Event(origins=[Origin()]))
+        event = Event(origins=[Origin()])
+        out = event.short_str()
         self.assertIsInstance(out, str)
+        self.assertEqual(out, 'None | None, None')
 
     def test_eq(self):
         """

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -56,6 +56,14 @@ class EventTestCase(unittest.TestCase):
         self.assertEqual("2012-04-04T14:18:37.000000Z | +39.342,  +41.044" +
                          " | 4.3 ML | manual", s)
 
+    def test_str_empty_origin(self):
+        """
+        Ensure an event with an empty origin returns a str without raising a
+        TypeError (#2119).
+        """
+        out = str(Event(origins=[Origin()]))
+        self.assertIsInstance(out, str)
+
     def test_eq(self):
         """
         Testing the __eq__ method of the Event object.


### PR DESCRIPTION
Supersedes #2127.

I took the liberty to rebase #2127 after #2130. Accidentially I force pushed the wrong local branch onto it and then lost permission to push again due to github's automatic push permission rules 🙈 Sorry about that.

In any case - here are the commits.