### PR TITLE
show nice error message when trying to write an empty stream to disk

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@ master:
    * Added __eq__ to QuantityError so empty instances equal None (see #2185).
    * Reworked the event scoped resource identifiers for the event classes
      hopefully fixing all edge-cases (see #2091).
+   * Calling Stream.write(...) on an empty stream will now raise an
+     ObsPyException consistently across all I/O plugins (see #2201)
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -34,6 +34,7 @@ from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
 from obspy.core.util.decorator import (map_example_filename,
                                        raise_if_masked, uncompress_file)
 from obspy.core.util.misc import get_window_times, buffered_load_entry_point
+from obspy.core.util.obspy_types import ObsPyException
 
 
 _headonly_warning_msg = (
@@ -1417,6 +1418,10 @@ class Stream(object):
 
         %s
         """
+        if not self.traces:
+            msg = 'Can not write empty stream to file.'
+            raise ObsPyException(msg)
+
         # Check all traces for masked arrays and raise exception.
         for trace in self.traces:
             if isinstance(trace.data, np.ma.masked_array):


### PR DESCRIPTION
### What does this PR do?

Shows a consistent (across different plugins) and meaningful error message when trying to write an empty stream to file. Also has a test.

```
In [2]: st = Stream()

In [3]: st.write('/tmp/blsdsd', 'SEGY')
---------------------------------------------------------------------------
ObsPyException                            Traceback (most recent call last)
<ipython-input-3-7f386cd6f6b3> in <module>()
----> 1 st.write('/tmp/blsdsd', 'SEGY')

/home/megies/git/obspy/obspy/core/stream.pyc in write(self, filename, format, **kwargs)
   1421         if not self.traces:
   1422             msg = 'Can not write empty stream to file.'
-> 1423             raise ObsPyException(msg)
   1424 
   1425         # Check all traces for masked arrays and raise exception.

ObsPyException: Can not write empty stream to file.
```

### Why was it initiated?  Any relevant Issues?

Right now some plugins execute a write on empty stream and create an empty file (MSEED), some others raise an IndexError (SEGY) etc...

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Significant changes have been added to `CHANGELOG.txt` .
