### PR TITLE
Bug comparing ComparingObject to an object without __dict__

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@
      creating a string representation (see #2119 and #2127).
    * Fix Stream.get_gaps() when a trace is completely overlapping another trace
      (see #2218).
+   * Fig Exception when comparing ComparingObjects (see #2220).
  - obspy.clients.arclink:
    * Raise a warning at import time that the ArcLink protocol will be
      deprecated soon (see #1987).

--- a/obspy/core/tests/test_util_base.py
+++ b/obspy/core/tests/test_util_base.py
@@ -4,13 +4,14 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 import os
+import copy
 import shutil
 import unittest
 
 from obspy.core.compatibility import mock
 from obspy.core.util.base import (NamedTemporaryFile, get_dependency_version,
                                   download_to_file, sanitize_filename,
-                                  create_empty_data_chunk)
+                                  create_empty_data_chunk, ComparingObject)
 from obspy.core.util.testing import ImageComparison, ImageComparisonException
 
 import numpy as np
@@ -139,6 +140,19 @@ class UtilBaseTestCase(unittest.TestCase):
         self.assertIsInstance(out, np.ma.MaskedArray)
         self.assertEqual(out.dtype, np.float32)
         np.testing.assert_allclose(out.mask, [True, True, True])
+
+    def test_comparing_object_eq(self):
+        co = ComparingObject()
+        # Compare to other types
+        self.assertNotEqual(co, 5)
+        self.assertNotEqual(co, None)
+        self.assertNotEqual(co, object())
+        # Compare same type, different instance, with attributes
+        co.at = 3
+        deep_copy = copy.deepcopy(co)
+        self.assertEqual(co, deep_copy)
+        deep_copy.at = 0
+        self.assertNotEqual(co, deep_copy)
 
 
 def suite():

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -513,7 +513,8 @@ class ComparingObject(object):
     Simple base class that implements == and != based on self.__dict__
     """
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return (isinstance(other, self.__class__)
+                and self.__dict__ == other.__dict__)
 
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
### Issue:
Comparing `ComparingObjects` to random objects with `==` / `__eq__` should return `False` not raise and excption.
### Actual case:
If you have 2 `Channels` one with a valid `Equipment` and the other with `None`
`chan1 == chan2` 
raises 
```
  File "/Users/lloyd/code/obspy/obspy/core/util/base.py", line 519, in __ne__
    return not self.__eq__(other)
  File "/Users/lloyd/code/obspy/obspy/core/util/base.py", line 516, in __eq__
    return self.__dict__ == other.__dict__
AttributeError: 'int' object has no attribute '__dict__'
```
The first commit only has the tests, you can pull and exersize.
### Solution:
At first I was worried about this solution breaking comparisons with other types that were compatible, e.g. `CustomComplex` == `complex`, but those kinds of types don't inherit from `ComparingObject`, and those seem to inherit from their compatible types... and the tests passed.
