### PR TITLE
[fdsnws] Add KNMI as data center

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@
    * A few fixes and stability improvements for the mass downloader
      (see #2081).
    * Fixed routing startup error when running under certain locales (see #2147)
+   * Adding a mapping for the KNMI (see #2270) services.
  - obspy.clients.nrl:
    * Set input units of overall sensitivity to input units of first stage
      in NRL.get_response() (see #2248)

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -44,6 +44,7 @@ INGV    http://webservices.ingv.it
 IPGP    http://ws.ipgp.fr
 IRIS    http://service.iris.edu
 ISC     http://isc-mirror.iris.washington.edu
+KNMI    http://rdsa.knmi.nl
 KOERI   http://eida.koeri.boun.edu.tr
 LMU     http://erde.geophysik.uni-muenchen.de
 NCEDC   http://service.ncedc.org

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -49,6 +49,7 @@ URL_MAPPINGS = {
     "IPGP": "http://ws.ipgp.fr",
     "IRIS": "http://service.iris.edu",
     "ISC": "http://isc-mirror.iris.washington.edu",
+    "KNMI": "http://rdsa.knmi.nl",
     "KOERI": "http://eida.koeri.boun.edu.tr",
     "LMU": "http://erde.geophysik.uni-muenchen.de",
     "NCEDC": "http://service.ncedc.org",


### PR DESCRIPTION
Could you please add KNMI in list of pre-configured FDSNws data centers?

`"KNMI" : "http://rdsa.knmi.nl/"`

The data center has just been included in the FDSN list:
http://www.fdsn.org/webservices/datacenters/

Many thanks!
