### PR TITLE
Read and write large negative longitudes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@
  - obspy.io.nordic
    * Bug-fix for amplitudes without magnitude_hint (see #2021)
    * Bug-fix for wavefiles with full path stripping (see #2021)
+   * Bug-fix for longitudes between -100 and -180 (see #2197)
  - obspy.io.reftek:
    * Fix problems reading some Reftek 130 files, presumably due to floating
      point accuracy issues in comparing timestamps. Internal representation of

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -274,7 +274,7 @@ def _readheader(f):
     # new_event.ev_id=topline[22]
     try:
         new_event.origins[0].latitude = float(topline[23:30])
-        new_event.origins[0].longitude = float(topline[31:38])
+        new_event.origins[0].longitude = float(topline[30:38])
         new_event.origins[0].depth = float(topline[39:43]) * 1000
     except ValueError:
         # The origin 'requires' a lat & long
@@ -931,7 +931,7 @@ def _write_nordic(event, filename, userid='OBSP', evtype='L', outdir='.',
                 str(evtime.minute).rjust(2) + ' ' +
                 str(evtime.second).rjust(2) + '.' +
                 str(evtime.microsecond).ljust(1)[0:1] + ' ' +
-                evtype.ljust(2) + lat.rjust(7) + ' ' + lon.rjust(7) +
+                evtype.ljust(2) + lat.rjust(7) + lon.rjust(8) +
                 depth.rjust(5) + agency.rjust(5) + ksta.rjust(3) +
                 timerms.rjust(4) +
                 conv_mags[0]['mag'].rjust(4) + conv_mags[0]['type'].rjust(1) +

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -569,6 +569,14 @@ class TestNordicMethods(unittest.TestCase):
             int([p for p in pick_strings if p.split()[0] == 'WZ11' and
                  p.split()[1] == 'HZ'][0].split()[-1]), 30)
 
+    def test_large_negative_longitude(self):
+        event = full_test_event()
+        event.origins[0].longitude = -120
+        with NamedTemporaryFile(suffix=".out") as tf:
+            event.write(tf.name, format="NORDIC")
+            event_back = read_events(tf.name)
+            _assert_similarity(event, event_back[0])
+
 
 def _assert_similarity(event_1, event_2, verbose=False):
     """


### PR DESCRIPTION
### What does this PR do?

Fixes a bug identified in #1991. Longitudes between -100 and -180 were not read or written properly. This is also fixed upstream in #2195, which may result in a merge issue when maintenance is merged into master... Both have the same tests, but master has updated string formatting which maintenance does not have.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
~~- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~
~~- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
~~- [ ] Any new or changed features have are fully documented.~~
- [x] Significant changes have been added to `CHANGELOG.txt` .
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~~
