### PR TITLE
Optional user-supplied marker styles

### DIFF
--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -548,6 +548,9 @@ class WaveformPlotting(object):
         else:
             time = event["time"]
             text = event["text"] if "text" in event else None
+            marker = event["marker"] if "marker" in event else "*"
+            marker_color = event["marker_color"] in event else "yellow"
+            marker_size = event["marker_size"] in event else 12
 
         # Nothing to do if the event is not on the plot.
         if time < self.starttime or time > self.endtime:
@@ -616,8 +619,8 @@ class WaveformPlotting(object):
                             relpos=relpos, shrinkB=7),
                         zorder=10)
         # Draw the actual point. Use a marker with a star shape.
-        ax.plot(x_pos, y_pos, "*", color="yellow",
-                markersize=12, linewidth=self.linewidth)
+        ax.plot(x_pos, y_pos, marker, color=marker_color,
+                markersize=marker_size, linewidth=self.linewidth)
 
         for pick in getattr(event, 'picks', []):
             # check that network/station/location matches


### PR DESCRIPTION
Allows the user to specify the marker style, color, and size for events. Defaults to a yellow star with size 12 if nothing is provided.

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

### What does this PR do?

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
