### PR TITLE
taup: py2 compat for #2129

### DIFF
--- a/obspy/taup/slowness_layer.py
+++ b/obspy/taup/slowness_layer.py
@@ -279,7 +279,7 @@ def evaluate_at_bullen(layer, depth, radius_of_planet):
                 a = top_p / a_denominator
                 answer = a * pow((radius_of_planet - depth), b)
         except FloatingPointError:
-            answer = math.nan
+            answer = np.nan
         if answer < 0 or math.isnan(answer) or math.isinf(answer):
             # numerical instability in power law calculation???
             # try a linear interpolation if the layer is small ( <2 km)


### PR DESCRIPTION
### What does this PR do?

Make #2129 Python 2 compatible. `math.nan` Does not exist on Python < 3.5

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] All tests still pass.
