### PR TITLE
Resource id rerefactor

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,11 @@ master:
    * Added __eq__ to QuantityError so empty instances equal None (see #2185).
    * Reworked the event scoped resource identifiers for the event classes
      hopefully fixing all edge-cases (see #2091).
+   * Fixed issue where resource_ids could refer to incorrect object if the
+     original object went out of scope and a new object shared the python
+     id of the old object (see #2278).
+   * Added a hook to allow users to customize finding objects for
+     resource_ids which are not found via the normal means (see #2279).
    * Calling Stream.write(...) on an empty stream will now raise an
      ObsPyException consistently across all I/O plugins (see #2201)
  - obspy.clients.fdsn:
@@ -37,7 +42,7 @@ master:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)
  - obspy.io.rg16:
-   * implement module to read waveforms and headers from fcnt format (see #2265). 
+   * implement module to read waveforms and headers from fcnt format (see #2265).
  - obspy.io.quakeml:
    * Allow writing invalid ids but raise a warning
      (see #2104, #2090, #2093, #1872).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,9 +17,6 @@ master:
    * Added __eq__ to QuantityError so empty instances equal None (see #2185).
    * Reworked the event scoped resource identifiers for the event classes
      hopefully fixing all edge-cases (see #2091).
-   * Fixed issue where resource_ids could refer to incorrect object if the
-     original object went out of scope and a new object shared the python
-     id of the old object (see #2278).
    * Added a hook to allow users to customize finding objects for
      resource_ids which are not found via the normal means (see #2279).
    * Calling Stream.write(...) on an empty stream will now raise an

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -578,6 +578,49 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             arrival.pick_id.get_referred_object()
         self.assertEqual(len(w), 0)
 
+    def test_issue_2278(self):
+        """
+        Tests for issue # 2278 which has to do with resource ids returning
+        the wrong objects when the bound object has gone out of scope and
+        a new object adopts the old object's python id.
+        """
+        # Create a simple class for resource_ids to refere to.
+        class Simple(object):
+
+            def __init__(self, value):
+                self.value = value
+
+        # keep track of objects, resource_ids, and used python ids
+        obj_list1, rid_list1, used_ids1 = [], [], set()
+        # create a slew of objects and resource_ids
+        for _ in range(100):
+            obj_list1.append(Simple(1))
+            used_ids1.add(id(obj_list1[-1]))
+        for obj in obj_list1:
+            rid_list1.append(ResourceIdentifier(referred_object=obj))
+        # delete objects and create second set
+        del obj_list1
+
+        # create another slew of objects and resource_ids. Some will reuse
+        # deleted object ids
+        obj_list2, rid_list2, used_ids2 = [], [], set()
+        for _ in range(100):
+            obj_list2.append(Simple(2))
+            used_ids2.add(id(obj_list2[-1]))
+        for obj in obj_list2:
+            rid_list2.append(ResourceIdentifier(referred_object=obj))
+
+        # since we cannot control which IDs python uses, skip the test if
+        # no overlapping ids were created.
+        if not used_ids1 & used_ids2:
+            self.skipTest('setup requires reuse of python ids')
+
+        # Iterate over first list of ids. Referred objects should be None
+        for rid in rid_list1:
+            # should raise a warning
+            with WarningsCapture():
+                self.assertIs(rid.get_referred_object(), None)
+
 
 def get_instances(obj, cls=None, is_attr=None, has_attr=None):
     """

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -20,7 +20,6 @@ import pickle
 import sys
 import unittest
 import warnings
-from collections import namedtuple
 
 from obspy import UTCDateTime, read_events
 from obspy.core import event as event
@@ -633,7 +632,6 @@ class ResourceIdentifierTestCase(unittest.TestCase):
 
         new_obj1 = MyClass()
         new_obj2 = MyClass()
-
 
         def _get_object_hook(arg):
             if str(arg) == '123':

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -590,6 +590,8 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             def __init__(self, value):
                 self.value = value
 
+        parent = Simple('parent1')
+
         # keep track of objects, resource_ids, and used python ids
         obj_list1, rid_list1, used_ids1 = [], [], set()
         # create a slew of objects and resource_ids
@@ -597,7 +599,8 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             obj_list1.append(Simple(1))
             used_ids1.add(id(obj_list1[-1]))
         for obj in obj_list1:
-            rid_list1.append(ResourceIdentifier(referred_object=obj))
+            kwargs = dict(referred_object=obj, parent=parent)
+            rid_list1.append(ResourceIdentifier(**kwargs))
         # delete objects and create second set
         del obj_list1
 
@@ -608,7 +611,8 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             obj_list2.append(Simple(2))
             used_ids2.add(id(obj_list2[-1]))
         for obj in obj_list2:
-            rid_list2.append(ResourceIdentifier(referred_object=obj))
+            kwargs = dict(referred_object=obj, parent=parent)
+            rid_list2.append(ResourceIdentifier(**kwargs))
 
         # since we cannot control which IDs python uses, skip the test if
         # no overlapping ids were created.


### PR DESCRIPTION
### What does this PR do?

This PR is yet another change to the `ResourceIdentifier` class. It does two things:

1) Fixes #2278 (which is a bug only found on the master branch).

2) Adds the ability for users to plug custom logic into `ResourceIdentifier` for returning objects with the `get_referred_object` method not found via the normal means.
 

### Why was it initiated?  Any relevant Issues?

#2278 

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
