### PR TITLE
Remove taup.tau.remove-create_taup_model() which is no longer used

### DIFF
--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from .helper_classes import Arrival
 from .tau_model import TauModel
-from .taup_create import TauPCreate
 from .taup_path import TauPPath
 from .taup_pierce import TauPPierce
 from .taup_time import TauPTime

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -871,20 +871,6 @@ class TauPyModel(object):
         return arrivals
 
 
-def create_taup_model(model_name, output_dir, input_dir):
-    """
-    Create a .taup model from a .tvel file.
-
-    :param model_name:
-    :param output_dir:
-    """
-    if "." in model_name:
-        model_file_name = model_name
-    else:
-        model_file_name = model_name + ".tvel"
-    TauPCreate.main(model_file_name, output_dir, input_dir)
-
-
 def plot_travel_times(source_depth, phase_list=("ttbasic",), min_degrees=0,
                       max_degrees=180, npoints=50, model='iasp91',
                       plot_all=True, legend=True, verbose=False, fig=None,


### PR DESCRIPTION
### What does this PR do?

Remove a function `taup.tau.remove-create_taup_model()`.

### Why was it initiated?  Any relevant Issues?

This function is never used in the source codes. It is also not tested at all. The function calls a method `TauPCreate.main`, which doesn't exists. The function is replaced by `taup.taup_create.build_taup_model()`. 

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
