### PR TITLE
Raise an error if the ar picker is called with arrays of non-equal length

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,8 @@
    * PPSD: for safety reasons, raise an ObsPyException if trying to read a PPSD
      npz file that was written with a newer version of the npz representation
      than is used by current ObsPy version (see #2051)
+   * The ar_pick() trigger function now raises an error if the three data arrays
+     don't have the same length (see #1801, #2148).
  - obspy.taup:
    * Fallback to linear slowness interpolation for very small and
      shallow layers (see #2126, #2129).

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -98,6 +98,14 @@ class TriggerTestCase(unittest.TestCase):
         # self.assertAlmostEqual(stime, 31.2800006866)
         self.assertEqual(int(stime + 0.5), 31)
 
+        # All three arrays must have the same length, otherwise an error is
+        # raised.
+        with self.assertRaises(ValueError) as err:
+            ar_pick(data[0], data[1], np.zeros(1), samp_rate, f1, f2, lta_p,
+                    sta_p, lta_s, sta_s, m_p, m_s, l_p, l_s)
+        self.assertEqual(err.exception.args[0],
+                         "All three data arrays must have the same length.")
+
     def test_trigger_onset(self):
         """
         Test trigger onset function

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -469,6 +469,10 @@ def ar_pick(a, b, c, samp_rate, f1, f2, lta_p, sta_p, lta_s, sta_s, m_p, m_s,
     a = np.ascontiguousarray(a, np.float32)
     b = np.ascontiguousarray(b, np.float32)
     c = np.ascontiguousarray(c, np.float32)
+
+    if not (len(a) == len(b) == len(c)):
+        raise ValueError("All three data arrays must have the same length.")
+
     s_pick = C.c_int(s_pick)  # pick S phase also
     ptime = C.c_float()
     stime = C.c_float()


### PR DESCRIPTION
See #1801 - it fixes at least one issue there.