### PR TITLE
Change dummy time.strptime call to use locale-independent format #2147

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@
      and/or `location` are set (see #1810, #2031, #2047).
    * A few fixes and stability improvements for the mass downloader
      (see #2081).
+   * Fixed routing startup error when running under certain locales (see #2147)
  - obspy.imaging:
    * Normalize moment tensors prior to plotting in the mopad wrapper to
      stabilize the algorithm (see #2114, #2125).

--- a/obspy/clients/fdsn/routing/__init__.py
+++ b/obspy/clients/fdsn/routing/__init__.py
@@ -22,7 +22,7 @@ from future.builtins import *  # NOQA
 #
 # See https://bugs.python.org/issue7980
 import time
-time.strptime("30 Nov 00", "%d %b %y")
+time.strptime("2000/11/30", "%Y/%m/%d")
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Fixes #2147 