### PR TITLE
add example and improve stream detrend docs

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2422,6 +2422,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         .. rubric:: Example
 
         Apply an order 3 spline detrend on all traces contained in the stream.
+
         >>> from obspy import read
         >>> st = read()
         >>> st.detrend("spline", order=3, dspline=500)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2408,6 +2408,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :meth:`~obspy.core.trace.Trace.detrend` method of
         :class:`~obspy.core.trace.Trace`.
 
+        :param options: collects keyword arguments which are passed to the
+            trace method call. Does not need to be used directly.
+            See the example that follows.
+
          .. note::
 
             This operation is performed in place on the actual data arrays. The

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2404,9 +2404,25 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         Remove a trend from all traces.
 
-        For details see the corresponding
+        For details on supported methods and parameters see the corresponding
         :meth:`~obspy.core.trace.Trace.detrend` method of
         :class:`~obspy.core.trace.Trace`.
+
+         .. note::
+
+            This operation is performed in place on the actual data arrays. The
+            raw data will no longer be accessible afterwards. To keep your
+            original data, use :meth:`~obspy.core.stream.Stream.copy` to create
+            a copy of your stream object.
+
+        .. rubric:: Example
+
+        Apply an order 3 spline detrend on all traces contained in the stream.
+        >>> from obspy import read
+        >>> st = read()
+        >>> st.detrend("spline", order=3, dspline=500)
+        ... # doctest: +ELLIPSIS
+        <...Stream object at 0x...>
         """
         for tr in self:
             tr.detrend(type=type, **options)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2408,11 +2408,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :meth:`~obspy.core.trace.Trace.detrend` method of
         :class:`~obspy.core.trace.Trace`.
 
-        :param options: collects keyword arguments which are passed to the
-            trace method call. Does not need to be used directly.
-            See the example that follows.
+        :param options:
+            Collects keyword arguments which are passed to the trace method
+            call. Does not need to be specified directly.
 
-         .. note::
+        .. note::
 
             This operation is performed in place on the actual data arrays. The
             raw data will no longer be accessible afterwards. To keep your
@@ -2421,7 +2421,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
         .. rubric:: Example
 
-        Apply an order 3 spline detrend on all traces contained in the stream.
+        Apply a third order spline detrend with 500 samples between nodes on
+        all traces contained in the stream.
 
         >>> from obspy import read
         >>> st = read()

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2408,27 +2408,12 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :meth:`~obspy.core.trace.Trace.detrend` method of
         :class:`~obspy.core.trace.Trace`.
 
-        :param options:
-            Collects keyword arguments which are passed to the trace method
-            call. Does not need to be specified directly.
-
         .. note::
 
             This operation is performed in place on the actual data arrays. The
             raw data will no longer be accessible afterwards. To keep your
             original data, use :meth:`~obspy.core.stream.Stream.copy` to create
             a copy of your stream object.
-
-        .. rubric:: Example
-
-        Apply a third order spline detrend with 500 samples between nodes on
-        all traces contained in the stream.
-
-        >>> from obspy import read
-        >>> st = read()
-        >>> st.detrend("spline", order=3, dspline=500)
-        ... # doctest: +ELLIPSIS
-        <...Stream object at 0x...>
         """
         for tr in self:
             tr.detrend(type=type, **options)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1932,8 +1932,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :param type: Method to use for detrending. Defaults to ``'simple'``.
             See the `Supported Methods`_ section below for further details.
         :param options:
-            Collects keyword arguments which are passed to the trace method
-            call. Does not need to be specified directly.
+            Collects keyword arguments which are passed to the selected
+            detrend function. Does not need to be specified directly.
 
         .. note::
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1931,6 +1931,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type type: str, optional
         :param type: Method to use for detrending. Defaults to ``'simple'``.
             See the `Supported Methods`_ section below for further details.
+        :param options:
+            Collects keyword arguments which are passed to the trace method
+            call. Does not need to be specified directly.
 
         .. note::
 
@@ -1962,6 +1965,16 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             Subtracts a spline of a given order with a given number of
             samples between spline nodes.
             (uses :func:`obspy.signal.detrend.spline`).
+
+        .. rubric:: Example
+
+        Apply a third order spline detrend with 500 samples between nodes.
+
+        >>> from obspy import read
+        >>> tr = read()[0]
+        >>> tr.detrend("spline", order=3, dspline=500)
+        ... # doctest: +ELLIPSIS
+        <...Trace object at 0x...>
         """
         type = type.lower()
         # retrieve function call from entry points


### PR DESCRIPTION
### What does this PR do?

Tries to improve the docstring for `obspy.core.stream.Stream.detrend` method by rewording slightly and adding an example.

### Why was it initiated?  Any relevant Issues?

see #2055

+DOCS
