### PR TITLE
UTCDateTime.strftime() raises ValueError with year <1900

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@
    * Fix Stream.get_gaps() when a trace is completely overlapping another trace
      (see #2218).
    * Fig Exception when comparing ComparingObjects (see #2220).
+   * Fix UTCDateTime.strftime() when year is <1900 on Python 2 (see #2167)
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -6,6 +6,7 @@ from future.utils import PY2, native_str
 
 import builtins
 import copy
+import io
 import os
 import sys
 import unittest
@@ -23,6 +24,7 @@ from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import (
     BASEMAP_VERSION, CARTOPY_VERSION, PROJ4_VERSION, MATPLOTLIB_VERSION)
 from obspy.core.util.base import _get_entry_points
+from obspy.core.util.misc import MatplotlibBackend
 from obspy.core.util.testing import ImageComparison
 from obspy.core.event.base import QuantityError
 
@@ -646,6 +648,21 @@ class CatalogBasemapTestCase(unittest.TestCase):
             cat.plot(method='basemap', outfile=ic.name, projection='local',
                      resolution='l', continent_fill_color='0.3',
                      color='date', colormap='gist_heat')
+
+    def test_plot_catalog_before_1900(self):
+        """
+        Tests plotting events with origin times before 1900
+        """
+        cat = read_events()
+        cat[1].origins[0].time = UTCDateTime(813, 2, 4, 14, 13)
+
+        # just checking this runs without error is fine, no need to check
+        # content
+        with MatplotlibBackend("AGG", sloppy=True):
+            cat.plot(outfile=io.BytesIO(), method='basemap')
+            # also test with just a single event
+            cat.events = [cat[1]]
+            cat.plot(outfile=io.BytesIO(), method='basemap')
 
 
 @unittest.skipIf(not HAS_CARTOPY, 'Cartopy not installed or too old')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1123,6 +1123,17 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertFalse(a == e)
         self.assertFalse(e == a)
 
+    def test_strftime_with_years_less_than_1900(self):
+        """
+        Try that some strftime commands we use (e.g. in plotting) work even
+        with years less than 1900 (underlying datetime.datetime.strftime raises
+        ValueError if year <1900.
+        """
+        t = UTCDateTime(1888, 1, 2, 1, 39, 37)
+        self.assertEqual(t.strftime('%Y-%m-%d'), '1888-01-02')
+        t = UTCDateTime(998, 11, 9, 1, 39, 37)
+        self.assertEqual(t.strftime('%Y-%m-%d'), '0998-11-09')
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1133,6 +1133,12 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(t.strftime('%Y-%m-%d'), '1888-01-02')
         t = UTCDateTime(998, 11, 9, 1, 39, 37)
         self.assertEqual(t.strftime('%Y-%m-%d'), '0998-11-09')
+        # some things we can't easily fix by string formatting alone..
+        with self.assertRaises(ValueError) as context:
+            self.assertEqual(t.strftime('%Y-%m-%d %A'), '0998-11-09')
+            self.assertTrue(
+                "the datetime strftime() methods require year >= 1900" in
+                str(context.exception))
 
 
 def suite():

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -5,6 +5,7 @@ from future.builtins import *  # NOQA @UnusedWildImport
 
 import copy
 import datetime
+import sys
 import unittest
 
 import numpy as np
@@ -1134,11 +1135,13 @@ class UTCDateTimeTestCase(unittest.TestCase):
         t = UTCDateTime(998, 11, 9, 1, 39, 37)
         self.assertEqual(t.strftime('%Y-%m-%d'), '0998-11-09')
         # some things we can't easily fix by string formatting alone..
-        with self.assertRaises(ValueError) as context:
-            self.assertEqual(t.strftime('%Y-%m-%d %A'), '0998-11-09')
-            self.assertTrue(
-                "the datetime strftime() methods require year >= 1900" in
-                str(context.exception))
+        # (but it only fails on Python <3.2, i.e. for us that means Python 2.7)
+        if sys.version_info.major == 2:
+            with self.assertRaises(ValueError) as context:
+                t.strftime('%Y-%m-%d %A')
+                self.assertTrue(
+                    "the datetime strftime() methods require year >= 1900" in
+                    str(context.exception))
 
 
 def suite():

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1143,6 +1143,17 @@ class UTCDateTimeTestCase(unittest.TestCase):
                     "the datetime strftime() methods require year >= 1900" in
                     str(context.exception))
 
+    def test_strftime_replacement(self):
+        """
+        Explicitly test this function.
+
+        Can be removed once we drop support for Python 2.
+        """
+        t = UTCDateTime(1888, 1, 2, 1, 39, 37)
+        self.assertEqual(t._strftime_replacement('%Y-%m-%d'), '1888-01-02')
+        t = UTCDateTime(998, 11, 9, 1, 39, 37)
+        self.assertEqual(t._strftime_replacement('%Y-%m-%d'), '0998-11-09')
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1154,6 +1154,17 @@ class UTCDateTimeTestCase(unittest.TestCase):
         t = UTCDateTime(998, 11, 9, 1, 39, 37)
         self.assertEqual(t._strftime_replacement('%Y-%m-%d'), '0998-11-09')
 
+    def test_string_parsing_at_instantiating_before_1000(self):
+        """
+        Try instantiating the UTCDateTime object with strings containing years
+        before 1000.
+        """
+        for value in ["998-01-01", "98-01-01", "9-01-01"]:
+            with self.assertRaises(ValueError) as e:
+                t = UTCDateTime(value)
+            msg = "'%s' does not start with a 4 digit year" % value
+            self.assertEqual(msg, e.exception.args[0])
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1161,7 +1161,7 @@ class UTCDateTimeTestCase(unittest.TestCase):
         """
         for value in ["998-01-01", "98-01-01", "9-01-01"]:
             with self.assertRaises(ValueError) as e:
-                t = UTCDateTime(value)
+                UTCDateTime(value)
             msg = "'%s' does not start with a 4 digit year" % value
             self.assertEqual(msg, e.exception.args[0])
 

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -21,12 +21,10 @@ import time
 
 import numpy as np
 
+
+# Regular expression used in the init function of the UTCDateTime objects which
+# is called a lot. Thus pre-compile it.
 _YEAR0REGEX = re.compile(r"^(\d{1,3}[-/,])(.*)$")
-
-
-def _year0repl(m):
-    return ("%5s%s" % m.groups()).replace(" ", "0")
-
 
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 # XXX the strftime problem seems to be specific to Python < 3.2
@@ -303,8 +301,8 @@ class UTCDateTime(object):
                 # Raising in the case where the leading string is less than 4
                 # chars; linked to #2167
                 if re.match(_YEAR0REGEX, value):
-                    raise ValueError("'%s' does not start with a 4 digit year" %
-                                     value)
+                    raise ValueError(
+                        "'%s' does not start with a 4 digit year" % value)
 
                 # check for ISO8601 date string
                 if value.count("T") == 1 or iso8601:

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -1260,8 +1260,11 @@ class UTCDateTime(object):
         See methods :meth:`~datetime.datetime.strftime()` and
         :meth:`~datetime.datetime.strptime()` for more information.
         """
-        if sys.version_info.major < 3 and sys.platform.startswith("linux"):
+        # See https://bugs.python.org/issue32195
+        # This is an attempt to get consistent behavior across platforms.
+        if sys.version_info.major > 2 and sys.platform.startswith("linux"):
             format = format.replace("%Y", "%04Y")
+
         try:
             ret = self.datetime.strftime(format)
         # this is trying to work around strftime refusing to work with years


### PR DESCRIPTION
### What does this PR do?

Trying to fix `UTCDateTime.strftime()` which raises `ValueError` in `datetime.datetime.strftime()` if year is <1900.

This currently fixes the problem for e.g. `.strftime('%Y-%m-%d')` by using simple string formatting instead of `datetime.datetime.strftime()`.

### Why was it initiated?  Any relevant Issues?

Plotting catalogs that have events with origin time <1900 currently does not work.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] All tests still pass.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
