### PR TITLE
FDSN client: bug in Client.set_credentials() (not using queryauth endpoint)

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -288,6 +288,7 @@ class Client(object):
         :type password: str
         :param password: Password for given user name.
         """
+        self.user = user
         self._set_opener(user, password)
 
     def set_eida_token(self, token):

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -282,6 +282,21 @@ class ClientTestCase(unittest.TestCase):
                     "queryauth?net=BW")
         self.assertEqual(got, expected)
 
+    def test_set_credentials(self):
+        """
+        Test for issue #2146
+
+        When setting credentials not during `__init__` but using
+        `set_credentials`, waveform queries should still properly go to
+        "queryauth" endpoint.
+        """
+        client = Client(base_url="IRIS", user_agent=USER_AGENT)
+        client.set_credentials(user="nobody@iris.edu", password="anonymous")
+        got = client._build_url("dataselect", "query", {'net': "BW"})
+        expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
+                    "queryauth?net=BW")
+        self.assertEqual(got, expected)
+
     def test_service_discovery_iris(self):
         """
         Tests the automatic discovery of services with the IRIS endpoint. The

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -291,11 +291,17 @@ class ClientTestCase(unittest.TestCase):
         "queryauth" endpoint.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT)
-        client.set_credentials(user="nobody@iris.edu", password="anonymous")
+        user = "nobody@iris.edu"
+        password = "anonymous"
+        client.set_credentials(user=user, password=password)
         got = client._build_url("dataselect", "query", {'net': "BW"})
         expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
                     "queryauth?net=BW")
         self.assertEqual(got, expected)
+        # more basic test: check that set_credentials has set Client.user
+        # (which is tested when checking which endpoint to use, query or
+        # queryauth)
+        self.assertEqual(client.user, user)
 
     def test_service_discovery_iris(self):
         """


### PR DESCRIPTION
There is a bug in FDSN client (current `maintenance_1.1.x`) when providing credentials via `Client.set_credentials()` (as opposed to providing credentials during `Client.__init__()`). Reported on the mailing list: https://lists.swapbytes.de/archives/obspy-users/2018-May/002749.html

+TESTS:clients.fdsn

### Works:
```python
from obspy.clients.fdsn import Client

client = Client(base_url="IRIS", user="nobody@iris.edu",
                password="anonymous")
print(client._build_url("dataselect", "query", {'net': "BW"}))
```
```
http://service.iris.edu/fdsnws/dataselect/1/queryauth?net=BW
```
### Also works:
```python
from obspy.clients.fdsn import Client

client = Client(base_url="IRIS", user="dummy")
client.set_credentials(user="nobody@iris.edu", password="anonymous")
print(client._build_url("dataselect", "query", {'net': "BW"}))
```
```
http://service.iris.edu/fdsnws/dataselect/1/queryauth?net=BW
```


### Does not work:
```python
from obspy.clients.fdsn import Client

client = Client(base_url="IRIS")
client.set_credentials(user="nobody@iris.edu", password="anonymous")
print(client._build_url("dataselect", "query", {'net': "BW"}))
```
```
http://service.iris.edu/fdsnws/dataselect/1/query?net=BW
```