### PR TITLE
try to fix basemap/pyproj/proj4 in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,14 @@ install:
   # Install default dependencies
   # pip 10.0.1 seems buggy and breaks all our appveyor builds
   - "conda install -q --yes \"pip<10\" numpy scipy matplotlib lxml sqlalchemy mock nose gdal decorator requests basemap jsonschema pyshp cryptography"
+  # somehow basemap/pyproj/proj4 can fail when PROJ_LIB is not set correctly
+  # for whatever reason, see:
+  #  - conda-forge/basemap-feedstock#36
+  #  - conda-forge/basemap-feedstock#30
+  #  - https://ci.appveyor.com/project/obspy/obspy/builds/19346925/job/prqqev70hy0qt786#L692
+  #  This is really ugly and should ideally reverted at some later point, in
+  #  case used paths / env var names change etc
+  - "SET PROJ_LIB=%CONDA_PREFIX%\\Library\\share"
   # additional dependencies
   - "pip install pyimgur"
   - "pip install -U future"


### PR DESCRIPTION
### What does this PR do?
Try to fix appveyor build

### Why was it initiated?  Any relevant Issues?

Basemap installation in appveyor is broken for the basemap/pyproj/proj4 combination getting installed currently. See conda-forge/basemap-feedstock#36

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
