### PR TITLE
Import Directive from stdlib in sphinx extension.

### DIFF
--- a/misc/docs/source/_ext/autosummary/__init__.py
+++ b/misc/docs/source/_ext/autosummary/__init__.py
@@ -62,13 +62,12 @@ import inspect
 import posixpath
 
 from six import text_type
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
 from docutils import nodes
 
 import sphinx
 from sphinx import addnodes
-from sphinx.util.compat import Directive
 
 
 # -- autosummary_toc node -----------------------------------------------------


### PR DESCRIPTION
We already do this in the `gallery.py` extension.

### Why was it initiated?  Any relevant Issues?

This fixes build against Sphinx 1.7 which removed the deprecated compatibility shims.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] All tests still pass.