### PR TITLE
obspy-scan: allow fnmatch wildcards when selecting specific SEED IDs during plotting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,9 @@ master:
      clients (see #2342 and #2344)
    * make it possible to use signed EIDA tokens and also skip token validation
      completely (see #2297)
+ - obspy.imaging:
+   * obspy-scan can now be used with wildcarded SEED IDs when specifying what
+     to plot after scanning data (see #2227)
  - obspy.io.nordic:
    * Add ability to read and write focal mechanisms and moment tensor
      information. (see #1924)

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -34,6 +34,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import fnmatch
 import os
 import sys
 import warnings
@@ -309,9 +310,25 @@ class Scanner(object):
         :type seed_ids: list of str
         :param seed_ids: Whether to consider only a specific set of SEED IDs
             (e.g. ``seed_ids=["GR.FUR..BHZ", "GR.WET..BHZ"]``) or just all SEED
-            IDs encountered in data (if left ``None``).
+            IDs encountered in data (if left ``None``). Given SEED IDs may
+            contain ``fnmatch``-style wildcards (e.g. ``"BW.UH?..[EH]H*"``).
         """
         import matplotlib.pyplot as plt
+
+        data_keys = list(self.data.keys())
+        if seed_ids is not None:
+            ids = []
+            for id_ in seed_ids:
+                # allow fnmatch type wildcards in given seed ids
+                if any(special in id_ for special in '*?[]!'):
+                    ids.extend(fnmatch.filter(data_keys, id_))
+                else:
+                    ids.append(id_)
+            # make sure we don't have duplicates in case multiple wildcard
+            # patterns were given and some ids were matched by more than one
+            # pattern
+            ids = list(set(ids))
+            seed_ids = ids
 
         if fig:
             if fig.axes:
@@ -434,7 +451,7 @@ class Scanner(object):
         :param endtime: Whether to use a fixed end time for the plot and
             data percentage calculation.
         :type seed_ids: list of str
-        :param endtime: Whether to consider only a specific set of SEED IDs
+        :param seed_ids: Whether to consider only a specific set of SEED IDs
             (e.g. ``seed_ids=["GR.FUR..BHZ", "GR.WET..BHZ"]``) or just all SEED
             IDs encountered in data (if left ``None``).
         """
@@ -712,9 +729,11 @@ def main(argv=None):
                              'time-axis axis accordingly.')
     parser.add_argument('--id', action='append',
                         help='Optional, a SEED channel identifier '
-                             "(e.g. 'GR.FUR..HHZ'). You may provide this " +
-                             'option multiple times. Only these ' +
-                             'channels will be plotted.')
+                             "(e.g. 'GR.FUR..HHZ'). You may provide this "
+                             'option multiple times. Only these '
+                             'channels will be plotted. Given SEED IDs may '
+                             'contain fnmatch-style wildcards (e.g. '
+                             "'BW.UH?..[EH]H*').")
     parser.add_argument('-t', '--event-time', default=None, type=UTCDateTime,
                         action='append',
                         help='Optional, a UTCDateTime compatible string ' +

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -12,8 +12,10 @@ import unittest
 from os.path import abspath, dirname, join, pardir
 import warnings
 
+import matplotlib.pyplot as plt
+
 from obspy import read, UTCDateTime
-from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.base import NamedTemporaryFile, get_example_file
 from obspy.core.util.misc import TemporaryWorkingDirectory, CatchOutput
 from obspy.core.util.testing import ImageComparison
 from obspy.imaging.scripts.scan import main as obspy_scan
@@ -72,6 +74,49 @@ class ScanTestCase(unittest.TestCase):
 
         with ImageComparison(self.path, 'scan.png') as ic:
             scanner.plot(ic.name)
+
+    def test_scan_plot_by_id_with_wildcard(self):
+        """
+        Test selecting what to plot after scanning with wildcards in selected
+        SEED IDs
+        """
+        files = [
+            "BW.UH1._.EHZ.D.2010.147.a.slist.gz",
+            "BW.UH1._.EHZ.D.2010.147.b.slist.gz",
+            "BW.UH1._.SHZ.D.2010.147.cut.slist.gz",
+            "BW.UH2._.SHZ.D.2010.147.cut.slist.gz",
+            "BW.UH3._.SHE.D.2010.147.cut.slist.gz",
+            "BW.UH3._.SHN.D.2010.147.cut.slist.gz",
+            "BW.UH3._.SHZ.D.2010.147.cut.slist.gz",
+            "BW.UH4._.EHZ.D.2010.147.cut.slist.gz",
+            "IUANMO.seed"]
+
+        scanner = Scanner()
+
+        for filename in files:
+            scanner.parse(get_example_file(filename))
+
+        expected = [
+            ('*.UH[12]*',
+             ['BW.UH2..SHZ\n100.0%',
+              'BW.UH1..SHZ\n100.0%',
+              'BW.UH1..EHZ\n10.7%',
+             ]),
+            ('*Z',
+             ['IU.ANMO.00.LHZ\n100.0%',
+              'BW.UH4..EHZ\n100.0%',
+              'BW.UH3..SHZ\n100.0%',
+              'BW.UH2..SHZ\n100.0%',
+              'BW.UH1..SHZ\n100.0%',
+              'BW.UH1..EHZ\n10.7%',
+             ])]
+
+        for seed_id, expected_labels in expected:
+            fig, ax = plt.subplots()
+            fig = scanner.plot(fig=fig, show=False, seed_ids=[seed_id])
+            got = [label.get_text() for label in ax.get_yticklabels()]
+            self.assertEqual(got, expected_labels)
+            plt.close(fig)
 
     def test_scanner_manually_add_streams(self):
         """

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -100,16 +100,14 @@ class ScanTestCase(unittest.TestCase):
             ('*.UH[12]*',
              ['BW.UH2..SHZ\n100.0%',
               'BW.UH1..SHZ\n100.0%',
-              'BW.UH1..EHZ\n10.7%',
-             ]),
+              'BW.UH1..EHZ\n10.7%']),
             ('*Z',
              ['IU.ANMO.00.LHZ\n100.0%',
               'BW.UH4..EHZ\n100.0%',
               'BW.UH3..SHZ\n100.0%',
               'BW.UH2..SHZ\n100.0%',
               'BW.UH1..SHZ\n100.0%',
-              'BW.UH1..EHZ\n10.7%',
-             ])]
+              'BW.UH1..EHZ\n10.7%'])]
 
         for seed_id, expected_labels in expected:
             fig, ax = plt.subplots()


### PR DESCRIPTION
### What does this PR do?

Allow fnmatch wildcards when selecting specific SEED IDs during plotting so one can e.g. select only "[EH]H*" channels for a plot after scanning an SDS tree.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .


Just needs a short test basically..