### PR TITLE
Update some FDSN WS urls

### DIFF
--- a/obspy/clients/arclink/client.py
+++ b/obspy/clients/arclink/client.py
@@ -99,7 +99,7 @@ class Client(object):
     * INGV:  --
     * ETHZ:  eida.ethz.ch:18001
     * BGR:   eida.bgr.de:18001
-    * IPGP:  eida.ipgp.fr:18001
+    * IPGP:  arclink.ipgp.fr:18001
     * USP:   seisrequest.iag.usp.br:18001
     """
     max_status_requests = MAX_REQUESTS

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -41,7 +41,7 @@ GEONET  http://service.geonet.org.nz
 GFZ     http://geofon.gfz-potsdam.de
 ICGC    http://ws.icgc.cat
 INGV    http://webservices.ingv.it
-IPGP    http://eida.ipgp.fr
+IPGP    http://fdsnws.ipgp.fr
 IRIS    http://service.iris.edu
 ISC     http://isc-mirror.iris.washington.edu
 KOERI   http://eida.koeri.boun.edu.tr

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -46,7 +46,7 @@ URL_MAPPINGS = {
     "GFZ": "http://geofon.gfz-potsdam.de",
     "ICGC": "http://ws.icgc.cat",
     "INGV": "http://webservices.ingv.it",
-    "IPGP": "http://eida.ipgp.fr",
+    "IPGP": "http://fdsnws.ipgp.fr",
     "IRIS": "http://service.iris.edu",
     "ISC": "http://isc-mirror.iris.washington.edu",
     "KOERI": "http://eida.koeri.boun.edu.tr",

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -37,7 +37,7 @@ class FDSNNoDataException(FDSNException):
 
 # A curated list collecting some implementations:
 # https://www.fdsn.org/webservices/datacenters/
-# http://www.orfeus-eu.org/eida/eida_odc.html
+# https://www.orfeus-eu.org/data/eida/nodes/
 URL_MAPPINGS = {
     "BGR": "http://eida.bgr.de",
     "ETH": "http://eida.ethz.ch",


### PR DESCRIPTION
IPGP has migrated its EIDA node to RESIF, it however still maintains an FDSN WS.
The current address is still http://eida.ipgp.fr, but it will soon change to http://fdsnws.ipgp.fr.

This pull request is a reminder of the fact that the URL mapping for `IPGP` should be changed as soon as the URL changes.

I hope that IPGP will be able to change the URL before the next maintenance release of ObsPy.

I also updated the link in the comments pointing to EIDA node list.