### PR TITLE
Fix 2198

### DIFF
--- a/obspy/io/rg16/core.py
+++ b/obspy/io/rg16/core.py
@@ -163,7 +163,8 @@ def _make_traces(fi, data_block_start, gheader, head_only=False,
             data = np.array([])
         else:  # else read data
             data_start = trace_position + 20 + theader['num_ext_blocks'] * 32
-            data = _read(fi, data_start, theader['samples'] * 4, '>f4')
+            data = _read(fi, data_start, theader['samples'] * 4, '>f4',
+                         np.float32)
             if standard_orientation and stats.channel[-1] == 'Z':
                 data = -data
         traces.append(Trace(data=data, header=stats))

--- a/obspy/io/rg16/tests/test_read_fcnt.py
+++ b/obspy/io/rg16/tests/test_read_fcnt.py
@@ -25,7 +25,7 @@ assert len(FCNT_FILES), 'No test files found'
 class TestReadRG16(unittest.TestCase):
 
     supported_samps = {250, 500, 1000, 2000}
-    supported_component_number = {1, 3}
+    supported_number_of_components = {1, 3}
 
     def test_rg16_files_identified(self):
         """
@@ -55,7 +55,7 @@ class TestReadRG16(unittest.TestCase):
         """
         for fcnt_stream in FCNT_STREAMS:
             seed_ids = len({tr.id for tr in fcnt_stream})
-            self.assertIn(seed_ids, self.supported_component_number)
+            self.assertIn(seed_ids, self.supported_number_of_components)
 
     def test_channel_code(self):
         """
@@ -70,11 +70,11 @@ class TestReadRG16(unittest.TestCase):
                 self.assertEqual(len(channel), 3)
                 self.assertIn(component, expected_components)
             seed_ids = len({tr.id for tr in fcnt_stream})
-            self.assertIn(seed_ids, self.supported_component_number)
+            self.assertIn(seed_ids, self.supported_number_of_components)
 
-    def test_standard_orientation(self):
+    def test_contacts_north(self):
         """
-        Ensure the standard orientation maps channels and flips Z trace data.
+        Ensure the contacts north option maps channels and flips Z trace data.
         """
         components = {'Z', 'N', 'E'}
         for filename, st_default in zip(FCNT_FILES, FCNT_STREAMS):
@@ -89,6 +89,15 @@ class TestReadRG16(unittest.TestCase):
             # we need to make sure a z component is found in each
             if len(tr_2) and len(tr_z):
                 self.assertTrue(np.all(tr_2[0].data == -tr_z[0].data))
+
+    def test_contacts_north_and_merge(self):
+        """
+        Ensure the "contacts_north" and "merge" parameters can be used
+        together. See #2198.
+        """
+        for filename in FCNT_FILES:
+            st = _read_rg16(filename, contacts_north=True, merge=True)
+            assert isinstance(st, obspy.Stream)
 
     def test_can_write(self):
         """

--- a/obspy/io/rg16/util.py
+++ b/obspy/io/rg16/util.py
@@ -60,7 +60,7 @@ def _read_block(fi, spec, start_bit=0):
     return out
 
 
-def _read(fi, position, length, dtype):
+def _read(fi, position, length, dtype, new_dtype=None):
     """
     Read one or more bytes using provided datatype.
 
@@ -76,6 +76,7 @@ def _read(fi, position, length, dtype):
             >i3 - big endian 3 byte int
             >i. - 4 bit int, left four bits
     :type dtype: str
+    :param new_dtype: Any valid numpy data type.
     :return:
     """
     # if a list is passed as parameters then recurse through each
@@ -94,8 +95,9 @@ def _read(fi, position, length, dtype):
     if dtype in READ_FUNCS:
         return READ_FUNCS[dtype](fi, length)
     else:
-        # multiply 1 to get new array with type np.float32 see #2198
-        data = np.fromstring(fi.read(int(length)), dtype).astype(np.float32)
+        data = np.fromstring(fi.read(int(length)), dtype)
+        if new_dtype is not None:  # cast data to new_dtype (due to #2198)
+            data = data.astype(new_dtype)
         return data[0] if len(data) == 1 else data
 
 

--- a/obspy/io/rg16/util.py
+++ b/obspy/io/rg16/util.py
@@ -94,7 +94,8 @@ def _read(fi, position, length, dtype):
     if dtype in READ_FUNCS:
         return READ_FUNCS[dtype](fi, length)
     else:
-        data = np.fromstring(fi.read(int(length)), dtype)
+        # multiply 1 to get new array with type np.float32 see #2198
+        data = np.fromstring(fi.read(int(length)), dtype) * 1
         return data[0] if len(data) == 1 else data
 
 

--- a/obspy/io/rg16/util.py
+++ b/obspy/io/rg16/util.py
@@ -95,7 +95,7 @@ def _read(fi, position, length, dtype):
         return READ_FUNCS[dtype](fi, length)
     else:
         # multiply 1 to get new array with type np.float32 see #2198
-        data = np.fromstring(fi.read(int(length)), dtype) * 1
+        data = np.fromstring(fi.read(int(length)), dtype).astype(np.float32)
         return data[0] if len(data) == 1 else data
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes issue #2198 by multiplying each trace array by 1 after reading it with `_read_rg16` and related functions. This creates a new array with dtype float32 rather than '>f4' thus ensuring the datatypes will always be the same for traces.  

Note: rg16 module is only in master, hence the master branch is selected. 

### Why was it initiated?  Any relevant Issues?
#2198.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
