### PR TITLE
Konno Ohmachi Smoothing refactor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,12 @@ master:
      (see #2045)
    * Fixed the check for new PSD slices whether they should be added or whether
      they would add unwanted duplicated data (see #2229)
+ - obspy.signal.konnoohmachismoothing:
+   * Added `center_frequencies` argument to `konno_ohmachi_smoothing`
+     (see #2277).
+   * Refactored internals to take better advantage of numpy vectorization
+     (see #2277).
+   * Fix bug in smoothing multiple spectra at once (see #2276).
  - obspy.signal.cross_correlation:
    * Add new `correlate_template()` function with 'full' normalization option,
      required for correlations in template-matching

--- a/misc/docs/source/bibliography/KvaernaRingdal1986.bib
+++ b/misc/docs/source/bibliography/KvaernaRingdal1986.bib
@@ -3,7 +3,6 @@
     type = {Scientific Report: Semiannual Technical Summary},
     institution = {NORSAR},
     number = {1 - 1986/1987},
-    pages = {29--48},
     title = {{Stability of various f-k estimation techniques}},
     year = {1986},
     address = {Kjeller, Norway},

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
@@ -2,10 +2,12 @@
 Konno-Ohmachi Smoothing
 =======================
 
-Obspy includes a smoothing function which follows the approach described by
-[Konno1998]_. Unlike most smoothing algorithms, this method applies a
-smoothing window with constant width in logarithmic space. Such an approach
-can be useful, for example, to reduce noise before fitting a spectral model.
+Obspy includes the
+:func:`~obspy.signal.konnoohmachismoothing.konno_ohmachi_smoothing`
+function which follows the approach described by [Konno1998]_. Unlike most
+smoothing algorithms, this method applies a smoothing window with constant
+width in logarithmic space. Such an approach can be useful, for example, to
+reduce noise before fitting a spectral model.
 
 The following example will apply Konno-Ohmachi smoothing and a Savitzky-Golay
 filter (included in scipy) and compare the results on a log-log plot. Note how
@@ -32,10 +34,7 @@ spectrum individually.
 
 The following example will generate a few large(ish) random time-series,
 calculate the amplitude spectra, then apply Konno-Ohmachi smoothing to all
-spectra simultaneously for selected frequencies of interest.
+spectra simultaneously for selected frequencies.
 
 .. plot:: tutorial/code_snippets//konno_ohmachi_smoothing_2.py
    :include-source:
-
-For more information see
-:func:`~obspy.signal.konnoohmachismoothing.konno_ohmachi_smoothing`.

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
@@ -22,7 +22,7 @@ Efficient Smoothing
 
 For large spectra it can be very time-consuming and memory intensive to
 calculate the smoothing coefficients for all frequencies. In these cases
-it is usually best specify a subset of frequencies using the
+it may be best to specify a subset of frequencies using the
 ``center_frequencies`` parameter. The output will then only contain values
 corresponding to the frequencies of interest.
 
@@ -30,5 +30,12 @@ Multiple spectra can also be smoothed simultaneously by passing a numpy array
 to the smoothing function, which is more efficient than smoothing each
 spectrum individually.
 
+The following example will generate a few large(ish) random time-series,
+calculate the amplitude spectra, then apply Konno-Ohmachi smoothing to all
+spectra simultaneously for selected frequencies of interest.
+
 .. plot:: tutorial/code_snippets//konno_ohmachi_smoothing_2.py
    :include-source:
+
+For more information see
+:func:`~obspy.signal.konnoohmachismoothing.konno_ohmachi_smoothing`.

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
@@ -1,0 +1,26 @@
+=======================
+Konno-Ohmachi Smoothing
+=======================
+
+This example shows how to apply smoothing to amplitude spectra following the
+approach by developed by [Konno1998]_. This method applies a smoothing window
+whose width is constant in log space rather than linear space. This can be
+useful, for example, to reduce noise before fitting a spectral model.
+
+The following example will apply Konno-Ohmachi smoothing and a Savitzky-Golay
+filter (included in scipy) and compare the results on a log-log plot. Note how
+the Savitzky-Golay filter appears over-smoothed at lower frequencies and
+under-smoothed at higher frequencies but the Konno-Ohmachi filtered data
+appears reasonable throughout.
+
+.. plot:: tutorial/code_snippets/konno_ohmachi_smoothing_1.py
+   :include-source:
+
+For large spectra it can be very time-consuming and memory intensive to
+calculate the smoothing coefficients for all frequencies. In these cases
+it is usually best specify a subset of frequencies of interest using the
+``center_frequencies`` parameter. Multiple spectra can also be smoothed
+simultaneously which is more efficient than smoothing each individually.
+
+.. plot:: tutorial/code_snippets//konno_ohmachi_smoothing_2.py
+   :include-source:

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing.rst
@@ -2,25 +2,33 @@
 Konno-Ohmachi Smoothing
 =======================
 
-This example shows how to apply smoothing to amplitude spectra following the
-approach by developed by [Konno1998]_. This method applies a smoothing window
-whose width is constant in log space rather than linear space. This can be
-useful, for example, to reduce noise before fitting a spectral model.
+Obspy includes a smoothing function which follows the approach described by
+[Konno1998]_. Unlike most smoothing algorithms, this method applies a
+smoothing window with constant width in logarithmic space. Such an approach
+can be useful, for example, to reduce noise before fitting a spectral model.
 
 The following example will apply Konno-Ohmachi smoothing and a Savitzky-Golay
 filter (included in scipy) and compare the results on a log-log plot. Note how
 the Savitzky-Golay filter appears over-smoothed at lower frequencies and
-under-smoothed at higher frequencies but the Konno-Ohmachi filtered data
+under-smoothed at higher frequencies but the Konno-Ohmachi smoothed data
 appears reasonable throughout.
 
 .. plot:: tutorial/code_snippets/konno_ohmachi_smoothing_1.py
    :include-source:
 
+-------------------
+Efficient Smoothing
+-------------------
+
 For large spectra it can be very time-consuming and memory intensive to
 calculate the smoothing coefficients for all frequencies. In these cases
-it is usually best specify a subset of frequencies of interest using the
-``center_frequencies`` parameter. Multiple spectra can also be smoothed
-simultaneously which is more efficient than smoothing each individually.
+it is usually best specify a subset of frequencies using the
+``center_frequencies`` parameter. The output will then only contain values
+corresponding to the frequencies of interest.
+
+Multiple spectra can also be smoothed simultaneously by passing a numpy array
+to the smoothing function, which is more efficient than smoothing each
+spectrum individually.
 
 .. plot:: tutorial/code_snippets//konno_ohmachi_smoothing_2.py
    :include-source:

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
@@ -7,14 +7,14 @@ from scipy.signal import savgol_filter
 
 # Load sample data.
 st = read()
-tr = st[0].data
+tr = st[0]
 
 # Get the amplitude spectra and corresponding frequencies.
 amp_spec = np.abs(np.fft.rfft(tr.data))
-freqs = np.fft.rfftfreq(len(tr.data), 1. / tr.stats.sampling_rate)
+freqs = np.fft.rfftfreq(tr.stats.npts, 1. / tr.stats.sampling_rate)
 
 # Apply Konno-Ohmachi smoothing
-konno_smooth = konno_ohmachi_smoothing(amp_spec[0], freqs, normalize=True)
+konno_smooth = konno_ohmachi_smoothing(amp_spec, freqs, normalize=True)
 
 # Apply a Savitzky-Golay filter (a linear space smoother).
 savitzky_smooth = savgol_filter(amp_spec, 51, 3)

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
@@ -1,9 +1,9 @@
-import numpy as np
-
 import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import savgol_filter
+
 from obspy import read
 from obspy.signal.konnoohmachismoothing import konno_ohmachi_smoothing
-from scipy.signal import savgol_filter
 
 # Load sample data.
 st = read()

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_1.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+import matplotlib.pyplot as plt
+from obspy import read
+from obspy.signal.konnoohmachismoothing import konno_ohmachi_smoothing
+from scipy.signal import savgol_filter
+
+# Load sample data.
+st = read()
+tr = st[0].data
+
+# Get the amplitude spectra and corresponding frequencies.
+amp_spec = np.abs(np.fft.rfft(tr.data))
+freqs = np.fft.rfftfreq(len(tr.data), 1. / tr.stats.sampling_rate)
+
+# Apply Konno-Ohmachi smoothing
+konno_smooth = konno_ohmachi_smoothing(amp_spec[0], freqs, normalize=True)
+
+# Apply a Savitzky-Golay filter (a linear space smoother).
+savitzky_smooth = savgol_filter(amp_spec, 51, 3)
+
+# Plot using matplotlib.
+plt.loglog(freqs, amp_spec, label='raw data', c='0.5', alpha=.6)
+plt.loglog(freqs, savitzky_smooth, label='Savitzky Golay smoothing')
+plt.loglog(freqs, konno_smooth, label='Konno Ohmachi smoothing')
+plt.xlabel('frequency')
+plt.ylabel('amplitude')
+plt.legend()
+plt.show()

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_2.py
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_2.py
@@ -1,4 +1,6 @@
 import numpy as np
+import matplotlib.pyplot as plt
+import scipy.signal
 
 from obspy.signal.konnoohmachismoothing import konno_ohmachi_smoothing
 
@@ -7,19 +9,27 @@ random = np.random.RandomState(13)
 # Generate 20 minutes of random data at 100 Hz with 3 components.
 sampling_rate = 100
 number_of_components = 3
-seconds = 1200
+seconds = 20 * 60
 data = random.rand(number_of_components, sampling_rate * seconds)
 
+# Detrend the data
+detrended_data = scipy.signal.detrend(data, type='linear')
+
 # Get the amplitude spectra and corresponding frequencies.
-amp_spec = np.abs(np.fft.rfft(data))
+spectra = np.abs(np.fft.rfft(detrended_data))
 freqs = np.fft.rfftfreq(data.shape[-1], 1. / sampling_rate)
 
 # Define a subset of frequencies which are of interest.
-center_freqs = np.logspace(-3, 1, num=200)
+center_freqs = np.logspace(-2, 1, num=250)
 
 # Apply smoothing on all three channels.
-konno_smooth = konno_ohmachi_smoothing(
-    amp_spec, freqs, normalize=True, center_frequencies=center_freqs
+smooth_spectra = konno_ohmachi_smoothing(
+    spectra, freqs, normalize=True, center_frequencies=center_freqs
 )
 
-print(konno_smooth.shape)
+# Iterate and plot each smoothed spectrum.
+for smooth_spectrum in smooth_spectra:
+    plt.loglog(center_freqs, smooth_spectrum)
+plt.xlabel('frequency')
+plt.ylabel('amplitude')
+plt.show()

--- a/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_2.py
+++ b/misc/docs/source/tutorial/code_snippets/konno_ohmachi_smoothing_2.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from obspy.signal.konnoohmachismoothing import konno_ohmachi_smoothing
+
+random = np.random.RandomState(13)
+
+# Generate 20 minutes of random data at 100 Hz with 3 components.
+sampling_rate = 100
+number_of_components = 3
+seconds = 1200
+data = random.rand(number_of_components, sampling_rate * seconds)
+
+# Get the amplitude spectra and corresponding frequencies.
+amp_spec = np.abs(np.fft.rfft(data))
+freqs = np.fft.rfftfreq(data.shape[-1], 1. / sampling_rate)
+
+# Define a subset of frequencies which are of interest.
+center_freqs = np.logspace(-3, 1, num=200)
+
+# Apply smoothing on all three channels.
+konno_smooth = konno_ohmachi_smoothing(
+    amp_spec, freqs, normalize=True, center_frequencies=center_freqs
+)
+
+print(konno_smooth.shape)

--- a/misc/docs/source/tutorial/index.rst
+++ b/misc/docs/source/tutorial/index.rst
@@ -40,6 +40,7 @@ Introduction to ObsPy
    code_snippets/beamforming_fk_analysis
    code_snippets/seismogram_envelopes
    code_snippets/plotting_spectrograms
+   code_snippets/konno_ohmachi_smoothing
    code_snippets/trigger_tutorial
    code_snippets/frequency_response
    code_snippets/seismometer_correction_simulation

--- a/obspy/signal/konnoohmachismoothing.py
+++ b/obspy/signal/konnoohmachismoothing.py
@@ -167,7 +167,7 @@ def _smooth_no_matrix(spectra, frequencies, bandwidth, normalize, count,
     # Calculate length of output array and init it.
     output_shape = [len(center_frequencies)]
     if len(spectra.shape) > 1:
-        output_shape.append(spectra.shape[0])
+        output_shape.insert(0, spectra.shape[0])
     new_spec = np.empty(tuple(output_shape), spectra.dtype)
     # Separate case for just one spectrum.
     if len(spectra.shape) == 1:

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -138,10 +138,12 @@ class KonnoOhmachiTestCase(unittest.TestCase):
         # Test the non-matrix mode for single spectra.
         smoothed_4 = konno_ohmachi_smoothing(
             np.require(spectra[0], dtype=np.float64),
-            np.require(frequencies, dtype=np.float64))
+            np.require(frequencies, dtype=np.float64),
+            enforce_no_matrix=True)
         smoothed_5 = konno_ohmachi_smoothing(
             np.require(spectra[0], dtype=np.float64),
             np.require(frequencies, dtype=np.float64),
+            enforce_no_matrix=True,
             normalize=True)
         # The normalized and not normalized should not be the same. That the
         # normalizing works has been tested before.

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -39,11 +39,11 @@ class KonnoOhmachiTestCase(unittest.TestCase):
         st.detrend('linear')
         data_len = len(st[0].data)
         sampling_period = 1. / st[0].stats.sampling_rate
-        # create spectrum
+        # Create spectra.
         cycle = itertools.cycle([tr.data for tr in st])
         data = np.array([x for _, x in zip(range(n), cycle)])
         spectrum = np.abs(np.fft.rfft(data, axis=-1))
-        # determine corresponding frequencies and return
+        # Determine corresponding frequencies and return.
         freq = np.fft.rfftfreq(data_len, sampling_period)
         assert spectrum.shape[-1] == freq.shape[-1]
         return spectrum, freq

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -177,8 +177,10 @@ class KonnoOhmachiTestCase(unittest.TestCase):
         spectra, frequencies = self.get_default_spectra(3)
 
         # # test normalization with disabled matrix and enabled ones
-        smoothed_1 = konno_ohmachi_smoothing(spectra, frequencies, normalize=True)
-        smoothed_2 = konno_ohmachi_smoothing(spectra, frequencies, normalize=True,
+        smoothed_1 = konno_ohmachi_smoothing(spectra, frequencies,
+                                             normalize=True)
+        smoothed_2 = konno_ohmachi_smoothing(spectra, frequencies,
+                                             normalize=True,
                                              enforce_no_matrix=True)
         np.testing.assert_almost_equal(smoothed_1, smoothed_2, 5)
         # # test normalization with disabled matrix and enabled ones

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -165,11 +165,27 @@ class KonnoOhmachiTestCase(unittest.TestCase):
             np.require(frequencies, dtype=np.float64),
             enforce_no_matrix=True,
             normalize=True)
-        # The normalized and not normalized should not be the same. That the
-        # normalizing works has been tested before.
         self.assertFalse(np.all(smoothed_4 == smoothed_5))
         # Input dtype should be output dtype.
         self.assertEqual(smoothed_4.dtype, np.float64)
+
+    def test_smoothing_with_and_without_smoothing_matrix(self):
+        """
+        The results of smoothing wih enforce_no_matrix should be the same
+        as without.
+        """
+        spectra, frequencies = self.get_default_spectra(3)
+
+        # # test normalization with disabled matrix and enabled ones
+        smoothed_1 = konno_ohmachi_smoothing(spectra, frequencies, normalize=True)
+        smoothed_2 = konno_ohmachi_smoothing(spectra, frequencies, normalize=True,
+                                             enforce_no_matrix=True)
+        np.testing.assert_almost_equal(smoothed_1, smoothed_2, 5)
+        # # test normalization with disabled matrix and enabled ones
+        smoothed_1 = konno_ohmachi_smoothing(spectra, frequencies)
+        smoothed_2 = konno_ohmachi_smoothing(spectra, frequencies,
+                                             enforce_no_matrix=True)
+        np.testing.assert_almost_equal(smoothed_1, smoothed_2, 5)
 
     def test_downsample_with_center_frequencies(self):
         """


### PR DESCRIPTION
### What does this PR do?
This PR is a refactor of the `konnoohmachi` module of obspy.signal. It makes three main changes:

1) Uses `outer` methods of numpys ufuncs to allow for the creation of a smoothing matrices for many center frequencies in one function call.

2) Adds an optional `center_frequencies` argument to `konno_ohmachi_smoothing` function, allowing users to specify which frequencies should be returned in the smoothed spectra. This is very for smoothing large spectra.

3) Adds a check in the `konno_ohmachi_smoothing_window` function to raise a `ValueError` if any of the center frequencies fall outside of the original frequencies (smoothing should not be used for extrapolation).

4) Fix issue #2276 and added appropriate regression test. The incorrect validation data from the `test_calibration` module still need to be corrected.

### Why was it initiated?  Any relevant Issues?

It is rather expensive to perform smoothing on large spectra so this PR attempts alleviate the issues in two ways: 1) increasing the efficiency of the calculations through use of numpy ufuncs 2) providing the option to specify center frequencies to avoid calculating the smoothing matrix for every frequency.

Deciding on the correct branch was a bit tricky since this refactor contains both a bug fix and new features as part of the refactor.

### Profiling
The following details a few profiling tests comparing the old implementation to the new one. The new implementation generally improves performance except at very high spectra lengths where both the old and the new implementations start to take a very long time (~30 seconds). At such a point using the `center_frequencies` parameter (only in the new implementation) to produce a decimated smoothed spectra is probably the only viable option.

In the following tables each row specifies the length of the spectra (number of frequencies) and each column specifies the number of spectra. The first table shows the timing for the old implementation and the second table shows the timing for the old implementation divided by the timing for the new implementation (e.g. a value of 2 means the new implementation took half as long to run). 

Table 1: Old implementation timing

| len | 1 | 2 | 5 | 15
| -- | -- | -- | -- | -- |
| 10 | 0.000117 | 0.000118 | 0.000118 | 0.000119
| 146 | 0.002264 | 0.002225 | 0.002252 | 0.002225
| 2154 | 0.181074 | 0.160287 | 0.164341 | 0.187391
| 31622 | 26.916137 | 27.242449 | 27.410050 | 27.571355

Table 2: Old implementation timing divided by new implementation timing

| len | 1 | 2 | 5 | 15
| -- | -- | -- | -- | -- |
| 10 | 1.743923 | 1.747119 | 1.738653 | 1.725658
| 146 | 3.045648 | 2.990663 | 3.023273 | 2.968179
| 2154 | 1.083153 | 1.147373 | 1.157857 | 1.228814
| 31622 | 0.841593 | 0.831586 | 0.842629 | 0.854545

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
