### PR TITLE
Fix time rounding edge case

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1212,6 +1212,21 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertFalse(a == e)
         self.assertFalse(e == a)
 
+    def test_issue_2165(self):
+        """
+        When a timestamp gets rounded it should increment seconds and not
+        result in 1_000_000 microsecond value. See #2072.
+        """
+        time = UTCDateTime(1.466387732999999762e+09)
+        # test microseconds are rounded
+        self.assertEqual(time.microsecond, 0)
+        # test __repr__
+        expected_repr = "UTCDateTime(2016, 6, 20, 1, 55, 33)"
+        self.assertEqual(time.__repr__(), expected_repr)
+        # test __str__
+        expected_str = "2016-06-20T01:55:33.000000Z"
+        self.assertEqual(str(time), expected_str)
+
     def test_ns_public_attribute(self):
         """
         Basic test for public ns interface to UTCDateTime

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -598,8 +598,9 @@ class UTCDateTime(object):
         """
         # datetime.utcfromtimestamp will cut off but not round
         # avoid through adding timedelta - also avoids the year 2038 problem
-        dt = datetime.timedelta(seconds=self._ns // 10**9,
-                                microseconds=self._ns % 10**9 // 1000)
+        rounded_ns = py3_round(self._ns, self.precision - 9)
+        dt = datetime.timedelta(seconds=rounded_ns // 10**9,
+                                microseconds=rounded_ns % 10**9 // 1000)
         try:
             return TIMESTAMP0 + dt
         except OverflowError:
@@ -830,7 +831,8 @@ class UTCDateTime(object):
         >>> dt.microsecond
         345234
         """
-        return int(py3_round(self._ns % 10**9, self.precision - 9) // 1000)
+        ms = int(py3_round(self._ns % 10**9, self.precision - 9) // 1000)
+        return ms % 1000000
 
     def _set_microsecond(self, value):
         """


### PR DESCRIPTION
### What does this PR do?

Fixes the UTCDateTime inconsistencies described in #2165. 

Note:
Although this is a bug fix, it is based on Master as the maintenance branch doesn't have some of the recent  code that make this fix easier, eg the `round_py3` function for consistent rounding across python versions. 