### PR TITLE
More verbose error when header packing in SEG-Y fails

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,8 @@ master:
      (see #2106, #2098, #2095)
  - obspy.io.sac:
    * Fix bug writing inventory with SOH channels to SACPZ (see #2200).
+ - obspy.io.segy:
+   * Raise nicer error messages when header packing fails (see #2194, #2196).
  - obspy.io.seiscomp:
    * Adding support for SC3ML 0.10 (see #2024).
    * Update xsl to allow conversion of amplitude picks not associated with

--- a/obspy/io/segy/segy.py
+++ b/obspy/io/segy/segy.py
@@ -30,7 +30,7 @@ from .header import (BINARY_FILE_HEADER_FORMAT,
                      DATA_SAMPLE_FORMAT_UNPACK_FUNCTIONS, ENDIAN,
                      TRACE_HEADER_FORMAT, TRACE_HEADER_KEYS)
 from .unpack import OnTheFlyDataUnpacker
-from .util import unpack_header_value
+from .util import unpack_header_value, _pack_attribute_nicer_exception
 
 
 class SEGYError(Exception):
@@ -498,13 +498,13 @@ class SEGYBinaryFileHeader(object):
             if length == 2:
                 format = ('%sh' % endian).encode('ascii', 'strict')
                 # Write to file.
-                file.write(pack(format, getattr(self, name)))
+                file.write(_pack_attribute_nicer_exception(self, name, format))
             # Update: Seems to be correct. Two's complement integers seem to be
             # the common way to store integer values.
             elif length == 4:
                 format = ('%si' % endian).encode('ascii', 'strict')
                 # Write to file.
-                file.write(pack(format, getattr(self, name)))
+                file.write(_pack_attribute_nicer_exception(self, name, format))
             # These are the two unassigned values in the binary file header.
             elif name.startswith('unassigned'):
                 temp = getattr(self, name)

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -762,6 +762,24 @@ class SEGYTestCase(unittest.TestCase):
         self.assertEqual(revision_number, "C39 SEG Y REV1")
         self.assertEqual(end_header_mark, "ABCDEFGHIJKLMNOPQRSTUV")
 
+    def test_packing_raises_nice_error_messages(self):
+        """
+        SEG-Y is fairly restrictive in what ranges are allowed for its header
+        values. Thus we attempt to raise nice and helpful error messages.
+        """
+        tr = obspy.read()[0]
+        tr.data = np.float32(np.zeros(100000))
+        with io.BytesIO() as buf:
+            with self.assertRaises(ValueError) as err:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    tr.write(buf, format="segy")
+        self.assertEqual(
+            err.exception.args[0],
+            "Failed to pack header value `number_of_samples_per_data_trace` "
+            "(100000) with format `>h` due to: `'h' format requires -32768 <="
+            " number <= 32767`")
+
 
 def rms(x, y):
     """

--- a/obspy/io/segy/util.py
+++ b/obspy/io/segy/util.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-from struct import unpack
+from struct import pack, unpack
 
 from obspy.core.util.libnames import _load_cdll
 
@@ -36,3 +36,20 @@ def unpack_header_value(endian, packed_value, length, special_format):
     # Should not happen
     else:
         raise Exception
+
+
+def _pack_attribute_nicer_exception(obj, name, format):
+    """
+    packs obj.name with the given format but raises a nicer error message.
+    """
+    x = getattr(obj, name)
+    try:
+        return pack(format, x)
+    except Exception as e:
+        msg = ("Failed to pack header value `%s` (%s) with format `%s` due "
+               "to: `%s`")
+        try:
+            format = format.decode()
+        except AttributeError:
+            pass
+        raise ValueError(msg % (name, str(x), format, e.args[0]))


### PR DESCRIPTION
SEG-Y is fairly restrictive in the value ranges of many of its header values. This PR causes this to raise nicer error messages to the error is easier to diagnose. The example from #2194 now fails with the following error message:

```
  File "/Users/lion/workspace/code/obspy/obspy/io/segy/util.py", line 55, in _pack_attribute_nicer_exception
    raise ValueError(msg % (name, str(x), format, e.args[0]))
ValueError: Failed to pack header value `number_of_data_traces_per_ensemble` (32768) with format `<h` due to: `short format requires (-32767 -1) <= number <= 32767`
```