### PR TITLE
Time overflow

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,9 +7,9 @@ master:
    * UTCDateTime objects now issue depreciation warnings when setting any
      attributes outside of init, or comparing UTCDateTime objects with
      different precisions (see #2077).
-   * UTCDateTime objects can now accept hour, minute, and second values
-     greater than their normal limits by setting the strict keyword argument
-     to False (see #2232).
+   * UTCDateTime objects can now accept hour, minute, second, and microsecond
+     values greater than their normal limits by setting the strict keyword
+     argument to False (see #2232).
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).
    * Added id property to WaveformStreamID (see #2131).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,7 +8,8 @@ master:
      attributes outside of init, or comparing UTCDateTime objects with
      different precisions (see #2077).
    * UTCDateTime objects can now accept hour, minute, and second values
-     greater than their normal limits when initialized with kwargs (see #2232)
+     greater than their normal limits by setting the strict keyword argument
+     to False (see #2232).
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).
    * Added id property to WaveformStreamID (see #2131).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@ master:
    * UTCDateTime objects now issue depreciation warnings when setting any
      attributes outside of init, or comparing UTCDateTime objects with
      different precisions (see #2077).
+   * UTCDateTime objects can now except hour, minute, and second values
+     greater than their normal limits when initialized with kwargs (see #2232)
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).
    * Added id property to WaveformStreamID (see #2131).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,7 @@ master:
    * UTCDateTime objects now issue depreciation warnings when setting any
      attributes outside of init, or comparing UTCDateTime objects with
      different precisions (see #2077).
-   * UTCDateTime objects can now except hour, minute, and second values
+   * UTCDateTime objects can now accept hour, minute, and second values
      greater than their normal limits when initialized with kwargs (see #2232)
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1457,6 +1457,15 @@ class UTCDateTimeTestCase(unittest.TestCase):
         utc = base_utc(second=120)
         self.assertEqual(utc, base_utc(minute=2))
 
+    def test_hour_minute_second_overflow_with_replace(self):
+        """
+        The replace method should also support the changes described in #2222.
+        """
+        utc = UTCDateTime('2017-09-18T00:00:00')
+        self.assertEqual(utc.replace(hour=25), utc + 25 * 3600)
+        self.assertEqual(utc.replace(minute=1000), utc + 1000 * 60)
+        self.assertEqual(utc.replace(second=60), utc + 60)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1448,26 +1448,34 @@ class UTCDateTimeTestCase(unittest.TestCase):
         kwargs = dict(year=2017, month=9, day=18, hour=0, minute=0, second=0)
         base_utc = partial(UTCDateTime, **kwargs)
         # ensure hour can exceed 23 and is equal to the day ticking forward
-        utc = base_utc(hour=25)
+        utc = base_utc(hour=25, strict=False)
         self.assertEqual(utc, base_utc(day=19, hour=1))
         # ensure minute can exceed 60
-        utc = base_utc(minute=61)
+        utc = base_utc(minute=61, strict=False)
         self.assertEqual(utc, base_utc(hour=1, minute=1))
         # ensure second can exceed 60
-        utc = base_utc(second=120)
+        utc = base_utc(second=120, strict=False)
         self.assertEqual(utc, base_utc(minute=2))
         # ensure not all kwargs are required for overflow behavior
-        utc = UTCDateTime(year=2017, month=9, day=18, second=60)
+        utc = UTCDateTime(year=2017, month=9, day=18, second=60, strict=False)
         self.assertEqual(utc, base_utc(minute=1))
+        # test for combination of args and kwargs
+        utc1 = UTCDateTime(2017, 5, 4, second=120, strict=False)
+        utc2 = UTCDateTime(2017, 5, 4, minute=2)
+        self.assertEqual(utc1, utc2)
+        # if strict == True a ValueError should be raised
+        with self.assertRaises(ValueError) as e:
+            base_utc(hour=60)
+        self.assertIn('hour must be in', str(e.exception))
 
     def test_hour_minute_second_overflow_with_replace(self):
         """
         The replace method should also support the changes described in #2222.
         """
         utc = UTCDateTime('2017-09-18T00:00:00')
-        self.assertEqual(utc.replace(hour=25), utc + 25 * 3600)
-        self.assertEqual(utc.replace(minute=1000), utc + 1000 * 60)
-        self.assertEqual(utc.replace(second=60), utc + 60)
+        self.assertEqual(utc.replace(hour=25, strict=0), utc + 25 * 3600)
+        self.assertEqual(utc.replace(minute=1000, strict=0), utc + 1000 * 60)
+        self.assertEqual(utc.replace(second=60, strict=0), utc + 60)
 
 
 def suite():

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1456,6 +1456,9 @@ class UTCDateTimeTestCase(unittest.TestCase):
         # ensure second can exceed 60
         utc = base_utc(second=120)
         self.assertEqual(utc, base_utc(minute=2))
+        # ensure not all kwargs are required for overflow behavior
+        utc = UTCDateTime(year=2017, month=9, day=18, second=60)
+        self.assertEqual(utc, base_utc(minute=1))
 
     def test_hour_minute_second_overflow_with_replace(self):
         """

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -9,6 +9,7 @@ import datetime
 import itertools
 import unittest
 import warnings
+from functools import partial
 from operator import ge, eq, lt, le, gt, ne
 
 import numpy as np
@@ -1436,6 +1437,25 @@ class UTCDateTimeTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             utc.replace(zweite=22)
         self.assertIn('zweite', str(e.exception))
+
+    def test_hour_minute_second_overflow(self):
+        """
+        Tests for allowing hour, minute, and second to exceed usual limits.
+        This only applies when using dates as kwargs to the UTCDateTime
+        constructor. See #2222.
+        """
+        # Create a UTCDateTime constructor with default values using partial
+        kwargs = dict(year=2017, month=9, day=18, hour=0, minute=0, second=0)
+        base_utc = partial(UTCDateTime, **kwargs)
+        # ensure hour can exceed 23 and is equal to the day ticking forward
+        utc = base_utc(hour=25)
+        self.assertEqual(utc, base_utc(day=19, hour=1))
+        # ensure minute can exceed 60
+        utc = base_utc(minute=61)
+        self.assertEqual(utc, base_utc(hour=1, minute=1))
+        # ensure second can exceed 60
+        utc = base_utc(second=120)
+        self.assertEqual(utc, base_utc(minute=2))
 
 
 def suite():

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1476,9 +1476,9 @@ class UTCDateTimeTestCase(unittest.TestCase):
         The replace method should also support the changes described in #2222.
         """
         utc = UTCDateTime('2017-09-18T00:00:00')
-        self.assertEqual(utc.replace(hour=25, strict=0), utc + 25 * 3600)
-        self.assertEqual(utc.replace(minute=1000, strict=0), utc + 1000 * 60)
-        self.assertEqual(utc.replace(second=60, strict=0), utc + 60)
+        self.assertEqual(utc.replace(hour=25, strict=False), utc + 25 * 3600)
+        self.assertEqual(utc.replace(minute=1000, strict=False), utc + 60000)
+        self.assertEqual(utc.replace(second=60, strict=False), utc + 60)
 
 
 def suite():

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1456,6 +1456,9 @@ class UTCDateTimeTestCase(unittest.TestCase):
         # ensure second can exceed 60
         utc = base_utc(second=120, strict=False)
         self.assertEqual(utc, base_utc(minute=2))
+        # ensure microsecond can exceed 1_000_000
+        utc = base_utc(microsecond=10000000, strict=False)
+        self.assertEqual(utc, base_utc(second=10))
         # ensure not all kwargs are required for overflow behavior
         utc = UTCDateTime(year=2017, month=9, day=18, second=60, strict=False)
         self.assertEqual(utc, base_utc(minute=1))

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -52,8 +52,8 @@ class UTCDateTime(object):
         as first input argument.
     :type strict: bool, optional
     :param strict: If True, Conform to `ISO8601:2004`_ limits on positional
-        and keyword arguments. If False, allow hour, minute and second values
-        to exceed 23, 59, and 59 respectively.
+        and keyword arguments. If False, allow hour, minute, second, and
+        microsecond values to exceed 23, 59, 59, and 1_000_000 respectively.
     :type precision: int, optional
     :param precision: Sets the precision used by the rich comparison operators.
         Defaults to ``6`` digits after the decimal point. See also `Precision`_

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -236,7 +236,7 @@ class UTCDateTime(object):
     _initialized = False
     _has_warned = False  # this is a temporary, it will be removed soon
 
-    def __init__(self, *args, strict=True, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Creates a new UTCDateTime object.
         """
@@ -244,6 +244,7 @@ class UTCDateTime(object):
         self.precision = kwargs.pop('precision', self.DEFAULT_PRECISION)
         # set directly to nanoseconds if given
         ns = kwargs.pop('ns', None)
+        strict = kwargs.pop('strict', True)
         if ns is not None:
             self._ns = ns
             return

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -396,11 +396,11 @@ class UTCDateTime(object):
                 extra_seconds += (kwargs['minute'] // 60) * 60 * 60
                 extra_seconds += (kwargs['second'] // 60) * 60
                 # reduce value in kwargs to be within normal bounds
-                kwargs['hour'] = kwargs['hour'] % 24
-                kwargs['minute'] = kwargs['minute'] % 60
-                kwargs['second'] = kwargs['second'] % 60
-            self._from_datetime(datetime.datetime(**kwargs))
-            self._ns = (self + extra_seconds)._ns
+                kwargs['hour'] %= 24
+                kwargs['minute'] %= 60
+                kwargs['second'] %= 60
+            # get the correct timestamp, add extra seconds
+            self._ns = (UTCDateTime(**kwargs) + extra_seconds).ns
         else:
             self._from_datetime(dt)
 
@@ -468,13 +468,7 @@ class UTCDateTime(object):
         :type dt: :class:`datetime.datetime`
         :param dt: Python datetime object.
         """
-        # see datetime.timedelta.total_seconds
-        try:
-            td = (dt - TIMESTAMP0)
-        except TypeError:
-            td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
-        self._ns = \
-            (td.days * 86400 + td.seconds) * 10**9 + td.microseconds * 1000
+        self._ns = _datetime_to_ns(dt)
 
     def _from_timestamp(self, value):
         """
@@ -1597,6 +1591,22 @@ class UTCDateTime(object):
         """
         from matplotlib.dates import date2num
         return date2num(self.datetime)
+
+
+def _datetime_to_ns(dt):
+    """
+    Use Python datetime object to return equivalent nanoseconds.
+
+    :type dt: :class:`datetime.datetime`
+    :param dt: Python datetime object.
+    :returns: nanoseconds as an int.
+    """
+    try:
+        td = (dt - TIMESTAMP0)
+    except TypeError:
+        td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
+    # see datetime.timedelta.total_seconds
+    return (td.days * 86400 + td.seconds) * 10**9 + td.microseconds * 1000
 
 
 if __name__ == '__main__':

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -412,20 +412,15 @@ class UTCDateTime(object):
         """
         Handles setting date if an overflow of usual value limits is detected.
         """
-        kwargs = locals()
-        kwargs.pop('self')
-        # ensure hour minute second are in kwargs
-        extra_seconds = 0
-        # keep track of second equiv. of overflow
-        extra_seconds += (kwargs['hour'] // 24) * 3600 * 24
-        extra_seconds += (kwargs['minute'] // 60) * 60 * 60
-        extra_seconds += (kwargs['second'] // 60) * 60
-        # reduce value in kwargs to be within normal bounds
-        kwargs['hour'] %= 24
-        kwargs['minute'] %= 60
-        kwargs['second'] %= 60
-        # get the correct timestamp, add extra seconds
-        self._ns = (UTCDateTime(**kwargs) + extra_seconds).ns
+        # Keep track of seconds due to hour, minute, second
+        seconds = 0
+        seconds += hour * 3600
+        seconds += minute * 60
+        seconds += second
+        # Init UTCDateTime based on year, month, day, add seconds
+        utc_base = UTCDateTime(year=year, month=month, day=day)
+        # Add seconds and set nanoseconds on self
+        self._ns = (utc_base + seconds + microsecond / 1000000).ns
 
     def _set(self, **kwargs):
         """

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -163,13 +163,18 @@ class UTCDateTime(object):
 
     (5) Using the following keyword arguments: `year, month, day, julday, hour,
         minute, second, microsecond`. Either the combination of year, month and
-        day, or year and Julian day are required.
+        day, or year and Julian day are required. This is the only input mode
+        that supports using hour, minute, or second values above the natural
+        limits of 24, 60, 60, respectively.
 
         >>> UTCDateTime(year=1970, month=1, day=1, minute=15, microsecond=20)
         UTCDateTime(1970, 1, 1, 0, 15, 0, 20)
 
         >>> UTCDateTime(year=2009, julday=234, hour=14, minute=13)
         UTCDateTime(2009, 8, 22, 14, 13)
+
+        >>> UTCDateTime(year=1970, month=1, day=1, hour=48, minute=60)
+        UTCDateTime(1970, 1, 3, 1, 0)
 
     (6) Using a Python :class:`datetime.datetime` object.
 
@@ -390,6 +395,9 @@ class UTCDateTime(object):
             if args:
                 raise
             else:
+                # ensure hour minute second are in kwargs
+                for time_unit in ('hour', 'minute', 'second'):
+                    kwargs[time_unit] = kwargs.get(time_unit, 0)
                 extra_seconds = 0
                 # keep track of second equiv. of overflow
                 extra_seconds += (kwargs['hour'] // 24) * 3600 * 24


### PR DESCRIPTION
### What does this PR do?
Allows for hour, minute, and second values to exceed the normal limits of 23, 59, 59 when creating a `UTCDateTime` object from key word arguments or using the `replace` method.

### Why was it initiated?  Any relevant Issues?
This change was discussed in #2222. It will allow several format parsers to favor using this approach when dealing with time values that may exceed their normal limits, rather than adding ad-hoc checks/handling logic in each parser. 

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
