### PR TITLE
Remove some urllib and future.standard_library usages

### DIFF
--- a/obspy/clients/httpproxy.py
+++ b/obspy/clients/httpproxy.py
@@ -13,14 +13,12 @@ J. MacCarthy, modified from https://gist.github.com/frxstrem/4487802
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future import standard_library
 from future.utils import native_str
 
 from base64 import b64encode
 import socket
-with standard_library.hooks():
-    from urllib.request import getproxies
-    from urllib.parse import urlparse
+
+from requests.compat import getproxies, urlparse
 
 
 def get_proxy_tuple():

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -25,6 +25,8 @@ else:
     from urllib.parse import urlencode
     import urllib.request as urllib_request
 
+import requests
+
 from obspy import Stream, UTCDateTime, __version__, read
 from obspy.core.util import NamedTemporaryFile, loadtxt
 
@@ -130,8 +132,8 @@ class Client(object):
             print('\nRequesting %s' % (remoteaddr))
         req = urllib_request.Request(url=remoteaddr, data=data,
                                      headers=headers)
-        response = urllib_request.urlopen(req, timeout=self.timeout)
-        doc = response.read()
+        response = requests.get(req, timeout=self.timeout)
+        doc = response.content
         return doc
 
     def _to_file_or_data(self, filename, data, binary=False):

--- a/obspy/clients/seedlink/easyseedlink.py
+++ b/obspy/clients/seedlink/easyseedlink.py
@@ -57,14 +57,8 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import sys
-
-if sys.version_info.major == 2:
-    from urlparse import urlparse
-else:
-    from urllib.parse import urlparse
-
 import lxml
+from requests.compat import urlparse
 
 from .client.seedlinkconnection import SeedLinkConnection
 from .client.slstate import SLState

--- a/obspy/clients/seishub/client.py
+++ b/obspy/clients/seishub/client.py
@@ -28,6 +28,7 @@ else:
     from urllib.parse import urlencode
     import urllib.request as urllib_request
 
+import requests
 from lxml import objectify
 from lxml.etree import Element, SubElement, tostring
 
@@ -159,7 +160,7 @@ class Client(object):
         """
         try:
             t1 = time.time()
-            urllib_request.urlopen(self.base_url, timeout=self.timeout).read()
+            requests.get(self.base_url, timeout=self.timeout).content
             return (time.time() - t1) * 1000.0
         except Exception:
             pass
@@ -207,17 +208,16 @@ class Client(object):
         # certain requests randomly fail on rare occasions, retry
         for _i in range(self.retries):
             try:
-                response = urllib_request.urlopen(remoteaddr,
-                                                  timeout=self.timeout)
-                doc = response.read()
+                response = requests.get(remoteaddr, timeout=self.timeout)
+                doc = response.content
                 return doc
             # XXX currently there are random problems with SeisHub's internal
             # XXX SQL database access ("cannot operate on a closed database").
             # XXX this can be circumvented by issuing the same request again..
             except Exception:
                 continue
-        response = urllib_request.urlopen(remoteaddr, timeout=self.timeout)
-        doc = response.read()
+        response = requests.get(remoteaddr, timeout=self.timeout)
+        doc = response.content
         return doc
 
     def _http_request(self, url, method, xml_string=None, headers={}):
@@ -247,8 +247,8 @@ class Client(object):
         # it seems the following always ends in a HTTPError even with
         # nice status codes...?!?
         try:
-            response = urllib_request.urlopen(req, timeout=self.timeout)
-            return response.code, response.msg
+            response = requests.get(req, timeout=self.timeout)
+            return response.status_code, response.text
         except urllib_request.HTTPError as e:
             return e.code, e.msg
 

--- a/obspy/clients/seishub/tests/test_client.py
+++ b/obspy/clients/seishub/tests/test_client.py
@@ -27,10 +27,11 @@ def _check_server_availability():
     otherwise.
     """
     try:
-        code = requests.get(TESTSERVER, timeout=3).status_code
-        assert(code == 200)
-    except Exception:
-        return TESTSERVER_UNREACHABLE_MSG
+        response = requests.get(TESTSERVER, timeout=3)
+        assert(response.status_code == 200)
+        response.raise_for_status()
+    except Exception as e:
+        return " ".join((TESTSERVER_UNREACHABLE_MSG, str(e)))
     return ""
 
 

--- a/obspy/clients/seishub/tests/test_client.py
+++ b/obspy/clients/seishub/tests/test_client.py
@@ -7,15 +7,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import sys
 import unittest
 
-if sys.version_info.major == 2:
-    from urllib2 import urlopen
-else:
-    from urllib.request import urlopen
 
 import numpy as np
+import requests
 
 from obspy.core import AttribDict, UTCDateTime
 from obspy.clients.seishub import Client
@@ -31,7 +27,7 @@ def _check_server_availability():
     otherwise.
     """
     try:
-        code = urlopen(TESTSERVER, timeout=3).getcode()
+        code = requests.get(TESTSERVER, timeout=3).status_code
         assert(code == 200)
     except Exception:
         return TESTSERVER_UNREACHABLE_MSG

--- a/obspy/imaging/cm.py
+++ b/obspy/imaging/cm.py
@@ -434,10 +434,10 @@ def _colormap_plot_similarity(cmaps):
     from future import standard_library
     standard_library.install_aliases()
     import io
-    from urllib.request import urlopen
+    import requests
 
     url = "https://examples.obspy.org/dissimilarities.npz"
-    with io.BytesIO(urlopen(url).read()) as fh, np.load(fh) as data:
+    with io.BytesIO(requests.get(url).content) as fh, np.load(fh) as data:
         dissimilarity = data['dissimilarity']
 
     for cmap in cmaps:

--- a/obspy/imaging/cm.py
+++ b/obspy/imaging/cm.py
@@ -431,8 +431,6 @@ def _colormap_plot_similarity(cmaps):
     :rtype: None
     """
     import matplotlib.pyplot as plt
-    from future import standard_library
-    standard_library.install_aliases()
     import io
     import requests
 

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -193,9 +193,6 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     default.
     """
     # import additional libraries here to speed up normal tests
-    from future import standard_library
-    with standard_library.hooks():
-        import urllib.parse
     import codecs
     from xml.etree import ElementTree
     from xml.sax.saxutils import escape
@@ -353,7 +350,7 @@ def _create_report(ttrs, timetaken, log, server, hostname, sorted_tests,
     xml_doc = ElementTree.tostring(root)
     print()
     # send result to report server
-    params = urllib.parse.urlencode({
+    params = requests.compat.urlencode({
         'timestamp': timestamp,
         'system': result['platform']['system'],
         'python_version': result['platform']['python_version'],


### PR DESCRIPTION
### What does this PR do?

- remove remaining instances of `with future.standard_library.hooks():` with either importing in a `if/else`  depending on Python 2/3 or by using `requests.compat` (which is internally doing just the same as well)
- remove some `urllib` usages with `requests`

### Why was it initiated?  Any relevant Issues?

Closes #1254. Even if not all urllib usage is replaced, I think getting rid of `future.standard_library` should resolve the problem reported in #1254 (e.g. seen here: http://tests.obspy.org/35446/)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] +DOCS because some changes might affect the gallery
- [x] +TESTS:ALL
- [ ] All tests still pass.
