### PR TITLE
MassDownloader: flexible string template

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -272,12 +272,13 @@ which is rather general but also quite long.
 
 **Option 2: String Template**
 
-For more control use the second possibility and provide a string containing
-``{network}``, ``{station}``, ``{location}``, ``{channel}``, ``{starttime}``,
-and ``{endtime}`` format specifiers. These values will be interpolated to
-acquire the final filename. The start and end times will be formatted with
-``strftime()`` with the specifier ``"%Y%m%dT%H%M%SZ"`` in an effort to
-avoid colons which are troublesome in file names on many systems.
+For more control use the second possibility and provide a string
+containing one or more of the following format specifiers: ``{network}``,
+``{station}``, ``{location}``, ``{channel}``, ``{starttime}``,
+``{endtime}``. These values will be interpolated to acquire the final
+filename. The start and end times will be formatted with ``strftime()``
+with the specifier ``"%Y%m%dT%H%M%SZ"`` in an effort to avoid colons
+which are troublesome in file names on many systems.
 
 >>> mseed_storage = ("some_folder/{network}/{station}/"
 ...                  "{channel}.{location}.{starttime}.{endtime}.mseed")

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -542,8 +542,9 @@ def get_mseed_filename(str_or_fct, network, station, location, channel,
     if callable(str_or_fct):
         path = str_or_fct(network, station, location, channel, starttime,
                           endtime)
-    elif any("{%s}" % key in str_or_fct for key in ("network", "station", \
-                "location", "channel", "starttime", "endtime")):
+    elif any("{%s}" % key in str_or_fct for key in ("network", "station",
+                                                    "location", "channel",
+                                                    "starttime", "endtime")):
         path = str_or_fct.format(
             network=network, station=station, location=location,
             channel=channel, starttime=starttime.strftime(strftime),

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -527,7 +527,7 @@ def get_mseed_filename(str_or_fct, network, station, location, channel,
     and the resulting string is returned. If the return values is ``True``,
     the particular time interval will be ignored.
 
-    If it is a string, and it contains ``"{network}"``,  ``"{station}"``,
+    If it is a string, and it contains the ``"{network}"``, ``"{station}"``,
     ``"{location}"``, ``"{channel}"``, ``"{starttime}"``, or ``"{endtime}"``
     formatting specifiers, ``str.format()`` is called.
 

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -528,7 +528,7 @@ def get_mseed_filename(str_or_fct, network, station, location, channel,
     the particular time interval will be ignored.
 
     If it is a string, and it contains ``"{network}"``,  ``"{station}"``,
-    ``"{location}"``, ``"{channel}"``, ``"{starttime}"``, and ``"{endtime}"``
+    ``"{location}"``, ``"{channel}"``, ``"{starttime}"``, or ``"{endtime}"``
     formatting specifiers, ``str.format()`` is called.
 
     Otherwise it is considered to be a folder name and the resulting
@@ -542,9 +542,8 @@ def get_mseed_filename(str_or_fct, network, station, location, channel,
     if callable(str_or_fct):
         path = str_or_fct(network, station, location, channel, starttime,
                           endtime)
-    elif ("{network}" in str_or_fct) and ("{station}" in str_or_fct) and \
-            ("{location}" in str_or_fct) and ("{channel}" in str_or_fct) and \
-            ("{starttime}" in str_or_fct) and ("{endtime}" in str_or_fct):
+    elif any("{%s}" % key in str_or_fct for key in ("network", "station", \
+                "location", "channel", "starttime", "endtime")):
         path = str_or_fct.format(
             network=network, station=station, location=location,
             channel=channel, starttime=starttime.strftime(strftime),

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -473,7 +473,7 @@ def get_stationxml_filename(str_or_fct, network, station, channels,
     The rules are simple, if it is a function, then the network, station,
     channels, start time, and end time parameters are passed to it.
 
-    If it is a string, and it contains ``"{network}"``, and ``"{station}"``
+    If it is a string, and it contains the ``"{network}"`` or ``"{station}"``
     formatting specifiers, ``str.format()`` is called.
 
     Otherwise it is considered to be a folder name and the resulting
@@ -486,7 +486,7 @@ def get_stationxml_filename(str_or_fct, network, station, channels,
     if callable(str_or_fct):
         path = str_or_fct(network, station, channels, starttime, endtime)
     # Check if it's a format template.
-    elif ("{network}" in str_or_fct) and ("{station}" in str_or_fct):
+    elif any("{%s}" % key in str_or_fct for key in ("network", "station")):
         path = str_or_fct.format(network=network, station=station)
     # Otherwise assume it's a path.
     else:


### PR DESCRIPTION
### What does this PR do?

Lets the mass downloader string template work without specifying all the fields.
Fixes: #2174. 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.fdsn"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt`.
