### PR TITLE
Update (again) the IPGP FDSN WS alias

### DIFF
--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -41,7 +41,7 @@ GEONET  http://service.geonet.org.nz
 GFZ     http://geofon.gfz-potsdam.de
 ICGC    http://ws.icgc.cat
 INGV    http://webservices.ingv.it
-IPGP    http://fdsnws.ipgp.fr
+IPGP    http://ws.ipgp.fr
 IRIS    http://service.iris.edu
 ISC     http://isc-mirror.iris.washington.edu
 KOERI   http://eida.koeri.boun.edu.tr

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -46,7 +46,7 @@ URL_MAPPINGS = {
     "GFZ": "http://geofon.gfz-potsdam.de",
     "ICGC": "http://ws.icgc.cat",
     "INGV": "http://webservices.ingv.it",
-    "IPGP": "http://fdsnws.ipgp.fr",
+    "IPGP": "http://ws.ipgp.fr",
     "IRIS": "http://service.iris.edu",
     "ISC": "http://isc-mirror.iris.washington.edu",
     "KOERI": "http://eida.koeri.boun.edu.tr",


### PR DESCRIPTION
This is hopefully the definitive one for IPGP:

http://ws.ipgp.fr/fdsnws

Thanks and sorry for the PR noise!