### PR TITLE
Fix get_gaps overlapping

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@
    * Event instances with Origin instances that have do not have defined
      latitude/longitude attributes will no longer raise a TypeError when
      creating a string representation (see #2119 and #2127).
+   * Fix Stream.get_gaps() when a trace is completely overlapping another trace
+     (see #2218).
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -804,7 +804,7 @@ class Stream(object):
             else:
                 same_sampling_rate = False
             stats = self.traces[_i].stats
-            stime = stats['endtime']
+            stime = min(stats['endtime'], self.traces[_i + 1].stats['endtime'])
             etime = self.traces[_i + 1].stats['starttime']
             # last sample of earlier trace represents data up to time of last
             # sample (stats.endtime) plus one delta

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1437,6 +1437,25 @@ class StreamTestCase(unittest.TestCase):
         gaps = st.get_gaps()
         self.assertEqual(len(gaps), 1)
 
+    def test_get_gaps_whole_overlap(self):
+        """
+        Test get_gaps method with a trace completely overlapping another trace.
+        """
+        tr1 = Trace(data=np.empty(3600))
+        tr1.stats.starttime = UTCDateTime("2018-09-25T00:00:00.000000Z")
+        tr1.stats.sampling_rate = 1.
+        tr2 = Trace(data=np.empty(60))
+        tr2.stats.starttime = UTCDateTime("2018-09-25T00:01:00.000000Z")
+        tr2.stats.sampling_rate = 1.
+        st = Stream([tr1, tr2])
+        gaps = st.get_gaps()
+        self.assertEqual(len(gaps), 1)
+        gap = gaps[0]
+        starttime = gap[4]
+        self.assertEqual(starttime, UTCDateTime("2018-09-25T00:01:59.000000Z"))
+        endtime = gap[5]
+        self.assertEqual(endtime, tr2.stats.starttime)
+
     def test_comparisons(self):
         """
         Tests all rich comparison operators (==, !=, <, <=, >, >=)


### PR DESCRIPTION
The [get_gaps](https://github.com/obspy/obspy/blob/master/obspy/core/stream.py#L745) method isn't working as expected if a trace is completely overlapping another trace. The `starttime` of the gaps is the `endtime` of the first trace even if the `endtime` of the second trace is previous.

This little PR just tries to fix that.