### PR TITLE
Warning capture fix

### DIFF
--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -15,6 +15,7 @@ from obspy.core.compatibility import mock
 from obspy.core.event import ResourceIdentifier as ResId
 from obspy.core.util.misc import CatchOutput, get_window_times, \
     _ENTRY_POINT_CACHE, _yield_obj_parent_attr
+from obspy.core.util.testing import WarningsCapture
 
 
 class UtilMiscTestCase(unittest.TestCase):
@@ -293,6 +294,18 @@ class UtilMiscTestCase(unittest.TestCase):
         for obj, parent, attr in out:
             self.assertEqual(attr, 'right')
             self.assertIsInstance(obj, ResId)
+
+    def test_warning_capture(self):
+        """
+        Tests for the WarningsCapture class in obspy.core.util.testing
+        """
+        # ensure a warning issued with warn is captured. Before, this could
+        # raise a TypeError.
+        with WarningsCapture() as w:
+            warnings.warn('something bad is happening in the world')
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('something bad', str(w.captured_warnings[0].message))
 
 
 def suite():

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -728,8 +728,7 @@ class WarningsCapture(object):
                                     category=category,
                                     filename="", lineno=0))
 
-    def _warn(self, message, category=None, *args, **kwargs):
-        category = Warning if category is None else category
+    def _warn(self, message, category=Warning, *args, **kwargs):
         if isinstance(message, Warning):
             self.captured_warnings.append(
                 warnings.WarningMessage(

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -729,6 +729,7 @@ class WarningsCapture(object):
                                     filename="", lineno=0))
 
     def _warn(self, message, category=None, *args, **kwargs):
+        category = Warning if category is None else category
         if isinstance(message, Warning):
             self.captured_warnings.append(
                 warnings.WarningMessage(


### PR DESCRIPTION
### What does this PR do?
fixes #2233 where the internal testing utility for capturing warnings reliably across python versions did not work for `warnings.warn`. 

### Why was it initiated?  Any relevant Issues?
#2233

Note: since this a small change to an internal tool I decided to base of master. Happy to change it if needed. 
