### PR TITLE
PPSD: fix/improve time overlap check

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,8 @@ master:
      integer nanosecond POSIX timestamps to avoid any potential floating point
      inaccuracies and since this is also what UTCDateTime is based on nowadays
      (see #2045)
+   * Fixed the check for new PSD slices whether they should be added or whether
+     they would add unwanted duplicated data (see #2229)
  - obspy.signal.cross_correlation:
    * Add new `correlate_template()` function with 'full' normalization option,
      required for correlations in template-matching


### PR DESCRIPTION
### What does this PR do?

Fixes the time check in PPSD that is done when determining if a given psd slice should be added to the PPSD or if it's representing a time span that already has been processed / overlaps too much with already present data.

### Why was it initiated?  Any relevant Issues?

Right now sometimes valid data that should go into PPSD are rejected. This e.g. happens when processing gapless data for two consecutive days in separate PPSD instances and storing each day in separate npz files. When loading/adding the two npz data files together in one PPSD instance (e.g. for later plotting), some time slices at the day border were rejected because they overlap, but that overlap is totally fine and actually what the PPSD instance does on processing (unless no overlap was specified during PPSD init).

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .


CC @ThomasLecocq I know you use PPSD so you might want to know about this PR.