### PR TITLE
NRL: set input units of overall sensitivity to input units of first stage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,9 @@
    * A few fixes and stability improvements for the mass downloader
      (see #2081).
    * Fixed routing startup error when running under certain locales (see #2147)
+ - obspy.clients.nrl:
+   * Set input units of overall sensitivity to input units of first stage
+     in NRL.get_response()
  - obspy.imaging:
    * Normalize moment tensors prior to plotting in the mopad wrapper to
      stabilize the algorithm (see #2114, #2125).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,7 +28,7 @@
    * Fixed routing startup error when running under certain locales (see #2147)
  - obspy.clients.nrl:
    * Set input units of overall sensitivity to input units of first stage
-     in NRL.get_response()
+     in NRL.get_response() (see #2248)
  - obspy.imaging:
    * Normalize moment tensors prior to plotting in the mopad wrapper to
      stabilize the algorithm (see #2114, #2125).

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -219,6 +219,7 @@ class NRL(object):
         sensor_stage0 = sensor_resp.response_stages[0]
         dl_resp.response_stages.insert(0, sensor_stage0)
         dl_resp.instrument_sensitivity.input_units = sensor_stage0.input_units
+        dl_resp.instrument_sensitivity.input_units_description = sensor_stage0.input_units_description
         try:
             dl_resp.recalculate_overall_sensitivity()
         except ValueError:

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -219,7 +219,8 @@ class NRL(object):
         sensor_stage0 = sensor_resp.response_stages[0]
         dl_resp.response_stages.insert(0, sensor_stage0)
         dl_resp.instrument_sensitivity.input_units = sensor_stage0.input_units
-        dl_resp.instrument_sensitivity.input_units_description = sensor_stage0.input_units_description
+        dl_resp.instrument_sensitivity.input_units_description = \
+            sensor_stage0.input_units_description
         try:
             dl_resp.recalculate_overall_sensitivity()
         except ValueError:

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -216,7 +216,9 @@ class NRL(object):
         # Combine both by replace stage one in the data logger with stage
         # one of the sensor.
         dl_resp.response_stages.pop(0)
-        dl_resp.response_stages.insert(0, sensor_resp.response_stages[0])
+        sensor_stage0 = sensor_resp.response_stages[0]
+        dl_resp.response_stages.insert(0, sensor_stage0)
+        dl_resp.instrument_sensitivity.input_units = sensor_stage0.input_units
         try:
             dl_resp.recalculate_overall_sensitivity()
         except ValueError:


### PR DESCRIPTION
When using an accelerometer in NRL.get_response the input unit of the resulting response object is 'M/S'. I think it should be 'M/S**2'.

```py
from obspy.clients.nrl import NRL
nrl = NRL()
sensor = ['Guralp', 'CMG-5', '4G_10V', '100 Hz']
datalogger = ['REF TEK', 'RT 130 & 130-SMA', '1', '100']
response = nrl.get_response(datalogger, sensor)
print(response)

Channel Response
	From M/S (Velocity in Meters per Second) to COUNTS (Digital Counts)
	Overall Sensitivity: 1.00856e+06 defined at 1.000 Hz
	11 stages:
		Stage 1: PolesZerosResponseStage from M/S**2 to V, gain: 0.254929
		Stage 2: ResponseStage from V to V, gain: 1
		Stage 3: CoefficientsTypeResponseStage from V to COUNTS, gain: 629129
		Stage 4: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 5: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 6: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 7: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 8: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 9: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 10: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 11: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
```

With this PR the output is

```
Channel Response
	From M/S**2 (Velocity in Meters per Second) to COUNTS (Digital Counts)
	Overall Sensitivity: 160518 defined at 1.000 Hz
	11 stages:
		Stage 1: PolesZerosResponseStage from M/S**2 to V, gain: 0.254929
		Stage 2: ResponseStage from V to V, gain: 1
		Stage 3: CoefficientsTypeResponseStage from V to COUNTS, gain: 629129
		Stage 4: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 5: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 6: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 7: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 8: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 9: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 10: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
		Stage 11: CoefficientsTypeResponseStage from COUNTS to COUNTS, gain: 1
```