### PR TITLE
minor fix in taup docs

### DIFF
--- a/obspy/taup/taup_create.py
+++ b/obspy/taup/taup_create.py
@@ -165,7 +165,7 @@ def build_taup_model(filename, output_folder=None, verbose=True):
     :type output_folder: str
     :param output_folder: Directory in which the built
         :class:`~obspy.taup.tau_model.TauModel` will be stored. Defaults to
-        directory of input file.
+        the `taup/data` directory of the current obspy installation.
     """
     if output_folder is None:
         output_folder = __DATA_DIR


### PR DESCRIPTION
### What does this PR do?

Fix an inaccurate docstring in taup

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
