### PR TITLE
Nordic to use preferred origin and handle large negative longitudes

### DIFF
--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -610,6 +610,33 @@ class TestNordicMethods(unittest.TestCase):
             int([p for p in pick_strings if p.split()[0] == 'WZ11' and
                  p.split()[1] == 'HZ'][0].split()[-1]), 30)
 
+    def test_large_negative_longitude(self):
+        event = full_test_event()
+        event.origins[0].longitude = -120
+        with NamedTemporaryFile(suffix=".out") as tf:
+            event.write(tf.name, format="NORDIC")
+            event_back = read_events(tf.name)
+            _assert_similarity(event, event_back[0])
+
+    def test_write_preferred_origin(self):
+        event = full_test_event()
+        preferred_origin = Origin(
+            time=UTCDateTime("2012-03-26") + 2.2, latitude=47.0,
+            longitude=35.0, depth=18000)
+        event.origins.append(preferred_origin)
+        event.preferred_origin_id = preferred_origin.resource_id
+        with NamedTemporaryFile(suffix=".out") as tf:
+            event.write(tf.name, format="NORDIC")
+            event_back = read_events(tf.name)
+            self.assertEqual(preferred_origin.latitude,
+                             event_back[0].origins[0].latitude)
+            self.assertEqual(preferred_origin.longitude,
+                             event_back[0].origins[0].longitude)
+            self.assertEqual(preferred_origin.depth,
+                             event_back[0].origins[0].depth)
+            self.assertEqual(preferred_origin.time,
+                             event_back[0].origins[0].time)
+
 
 def _assert_similarity(event_1, event_2, verbose=False):
     """


### PR DESCRIPTION
### What does this PR do?

Forces nordic IO to write the preferred origin rather than the first one. Also properly fixes for large negative longitude values (<= -100).

Selected master for this as #2181 was tagged at 1.2.0.

### Why was it initiated?  Any relevant Issues?

Closes #2181, and properly fixes #1991 (which was patched so that reading happened, but writing was improperly formatted, generating files that failed the test for `_is_sfile`).

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
~~- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~
~~- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~~
