### PR TITLE
add read support for FOCMEC output files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ master:
      objects to shapefile (see #2012)
  - obspy.io
     * added read support for receiver gather format v. 1.6 (see #2070)
+    * added read support for FOCMEC 'out' and 'lst' files (see #2156)
  - obspy.signal.trigger:
     * fix a bug in AR picker (see #2157)
  - obspy.signal.PPSD:

--- a/misc/docs/source/packages/index.rst
+++ b/misc/docs/source/packages/index.rst
@@ -134,6 +134,7 @@ categories.*
 
     obspy.io.cmtsolution
     obspy.io.cnv
+    obspy.io.focmec
     obspy.io.gse2
     obspy.io.iaspei
     obspy.io.json

--- a/misc/docs/source/packages/obspy.io.focmec.rst
+++ b/misc/docs/source/packages/obspy.io.focmec.rst
@@ -1,0 +1,14 @@
+.. currentmodule:: obspy.io.focmec
+.. automodule:: obspy.io.focmec
+
+    .. comment to end block
+
+    Modules
+    -------
+    .. autosummary::
+       :toctree: autogen
+       :nosignatures:
+
+       core
+
+    .. comment to end block

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -36,8 +36,8 @@ from obspy.core.util.misc import to_int_or_zero, buffered_load_entry_point
 # defining ObsPy modules currently used by runtests and the path function
 DEFAULT_MODULES = ['clients.filesystem', 'core', 'db', 'geodetics', 'imaging',
                    'io.ah', 'io.arclink', 'io.ascii', 'io.cmtsolution',
-                   'io.cnv', 'io.css', 'io.iaspei', 'io.win', 'io.gcf',
-                   'io.gse2', 'io.json', 'io.kinemetrics', 'io.kml',
+                   'io.cnv', 'io.css', 'io.focmec', 'io.iaspei', 'io.win',
+                   'io.gcf', 'io.gse2', 'io.json', 'io.kinemetrics', 'io.kml',
                    'io.mseed', 'io.ndk', 'io.nied', 'io.nlloc', 'io.nordic',
                    'io.pdas', 'io.pde', 'io.quakeml', 'io.reftek', 'io.rg16',
                    'io.sac', 'io.scardec', 'io.seg2', 'io.segy', 'io.seisan',

--- a/obspy/io/focmec/__init__.py
+++ b/obspy/io/focmec/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+obspy.io.focmec - FOCMEC file format support for ObsPy
+======================================================
+
+This module provides read support for some FOCMEC file formats.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod(exclude_empty=True)

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -156,6 +156,7 @@ def _read_focmec_lst(lines):
     if not separator_indices:
         return event
     header = lines[:separator_indices[0]]
+    event.comments.append(Comment(text='\n'.join(header)))
     blocks = []
     for i in separator_indices[::-1]:
         blocks.append(lines[i + 1:])
@@ -219,6 +220,8 @@ def _read_focmec_out(lines):
             break
     else:
         return event
+    header = lines[:i]
+    event.comments.append(Comment(text='\n'.join(header)))
     try:
         lines = lines[i + 1:]
     except IndexError:
@@ -259,9 +262,6 @@ def _read_common_header(lines):
     event.creation_info = CreationInfo()
     event.creation_info.creation_time = UTCDateTime(
         year, month, day, hour, minute, second)
-    # parse comments given in the next lines
-    text = '\n'.join([l.strip() for l in lines[1:4]])
-    event.comments.append(Comment(text=text))
     # get rid of those common lines already parsed
     lines = lines[4:]
     return event, lines

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -25,7 +25,7 @@ from obspy.core.event import (
 
 # XXX some current PR was doing similar, should be merged to
 # XXX core/utcdatetime.py eventually..
-months = {
+MONTHS = {
     'jan': 1,
     'feb': 2,
     'mar': 3,
@@ -38,6 +38,9 @@ months = {
     'oct': 10,
     'nov': 11,
     'dec': 12}
+POLARITIES_IMPULSIVE = 'CUD<>LRFB'
+POLARITIES_EMERGENT = '+-lrfb'
+POLARITIES = POLARITIES_IMPULSIVE + POLARITIES_EMERGENT
 
 
 def _is_focmec(filename):
@@ -192,7 +195,7 @@ def _read_focmec_lst(lines):
             # these are all keys that identify a station polarity in FOCMEC,
             # because here we do not take into account amplitude ratios for the
             # azimuthal gap
-            if key.upper() in 'CUD+-<>LRFB':
+            if key in POLARITIES:
                 azimuths.append(float(azimuth))
     except IndexError:
         pass
@@ -322,7 +325,7 @@ def _read_common_header(lines):
     month, day, time_of_day, year = lines[0].split()[1:5]
     year = int(year)
     day = int(day)
-    month = int(months[month.lower()])
+    month = int(MONTHS[month.lower()])
     hour, minute, second = [int(x) for x in time_of_day.split(':')]
     event.creation_info = CreationInfo()
     event.creation_info.creation_time = UTCDateTime(

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -219,9 +219,12 @@ def _read_focmec_lst(lines):
     for block in blocks:
         focmec, lines = _read_focmec_lst_one_block(
             block, polarity_count)
-        if focmec is not None:
-            focmec.azimuthal_gap = azimuthal_gap
-            event.focal_mechanisms.append(focmec)
+        if focmec is None:
+            continue
+        focmec.azimuthal_gap = azimuthal_gap
+        focmec.creation_info = CreationInfo(
+            version='FOCMEC', creation_time=event.creation_info.creation_time)
+        event.focal_mechanisms.append(focmec)
     return event
 
 
@@ -291,6 +294,8 @@ def _read_focmec_out(lines):
         # XXX ideally should compute the auxilliary plane..
         focmec = FocalMechanism(nodal_planes=planes)
         focmec.station_polarity_count = polarity_count
+        focmec.creation_info = CreationInfo(
+            version='FOCMEC', creation_time=event.creation_info.creation_time)
         if not weighted:
             errors = sum([int(x) for x in items[3:6]])
             focmec.misfit = float(errors) / polarity_count

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -53,7 +53,7 @@ def _is_focmec(filename):
     #   Fri Sep  8 14:54:58 2017 for program Focmec
     try:
         line = line.decode('ASCII')
-    except:
+    except Exception:
         return False
     line = line.split()
     # program name 'focmec' at the end is written slightly differently

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+FOCMEC file format support for ObsPy
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA @UnusedWildImport
+
+
+from obspy.core.event import Catalog
+
+
+def _is_focmec(filename):
+    """
+    Checks that a file is actually a FOCMEC output data file
+    """
+    try:
+        with open(filename, 'rb') as fh:
+            line = fh.readline()
+    except Exception:
+        return False
+    # first line should be ASCII only, something like:
+    #   Fri Sep  8 14:54:58 2017 for program Focmec
+    try:
+        line = line.decode('ASCII')
+    except:
+        return False
+    line = line.split()
+    # program name 'focmec' at the end is written slightly differently
+    # depending on how focmec was compiled, sometimes all lower case sometimes
+    # capitalized..
+    line[-1] = line[-1].lower()
+    if line[-3:] == ['for', 'program', 'focmec']:
+        return True
+    return False
+
+
+def _read_focmec(filename, **kwargs):
+    """
+    Reads a FOCMEC '.lst' or '.out' file to a
+    :class:`~obspy.core.event.Catalog` object.
+
+    .. warning::
+        This function should NOT be called directly, it registers via the
+        ObsPy :func:`~obspy.core.event.catalog.read_events()` function, call
+        this instead.
+
+    :param filename: File or file-like object in text mode.
+    :rtype: :class:`~obspy.core.event.Catalog`
+    """
+    return Catalog()
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod(exclude_empty=True)

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -212,11 +212,18 @@ def _read_focmec_out(lines):
     :param lines: List of decoded unicode strings with data from a FOCMEC out
         file.
     """
-    event, lines = _read_common_header(lines)
+    event, _ = _read_common_header(lines)
     # now move to first line with a focal mechanism
-    while lines and lines[0].split()[:3] != ['Dip', 'Strike', 'Rake']:
-        lines.pop(0)
-    for line in lines[1:]:
+    for i, line in enumerate(lines):
+        if line.split()[:3] == ['Dip', 'Strike', 'Rake']:
+            break
+    else:
+        return event
+    try:
+        lines = lines[i + 1:]
+    except IndexError:
+        return event
+    for line in lines:
         # allow for empty lines (maybe they can happen at the end sometimes..)
         if not line.strip():
             continue

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -177,6 +177,7 @@ def _read_focmec_lst(lines):
 
 
 def _read_focmec_lst_one_block(lines, polarity_count=None):
+    comment = Comment(text='\n'.join(lines))
     while lines and not lines[0].lstrip().startswith('Dip,Strike,Rake'):
         lines.pop(0)
     # the last block does not contain a focmec but only a short comment how
@@ -192,6 +193,7 @@ def _read_focmec_lst_one_block(lines, polarity_count=None):
     planes = NodalPlanes(nodal_plane_1=plane1, nodal_plane_2=plane2,
                          preferred_plane=1)
     focmec = FocalMechanism(nodal_planes=planes)
+    focmec.comments.append(comment)
     if polarity_count is not None:
         pattern = re.compile(r'^ *(P|S[HV]) Polarity error at *[a-zA-Z]+')
         polarity_errors = 0
@@ -221,6 +223,7 @@ def _read_focmec_out(lines):
     else:
         return event
     header = lines[:i]
+    focmec_list_header = lines[i]
     event.comments.append(Comment(text='\n'.join(header)))
     try:
         lines = lines[i + 1:]
@@ -235,6 +238,8 @@ def _read_focmec_out(lines):
         planes = NodalPlanes(nodal_plane_1=plane, preferred_plane=1)
         # XXX ideally should compute the auxilliary plane..
         focmec = FocalMechanism(nodal_planes=planes)
+        focmec.comments.append(
+            Comment(text='\n'.join((focmec_list_header, line))))
         event.focal_mechanisms.append(focmec)
     return event
 

--- a/obspy/io/focmec/tests/__init__.py
+++ b/obspy/io/focmec/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+from obspy.core.util import add_doctests, add_unittests
+
+
+MODULE_NAME = "obspy.io.focmec"
+
+
+def suite():
+    suite = unittest.TestSuite()
+    add_doctests(suite, MODULE_NAME)
+    add_unittests(suite, MODULE_NAME)
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/io/focmec/tests/data/focmec_8sta-noratios.lst
+++ b/obspy/io/focmec/tests/data/focmec_8sta-noratios.lst
@@ -1,0 +1,1326 @@
+  Fri Jun  2 11:28:31 2017 for program Focmec
+ Sakhalin:  8 BB stations no ratios, 0 polarity errors: ak135 with no crust
+ Input from a file focmec_8sta-noratios.inp
+  12-MAY-90 Sakhalin Island Event:  161221 disp picks with no ratios
+
+ Statn  Azimuth    TOA   Key  Log10 Ratio  NumPol  DenTOA  Comment
+  BLA     32.6     28.1   D                                
+  BLA     32.6     31.0   R                                
+  BLA     32.6     31.0   F                                
+  CCM     39.7     30.6   D                                
+  CCM     39.7     33.2   R                                
+  COR     54.7     40.8   D                                
+  COR     54.7     42.5   R                                
+  COR     54.7     42.5   B                                
+  HRV     24.2     29.2   D                                
+  HRV     24.2     32.0   R                                
+  HRV     24.2     32.0   F                                
+  KEV    336.5     45.2   D                                
+  KEV    336.5     46.4   L                                
+  KEV    336.5     46.4   B                                
+  KIP     97.8     44.0   C                                
+  KIP     97.8     45.4   R                                
+  KIP     97.8     45.4   B                                
+  PAS     59.8     35.7   D                                
+  PAS     59.8     37.9   R                                
+  PAS     59.8     37.9   B                                
+  TOL    334.5     28.0   D                                
+  TOL    334.5     30.9   L                                
+  TOL    334.5     30.9   F                                
+   8 P Pol.  7 SV Pol.  8 SH Pol.   0 allowed  errors
+ There are no amplitude ratio data
+ The minimum, increment and maximum B axis trend:     0.00    5.00  355.00
+ The limits for the B axis plunge:     0.00    5.00   90.00
+ The limits for Angle:     0.00    5.00  175.00
+ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     10.00   250.00   -90.00
+     Dip,Strike,Rake     80.00    70.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    340.00    10.00   160.00    80.00
+     Lower Hem. Trend, Plunge of P,T    340.00    55.00   160.00    35.00
+     B trend, B plunge, Angle:   70.00   0.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      5.00   250.00   -90.00
+     Dip,Strike,Rake     85.00    70.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    340.00     5.00   160.00    85.00
+     Lower Hem. Trend, Plunge of P,T    340.00    50.00   160.00    40.00
+     B trend, B plunge, Angle:   70.00   0.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     10.00   255.00   -90.00
+     Dip,Strike,Rake     80.00    75.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    345.00    10.00   165.00    80.00
+     Lower Hem. Trend, Plunge of P,T    345.00    55.00   165.00    35.00
+     B trend, B plunge, Angle:   75.00   0.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      5.00   255.00   -90.00
+     Dip,Strike,Rake     85.00    75.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    345.00     5.00   165.00    85.00
+     Lower Hem. Trend, Plunge of P,T    345.00    50.00   165.00    40.00
+     B trend, B plunge, Angle:   75.00   0.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     10.00   260.00   -90.00
+     Dip,Strike,Rake     80.00    80.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    350.00    10.00   170.00    80.00
+     Lower Hem. Trend, Plunge of P,T    350.00    55.00   170.00    35.00
+     B trend, B plunge, Angle:   80.00   0.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      5.00   260.00   -90.00
+     Dip,Strike,Rake     85.00    80.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    350.00     5.00   170.00    85.00
+     Lower Hem. Trend, Plunge of P,T    350.00    50.00   170.00    40.00
+     B trend, B plunge, Angle:   80.00   0.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     10.00   265.00   -90.00
+     Dip,Strike,Rake     80.00    85.00   -90.00   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    355.00    10.00   175.00    80.00
+     Lower Hem. Trend, Plunge of P,T    355.00    55.00   175.00    35.00
+     B trend, B plunge, Angle:   85.00   0.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      7.07   299.89   -44.89
+     Dip,Strike,Rake     85.02    74.56   -95.02   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    344.56     4.98   209.89    82.93
+     Lower Hem. Trend, Plunge of P,T    339.07    49.74   169.18    39.82
+     B trend, B plunge, Angle:   75.00   5.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     11.17   286.30   -63.26
+     Dip,Strike,Rake     80.04    79.12   -95.08   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    349.12     9.96   196.30    78.83
+     Lower Hem. Trend, Plunge of P,T    342.90    54.69   173.49    34.85
+     B trend, B plunge, Angle:   80.00   5.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      7.07   304.89   -44.89
+     Dip,Strike,Rake     85.02    79.56   -95.02   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    349.56     4.98   214.89    82.93
+     Lower Hem. Trend, Plunge of P,T    344.07    49.74   174.18    39.82
+     B trend, B plunge, Angle:   80.00   5.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     11.17   291.30   -63.26
+     Dip,Strike,Rake     80.04    84.12   -95.08   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    354.12     9.96   201.30    78.83
+     Lower Hem. Trend, Plunge of P,T    347.90    54.69   178.49    34.85
+     B trend, B plunge, Angle:   85.00   5.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      7.07   309.89   -44.89
+     Dip,Strike,Rake     85.02    84.56   -95.02   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    354.56     4.98   219.89    82.93
+     Lower Hem. Trend, Plunge of P,T    349.07    49.74   179.18    39.82
+     B trend, B plunge, Angle:   85.00   5.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake      7.07   314.89   -44.89
+     Dip,Strike,Rake     85.02    89.56   -95.02   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    359.56     4.98   224.89    82.93
+     Lower Hem. Trend, Plunge of P,T    354.07    49.74   184.18    39.82
+     B trend, B plunge, Angle:   90.00   5.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    60.88   -84.92
+     Dip,Strike,Rake     11.17   213.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    123.70    78.83   330.88     9.96
+     Lower Hem. Trend, Plunge of P,T    337.10    54.69   146.51    34.85
+     B trend, B plunge, Angle:  240.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.02    65.44   -84.98
+     Dip,Strike,Rake      7.07   200.11  -135.11   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    110.11    82.93   335.44     4.98
+     Lower Hem. Trend, Plunge of P,T    340.93    49.74   150.82    39.82
+     B trend, B plunge, Angle:  245.00   5.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    65.88   -84.92
+     Dip,Strike,Rake     11.17   218.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    128.70    78.83   335.88     9.96
+     Lower Hem. Trend, Plunge of P,T    342.10    54.69   151.51    34.85
+     B trend, B plunge, Angle:  245.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.02    70.44   -84.98
+     Dip,Strike,Rake      7.07   205.11  -135.11   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    115.11    82.93   340.44     4.98
+     Lower Hem. Trend, Plunge of P,T    345.93    49.74   155.82    39.82
+     B trend, B plunge, Angle:  250.00   5.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    70.88   -84.92
+     Dip,Strike,Rake     11.17   223.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    133.70    78.83   340.88     9.96
+     Lower Hem. Trend, Plunge of P,T    347.10    54.69   156.51    34.85
+     B trend, B plunge, Angle:  250.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.02    75.44   -84.98
+     Dip,Strike,Rake      7.07   210.11  -135.11   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    120.11    82.93   345.44     4.98
+     Lower Hem. Trend, Plunge of P,T    350.93    49.74   160.82    39.82
+     B trend, B plunge, Angle:  255.00   5.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    75.88   -84.92
+     Dip,Strike,Rake     11.17   228.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    138.70    78.83   345.88     9.96
+     Lower Hem. Trend, Plunge of P,T    352.10    54.69   161.51    34.85
+     B trend, B plunge, Angle:  255.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    80.88   -84.92
+     Dip,Strike,Rake     11.17   233.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    143.70    78.83   350.88     9.96
+     Lower Hem. Trend, Plunge of P,T    357.10    54.69   166.51    34.85
+     B trend, B plunge, Angle:  260.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.04    85.88   -84.92
+     Dip,Strike,Rake     11.17   238.70  -116.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    148.70    78.83   355.88     9.96
+     Lower Hem. Trend, Plunge of P,T      2.10    54.69   171.51    34.85
+     B trend, B plunge, Angle:  265.00   5.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     11.17   324.39   -26.30
+     Dip,Strike,Rake     85.08    80.26  -100.04   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    350.26     4.92   234.39    78.83
+     Lower Hem. Trend, Plunge of P,T    339.43    48.97   179.42    39.27
+     B trend, B plunge, Angle:   81.13  10.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     14.11   310.76   -44.56
+     Dip,Strike,Rake     80.15    84.44  -100.15   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    354.44     9.85   220.76    75.89
+     Lower Hem. Trend, Plunge of P,T    342.27    53.78   183.13    34.39
+     B trend, B plunge, Angle:   86.20  10.00 170.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     11.17   329.46   -26.30
+     Dip,Strike,Rake     85.08    85.33  -100.04   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    355.33     4.92   239.46    78.83
+     Lower Hem. Trend, Plunge of P,T    344.51    48.97   184.49    39.27
+     B trend, B plunge, Angle:   86.20  10.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     11.17   334.53   -26.30
+     Dip,Strike,Rake     85.08    90.40  -100.04   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N      0.40     4.92   244.53    78.83
+     Lower Hem. Trend, Plunge of P,T    349.58    48.97   189.56    39.27
+     B trend, B plunge, Angle:   91.27  10.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    54.99   -79.85
+     Dip,Strike,Rake     14.11   188.68  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     98.68    75.89   324.99     9.85
+     Lower Hem. Trend, Plunge of P,T    337.17    53.78   136.31    34.39
+     B trend, B plunge, Angle:  233.24  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.08    59.18   -79.96
+     Dip,Strike,Rake     11.17   175.05  -153.70   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     85.05    78.83   329.18     4.92
+     Lower Hem. Trend, Plunge of P,T    340.00    48.97   140.02    39.27
+     B trend, B plunge, Angle:  238.31  10.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    60.06   -79.85
+     Dip,Strike,Rake     14.11   193.75  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    103.75    75.89   330.06     9.85
+     Lower Hem. Trend, Plunge of P,T    342.24    53.78   141.38    34.39
+     B trend, B plunge, Angle:  238.31  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.08    64.25   -79.96
+     Dip,Strike,Rake     11.17   180.12  -153.70   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     90.12    78.83   334.25     4.92
+     Lower Hem. Trend, Plunge of P,T    345.07    48.97   145.09    39.27
+     B trend, B plunge, Angle:  243.38  10.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    65.13   -79.85
+     Dip,Strike,Rake     14.11   198.82  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    108.82    75.89   335.13     9.85
+     Lower Hem. Trend, Plunge of P,T    347.31    53.78   146.45    34.39
+     B trend, B plunge, Angle:  243.38  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.08    69.32   -79.96
+     Dip,Strike,Rake     11.17   185.19  -153.70   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     95.19    78.83   339.32     4.92
+     Lower Hem. Trend, Plunge of P,T    350.14    48.97   150.16    39.27
+     B trend, B plunge, Angle:  248.45  10.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    70.20   -79.85
+     Dip,Strike,Rake     14.11   203.89  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    113.89    75.89   340.20     9.85
+     Lower Hem. Trend, Plunge of P,T    352.38    53.78   151.52    34.39
+     B trend, B plunge, Angle:  248.45  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    75.27   -79.85
+     Dip,Strike,Rake     14.11   208.96  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    118.96    75.89   345.27     9.85
+     Lower Hem. Trend, Plunge of P,T    357.45    53.78   156.59    34.39
+     B trend, B plunge, Angle:  253.52  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    80.35   -79.85
+     Dip,Strike,Rake     14.11   214.03  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    124.03    75.89   350.35     9.85
+     Lower Hem. Trend, Plunge of P,T      2.52    53.78   161.66    34.39
+     B trend, B plunge, Angle:  258.59  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    85.42   -79.85
+     Dip,Strike,Rake     14.11   219.10  -135.44   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    129.10    75.89   355.42     9.85
+     Lower Hem. Trend, Plunge of P,T      7.59    53.78   166.73    34.39
+     B trend, B plunge, Angle:  263.66  10.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     15.79   338.75   -18.02
+     Dip,Strike,Rake     85.17    86.13  -105.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    356.13     4.83   248.75    74.21
+     Lower Hem. Trend, Plunge of P,T    340.29    47.73   189.68    38.38
+     B trend, B plunge, Angle:   87.43  15.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     15.79   343.89   -18.02
+     Dip,Strike,Rake     85.17    91.27  -105.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N      1.27     4.83   253.89    74.21
+     Lower Hem. Trend, Plunge of P,T    345.43    47.73   194.82    38.38
+     B trend, B plunge, Angle:   92.57  15.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    54.04   -74.78
+     Dip,Strike,Rake     17.96   175.69  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     85.69    72.04   324.04     9.66
+     Lower Hem. Trend, Plunge of P,T    341.71    52.30   131.16    33.64
+     B trend, B plunge, Angle:  231.43  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.52    55.40   -74.50
+     Dip,Strike,Rake     21.09   187.42  -135.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     97.42    68.91   325.40    14.48
+     Lower Hem. Trend, Plunge of P,T    345.57    56.77   132.93    28.88
+     B trend, B plunge, Angle:  231.43  15.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.17    57.87   -74.95
+     Dip,Strike,Rake     15.79   165.25  -161.98   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     75.25    74.21   327.87     4.83
+     Lower Hem. Trend, Plunge of P,T    343.71    47.73   134.32    38.38
+     B trend, B plunge, Angle:  236.57  15.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    59.18   -74.78
+     Dip,Strike,Rake     17.96   180.84  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     90.84    72.04   329.18     9.66
+     Lower Hem. Trend, Plunge of P,T    346.86    52.30   136.30    33.64
+     B trend, B plunge, Angle:  236.57  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.52    60.54   -74.50
+     Dip,Strike,Rake     21.09   192.56  -135.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    102.56    68.91   330.54    14.48
+     Lower Hem. Trend, Plunge of P,T    350.72    56.77   138.07    28.88
+     B trend, B plunge, Angle:  236.57  15.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.17    63.01   -74.95
+     Dip,Strike,Rake     15.79   170.39  -161.98   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.39    74.21   333.01     4.83
+     Lower Hem. Trend, Plunge of P,T    348.86    47.73   139.46    38.38
+     B trend, B plunge, Angle:  241.71  15.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    64.33   -74.78
+     Dip,Strike,Rake     17.96   185.98  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     95.98    72.04   334.33     9.66
+     Lower Hem. Trend, Plunge of P,T    352.00    52.30   141.44    33.64
+     B trend, B plunge, Angle:  241.71  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.17    68.15   -74.95
+     Dip,Strike,Rake     15.79   175.53  -161.98   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     85.53    74.21   338.15     4.83
+     Lower Hem. Trend, Plunge of P,T    354.00    47.73   144.60    38.38
+     B trend, B plunge, Angle:  246.86  15.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    69.47   -74.78
+     Dip,Strike,Rake     17.96   191.12  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    101.12    72.04   339.47     9.66
+     Lower Hem. Trend, Plunge of P,T    357.14    52.30   146.59    33.64
+     B trend, B plunge, Angle:  246.86  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    74.61   -74.78
+     Dip,Strike,Rake     17.96   196.27  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    106.27    72.04   344.61     9.66
+     Lower Hem. Trend, Plunge of P,T      2.29    52.30   151.73    33.64
+     B trend, B plunge, Angle:  252.00  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.34    79.76   -74.78
+     Dip,Strike,Rake     17.96   201.41  -147.05   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    111.41    72.04   349.76     9.66
+     Lower Hem. Trend, Plunge of P,T      7.43    52.30   156.87    33.64
+     B trend, B plunge, Angle:  257.14  15.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     20.59   345.65   -13.47
+     Dip,Strike,Rake     85.30    88.29  -110.07   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    358.29     4.70   255.65    69.41
+     Lower Hem. Trend, Plunge of P,T    337.82    46.04   196.01    37.16
+     B trend, B plunge, Angle:   90.00  20.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.92    47.59   -69.35
+     Dip,Strike,Rake     24.81   170.43  -144.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.43    65.19   317.59    14.08
+     Lower Hem. Trend, Plunge of P,T    343.00    54.47   121.18    28.02
+     B trend, B plunge, Angle:  222.35  20.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    51.10   -69.72
+     Dip,Strike,Rake     22.27   164.92  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     74.92    67.73   321.10     9.39
+     Lower Hem. Trend, Plunge of P,T    343.68    50.33   124.18    32.61
+     B trend, B plunge, Angle:  227.65  20.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.92    52.88   -69.35
+     Dip,Strike,Rake     24.81   175.72  -144.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     85.72    65.19   322.88    14.08
+     Lower Hem. Trend, Plunge of P,T    348.29    54.47   126.48    28.02
+     B trend, B plunge, Angle:  227.65  20.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.30    54.66   -69.93
+     Dip,Strike,Rake     20.59   157.29  -166.53   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     67.29    69.41   324.66     4.70
+     Lower Hem. Trend, Plunge of P,T    345.12    46.04   126.93    37.16
+     B trend, B plunge, Angle:  232.94  20.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    56.39   -69.72
+     Dip,Strike,Rake     22.27   170.21  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.21    67.73   326.39     9.39
+     Lower Hem. Trend, Plunge of P,T    348.97    50.33   129.47    32.61
+     B trend, B plunge, Angle:  232.94  20.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.92    58.18   -69.35
+     Dip,Strike,Rake     24.81   181.02  -144.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     91.02    65.19   328.18    14.08
+     Lower Hem. Trend, Plunge of P,T    353.58    54.47   131.77    28.02
+     B trend, B plunge, Angle:  232.94  20.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.30    59.95   -69.93
+     Dip,Strike,Rake     20.59   162.58  -166.53   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     72.58    69.41   329.95     4.70
+     Lower Hem. Trend, Plunge of P,T    350.41    46.04   132.22    37.16
+     B trend, B plunge, Angle:  238.24  20.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    61.69   -69.72
+     Dip,Strike,Rake     22.27   175.51  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     85.51    67.73   331.69     9.39
+     Lower Hem. Trend, Plunge of P,T    354.27    50.33   134.77    32.61
+     B trend, B plunge, Angle:  238.24  20.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.92    63.47   -69.35
+     Dip,Strike,Rake     24.81   186.31  -144.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     96.31    65.19   333.47    14.08
+     Lower Hem. Trend, Plunge of P,T    358.88    54.47   137.07    28.02
+     B trend, B plunge, Angle:  238.24  20.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    66.98   -69.72
+     Dip,Strike,Rake     22.27   180.80  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     90.80    67.73   336.98     9.39
+     Lower Hem. Trend, Plunge of P,T    359.56    50.33   140.06    32.61
+     B trend, B plunge, Angle:  243.53  20.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    72.27   -69.72
+     Dip,Strike,Rake     22.27   186.10  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     96.10    67.73   342.27     9.39
+     Lower Hem. Trend, Plunge of P,T      4.86    50.33   145.36    32.61
+     B trend, B plunge, Angle:  248.82  20.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     25.46   352.46   -10.59
+     Dip,Strike,Rake     85.47    92.04  -115.08   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N      2.04     4.53   262.46    64.54
+     Lower Hem. Trend, Plunge of P,T    337.42    43.97   203.68    35.63
+     B trend, B plunge, Angle:   94.15  25.00 175.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    48.00   -64.23
+     Dip,Strike,Rake     28.90   163.91  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     73.91    61.10   318.00    13.57
+     Lower Hem. Trend, Plunge of P,T    347.74    51.71   117.83    26.95
+     B trend, B plunge, Angle:  221.54  25.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.95    51.34   -64.66
+     Dip,Strike,Rake     26.81   159.72  -159.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     69.72    63.19   321.34     9.05
+     Lower Hem. Trend, Plunge of P,T    348.19    47.94   120.59    31.32
+     B trend, B plunge, Angle:  227.08  25.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    53.54   -64.23
+     Dip,Strike,Rake     28.90   169.45  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     79.45    61.10   323.54    13.57
+     Lower Hem. Trend, Plunge of P,T    353.28    51.71   123.36    26.95
+     B trend, B plunge, Angle:  227.08  25.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.47    54.73   -64.92
+     Dip,Strike,Rake     25.46   154.31  -169.41   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.31    64.54   324.73     4.53
+     Lower Hem. Trend, Plunge of P,T    349.35    43.97   123.09    35.63
+     B trend, B plunge, Angle:  232.62  25.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.95    56.88   -64.66
+     Dip,Strike,Rake     26.81   165.26  -159.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     75.26    63.19   326.88     9.05
+     Lower Hem. Trend, Plunge of P,T    353.73    47.94   126.13    31.32
+     B trend, B plunge, Angle:  232.62  25.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    59.08   -64.23
+     Dip,Strike,Rake     28.90   174.99  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     84.99    61.10   329.08    13.57
+     Lower Hem. Trend, Plunge of P,T    358.82    51.71   128.90    26.95
+     B trend, B plunge, Angle:  232.62  25.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.47    60.27   -64.92
+     Dip,Strike,Rake     25.46   159.85  -169.41   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     69.85    64.54   330.27     4.53
+     Lower Hem. Trend, Plunge of P,T    354.89    43.97   128.63    35.63
+     B trend, B plunge, Angle:  238.15  25.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.95    62.42   -64.66
+     Dip,Strike,Rake     26.81   170.80  -159.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.80    63.19   332.42     9.05
+     Lower Hem. Trend, Plunge of P,T    359.27    47.94   131.67    31.32
+     B trend, B plunge, Angle:  238.15  25.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    64.61   -64.23
+     Dip,Strike,Rake     28.90   180.53  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     90.53    61.10   334.61    13.57
+     Lower Hem. Trend, Plunge of P,T      4.36    51.71   134.44    26.95
+     B trend, B plunge, Angle:  238.15  25.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.95    67.95   -64.66
+     Dip,Strike,Rake     26.81   176.34  -159.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     86.34    63.19   337.95     9.05
+     Lower Hem. Trend, Plunge of P,T      4.81    47.94   137.21    31.32
+     B trend, B plunge, Angle:  243.69  25.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    42.47   -59.13
+     Dip,Strike,Rake     33.23   153.03  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.03    56.77   312.47    12.95
+     Lower Hem. Trend, Plunge of P,T    345.73    48.59   108.74    25.66
+     B trend, B plunge, Angle:  214.84  30.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     72.77    45.15   -58.43
+     Dip,Strike,Rake     35.53   160.89  -149.36   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     70.89    54.47   315.15    17.23
+     Lower Hem. Trend, Plunge of P,T    351.84    51.71   111.71    21.47
+     B trend, B plunge, Angle:  214.84  30.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    48.28   -59.13
+     Dip,Strike,Rake     33.23   158.83  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     68.83    56.77   318.28    12.95
+     Lower Hem. Trend, Plunge of P,T    351.54    48.59   114.54    25.66
+     B trend, B plunge, Angle:  220.65  30.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     72.77    50.96   -58.43
+     Dip,Strike,Rake     35.53   166.70  -149.36   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     76.70    54.47   320.96    17.23
+     Lower Hem. Trend, Plunge of P,T    357.64    51.71   117.52    21.47
+     B trend, B plunge, Angle:  220.65  30.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.35    51.49   -59.62
+     Dip,Strike,Rake     31.47   155.88  -163.26   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.88    58.53   321.49     8.65
+     Lower Hem. Trend, Plunge of P,T    351.98    45.19   117.16    29.78
+     B trend, B plunge, Angle:  226.45  30.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    54.08   -59.13
+     Dip,Strike,Rake     33.23   164.64  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     74.64    56.77   324.08    12.95
+     Lower Hem. Trend, Plunge of P,T    357.35    48.59   120.35    25.66
+     B trend, B plunge, Angle:  226.45  30.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.67    54.76   -59.91
+     Dip,Strike,Rake     30.38   152.18  -171.42   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.18    59.62   324.76     4.33
+     Lower Hem. Trend, Plunge of P,T    353.05    41.56   119.50    33.83
+     B trend, B plunge, Angle:  232.26  30.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.35    57.30   -59.62
+     Dip,Strike,Rake     31.47   161.68  -163.26   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     71.68    58.53   327.30     8.65
+     Lower Hem. Trend, Plunge of P,T    357.79    45.19   122.96    29.78
+     B trend, B plunge, Angle:  232.26  30.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    59.89   -59.13
+     Dip,Strike,Rake     33.23   170.44  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.44    56.77   329.89    12.95
+     Lower Hem. Trend, Plunge of P,T      3.15    48.59   126.16    25.66
+     B trend, B plunge, Angle:  232.26  30.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.67    60.57   -59.91
+     Dip,Strike,Rake     30.38   157.99  -171.42   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     67.99    59.62   330.57     4.33
+     Lower Hem. Trend, Plunge of P,T    358.85    41.56   125.30    33.83
+     B trend, B plunge, Angle:  238.06  30.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.35    63.10   -59.62
+     Dip,Strike,Rake     31.47   167.49  -163.26   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     77.49    58.53   333.10     8.65
+     Lower Hem. Trend, Plunge of P,T      3.59    45.19   128.77    29.78
+     B trend, B plunge, Angle:  238.06  30.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    65.70   -59.13
+     Dip,Strike,Rake     33.23   176.25  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     86.25    56.77   335.70    12.95
+     Lower Hem. Trend, Plunge of P,T      8.96    48.59   131.96    25.66
+     B trend, B plunge, Angle:  238.06  30.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    42.30   -54.06
+     Dip,Strike,Rake     37.70   148.60  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.60    52.30   312.30    12.24
+     Lower Hem. Trend, Plunge of P,T    348.37    45.19   105.24    24.18
+     B trend, B plunge, Angle:  213.56  35.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.73    45.35   -53.31
+     Dip,Strike,Rake     39.67   155.96  -153.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.96    50.33   315.35    16.27
+     Lower Hem. Trend, Plunge of P,T    354.45    47.94   108.59    20.25
+     B trend, B plunge, Angle:  213.56  35.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    48.40   -54.06
+     Dip,Strike,Rake     37.70   154.70  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.70    52.30   318.40    12.24
+     Lower Hem. Trend, Plunge of P,T    354.47    45.19   111.34    24.18
+     B trend, B plunge, Angle:  219.66  35.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.73    51.45   -53.31
+     Dip,Strike,Rake     39.67   162.06  -153.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     72.06    50.33   321.45    16.27
+     Lower Hem. Trend, Plunge of P,T      0.55    47.94   114.69    20.25
+     B trend, B plunge, Angle:  219.66  35.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.82    51.54   -54.59
+     Dip,Strike,Rake     36.22   152.85  -166.07   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.85    53.78   321.54     8.18
+     Lower Hem. Trend, Plunge of P,T    355.09    42.15   113.88    28.02
+     B trend, B plunge, Angle:  225.76  35.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    54.50   -54.06
+     Dip,Strike,Rake     37.70   160.80  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     70.80    52.30   324.50    12.24
+     Lower Hem. Trend, Plunge of P,T      0.57    45.19   117.44    24.18
+     B trend, B plunge, Angle:  225.76  35.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.73    57.55   -53.31
+     Dip,Strike,Rake     39.67   168.16  -153.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     78.16    50.33   327.55    16.27
+     Lower Hem. Trend, Plunge of P,T      6.65    47.94   120.79    20.25
+     B trend, B plunge, Angle:  225.76  35.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     85.91    54.74   -54.90
+     Dip,Strike,Rake     35.31   150.54  -172.90   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.54    54.69   324.74     4.09
+     Lower Hem. Trend, Plunge of P,T    356.22    38.87   116.16    31.77
+     B trend, B plunge, Angle:  231.86  35.00  95.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.82    57.64   -54.59
+     Dip,Strike,Rake     36.22   158.95  -166.07   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     68.95    53.78   327.64     8.18
+     Lower Hem. Trend, Plunge of P,T      1.19    42.15   119.98    28.02
+     B trend, B plunge, Angle:  231.86  35.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    60.60   -54.06
+     Dip,Strike,Rake     37.70   166.90  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     76.90    52.30   330.60    12.24
+     Lower Hem. Trend, Plunge of P,T      6.68    45.19   123.54    24.18
+     B trend, B plunge, Angle:  231.86  35.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     81.82    63.74   -54.59
+     Dip,Strike,Rake     36.22   165.05  -166.07   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     75.05    53.78   333.74     8.18
+     Lower Hem. Trend, Plunge of P,T      7.29    42.15   126.08    28.02
+     B trend, B plunge, Angle:  237.97  35.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    66.70   -54.06
+     Dip,Strike,Rake     37.70   173.01  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     83.01    52.30   336.70    12.24
+     Lower Hem. Trend, Plunge of P,T     12.78    45.19   129.64    24.18
+     B trend, B plunge, Angle:  237.97  35.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     51.13    32.73   -34.36
+     Dip,Strike,Rake     63.94   145.95  -135.69   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.95    26.06   302.73    38.87
+     Lower Hem. Trend, Plunge of P,T      5.52    48.97   266.65     7.64
+     B trend, B plunge, Angle:  170.18  40.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     63.94    40.60   -44.31
+     Dip,Strike,Rake     51.13   153.81  -145.64   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.81    38.87   310.60    26.06
+     Lower Hem. Trend, Plunge of P,T      1.02    48.97    99.90     7.64
+     B trend, B plunge, Angle:  196.36  40.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.11    39.59   -47.21
+     Dip,Strike,Rake     46.03   148.87  -153.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.87    43.97   309.59    18.89
+     Lower Hem. Trend, Plunge of P,T    353.39    46.04    99.74    15.19
+     B trend, B plunge, Angle:  202.91  40.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     67.48    43.27   -45.90
+     Dip,Strike,Rake     48.44   154.84  -149.21   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.84    41.56   313.27    22.52
+     Lower Hem. Trend, Plunge of P,T      0.28    47.73   103.14    11.44
+     B trend, B plunge, Angle:  202.91  40.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.81    42.62   -48.24
+     Dip,Strike,Rake     43.96   148.97  -157.82   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.97    46.04   312.62    15.19
+     Lower Hem. Trend, Plunge of P,T    353.50    43.97   102.77    18.89
+     B trend, B plunge, Angle:  209.45  40.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.11    46.14   -47.21
+     Dip,Strike,Rake     46.03   155.41  -153.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.41    43.97   316.14    18.89
+     Lower Hem. Trend, Plunge of P,T    359.93    46.04   106.29    15.19
+     B trend, B plunge, Angle:  209.45  40.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     78.56    45.77   -49.02
+     Dip,Strike,Rake     42.27   148.63  -162.86   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.63    47.73   315.77    11.44
+     Lower Hem. Trend, Plunge of P,T    354.07    41.56   105.64    22.52
+     B trend, B plunge, Angle:  216.00  40.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.81    49.17   -48.24
+     Dip,Strike,Rake     43.96   155.52  -157.82   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.52    46.04   319.17    15.19
+     Lower Hem. Trend, Plunge of P,T      0.04    43.97   109.31    18.89
+     B trend, B plunge, Angle:  216.00  40.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.11    52.69   -47.21
+     Dip,Strike,Rake     46.03   161.96  -153.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     71.96    43.97   322.69    18.89
+     Lower Hem. Trend, Plunge of P,T      6.48    46.04   112.83    15.19
+     B trend, B plunge, Angle:  216.00  40.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     78.56    52.32   -49.02
+     Dip,Strike,Rake     42.27   155.17  -162.86   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.17    47.73   322.32    11.44
+     Lower Hem. Trend, Plunge of P,T      0.62    41.56   112.18    22.52
+     B trend, B plunge, Angle:  222.55  40.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.81    55.71   -48.24
+     Dip,Strike,Rake     43.96   162.07  -157.82   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     72.07    46.04   325.71    15.19
+     Lower Hem. Trend, Plunge of P,T      6.59    43.97   115.86    18.89
+     B trend, B plunge, Angle:  222.55  40.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     82.36    55.56   -49.57
+     Dip,Strike,Rake     41.03   154.43  -168.31   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.43    48.97   325.56     7.64
+     Lower Hem. Trend, Plunge of P,T      1.64    38.87   114.86    26.06
+     B trend, B plunge, Angle:  229.09  40.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     78.56    58.86   -49.02
+     Dip,Strike,Rake     42.27   161.72  -162.86   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     71.72    47.73   328.86    11.44
+     Lower Hem. Trend, Plunge of P,T      7.16    41.56   118.73    22.52
+     B trend, B plunge, Angle:  229.09  40.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     82.36    62.10   -49.57
+     Dip,Strike,Rake     41.03   160.98  -168.31   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     70.98    48.97   332.10     7.64
+     Lower Hem. Trend, Plunge of P,T      8.19    38.87   121.40    26.06
+     B trend, B plunge, Angle:  235.64  40.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     78.56    65.41   -49.02
+     Dip,Strike,Rake     42.27   168.27  -162.86   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     78.27    47.73   335.41    11.44
+     Lower Hem. Trend, Plunge of P,T     13.71    41.56   125.28    22.52
+     B trend, B plunge, Angle:  235.64  40.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     50.14    31.89   -22.91
+     Dip,Strike,Rake     72.61   137.05  -137.81   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     47.05    17.39   301.89    39.86
+     Lower Hem. Trend, Plunge of P,T      2.53    41.64   259.73    14.00
+     B trend, B plunge, Angle:  155.29  45.00 155.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     52.24    33.12   -26.57
+     Dip,Strike,Rake     69.30   140.15  -139.11   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     50.15    20.70   303.12    37.76
+     Lower Hem. Trend, Plunge of P,T      3.11    43.08   263.08    10.55
+     B trend, B plunge, Angle:  162.35  45.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     54.60    34.69   -29.84
+     Dip,Strike,Rake     66.07   143.07  -140.68   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     53.07    23.93   304.69    35.40
+     Lower Hem. Trend, Plunge of P,T      3.41    44.14   266.52     7.05
+     B trend, B plunge, Angle:  169.41  45.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     52.24    40.18   -26.57
+     Dip,Strike,Rake     69.30   147.20  -139.11   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     57.20    20.70   310.18    37.76
+     Lower Hem. Trend, Plunge of P,T     10.17    43.08   270.14    10.55
+     B trend, B plunge, Angle:  169.41  45.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     57.20    36.59   -32.73
+     Dip,Strike,Rake     62.97   145.79  -142.55   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.79    27.03   306.59    32.80
+     Lower Hem. Trend, Plunge of P,T      3.52    44.78   270.01     3.53
+     B trend, B plunge, Angle:  176.47  45.00 140.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     54.60    41.75   -29.84
+     Dip,Strike,Rake     66.07   150.13  -140.68   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.13    23.93   311.75    35.40
+     Lower Hem. Trend, Plunge of P,T     10.47    44.14   273.58     7.05
+     B trend, B plunge, Angle:  176.47  45.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     60.00    38.79   -35.26
+     Dip,Strike,Rake     60.00   148.27  -144.74   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.27    30.00   308.79    30.00
+     Lower Hem. Trend, Plunge of P,T      3.53    45.00   273.53     0.00
+     B trend, B plunge, Angle:  183.53  45.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     66.07    36.93   -39.32
+     Dip,Strike,Rake     54.60   145.31  -150.16   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.31    35.40   306.93    23.93
+     Lower Hem. Trend, Plunge of P,T    356.59    44.14    93.48     7.05
+     B trend, B plunge, Angle:  190.59  45.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     62.97    41.27   -37.45
+     Dip,Strike,Rake     57.20   150.47  -147.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.47    32.80   311.27    27.03
+     Lower Hem. Trend, Plunge of P,T      3.54    44.78    97.05     3.53
+     B trend, B plunge, Angle:  190.59  45.00 130.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     69.30    39.85   -40.89
+     Dip,Strike,Rake     52.24   146.88  -153.43   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     56.88    37.76   309.85    20.70
+     Lower Hem. Trend, Plunge of P,T    356.89    43.08    96.92    10.55
+     B trend, B plunge, Angle:  197.65  45.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     66.07    43.99   -39.32
+     Dip,Strike,Rake     54.60   152.37  -150.16   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.37    35.40   313.99    23.93
+     Lower Hem. Trend, Plunge of P,T      3.65    44.14   100.54     7.05
+     B trend, B plunge, Angle:  197.65  45.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     72.61    42.95   -42.19
+     Dip,Strike,Rake     50.14   148.11  -157.09   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.11    39.86   312.95    17.39
+     Lower Hem. Trend, Plunge of P,T    357.47    41.64   100.27    14.00
+     B trend, B plunge, Angle:  204.71  45.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     69.30    46.91   -40.89
+     Dip,Strike,Rake     52.24   153.94  -153.43   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.94    37.76   316.91    20.70
+     Lower Hem. Trend, Plunge of P,T      3.95    43.08   103.98    10.55
+     B trend, B plunge, Angle:  204.71  45.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.00    46.20   -43.22
+     Dip,Strike,Rake     48.36   149.00  -161.12   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.00    41.64   316.20    14.00
+     Lower Hem. Trend, Plunge of P,T    358.36    39.86   103.52    17.39
+     B trend, B plunge, Angle:  211.76  45.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     72.61    50.01   -42.19
+     Dip,Strike,Rake     50.14   155.17  -157.09   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.17    39.86   320.01    17.39
+     Lower Hem. Trend, Plunge of P,T      4.53    41.64   107.33    14.00
+     B trend, B plunge, Angle:  211.76  45.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     79.45    49.55   -44.01
+     Dip,Strike,Rake     46.92   149.58  -165.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.58    43.08   319.55    10.55
+     Lower Hem. Trend, Plunge of P,T    359.59    37.76   106.62    20.70
+     B trend, B plunge, Angle:  218.82  45.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.00    53.26   -43.22
+     Dip,Strike,Rake     48.36   156.06  -161.12   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     66.06    41.64   323.26    14.00
+     Lower Hem. Trend, Plunge of P,T      5.42    39.86   110.57    17.39
+     B trend, B plunge, Angle:  218.82  45.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     72.61    57.07   -42.19
+     Dip,Strike,Rake     50.14   162.23  -157.09   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     72.23    39.86   327.07    17.39
+     Lower Hem. Trend, Plunge of P,T     11.59    41.64   114.39    14.00
+     B trend, B plunge, Angle:  218.82  45.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     82.95    52.99   -44.56
+     Dip,Strike,Rake     45.86   149.88  -170.15   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.88    44.14   322.99     7.05
+     Lower Hem. Trend, Plunge of P,T      1.16    35.40   109.54    23.93
+     B trend, B plunge, Angle:  225.88  45.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     79.45    56.61   -44.01
+     Dip,Strike,Rake     46.92   156.64  -165.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     66.64    43.08   326.61    10.55
+     Lower Hem. Trend, Plunge of P,T      6.65    37.76   113.67    20.70
+     B trend, B plunge, Angle:  225.88  45.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.00    60.32   -43.22
+     Dip,Strike,Rake     48.36   163.12  -161.12   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     73.12    41.64   330.32    14.00
+     Lower Hem. Trend, Plunge of P,T     12.48    39.86   117.63    17.39
+     B trend, B plunge, Angle:  225.88  45.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     82.95    60.05   -44.56
+     Dip,Strike,Rake     45.86   156.94  -170.15   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     66.94    44.14   330.05     7.05
+     Lower Hem. Trend, Plunge of P,T      8.22    35.40   116.60    23.93
+     B trend, B plunge, Angle:  232.94  45.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     56.17    37.34   -22.76
+     Dip,Strike,Rake     71.25   140.49  -143.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     50.49    18.75   307.34    33.83
+     Lower Hem. Trend, Plunge of P,T      3.63    38.38   265.95     9.58
+     B trend, B plunge, Angle:  164.35  50.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     54.37    43.02   -19.53
+     Dip,Strike,Rake     74.24   144.69  -142.75   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     54.69    15.76   313.02    35.63
+     Lower Hem. Trend, Plunge of P,T      9.76    37.16   269.93    12.70
+     B trend, B plunge, Angle:  164.35  50.00 155.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     60.50    34.57   -28.34
+     Dip,Strike,Rake     65.60   139.44  -147.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     49.44    24.40   304.57    29.50
+     Lower Hem. Trend, Plunge of P,T    358.69    39.82   266.01     3.21
+     B trend, B plunge, Angle:  172.17  50.00 140.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     58.23    39.74   -25.70
+     Dip,Strike,Rake     68.37   143.97  -145.50   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     53.97    21.63   309.74    31.77
+     Lower Hem. Trend, Plunge of P,T      5.14    39.27   269.87     6.41
+     B trend, B plunge, Angle:  172.17  50.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     56.17    45.17   -22.76
+     Dip,Strike,Rake     71.25   148.32  -143.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.32    18.75   315.17    33.83
+     Lower Hem. Trend, Plunge of P,T     11.45    38.38   273.77     9.58
+     B trend, B plunge, Angle:  172.17  50.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     62.97    37.45   -30.68
+     Dip,Strike,Rake     62.97   142.55  -149.32   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     52.55    27.03   307.45    27.03
+     Lower Hem. Trend, Plunge of P,T    360.00    40.00   270.00     0.00
+     B trend, B plunge, Angle:  180.00  50.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     60.50    42.39   -28.34
+     Dip,Strike,Rake     65.60   147.27  -147.27   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     57.27    24.40   312.39    29.50
+     Lower Hem. Trend, Plunge of P,T      6.52    39.82   273.83     3.21
+     B trend, B plunge, Angle:  180.00  50.00 140.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     58.23    47.57   -25.70
+     Dip,Strike,Rake     68.37   151.79  -145.50   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     61.79    21.63   317.57    31.77
+     Lower Hem. Trend, Plunge of P,T     12.96    39.27   277.69     6.41
+     B trend, B plunge, Angle:  180.00  50.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     68.37    36.03   -34.50
+     Dip,Strike,Rake     58.23   140.26  -154.30   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     50.26    31.77   306.03    21.63
+     Lower Hem. Trend, Plunge of P,T    354.86    39.27    90.13     6.41
+     B trend, B plunge, Angle:  187.83  50.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     65.60    40.56   -32.73
+     Dip,Strike,Rake     60.50   145.43  -151.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.43    29.50   310.56    24.40
+     Lower Hem. Trend, Plunge of P,T      1.31    39.82    93.99     3.21
+     B trend, B plunge, Angle:  187.83  50.00 130.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     62.97    45.28   -30.68
+     Dip,Strike,Rake     62.97   150.37  -149.32   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.37    27.03   315.28    27.03
+     Lower Hem. Trend, Plunge of P,T      7.83    40.00   277.83     0.00
+     B trend, B plunge, Angle:  187.83  50.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.25    39.51   -36.01
+     Dip,Strike,Rake     56.17   142.66  -157.24   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     52.66    33.83   309.51    18.75
+     Lower Hem. Trend, Plunge of P,T    356.37    38.38    94.05     9.58
+     B trend, B plunge, Angle:  195.65  50.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     68.37    43.86   -34.50
+     Dip,Strike,Rake     58.23   148.08  -154.30   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.08    31.77   313.86    21.63
+     Lower Hem. Trend, Plunge of P,T      2.69    39.27    97.96     6.41
+     B trend, B plunge, Angle:  195.65  50.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     65.60    48.38   -32.73
+     Dip,Strike,Rake     60.50   153.26  -151.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.26    29.50   318.38    24.40
+     Lower Hem. Trend, Plunge of P,T      9.14    39.82   101.82     3.21
+     B trend, B plunge, Angle:  195.65  50.00 130.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.24    43.14   -37.25
+     Dip,Strike,Rake     54.37   144.81  -160.47   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     54.81    35.63   313.14    15.76
+     Lower Hem. Trend, Plunge of P,T    358.06    37.16    97.90    12.70
+     B trend, B plunge, Angle:  203.48  50.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.25    47.34   -36.01
+     Dip,Strike,Rake     56.17   150.48  -157.24   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.48    33.83   317.34    18.75
+     Lower Hem. Trend, Plunge of P,T      4.20    38.38   101.88     9.58
+     B trend, B plunge, Angle:  203.48  50.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     68.37    51.69   -34.50
+     Dip,Strike,Rake     58.23   155.91  -154.30   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.91    31.77   321.69    21.63
+     Lower Hem. Trend, Plunge of P,T     10.52    39.27   105.79     6.41
+     B trend, B plunge, Angle:  203.48  50.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.30    46.88   -38.26
+     Dip,Strike,Rake     52.84   146.72  -163.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     56.72    37.16   316.88    12.70
+     Lower Hem. Trend, Plunge of P,T    359.97    35.63   101.65    15.76
+     B trend, B plunge, Angle:  211.30  50.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.24    50.96   -37.25
+     Dip,Strike,Rake     54.37   152.63  -160.47   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.63    35.63   320.96    15.76
+     Lower Hem. Trend, Plunge of P,T      5.89    37.16   105.72    12.70
+     B trend, B plunge, Angle:  211.30  50.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.25    55.16   -36.01
+     Dip,Strike,Rake     56.17   158.31  -157.24   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     68.31    33.83   325.16    18.75
+     Lower Hem. Trend, Plunge of P,T     12.03    38.38   109.70     9.58
+     B trend, B plunge, Angle:  211.30  50.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.42    50.73   -39.03
+     Dip,Strike,Rake     51.62   148.41  -167.75   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.41    38.38   320.73     9.58
+     Lower Hem. Trend, Plunge of P,T      2.13    33.83   105.27    18.75
+     B trend, B plunge, Angle:  219.13  50.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.30    54.71   -38.26
+     Dip,Strike,Rake     52.84   154.54  -163.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.54    37.16   324.71    12.70
+     Lower Hem. Trend, Plunge of P,T      7.80    35.63   109.47    15.76
+     B trend, B plunge, Angle:  219.13  50.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     74.24    58.79   -37.25
+     Dip,Strike,Rake     54.37   160.46  -160.47   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     70.46    35.63   328.79    15.76
+     Lower Hem. Trend, Plunge of P,T     13.72    37.16   113.55    12.70
+     B trend, B plunge, Angle:  219.13  50.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     83.59    54.65   -39.57
+     Dip,Strike,Rake     50.73   149.92  -171.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.92    39.27   324.65     6.41
+     Lower Hem. Trend, Plunge of P,T      4.53    31.77   108.75    21.63
+     B trend, B plunge, Angle:  226.96  50.00 100.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.42    58.56   -39.03
+     Dip,Strike,Rake     51.62   156.24  -167.75   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     66.24    38.38   328.56     9.58
+     Lower Hem. Trend, Plunge of P,T      9.95    33.83   113.10    18.75
+     B trend, B plunge, Angle:  226.96  50.00 105.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.30    62.54   -38.26
+     Dip,Strike,Rake     52.84   162.37  -163.99   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     72.37    37.16   332.54    12.70
+     Lower Hem. Trend, Plunge of P,T     15.63    35.63   117.30    15.76
+     B trend, B plunge, Angle:  226.96  50.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     57.39    52.87   -13.47
+     Dip,Strike,Rake     78.69   150.23  -146.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.23    11.31   322.87    32.61
+     Lower Hem. Trend, Plunge of P,T     16.48    31.32   277.73    14.03
+     B trend, B plunge, Angle:  166.83  55.00 160.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     61.98    45.09   -21.88
+     Dip,Strike,Rake     70.79   145.77  -150.16   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.77    19.21   315.09    28.02
+     Lower Hem. Trend, Plunge of P,T      7.76    34.39   273.83     5.72
+     B trend, B plunge, Angle:  175.61  55.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     60.22    50.43   -19.30
+     Dip,Strike,Rake     73.33   150.30  -148.77   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.30    16.67   320.43    29.78
+     Lower Hem. Trend, Plunge of P,T     13.72    33.64   277.99     8.54
+     B trend, B plunge, Angle:  175.61  55.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     66.07    43.71   -26.34
+     Dip,Strike,Rake     66.07   145.07  -153.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     55.07    23.93   313.71    23.93
+     Lower Hem. Trend, Plunge of P,T      4.39    35.00   274.39     0.00
+     B trend, B plunge, Angle:  184.39  55.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     63.94    48.70   -24.23
+     Dip,Strike,Rake     68.37   149.89  -151.79   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.89    21.63   318.70    26.06
+     Lower Hem. Trend, Plunge of P,T     10.49    34.85   278.49     2.87
+     B trend, B plunge, Angle:  184.39  55.00 140.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     70.79    43.01   -29.84
+     Dip,Strike,Rake     61.98   143.69  -158.12   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     53.69    28.02   313.01    19.21
+     Lower Hem. Trend, Plunge of P,T      1.02    34.39    94.95     5.72
+     B trend, B plunge, Angle:  193.17  55.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     68.37    47.67   -28.21
+     Dip,Strike,Rake     63.94   148.86  -155.77   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.86    26.06   317.67    21.63
+     Lower Hem. Trend, Plunge of P,T      7.07    34.85    99.07     2.87
+     B trend, B plunge, Angle:  193.17  55.00 130.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     66.07    52.49   -26.34
+     Dip,Strike,Rake     66.07   153.85  -153.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.85    23.93   322.49    23.93
+     Lower Hem. Trend, Plunge of P,T     13.17    35.00   283.17     0.00
+     B trend, B plunge, Angle:  193.17  55.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.33    47.26   -31.23
+     Dip,Strike,Rake     60.22   147.13  -160.70   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     57.13    29.78   317.26    16.67
+     Lower Hem. Trend, Plunge of P,T      3.84    33.64    99.57     8.54
+     B trend, B plunge, Angle:  201.95  55.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     70.79    51.79   -29.84
+     Dip,Strike,Rake     61.98   152.47  -158.12   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.47    28.02   321.79    19.21
+     Lower Hem. Trend, Plunge of P,T      9.80    34.39   103.73     5.72
+     B trend, B plunge, Angle:  201.95  55.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.97    51.64   -32.40
+     Dip,Strike,Rake     58.68   150.38  -163.52   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     60.38    31.32   321.64    14.03
+     Lower Hem. Trend, Plunge of P,T      6.77    32.61   104.13    11.31
+     B trend, B plunge, Angle:  210.73  55.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.33    56.04   -31.23
+     Dip,Strike,Rake     60.22   155.91  -160.70   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     65.91    29.78   326.04    16.67
+     Lower Hem. Trend, Plunge of P,T     12.62    33.64   108.35     8.54
+     B trend, B plunge, Angle:  210.73  55.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     78.69    56.11   -33.34
+     Dip,Strike,Rake     57.39   153.47  -166.53   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.47    32.61   326.11    11.31
+     Lower Hem. Trend, Plunge of P,T      9.86    31.32   108.61    14.03
+     B trend, B plunge, Angle:  219.51  55.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.97    60.42   -32.40
+     Dip,Strike,Rake     58.68   159.16  -163.52   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     69.16    31.32   330.42    14.03
+     Lower Hem. Trend, Plunge of P,T     15.56    32.61   112.91    11.31
+     B trend, B plunge, Angle:  219.51  55.00 115.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     61.98    57.20   -11.17
+     Dip,Strike,Rake     80.15   152.50  -151.52   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.50     9.85   327.20    28.02
+     Lower Hem. Trend, Plunge of P,T     18.30    26.95   281.99    12.20
+     B trend, B plunge, Angle:  170.00  60.00 160.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     65.82    51.04   -18.32
+     Dip,Strike,Rake     73.33   148.77  -154.69   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.77    16.67   321.04    24.18
+     Lower Hem. Trend, Plunge of P,T     11.51    29.50   278.68     4.98
+     B trend, B plunge, Angle:  180.00  60.00 145.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     64.34    56.31   -16.10
+     Dip,Strike,Rake     75.52   153.43  -153.43   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.43    14.48   326.31    25.66
+     Lower Hem. Trend, Plunge of P,T     17.19    28.88   283.06     7.44
+     B trend, B plunge, Angle:  180.00  60.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     69.30    50.89   -22.21
+     Dip,Strike,Rake     69.30   149.11  -157.79   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     59.11    20.70   320.89    20.70
+     Lower Hem. Trend, Plunge of P,T    180.00    90.00   280.00     0.00
+     B trend, B plunge, Angle:  190.00  60.00 135.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     67.48    55.90   -20.36
+     Dip,Strike,Rake     71.25   153.99  -156.14   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.99    18.75   325.90    22.52
+     Lower Hem. Trend, Plunge of P,T     15.77    29.87   284.33     2.50
+     B trend, B plunge, Angle:  190.00  60.00 140.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     73.33    51.23   -25.31
+     Dip,Strike,Rake     65.82   148.96  -161.68   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     58.96    24.18   321.23    16.67
+     Lower Hem. Trend, Plunge of P,T      8.49    29.50   101.32     4.98
+     B trend, B plunge, Angle:  200.00  60.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     71.25    56.01   -23.86
+     Dip,Strike,Rake     67.48   154.10  -159.64   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     64.10    22.52   326.01    18.75
+     Lower Hem. Trend, Plunge of P,T     14.23    29.87   105.67     2.50
+     B trend, B plunge, Angle:  200.00  60.00 130.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.52    56.57   -26.57
+     Dip,Strike,Rake     64.34   153.69  -163.90   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     63.69    25.66   326.57    14.48
+     Lower Hem. Trend, Plunge of P,T     12.81    28.88   106.94     7.44
+     B trend, B plunge, Angle:  210.00  60.00 120.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.15    57.50   -28.48
+     Dip,Strike,Rake     61.98   152.80  -168.83   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.80    28.02   327.50     9.85
+     Lower Hem. Trend, Plunge of P,T     11.70    26.95   108.01    12.20
+     B trend, B plunge, Angle:  220.00  60.00 110.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     68.53    57.50   -13.12
+     Dip,Strike,Rake     77.80   152.38  -158.01   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     62.38    12.20   327.50    21.47
+     Lower Hem. Trend, Plunge of P,T     16.47    24.09   283.65     6.28
+     B trend, B plunge, Angle:  180.00  65.00 150.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     75.97    56.40   -20.91
+     Dip,Strike,Rake     69.75   151.69  -165.03   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     61.69    20.25   326.40    14.03
+     Lower Hem. Trend, Plunge of P,T     12.99    24.59   104.92     4.21
+     B trend, B plunge, Angle:  204.00  65.00 125.00
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+ There are 184 acceptable solutions

--- a/obspy/io/focmec/tests/data/focmec_8sta.lst
+++ b/obspy/io/focmec/tests/data/focmec_8sta.lst
@@ -1,0 +1,152 @@
+  Fri Sep  8 14:54:58 2017 for program Focmec
+ Sakhalin:  8 BB stations 0.2 polarity errors 1 ratio error:  0.16 cut-off
+ Input from a file focmec_8sta.inp
+ 12-MAY-90 Sakhalin Island event:  161221 disp picks
+
+ Statn  Azimuth    TOA   Key  Log10 Ratio  NumPol  DenTOA  Comment
+  BLA     32.6     28.1   D                                
+  BLA     32.6     31.0   R                                
+  BLA     32.6     31.0   F                                
+  CCM     39.7     30.6   D                                
+  CCM     39.7     33.2   R                                
+  COR     54.7     40.8   D                                
+  COR     54.7     42.5   R                                
+  COR     54.7     42.5   B                                
+  HRV     24.2     29.2   D                                
+  HRV     24.2     32.0   R                                
+  HRV     24.2     32.0   F                                
+  KEV    336.5     45.2   D                                
+  KEV    336.5     46.4   L                                
+  KEV    336.5     46.4   B                                
+  KIP     97.8     44.0   C                                
+  KIP     97.8     45.4   R                                
+  KIP     97.8     45.4   B                                
+  PAS     59.8     35.7   D                                
+  PAS     59.8     37.9   R                                
+  PAS     59.8     37.9   B                                
+  TOL    334.5     28.0   D                                
+  TOL    334.5     30.9   L                                
+  TOL    334.5     30.9   F                                
+  BLA     44.8     31.0   H      0.8847 SH    R      28.06  -119100.0,-18450.0,500,1000,0.03,0
+  COR     54.7     42.5   H      1.1785 SH    R      40.75  -227400.0,-15830.0,500,1000,0.03,0
+  HRV     24.2     32.0   H      0.6013 SH    R      29.25  -85120.0,-25080.0,500,1000,0.03,0.
+  KEV    336.5     46.4   H      0.3287 SH    L      45.20  95680.0,-44900.0,500,1000,0.03,0.0
+  KIP     97.8     45.4   H      0.8291 SH    R      44.05  -138800.0,20840.0,500,1000,0.03,0.
+  KIP     97.8     45.4   V      0.8033 SV    B      44.05  -131700.0,20840.0,500,1000,0.03,0.
+  PAS     59.8     37.9   H      1.0783 SH    R      35.68  -140400.0,-12980.0,500,1000,0.03,0
+  TOL    334.5     30.9   H      0.2576 SH    L      28.00  47310.0,-31070.0,500,1000,0.03,0.0
+  TOL    334.5     30.9   S     -0.2762 SS    F      30.90  1013.0,2103.0
+  HRV     24.2     32.0   S     -0.4283 SS    F      31.95  2619.0,-7748.0
+  KEV    336.5     46.4   S     -0.0830 SS    B      46.37  -3618.0,4124.0
+   8 P Pol.  7 SV Pol.  8 SH Pol.  0.2 allowed (weighted) errors
+ 11 ratios, maximum of  1 with |o-c| diff >  0.1600    Focus VP/VS: 1.8225
+For ratios,  0.100 = P radiation cutoff  0.100 = S radiation cutoff
+ FLAG is NUM, DEN, N&D if n, d, both below curoff
+ If FLAG N&D, total ratios used decreased by 1
+ The minimum, increment and maximum B axis trend:     0.00    5.00  355.00
+ The limits for the B axis plunge:     0.00    5.00   90.00
+ The limits for Angle:     0.00    5.00  175.00
+ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    59.08   -64.23
+     Dip,Strike,Rake     28.90   174.99  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     84.99    61.10   329.08    13.57
+     Lower Hem. Trend, Plunge of P,T    358.82    51.71   128.90    26.95
+     B trend, B plunge, Angle:  232.62  25.00 105.00
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.8950      -0.0103      BLA        SH       R      R       
+      1.1785      1.0810       0.0975      COR        SH       R      R       
+      0.6013      0.5442       0.0571      HRV        SH       R      R       
+      0.3287      0.3666      -0.0379      KEV        SH       L      L       
+      0.8291      0.9341      -0.1050      KIP        SH       R      R       
+      0.8033      0.7815       0.0218      KIP        SV       B      B       
+      1.0783      1.1857      -0.1074      PAS        SH       R      R       
+      0.2576      0.2271       0.0305      TOL        SH       L      L       
+     -0.2762     -0.4076       0.1314      TOL        SS       F      F    NUM
+     -0.4283     -0.4503       0.0220      HRV        SS       F      F       
+     -0.0830      0.0713      -0.1543      KEV        SS       B      B       
+
+Total number of ratios used is  11
+RMS error for the 11 acceptable solutions is 0.0852
+  Highest absolute velue of diff for those solutions is  0.1543
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    54.08   -59.13
+     Dip,Strike,Rake     33.23   164.64  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     74.64    56.77   324.08    12.95
+     Lower Hem. Trend, Plunge of P,T    357.35    48.59   120.35    25.66
+     B trend, B plunge, Angle:  226.45  30.00 105.00
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.9935      -0.1088      BLA        SH       R      R       
+      1.1785      1.2400      -0.0615      COR        SH       R      R       
+      0.6013      0.6442      -0.0429      HRV        SH       R      R       
+      0.3287      0.3735      -0.0448      KEV        SH       L      L       
+      0.8291      0.7903       0.0388      KIP        SH       R      R       
+      0.8033      0.7316       0.0717      KIP        SV       B      B       
+      1.0783      1.3614      -0.2831     *PAS        SH       R      R       
+      0.2576      0.2301       0.0275      TOL        SH       L      L       
+     -0.2762     -0.3168       0.0406      TOL        SS       F      F       
+     -0.4283     -0.4598       0.0315      HRV        SS       F      F       
+     -0.0830     -0.0675      -0.0155      KEV        SS       B      B       
+
+Total number of ratios used is  10
+RMS error for the 11 acceptable solutions is 0.0545
+  Highest absolute velue of diff for those solutions is  0.1088
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.05    59.89   -59.13
+     Dip,Strike,Rake     33.23   170.44  -155.85   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.44    56.77   329.89    12.95
+     Lower Hem. Trend, Plunge of P,T      3.15    48.59   126.16    25.66
+     B trend, B plunge, Angle:  232.26  30.00 105.00
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.8993      -0.0146      BLA        SH       R      R       
+      1.1785      1.0816       0.0969      COR        SH       R      R       
+      0.6013      0.5304       0.0709      HRV        SH       R      R       
+      0.3287      0.4612      -0.1325      KEV        SH       L      L       
+      0.8291      0.9300      -0.1009      KIP        SH       R      R       
+      0.8033      0.7843       0.0190      KIP        SV       B      B       
+      1.0783      1.1907      -0.1124      PAS        SH       R      R       
+      0.2576      0.3384      -0.0808      TOL        SH       L      L       
+     -0.2762     -0.4976       0.2214     *TOL        SS       F      F    NUM
+     -0.4283     -0.3138      -0.1145      HRV        SS       F      F       
+     -0.0830     -0.0562      -0.0268      KEV        SS       B      B       
+
+Total number of ratios used is  10
+RMS error for the 11 acceptable solutions is 0.0870
+  Highest absolute velue of diff for those solutions is  0.1325
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     77.76    54.50   -54.06
+     Dip,Strike,Rake     37.70   160.80  -159.71   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     70.80    52.30   324.50    12.24
+     Lower Hem. Trend, Plunge of P,T      0.57    45.19   117.44    24.18
+     B trend, B plunge, Angle:  225.76  35.00 105.00
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      1.0094      -0.1247      BLA        SH       R      R       
+      1.1785      1.2565      -0.0780      COR        SH       R      R       
+      0.6013      0.6467      -0.0454      HRV        SH       R      R       
+      0.3287      0.4517      -0.1230      KEV        SH       L      L       
+      0.8291      0.7705       0.0586      KIP        SH       R      R       
+      0.8033      0.7299       0.0734      KIP        SV       B      B       
+      1.0783      1.3868      -0.3085     *PAS        SH       R      R       
+      0.2576      0.3317      -0.0741      TOL        SH       L      L       
+     -0.2762     -0.3104       0.0342      TOL        SS       F      F       
+     -0.4283     -0.3560      -0.0723      HRV        SS       F      F       
+     -0.0830     -0.2170       0.1340      KEV        SS       B      B       
+
+Total number of ratios used is  10
+RMS error for the 11 acceptable solutions is 0.0880
+  Highest absolute velue of diff for those solutions is  0.1340
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+ There are   4 acceptable solutions

--- a/obspy/io/focmec/tests/data/focmec_8sta.out
+++ b/obspy/io/focmec/tests/data/focmec_8sta.out
@@ -1,0 +1,20 @@
+  Fri Sep  8 14:54:58 2017 for program Focmec
+ Sakhalin:  8 BB stations 0.2 polarity errors 1 ratio error:  0.16 cut-off
+ Input from a file focmec_8sta.inp
+ 12-MAY-90 Sakhalin Island event:  161221 disp picks
+   8 P Pol.  7 SV Pol.  8 SH Pol.  0.2 allowed (weighted) errors
+ 11 ratios, maximum of  1 with |o-c| diff >  0.1600    Focus VP/VS: 1.8225
+For ratios,  0.100 = P radiation cutoff  0.100 = S radiation cutoff
+ FLAG is NUM, DEN, N&D if n, d, both below curoff
+ If FLAG N&D, total ratios used decreased by 1
+ R Ac/Tot: # acceptable / total ratios minus M&D
+ RMS Err: RMS of acceptable obs ratios
+ AbsMaxDiff: max abs difference for ok solutions
+ The minimum, increment and maximum B axis trend:     0.00    5.00  355.00
+ The limits for the B axis plunge:     0.00    5.00   90.00
+ The limits for Angle:     0.00    5.00  175.00
+    Dip   Strike   Rake    Pol: P     SV    SH  AccR/TotR  RMS RErr  AbsMaxDiff
+   76.43   59.08  -64.23       0.00  0.00  0.00    11/11    0.0852    0.1543
+   77.05   54.08  -59.13       0.00  0.00  0.00    10/11    0.0545    0.1088
+   77.05   59.89  -59.13       0.00  0.00  0.00    10/11    0.0870    0.1325
+   77.76   54.50  -54.06       0.00  0.00  0.00    10/11    0.0880    0.1340

--- a/obspy/io/focmec/tests/data/focmec_all.lst
+++ b/obspy/io/focmec/tests/data/focmec_all.lst
@@ -1,0 +1,350 @@
+  Fri Sep  8 14:57:09 2017 for program Focmec
+ Sakhalin:  8 BB  + 198 NEIC P 0.2 rat thresh 20 P, 0.2 SH, 0.2 SV
+ Input from a file focmec_all.inp
+ 12-MAY-90 Sakhalin Island Event: 8 BB stations nocrust odel , 1990 QED
+
+ Statn  Azimuth    TOA   Key  Log10 Ratio  NumPol  DenTOA  Comment
+  YSS    164.2    154.9   D                                
+  PET     63.0     91.6   C                                
+  MAT    193.5     86.2   D                                
+  TSRJ   200.0     81.7   D                                
+  YONJ   207.3     79.1   D                                
+  WKYJ   199.8     78.3   C                                
+  SHK    208.6     77.3   C                                
+  TKSJ   204.1     77.1   C                                
+  SHNJ   212.2     75.6   C                                
+  BJI    253.4     70.7   -                                
+ Not including emergent polarity picks
+  TIK    349.7     65.8   D                                
+  SSE    228.7     65.3   -                                
+  IRK    292.1     65.3   D                                
+  ILT     31.7     62.5   D                                
+  LZH    259.3     60.3   D                                
+  GUMO   175.0     57.3   C                                
+  GUA    174.9     57.3   +                                
+  BAG    215.5     56.6   C                                
+  KMI    246.3     55.6   -                                
+  DAV    203.6     52.5   C                                
+  LOE    240.1     51.7   D                                
+  CHG    244.2     51.3   D                                
+  FRU    288.9     51.3   D                                
+  NST    240.4     50.1   D                                
+  DSH    287.5     47.3   D                                
+  APA    332.5     47.2   D                                
+  NDI    272.2     46.9   D                                
+  DAG    354.6     46.2   C                                
+  LAT    173.8     45.1   C                                
+  PGC     51.1     43.5   C                                
+  QUE    280.8     43.4   D                                
+  PMG    173.9     43.4   C                                
+  MCW     50.8     43.3   D                                
+  OBN    319.6     43.1   D                                
+  GMW     51.8     42.9   D                                
+  HYB    261.5     42.7   D                                
+  PNT     48.6     42.6   D                                
+  BMW     52.9     42.6   C                                
+  RMW     51.3     42.6   C                                
+  EDM     42.2     42.4   D                                
+  LON     52.0     42.3   D                                
+  SHW     52.7     42.2   C                                
+  DPW     49.1     41.6   D                                
+  GDH      6.2     41.5   C                                
+  NEW     48.2     41.4   C                                
+  VGB     52.5     41.4   D                                
+  POO    266.1     41.3   D                                
+  BOM    267.2     41.0   D                                
+  MTN    191.9     41.0   C                                
+  SES     43.4     40.6   D                                
+  FFC     35.6     40.2   D                                
+  AKU    351.0     39.6   D                                
+  BKR    305.0     39.6   D                                
+  HRY     46.7     39.2   D                                
+  ORV     57.8     39.2   D                                
+  KNA    193.9     39.1   C                                
+  LRM     47.7     39.1   D                                
+  LCCM    47.4     38.9   D                                
+  BGMT    47.9     38.7   D                                
+  MEMT    47.0     38.6   -                                
+  REY    352.3     38.6   D                                
+  CMB     58.3     38.3   D                                
+  SIM    312.8     38.2   D                                
+  COP    331.7     38.1   C                                
+  IMW     48.3     37.9   D                                
+  PTI     49.9     37.9   D                                
+  CTA    175.6     37.3   C                                
+  WB5    187.6     37.3   C                                
+  BCH     60.2     37.2   D                                
+  CLI    317.8     37.2   C                                
+  BW06    48.3     37.2   D                                
+  QIS    182.3     37.1   C                                
+  KRA    324.2     37.0   D                                
+  DUG     52.1     37.0   D                                
+  UZH    322.0     36.9   D                                
+  CFR    316.4     36.9   D                                
+  BRN    329.4     36.8   D                                
+  VRI    317.7     36.8   D                                
+  SPC    323.5     36.8   D                                
+  DAU     51.0     36.7   D                                
+  KSP    326.8     36.7   D                                
+  TLB    316.0     36.6   C                                
+  MLR    317.9     36.5   D                                
+  RSSD    44.1     36.4   D                                
+  CLL    328.9     36.3   D                                
+  PSN    315.4     36.3   D                                
+  BRG    328.1     36.3   D                                
+  MSU     52.9     36.3   C                                
+  CMP    318.2     36.2   C                                
+  PRU    327.2     36.1   -                                
+  WIT    333.2     36.0   D                                
+  PEC     59.3     36.0   D                                
+  SRO    323.8     35.9   D                                
+  DRA    318.3     35.8   D                                
+  MOX    329.3     35.8   D                                
+  EKA    339.9     35.8   -                                
+  GZR    319.7     35.8   D                                
+  ZST    324.7     35.8   D                                
+  VKA    325.2     35.7   D                                
+  WTS    332.7     35.6   D                                
+  BZS    320.5     35.6   C                                
+  TIM    320.8     35.6   D                                
+  KHC    327.3     35.5   D                                
+  MBL    201.5     35.5   C                                
+  PVL    316.7     35.5   D                                
+  JMB    315.5     35.5   D                                
+  DBN    333.7     35.5   D                                
+  GRF    329.0     35.4   -                                
+  UDU    141.7     35.3   -                                
+  KMR    326.4     35.2   D                                
+  NDE    142.5     35.2   C                                
+  DIM    315.9     35.1   D                                
+  GOL     47.9     35.1   D                                
+  GLD     47.8     35.1   D                                
+  ENN    332.6     35.0   D                                
+  PGB    317.0     35.0   D                                
+  SCH     16.8     35.0   D                                
+  MEM    332.5     35.0   D                                
+  PLD    316.4     35.0   D                                
+  KRO    142.8     34.9   C                                
+  BHG    326.9     34.9   D                                
+  VTS    317.6     34.9   D                                
+  UCC    333.5     34.9   D                                
+  RZN    316.1     34.9   D                                
+  FUR    328.1     34.8   D                                
+  VUN    143.9     34.8   C                                
+  PTJ    324.0     34.7   D                                
+  DOU    333.1     34.6   D                                
+  KKB    317.3     34.6   D                                
+  SQTA   327.6     34.5   D                                
+  QLP    177.8     34.4   C                                
+  SKO    318.4     34.3   D                                
+  VAY    317.2     34.3   D                                
+  RMO     28.0     31.0   C                                
+  SLE    329.6     34.3   D                                
+  ADI    303.8     34.3   D                                
+  SAX    328.8     34.2   D                                
+  ZLA    329.5     34.2   D                                
+  OSS    328.0     34.1   D                                
+  MML    303.2     34.1   D                                
+  LLS    328.8     34.0   D                                
+  VDL    328.3     33.9   D                                
+  OHR    318.2     33.9   D                                
+  BRS    170.1     33.7   D                                
+  TMA    328.5     33.6   D                                
+  MMK    329.0     33.4   D                                
+  DIX    329.4     33.2   D                                
+  EMS    329.7     33.1   D                                
+  PRNI   302.1     33.0   D                                
+  MEKA   201.3     32.7   C                                
+  MBH    301.9     32.7   D                                
+  HLW    304.3     31.7   D                                
+  MEO     46.5     31.4   D                                
+  CMS    176.6     31.6   C                                
+  FORR   192.0     31.5   C                                
+  CBM     20.3     31.4   C                                
+  MRWA   202.7     31.2   C                                
+  COOL   197.9     31.0   C                                
+  ETER   330.6     30.9   D                                
+  BAL    201.7     30.8   C                                
+  RIV    172.2     30.6   D                                
+  ECRI   334.4     30.1   D                                
+  ADE    182.6     30.1   C                                
+  MUN    201.7     30.0   C                                
+  EMON   338.0     29.9   D                                
+  KCHT   323.3     29.8   D                                
+  CNB    173.9     29.8   D                                
+  SBS    322.9     29.8   D                                
+  ESEL   329.5     29.7   D                                
+  NWAO   200.6     29.6   C                                
+  ZGN    322.8     29.6   D                                
+  STS    338.6     29.5   D                                
+  ERUA   337.5     29.5   D                                
+  ETOR   333.4     29.5   D                                
+  RSCP    37.0     29.2   D                                
+  GUD    334.8     29.2   D                                
+  ECHE   332.1     29.2   D                                
+  TOO    177.1     29.1   C                                
+  ACU    331.3     29.0   D                                
+  EPLA   335.9     28.9   D                                
+  EVIA   332.8     28.9   D                                
+  ARO    284.3     28.9   D                                
+  EALH   331.7     28.8   D                                
+  EBAN   333.6     28.8   D                                
+  JSC     34.5     28.8   C                                
+  ENIJ   332.0     28.8   D                                
+  EHOR   334.5     28.8   D                                
+  AFC    333.1     28.8   D                                
+  LIS    337.7     28.7   D                                
+  EVAL   335.6     28.6   D                                
+  EPRU   334.2     28.6   D                                
+  EJIF   334.2     28.5   D                                
+  CFTV   338.6     27.1   D                                
+  BUL    273.6     11.1   C                                
+  SBA    173.6     11.0   C                                
+  ARE     51.6     10.6   C                                
+  SPA    180.0     10.5   C                                
+  LPB     47.5     10.4   C                                
+  BLA     32.6     28.1   D                                
+  BLA     32.6     31.0   R                                
+  BLA     32.6     31.0   F                                
+  CCM     39.7     30.6   D                                
+  CCM     39.7     33.2   R                                
+  COR     54.7     40.8   D                                
+  COR     54.7     42.5   R                                
+  COR     54.7     42.5   B                                
+  HRV     24.2     29.2   D                                
+  HRV     24.2     32.0   R                                
+  HRV     24.2     32.0   F                                
+  KEV    336.5     45.2   D                                
+  KEV    336.5     46.4   L                                
+  KEV    336.5     46.4   B                                
+  KIP     97.8     44.0   C                                
+  KIP     97.8     45.4   R                                
+  KIP     97.8     45.4   B                                
+  PAS     59.8     35.7   D                                
+  PAS     59.8     37.9   R                                
+  PAS     59.8     37.9   B                                
+  TOL    334.5     28.0   D                                
+  TOL    334.5     30.9   L                                
+  TOL    334.5     30.9   F                                
+  BLA     44.8     31.0   H      0.8847 SH    R      28.06  -119100.0,-18450.0,500,1000,0.03,0
+  COR     54.7     42.5   H      1.1785 SH    R      40.75  -227400.0,-15830.0,500,1000,0.03,0
+  HRV     24.2     32.0   H      0.6013 SH    R      29.25  -85120.0,-25080.0,500,1000,0.03,0.
+  KEV    336.5     46.4   H      0.3287 SH    L      45.20  95680.0,-44900.0,500,1000,0.03,0.0
+  KIP     97.8     45.4   H      0.8291 SH    R      44.05  -138800.0,20840.0,500,1000,0.03,0.
+  KIP     97.8     45.4   V      0.8033 SV    B      44.05  -131700.0,20840.0,500,1000,0.03,0.
+  PAS     59.8     37.9   H      1.0783 SH    R      35.68  -140400.0,-12980.0,500,1000,0.03,0
+  TOL    334.5     30.9   H      0.2576 SH    L      28.00  47310.0,-31070.0,500,1000,0.03,0.0
+  TOL    334.5     30.9   S     -0.2762 SS    F      30.90  1013.0,2103.0
+  HRV     24.2     32.0   S     -0.4283 SS    F      31.95  2619.0,-7748.0
+  KEV    336.5     46.4   S     -0.0830 SS    B      46.37  -3618.0,4124.0
+ Polarities/Errors:  P 197/20.0  SV 007/ 0.2  SH 008/ 0.2
+ 11 ratios, maximum of  0 with |o-c| diff >  0.2000    Focus VP/VS: 1.8225
+For ratios,  0.100 = P radiation cutoff  0.100 = S radiation cutoff
+ FLAG is NUM, DEN, N&D if n, d, both below curoff
+ If FLAG N&D, total ratios used decreased by 1
+ The minimum, increment and maximum B axis trend:     0.00    5.00  355.00
+ The limits for the B axis plunge:     0.00    5.00   90.00
+ The limits for Angle:     0.00    5.00  175.00
+ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.61    66.98   -69.72
+     Dip,Strike,Rake     22.27   180.80  -154.49   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     90.80    67.73   336.98     9.39
+     Lower Hem. Trend, Plunge of P,T    359.56    50.33   140.06    32.61
+     B trend, B plunge, Angle:  243.53  20.00 100.00
+
+ P Polarity error at  PET  TSRJ YONJ DAG  PGC  BMW  RMW  SHW  GDH  NEW  COP 
+ P Polarity weights:  0.04 0.01 0.01 0.97 0.53 0.50 0.53 0.50 0.99 0.58 0.90
+                      CLI  TLB  MSU  CMP  BZS  RMO  BRS  CBM  RIV  CNB  JSC 
+                      0.81 0.79 0.50 0.81 0.83 0.81 0.64 0.88 0.57 0.54 0.73
+                      BUL  ARE  LPB 
+                      0.41 0.40 0.42
+  Total P polarity weight is 14.723   Total number:  25
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.8833       0.0014      BLA        SH       R      R       
+      1.1785      1.0116       0.1669      COR        SH       R      R       
+      0.6013      0.5223       0.0790      HRV        SH       R      R       
+      0.3287      0.2978       0.0309      KEV        SH       L      L       
+      0.8291      1.0280      -0.1989      KIP        SH       R      R       
+      0.8033      0.6702       0.1331      KIP        SV       B      B       
+      1.0783      1.1370      -0.0587      PAS        SH       R      R       
+      0.2576      0.2282       0.0294      TOL        SH       L      L       
+     -0.2762     -0.2558      -0.0204      TOL        SS       F      F       
+     -0.4283     -0.2806      -0.1477      HRV        SS       F      F       
+     -0.0830      0.0782      -0.1612      KEV        SS       B      B       
+
+Total number of ratios used is  11
+RMS error for the 11 acceptable solutions is 0.1147
+  Highest absolute velue of diff for those solutions is  0.1989
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     76.43    59.08   -64.23
+     Dip,Strike,Rake     28.90   174.99  -150.97   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     84.99    61.10   329.08    13.57
+     Lower Hem. Trend, Plunge of P,T    358.82    51.71   128.90    26.95
+     B trend, B plunge, Angle:  232.62  25.00 105.00
+
+ P Polarity error at  WKYJ SHK  TKSJ SHNJ IRK  DAG  PGC  BMW  RMW  SHW  GDH 
+ P Polarity weights:  0.02 0.06 0.03 0.05 0.04 0.96 0.48 0.45 0.48 0.46 0.99
+                      NEW  COP  CLI  TLB  MSU  CMP  BZS  RMO  BRS  CBM  RIV 
+                      0.54 0.90 0.79 0.79 0.48 0.81 0.83 0.81 0.46 0.88 0.39
+                      CNB  JSC  BUL  SBA  ARE  SPA  LPB 
+                      0.36 0.73 0.52 0.11 0.47 0.14 0.50
+  Total P polarity weight is 14.509   Total number:  29
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.8950      -0.0103      BLA        SH       R      R       
+      1.1785      1.0810       0.0975      COR        SH       R      R       
+      0.6013      0.5442       0.0571      HRV        SH       R      R       
+      0.3287      0.3666      -0.0379      KEV        SH       L      L       
+      0.8291      0.9341      -0.1050      KIP        SH       R      R       
+      0.8033      0.7815       0.0218      KIP        SV       B      B       
+      1.0783      1.1857      -0.1074      PAS        SH       R      R       
+      0.2576      0.2271       0.0305      TOL        SH       L      L       
+     -0.2762     -0.4076       0.1314      TOL        SS       F      F    NUM
+     -0.4283     -0.4503       0.0220      HRV        SS       F      F       
+     -0.0830      0.0713      -0.1543      KEV        SS       B      B       
+
+Total number of ratios used is  11
+RMS error for the 11 acceptable solutions is 0.0852
+  Highest absolute velue of diff for those solutions is  0.1543
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     80.95    62.42   -64.66
+     Dip,Strike,Rake     26.81   170.80  -159.58   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N     80.80    63.19   332.42     9.05
+     Lower Hem. Trend, Plunge of P,T    359.27    47.94   131.67    31.32
+     B trend, B plunge, Angle:  238.15  25.00 100.00
+
+ P Polarity error at  WKYJ SHK  TKSJ SHNJ DAG  PGC  BMW  RMW  SHW  GDH  NEW 
+ P Polarity weights:  0.04 0.07 0.05 0.06 0.98 0.45 0.42 0.45 0.43 0.99 0.51
+                      COP  CLI  TLB  MSU  CMP  BZS  RMO  BRS  CBM  RIV  CNB 
+                      0.90 0.79 0.78 0.43 0.80 0.82 0.76 0.58 0.84 0.51 0.49
+                      JSC  BUL  ARE  LPB 
+                      0.67 0.40 0.36 0.38
+  Total P polarity weight is 13.966   Total number:  26
+
+          Log10(Ratio)                              Ratio     S Polarity
+     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
+      0.8847      0.9667      -0.0820      BLA        SH       R      R       
+      1.1785      1.1329       0.0456      COR        SH       R      R       
+      0.6013      0.6017      -0.0004      HRV        SH       R      R       
+      0.3287      0.3386      -0.0099      KEV        SH       L      L       
+      0.8291      0.9053      -0.0762      KIP        SH       R      R       
+      0.8033      0.6341       0.1692      KIP        SV       B      B       
+      1.0783      1.2733      -0.1950      PAS        SH       R      R       
+      0.2576      0.2422       0.0154      TOL        SH       L      L       
+     -0.2762     -0.1664      -0.1098      TOL        SS       F      F       
+     -0.4283     -0.2877      -0.1406      HRV        SS       F      F       
+     -0.0830     -0.0430      -0.0400      KEV        SS       B      B       
+
+Total number of ratios used is  11
+RMS error for the 11 acceptable solutions is 0.1023
+  Highest absolute velue of diff for those solutions is  0.1950
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+ There are   3 acceptable solutions

--- a/obspy/io/focmec/tests/data/focmec_qedUWne.lst
+++ b/obspy/io/focmec/tests/data/focmec_qedUWne.lst
@@ -1,0 +1,280 @@
+  Mon Sep  4 19:17:59 2017 for program Focmec
+ Sakhalin: NEIC/QED 190 stations 22 errors not including emergent arriv.
+ Input from a file focmec_qed.inp
+  12-MAY-90 Sakhalin Island Event:  NEIC/QED (11-JUNE-90)
+
+ Statn  Azimuth    TOA   Key  Log10 Ratio  NumPol  DenTOA  Comment
+  YSS    164.2    154.9   D                                
+  PET     63.0     91.6   C                                
+  MAT    193.5     86.2   D                                
+  TSRJ   200.0     81.7   D                                
+  YONJ   207.3     79.1   D                                
+  WKYJ   199.8     78.3   C                                
+  SHK    208.6     77.3   C                                
+  TKSJ   204.1     77.1   C                                
+  SHNJ   212.2     75.6   C                                
+  BJI    253.4     70.7   -                                
+ Not including emergent polarity picks
+  TIK    349.7     65.8   D                                
+  SSE    228.7     65.3   -                                
+  IRK    292.1     65.3   D                                
+  ILT     31.7     62.5   D                                
+  LZH    259.3     60.3   D                                
+  GUMO   175.0     57.3   C                                
+  GUA    174.9     57.3   +                                
+  BAG    215.5     56.6   C                                
+  KMI    246.3     55.6   -                                
+  DAV    203.6     52.5   C                                
+  LOE    240.1     51.7   D                                
+  CHG    244.2     51.3   D                                
+  FRU    288.9     51.3   D                                
+  NST    240.4     50.1   D                                
+  DSH    287.5     47.3   D                                
+  APA    332.5     47.2   D                                
+  NDI    272.2     46.9   D                                
+  DAG    354.6     46.2   C                                
+  LAT    173.8     45.1   C                                
+  PGC     51.1     43.5   C                                
+  QUE    280.8     43.4   D                                
+  PMG    173.9     43.4   C                                
+  MCW     50.8     43.3   D                                
+  OBN    319.6     43.1   D                                
+  GMW     51.8     42.9   D                                
+  HYB    261.5     42.7   D                                
+  PNT     48.6     42.6   D                                
+  BMW     52.9     42.6   C                                
+  RMW     51.3     42.6   C                                
+  EDM     42.2     42.4   D                                
+  LON     52.0     42.3   D                                
+  SHW     52.7     42.2   C                                
+  DPW     49.1     41.6   D                                
+  GDH      6.2     41.5   C                                
+  NEW     48.2     41.4   C                                
+  VGB     52.5     41.4   D                                
+  POO    266.1     41.3   D                                
+  BOM    267.2     41.0   D                                
+  MTN    191.9     41.0   C                                
+  SES     43.4     40.6   D                                
+  FFC     35.6     40.2   D                                
+  AKU    351.0     39.6   D                                
+  BKR    305.0     39.6   D                                
+  HRY     46.7     39.2   D                                
+  ORV     57.8     39.2   D                                
+  KNA    193.9     39.1   C                                
+  LRM     47.7     39.1   D                                
+  LCCM    47.4     38.9   D                                
+  BGMT    47.9     38.7   D                                
+  MEMT    47.0     38.6   -                                
+  REY    352.3     38.6   D                                
+  CMB     58.3     38.3   D                                
+  SIM    312.8     38.2   D                                
+  COP    331.7     38.1   C                                
+  IMW     48.3     37.9   D                                
+  PTI     49.9     37.9   D                                
+  CTA    175.6     37.3   C                                
+  WB5    187.6     37.3   C                                
+  BCH     60.2     37.2   D                                
+  CLI    317.8     37.2   C                                
+  BW06    48.3     37.2   D                                
+  QIS    182.3     37.1   C                                
+  KRA    324.2     37.0   D                                
+  DUG     52.1     37.0   D                                
+  UZH    322.0     36.9   D                                
+  CFR    316.4     36.9   D                                
+  BRN    329.4     36.8   D                                
+  VRI    317.7     36.8   D                                
+  SPC    323.5     36.8   D                                
+  DAU     51.0     36.7   D                                
+  KSP    326.8     36.7   D                                
+  TLB    316.0     36.6   C                                
+  MLR    317.9     36.5   D                                
+  RSSD    44.1     36.4   D                                
+  CLL    328.9     36.3   D                                
+  PSN    315.4     36.3   D                                
+  BRG    328.1     36.3   D                                
+  MSU     52.9     36.3   C                                
+  CMP    318.2     36.2   C                                
+  PRU    327.2     36.1   -                                
+  WIT    333.2     36.0   D                                
+  PEC     59.3     36.0   D                                
+  SRO    323.8     35.9   D                                
+  DRA    318.3     35.8   D                                
+  MOX    329.3     35.8   D                                
+  EKA    339.9     35.8   -                                
+  GZR    319.7     35.8   D                                
+  ZST    324.7     35.8   D                                
+  VKA    325.2     35.7   D                                
+  WTS    332.7     35.6   D                                
+  BZS    320.5     35.6   C                                
+  TIM    320.8     35.6   D                                
+  KHC    327.3     35.5   D                                
+  MBL    201.5     35.5   C                                
+  PVL    316.7     35.5   D                                
+  JMB    315.5     35.5   D                                
+  DBN    333.7     35.5   D                                
+  GRF    329.0     35.4   -                                
+  UDU    141.7     35.3   -                                
+  KMR    326.4     35.2   D                                
+  NDE    142.5     35.2   C                                
+  DIM    315.9     35.1   D                                
+  GOL     47.9     35.1   D                                
+  GLD     47.8     35.1   D                                
+  ENN    332.6     35.0   D                                
+  PGB    317.0     35.0   D                                
+  SCH     16.8     35.0   D                                
+  MEM    332.5     35.0   D                                
+  PLD    316.4     35.0   D                                
+  KRO    142.8     34.9   C                                
+  BHG    326.9     34.9   D                                
+  VTS    317.6     34.9   D                                
+  UCC    333.5     34.9   D                                
+  RZN    316.1     34.9   D                                
+  FUR    328.1     34.8   D                                
+  VUN    143.9     34.8   C                                
+  PTJ    324.0     34.7   D                                
+  DOU    333.1     34.6   D                                
+  KKB    317.3     34.6   D                                
+  SQTA   327.6     34.5   D                                
+  QLP    177.8     34.4   C                                
+  SKO    318.4     34.3   D                                
+  VAY    317.2     34.3   D                                
+  RMO     28.0     31.0   C                                
+  SLE    329.6     34.3   D                                
+  ADI    303.8     34.3   D                                
+  SAX    328.8     34.2   D                                
+  ZLA    329.5     34.2   D                                
+  OSS    328.0     34.1   D                                
+  MML    303.2     34.1   D                                
+  LLS    328.8     34.0   D                                
+  VDL    328.3     33.9   D                                
+  OHR    318.2     33.9   D                                
+  BRS    170.1     33.7   D                                
+  TMA    328.5     33.6   D                                
+  MMK    329.0     33.4   D                                
+  DIX    329.4     33.2   D                                
+  EMS    329.7     33.1   D                                
+  PRNI   302.1     33.0   D                                
+  MEKA   201.3     32.7   C                                
+  MBH    301.9     32.7   D                                
+  HLW    304.3     31.7   D                                
+  MEO     46.5     31.4   D                                
+  CMS    176.6     31.6   C                                
+  FORR   192.0     31.5   C                                
+  CBM     20.3     31.4   C                                
+  MRWA   202.7     31.2   C                                
+  COOL   197.9     31.0   C                                
+  ETER   330.6     30.9   D                                
+  BAL    201.7     30.8   C                                
+  RIV    172.2     30.6   D                                
+  ECRI   334.4     30.1   D                                
+  ADE    182.6     30.1   C                                
+  MUN    201.7     30.0   C                                
+  EMON   338.0     29.9   D                                
+  KCHT   323.3     29.8   D                                
+  CNB    173.9     29.8   D                                
+  SBS    322.9     29.8   D                                
+  ESEL   329.5     29.7   D                                
+  NWAO   200.6     29.6   C                                
+  ZGN    322.8     29.6   D                                
+  STS    338.6     29.5   D                                
+  ERUA   337.5     29.5   D                                
+  ETOR   333.4     29.5   D                                
+  RSCP    37.0     29.2   D                                
+  GUD    334.8     29.2   D                                
+  ECHE   332.1     29.2   D                                
+  TOO    177.1     29.1   C                                
+  TOL    334.4     29.0   D                                
+  ACU    331.3     29.0   D                                
+  EPLA   335.9     28.9   D                                
+  EVIA   332.8     28.9   D                                
+  ARO    284.3     28.9   D                                
+  EALH   331.7     28.8   D                                
+  EBAN   333.6     28.8   D                                
+  JSC     34.5     28.8   C                                
+  ENIJ   332.0     28.8   D                                
+  EHOR   334.5     28.8   D                                
+  AFC    333.1     28.8   D                                
+  LIS    337.7     28.7   D                                
+  EVAL   335.6     28.6   D                                
+  EPRU   334.2     28.6   D                                
+  EJIF   334.2     28.5   D                                
+  CFTV   338.6     27.1   D                                
+  BUL    273.6     11.1   C                                
+  SBA    173.6     11.0   C                                
+  ARE     51.6     10.6   C                                
+  SPA    180.0     10.5   C                                
+  LPB     47.5     10.4   C                                
+ Polarities/Errors:  P 190/21  SV 000/00  SH 000/00
+ There are no amplitude ratio data
+ The minimum, increment and maximum B axis trend:     0.00    5.00  355.00
+ The limits for the B axis plunge:     0.00    5.00   90.00
+ The limits for Angle:     0.00    5.00  175.00
+ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     58.68   308.43    16.48
+     Dip,Strike,Rake     75.97   209.69   147.60   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    119.69    14.03   218.43    31.32
+     Lower Hem. Trend, Plunge of P,T    262.18    11.31   164.82    32.61
+     B trend, B plunge, Angle:    8.78  55.00  25.00
+
+ P Polarity error at  PET  MAT  TSRJ YONJ TIK  PGC  BMW  RMW  SHW  NEW  COP 
+ P Polarity weights:  1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+                      CLI  TLB  MSU  CMP  BZS  BRS  MEO  RIV  CNB  RSCP
+                      1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+  Total P polarity weight is 21.000   Total number:  21
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     60.22   313.96    19.30
+     Dip,Strike,Rake     73.33   214.09   148.77   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    124.09    16.67   223.96    29.78
+     Lower Hem. Trend, Plunge of P,T    266.40     8.54   170.67    33.64
+     B trend, B plunge, Angle:    8.78  55.00  30.00
+
+ P Polarity error at  PET  MAT  TSRJ YONJ TIK  PGC  BMW  RMW  SHW  NEW  COP 
+ P Polarity weights:  1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+                      CLI  TLB  MSU  CMP  BZS  RMO  BRS  RIV  CNB  RSCP
+                      1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+  Total P polarity weight is 21.000   Total number:  21
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     61.98   319.30    21.88
+     Dip,Strike,Rake     70.79   218.62   150.16   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    128.62    19.21   229.30    28.02
+     Lower Hem. Trend, Plunge of P,T    270.56     5.72   176.63    34.39
+     B trend, B plunge, Angle:    8.78  55.00  35.00
+
+ P Polarity error at  PET  MAT  TSRJ YONJ TIK  PGC  BMW  RMW  SHW  NEW  COP 
+ P Polarity weights:  1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+                      CLI  TLB  MSU  CMP  BZS  RMO  BRS  CBM  RIV  CNB 
+                      1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+  Total P polarity weight is 21.000   Total number:  21
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     57.39   311.52    13.47
+     Dip,Strike,Rake     78.69   214.16   146.66   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    124.16    11.31   221.52    32.61
+     Lower Hem. Trend, Plunge of P,T    266.66    14.03   167.91    31.32
+     B trend, B plunge, Angle:   17.56  55.00  20.00
+
+ P Polarity error at  PET  MAT  TSRJ YONJ TIK  PGC  BMW  RMW  SHW  NEW  COP 
+ P Polarity weights:  1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+                      CLI  TLB  MSU  CMP  BZS  BRS  MEO  RIV  CNB  RSCP
+                      1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+  Total P polarity weight is 21.000   Total number:  21
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+     Dip,Strike,Rake     58.68   317.21    16.48
+     Dip,Strike,Rake     75.97   218.47   147.60   Auxiliary Plane
+     Lower Hem. Trend, Plunge of A,N    128.47    14.03   227.21    31.32
+     Lower Hem. Trend, Plunge of P,T    270.96    11.31   173.60    32.61
+     B trend, B plunge, Angle:   17.56  55.00  25.00
+
+ P Polarity error at  PET  MAT  TSRJ YONJ TIK  PGC  BMW  RMW  SHW  NEW  COP 
+ P Polarity weights:  1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+                      CLI  TLB  MSU  CMP  BZS  BRS  RIV  CNB  RSCP
+                      1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00 1.00
+  Total P polarity weight is 20.000   Total number:  20
+ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+ There are   5 acceptable solutions

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -34,6 +34,18 @@ class FOCMECTestCase(unittest.TestCase):
             '0.16 cut-off\nInput from a file focmec_8sta.inp\n12-MAY-90 '
             'Sakhalin Island event:  161221 disp picks')
         self.assertEqual(len(event.focal_mechanisms), 4)
+        expected_dip_strike_rake = (
+            (76.43, 59.08, -64.23),
+            (77.05, 54.08, -59.13),
+            (77.05, 59.89, -59.13),
+            (77.76, 54.50, -54.06))
+        for focmec, (dip, strike, rake) in zip(
+                event.focal_mechanisms, expected_dip_strike_rake):
+            plane1 = focmec.nodal_planes.nodal_plane_1
+            self.assertEqual(plane1.strike, strike)
+            self.assertEqual(plane1.dip, dip)
+            self.assertEqual(plane1.rake, rake)
+            self.assertEqual(focmec.nodal_planes.preferred_plane, 1)
 
     def _assert_cat_out(self, cat):
         self._assert_cat_common_parts(cat)

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -138,9 +138,21 @@ class FOCMECTestCase(unittest.TestCase):
         cat = _read_focmec(self.out_file)
         self._assert_cat_out(cat)
 
+    def test_read_focmec_out_open_file(self):
+        for mode in ('rb', 'rt'):
+            with open(self.out_file, mode) as fh:
+                cat = _read_focmec(fh)
+            self._assert_cat_out(cat)
+
     def test_read_focmec_lst(self):
         cat = _read_focmec(self.lst_file)
         self._assert_cat_lst(cat)
+
+    def test_read_focmec_lst_open_file(self):
+        for mode in ('rb', 'rt'):
+            with open(self.lst_file, mode) as fh:
+                cat = _read_focmec(fh)
+            self._assert_cat_lst(cat)
 
     def test_read_focmec_out_through_plugin(self):
         cat = read_events(self.out_file)

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -11,6 +11,51 @@ from obspy.core.event import Event
 from obspy.io.focmec.core import _is_focmec, _read_focmec
 
 
+lst_file_first_comment = '\n'.join((
+    "",
+    "     Dip,Strike,Rake     76.43    59.08   -64.23",
+    "     Dip,Strike,Rake     28.90   174.99  -150.97   Auxiliary Plane",
+    "     Lower Hem. Trend, Plunge of A,N     84.99    61.10   329.08    "
+    "13.57",
+    "     Lower Hem. Trend, Plunge of P,T    358.82    51.71   128.90    "
+    "26.95",
+    "     B trend, B plunge, Angle:  232.62  25.00 105.00",
+    "",
+    "          Log10(Ratio)                              Ratio     S Polarity",
+    "     Observed  Calculated    Difference  Station     Type     Obs.  "
+    "Calc. Flag",
+    "      0.8847      0.8950      -0.0103      BLA        SH       R      "
+    "R       ",
+    "      1.1785      1.0810       0.0975      COR        SH       R      "
+    "R       ",
+    "      0.6013      0.5442       0.0571      HRV        SH       R      "
+    "R       ",
+    "      0.3287      0.3666      -0.0379      KEV        SH       L      "
+    "L       ",
+    "      0.8291      0.9341      -0.1050      KIP        SH       R      "
+    "R       ",
+    "      0.8033      0.7815       0.0218      KIP        SV       B      "
+    "B       ",
+    "      1.0783      1.1857      -0.1074      PAS        SH       R      "
+    "R       ",
+    "      0.2576      0.2271       0.0305      TOL        SH       L      "
+    "L       ",
+    "     -0.2762     -0.4076       0.1314      TOL        SS       F      "
+    "F    NUM",
+    "     -0.4283     -0.4503       0.0220      HRV        SS       F      "
+    "F       ",
+    "     -0.0830      0.0713      -0.1543      KEV        SS       B      "
+    "B       ",
+    "",
+    "Total number of ratios used is  11",
+    "RMS error for the 11 acceptable solutions is 0.0852",
+    "  Highest absolute velue of diff for those solutions is  0.1543"))
+out_file_first_comment = (
+    "    Dip   Strike   Rake    Pol: P     SV    SH  AccR/TotR  RMS RErr  "
+    "AbsMaxDiff\n   76.43   59.08  -64.23       0.00  0.00  0.00    11/11    "
+    "0.0852    0.1543")
+
+
 class FOCMECTestCase(unittest.TestCase):
     """
     Test everything related to reading FOCMEC files
@@ -55,6 +100,8 @@ class FOCMECTestCase(unittest.TestCase):
     def _assert_cat_out(self, cat):
         self._assert_cat_common_parts(cat)
         self.assertEqual(cat[0].comments[0].text, self.out_file_header)
+        self.assertEqual(cat[0].focal_mechanisms[0].comments[0].text,
+                         out_file_first_comment)
 
     def _assert_cat_lst(self, cat):
         self._assert_cat_common_parts(cat)
@@ -62,6 +109,8 @@ class FOCMECTestCase(unittest.TestCase):
             self.assertEqual(focmec.misfit, 0.0)
             self.assertEqual(focmec.station_polarity_count, 23)
         self.assertEqual(cat[0].comments[0].text, self.lst_file_header)
+        self.assertEqual(cat[0].focal_mechanisms[0].comments[0].text,
+                         lst_file_first_comment)
 
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -52,6 +52,9 @@ class FOCMECTestCase(unittest.TestCase):
 
     def _assert_cat_lst(self, cat):
         self._assert_cat_common_parts(cat)
+        for focmec in cat[0].focal_mechanisms:
+            self.assertEqual(focmec.misfit, 0.0)
+            self.assertEqual(focmec.station_polarity_count, 23)
 
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -20,6 +20,16 @@ class FOCMECTestCase(unittest.TestCase):
         self.path = os.path.dirname(__file__)
         self.lst_file = os.path.join(self.path, 'data', 'focmec_8sta.lst')
         self.out_file = os.path.join(self.path, 'data', 'focmec_8sta.out')
+        with open(self.out_file, 'rb') as fh:
+            header = []
+            for i in range(15):
+                header.append(fh.readline().decode('ASCII'))
+            self.out_file_header = ''.join(header).rstrip()
+        with open(self.lst_file, 'rb') as fh:
+            header = []
+            for i in range(48):
+                header.append(fh.readline().decode('ASCII'))
+            self.lst_file_header = ''.join(header).rstrip()
 
     def _assert_cat_common_parts(self, cat):
         self.assertTrue(isinstance(cat, Catalog))
@@ -28,11 +38,6 @@ class FOCMECTestCase(unittest.TestCase):
         self.assertTrue(isinstance(event, Event))
         self.assertEqual(event.creation_info.creation_time,
                          UTCDateTime(2017, 9, 8, 14, 54, 58))
-        self.assertEqual(
-            event.comments[0].text,
-            'Sakhalin:  8 BB stations 0.2 polarity errors 1 ratio error:  '
-            '0.16 cut-off\nInput from a file focmec_8sta.inp\n12-MAY-90 '
-            'Sakhalin Island event:  161221 disp picks')
         self.assertEqual(len(event.focal_mechanisms), 4)
         expected_dip_strike_rake = (
             (76.43, 59.08, -64.23),
@@ -49,12 +54,14 @@ class FOCMECTestCase(unittest.TestCase):
 
     def _assert_cat_out(self, cat):
         self._assert_cat_common_parts(cat)
+        self.assertEqual(cat[0].comments[0].text, self.out_file_header)
 
     def _assert_cat_lst(self, cat):
         self._assert_cat_common_parts(cat)
         for focmec in cat[0].focal_mechanisms:
             self.assertEqual(focmec.misfit, 0.0)
             self.assertEqual(focmec.station_polarity_count, 23)
+        self.assertEqual(cat[0].comments[0].text, self.lst_file_header)
 
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -54,6 +54,7 @@ out_file_first_comment = (
     "    Dip   Strike   Rake    Pol: P     SV    SH  AccR/TotR  RMS RErr  "
     "AbsMaxDiff\n   76.43   59.08  -64.23       0.00  0.00  0.00    11/11    "
     "0.0852    0.1543")
+creation_time = UTCDateTime(2017, 9, 8, 14, 54, 58)
 
 
 class FOCMECTestCase(unittest.TestCase):
@@ -98,6 +99,10 @@ class FOCMECTestCase(unittest.TestCase):
             self.assertEqual(focmec.nodal_planes.preferred_plane, 1)
         for focmec in cat[0].focal_mechanisms:
             self.assertEqual(focmec.station_polarity_count, 23)
+            # check creation time
+            self.assertEqual(focmec.creation_info.creation_time, creation_time)
+            # check creation info version
+            self.assertEqual(focmec.creation_info.version, 'FOCMEC')
 
     def _assert_cat_out(self, cat):
         self._assert_cat_common_parts(cat)

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -6,7 +6,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import os
 import unittest
 
-from obspy import read_events, Catalog
+from obspy import read_events, Catalog, UTCDateTime
 from obspy.core.event import Event
 from obspy.io.focmec.core import _is_focmec, _read_focmec
 
@@ -26,6 +26,13 @@ class FOCMECTestCase(unittest.TestCase):
         self.assertEqual(len(cat), 1)
         event = cat[0]
         self.assertTrue(isinstance(event, Event))
+        self.assertEqual(event.creation_info.creation_time,
+                         UTCDateTime(2017, 9, 8, 14, 54, 58))
+        self.assertEqual(
+            event.comments[0].text,
+            'Sakhalin:  8 BB stations 0.2 polarity errors 1 ratio error:  '
+            '0.16 cut-off\nInput from a file focmec_8sta.inp\n12-MAY-90 '
+            'Sakhalin Island event:  161221 disp picks')
         self.assertEqual(len(event.focal_mechanisms), 4)
 
     def _assert_cat_out(self, cat):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -6,7 +6,9 @@ from future.builtins import *  # NOQA @UnusedWildImport
 import os
 import unittest
 
-from obspy.io.focmec.core import _is_focmec
+from obspy import read_events, Catalog
+from obspy.core.event import Event
+from obspy.io.focmec.core import _is_focmec, _read_focmec
 
 
 class FOCMECTestCase(unittest.TestCase):
@@ -19,9 +21,38 @@ class FOCMECTestCase(unittest.TestCase):
         self.lst_file = os.path.join(self.path, 'data', 'focmec_8sta.lst')
         self.out_file = os.path.join(self.path, 'data', 'focmec_8sta.out')
 
+    def _assert_cat_common_parts(self, cat):
+        self.assertTrue(isinstance(cat, Catalog))
+        self.assertEqual(len(cat), 1)
+        event = cat[0]
+        self.assertTrue(isinstance(event, Event))
+        self.assertEqual(len(event.focal_mechanisms), 4)
+
+    def _assert_cat_out(self, cat):
+        self._assert_cat_common_parts(cat)
+
+    def _assert_cat_lst(self, cat):
+        self._assert_cat_common_parts(cat)
+
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):
             self.assertTrue(_is_focmec(file_))
+
+    def test_read_focmec_out(self):
+        cat = _read_focmec(self.out_file)
+        self._assert_cat_out(cat)
+
+    def test_read_focmec_lst(self):
+        cat = _read_focmec(self.lst_file)
+        self._assert_cat_lst(cat)
+
+    def test_read_focmec_out_through_plugin(self):
+        cat = read_events(self.out_file)
+        self._assert_cat_out(cat)
+
+    def test_read_focmec_lst_through_plugin(self):
+        cat = read_events(self.lst_file)
+        self._assert_cat_lst(cat)
 
 
 def suite():

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -96,21 +96,29 @@ class FOCMECTestCase(unittest.TestCase):
             self.assertEqual(plane1.dip, dip)
             self.assertEqual(plane1.rake, rake)
             self.assertEqual(focmec.nodal_planes.preferred_plane, 1)
+        for focmec in cat[0].focal_mechanisms:
+            self.assertEqual(focmec.station_polarity_count, 23)
 
     def _assert_cat_out(self, cat):
         self._assert_cat_common_parts(cat)
         self.assertEqual(cat[0].comments[0].text, self.out_file_header)
         self.assertEqual(cat[0].focal_mechanisms[0].comments[0].text,
                          out_file_first_comment)
+        for focmec in cat[0].focal_mechanisms:
+            # misfit should be None, because the file specifies that polarity
+            # errors are weighted and in the out file format we can't know how
+            # many individual errors there are
+            self.assertEqual(focmec.misfit, None)
 
     def _assert_cat_lst(self, cat):
         self._assert_cat_common_parts(cat)
-        for focmec in cat[0].focal_mechanisms:
-            self.assertEqual(focmec.misfit, 0.0)
-            self.assertEqual(focmec.station_polarity_count, 23)
         self.assertEqual(cat[0].comments[0].text, self.lst_file_header)
         self.assertEqual(cat[0].focal_mechanisms[0].comments[0].text,
                          lst_file_first_comment)
+        for focmec in cat[0].focal_mechanisms:
+            # misfit should be 0.0, because in the lst file we can count the
+            # number of individual errors
+            self.assertEqual(focmec.misfit, 0.0)
 
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -109,6 +109,8 @@ class FOCMECTestCase(unittest.TestCase):
             # errors are weighted and in the out file format we can't know how
             # many individual errors there are
             self.assertEqual(focmec.misfit, None)
+            # we can't tell the gap from the out format
+            self.assertEqual(focmec.azimuthal_gap, None)
 
     def _assert_cat_lst(self, cat):
         self._assert_cat_common_parts(cat)
@@ -117,8 +119,10 @@ class FOCMECTestCase(unittest.TestCase):
                          lst_file_first_comment)
         for focmec in cat[0].focal_mechanisms:
             # misfit should be 0.0, because in the lst file we can count the
-            # number of individual errors
+            # number of individual errors (and there's no polarity errors)
             self.assertEqual(focmec.misfit, 0.0)
+            # we can't tell the gap from the out format
+            self.assertEqual(focmec.azimuthal_gap, 236.7)
 
     def test_is_focmec(self):
         for file_ in (self.lst_file, self.out_file):

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA @UnusedWildImport
+
+import os
+import unittest
+
+from obspy.io.focmec.core import _is_focmec
+
+
+class FOCMECTestCase(unittest.TestCase):
+    """
+    Test everything related to reading FOCMEC files
+    """
+    def setUp(self):
+        # Directory where the test files are located
+        self.path = os.path.dirname(__file__)
+        self.lst_file = os.path.join(self.path, 'data', 'focmec_8sta.lst')
+        self.out_file = os.path.join(self.path, 'data', 'focmec_8sta.out')
+
+    def test_is_focmec(self):
+        for file_ in (self.lst_file, self.out_file):
+            self.assertTrue(_is_focmec(file_))
+
+
+def suite():
+    return unittest.makeSuite(FOCMECTestCase, 'test')
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/setup.py
+++ b/setup.py
@@ -88,18 +88,18 @@ KEYWORDS = [
     'beamforming', 'cross correlation', 'database', 'dataless',
     'Dataless SEED', 'win', 'earthquakes', 'Earthworm', 'EIDA',
     'envelope', 'ESRI', 'events', 'FDSN', 'features', 'filter',
-    'focal mechanism', 'GCF', 'GSE1', 'GSE2', 'hob', 'Tau-P', 'IASPEI',
-    'imaging', 'IMS', 'instrument correction', 'instrument simulation', 'IRIS',
-    'ISF', 'kinemetrics', 'KML', 'magnitude', 'MiniSEED', 'misfit', 'mopad',
-    'MSEED', 'NDK', 'NERA', 'NERIES', 'NonLinLoc', 'NLLOC', 'Nordic', 'NRL',
-    'observatory', 'ORFEUS', 'PDAS', 'picker', 'processing', 'PQLX', 'Q',
-    'real time', 'realtime', 'REFTEK', 'REFTEK130', 'RG-1.6', 'RT-130', 'RESP',
-    'response file', 'RT', 'SAC', 'scardec', 'sc3ml', 'SDS', 'SEED',
-    'SeedLink', 'SEG-2', 'SEG Y', 'SEISAN', 'SeisHub', 'Seismic Handler',
-    'seismology', 'seismogram', 'seismograms', 'shapefile', 'signal', 'slink',
-    'spectrogram', 'StationXML', 'taper', 'taup', 'travel time', 'trigger',
-    'VERCE', 'WAV', 'waveform', 'WaveServer', 'WaveServerV', 'WebDC',
-    'web service', 'Winston', 'XML-SEED', 'XSEED', ]
+    'focal mechanism', 'FOCMEC', 'GCF', 'GSE1', 'GSE2', 'hob', 'Tau-P',
+    'IASPEI', 'imaging', 'IMS', 'instrument correction',
+    'instrument simulation', 'IRIS', 'ISF', 'kinemetrics', 'KML', 'magnitude',
+    'MiniSEED', 'misfit', 'mopad', 'MSEED', 'NDK', 'NERA', 'NERIES',
+    'NonLinLoc', 'NLLOC', 'Nordic', 'NRL', 'observatory', 'ORFEUS', 'PDAS',
+    'picker', 'processing', 'PQLX', 'Q', 'real time', 'realtime', 'REFTEK',
+    'REFTEK130', 'RG-1.6', 'RT-130', 'RESP', 'response file', 'RT', 'SAC',
+    'scardec', 'sc3ml', 'SDS', 'SEED', 'SeedLink', 'SEG-2', 'SEG Y', 'SEISAN',
+    'SeisHub', 'Seismic Handler', 'seismology', 'seismogram', 'seismograms',
+    'shapefile', 'signal', 'slink', 'spectrogram', 'StationXML', 'taper',
+    'taup', 'travel time', 'trigger', 'VERCE', 'WAV', 'waveform', 'WaveServer',
+    'WaveServerV', 'WebDC', 'web service', 'Winston', 'XML-SEED', 'XSEED', ]
 
 # when bumping to numpy 1.9.0: replace bytes() in io.reftek with np.tobytes()
 # when bumping to numpy 1.7.0: get rid of if/else when loading npz file to PPSD
@@ -303,7 +303,8 @@ ENTRY_POINTS = {
         'FNETMT = obspy.io.nied.fnetmt',
         'GSE2 = obspy.io.gse2.bulletin',
         'IMS10BULLETIN = obspy.io.iaspei.core',
-        'EVT = obspy.io.sh.evt'
+        'EVT = obspy.io.sh.evt',
+        'FOCMEC = obspy.io.focmec.core',
         ],
     'obspy.plugin.event.QUAKEML': [
         'isFormat = obspy.io.quakeml.core:_is_quakeml',
@@ -377,6 +378,10 @@ ENTRY_POINTS = {
     'obspy.plugin.event.EVT': [
         'isFormat = obspy.io.sh.evt:_is_evt',
         'readFormat = obspy.io.sh.evt:_read_evt',
+        ],
+    'obspy.plugin.event.FOCMEC': [
+        'isFormat = obspy.io.focmec.core:_is_focmec',
+        'readFormat = obspy.io.focmec.core:_read_focmec',
         ],
     'obspy.plugin.inventory': [
         'STATIONXML = obspy.io.stationxml.core',


### PR DESCRIPTION
### What does this PR do?

Add read support for focal mechanisms calculated using program FOCMEC (`out` and `lst` files)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] the PR is making changes to documentation   +DOCS
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .


---

```python
In [1]: cat = read_events('/path/to/focmec_8sta.lst')

In [2]: print(cat[0].focal_mechanisms[0])
FocalMechanism
	            resource_id: ResourceIdentifier(id="smi:local/ab869739-a73b-411f-b788-9d39e5edaf0a")
	           nodal_planes: NodalPlanes(nodal_plane_1=NodalPlane(strike=59.08, dip=76.43, rake=-64.23), nodal_plane_2=NodalPlane(strike=174.99, dip=28.9, rake=-150.97), preferred_plane=1)
	          azimuthal_gap: 236.7
	 station_polarity_count: 23
	                 misfit: 0.0
	          creation_info: CreationInfo(creation_time=UTCDateTime(2017, 9, 8, 14, 54, 58), version='FOCMEC')
	                   ---------
	               comments: 1 Elements

In [3]: print(cat[0].focal_mechanisms[0].comments[0].text)

     Dip,Strike,Rake     76.43    59.08   -64.23
     Dip,Strike,Rake     28.90   174.99  -150.97   Auxiliary Plane
     Lower Hem. Trend, Plunge of A,N     84.99    61.10   329.08    13.57
     Lower Hem. Trend, Plunge of P,T    358.82    51.71   128.90    26.95
     B trend, B plunge, Angle:  232.62  25.00 105.00

          Log10(Ratio)                              Ratio     S Polarity
     Observed  Calculated    Difference  Station     Type     Obs.  Calc. Flag
      0.8847      0.8950      -0.0103      BLA        SH       R      R       
      1.1785      1.0810       0.0975      COR        SH       R      R       
      0.6013      0.5442       0.0571      HRV        SH       R      R       
      0.3287      0.3666      -0.0379      KEV        SH       L      L       
      0.8291      0.9341      -0.1050      KIP        SH       R      R       
      0.8033      0.7815       0.0218      KIP        SV       B      B       
      1.0783      1.1857      -0.1074      PAS        SH       R      R       
      0.2576      0.2271       0.0305      TOL        SH       L      L       
     -0.2762     -0.4076       0.1314      TOL        SS       F      F    NUM
     -0.4283     -0.4503       0.0220      HRV        SS       F      F       
     -0.0830      0.0713      -0.1543      KEV        SS       B      B       

Total number of ratios used is  11
RMS error for the 11 acceptable solutions is 0.0852
  Highest absolute velue of diff for those solutions is  0.1543

```