### PR TITLE
Fix taup py37 failures

### DIFF
--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -481,8 +481,8 @@ class TauBranch(object):
     @staticmethod
     def _robust_resize(arr, new_size):
         """
-        Try to resize an array inplace. If an error is raised used numpy
-        resize function then return the array.
+        Try to resize an array inplace. If an error is raised use numpy
+        resize function to create a new array. Return the array.
         """
         try:
             arr.resize(new_size)

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -153,19 +153,15 @@ class TauBranch(object):
     def shift_branch(self, index):
         new_size = len(self.dist) + 1
 
-        try:
-            self.time.resize(new_size)
-        except ValueError:  # Value Error gets raised on py37, assume its ok
-            self.time.resize(new_size, refcheck=False)
-
+        self.time = self._robust_resize(self.time, new_size)
         self.time[index + 1:] = self.time[index:-1]
         self.time[index] = 0
 
-        self.dist.resize(new_size)
+        self.dist = self._robust_resize(self.dist, new_size)
         self.dist[index + 1:] = self.dist[index:-1]
         self.dist[index] = 0
 
-        self.tau.resize(new_size)
+        self.tau = self._robust_resize(self.tau, new_size)
         self.tau[index + 1:] = self.tau[index:-1]
         self.tau[index] = 0
 
@@ -481,3 +477,15 @@ class TauBranch(object):
                 arr_ = arr_[()]
             setattr(branch, key, arr_)
         return branch
+
+    @staticmethod
+    def _robust_resize(arr, new_size):
+        """
+        Try to resize an array inplace. If an error is raised used numpy
+        resize function then return the array.
+        """
+        try:
+            arr.resize(new_size)
+        except ValueError:
+            arr = np.resize(arr, new_size)
+        return arr

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -156,7 +156,7 @@ class TauBranch(object):
         try:
             self.time.resize(new_size)
         except ValueError:  # Value Error gets raised on py37, assume its ok
-            self.time.resize(refcheck=False)
+            self.time.resize(new_size, refcheck=False)
 
         self.time[index + 1:] = self.time[index:-1]
         self.time[index] = 0

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -153,7 +153,11 @@ class TauBranch(object):
     def shift_branch(self, index):
         new_size = len(self.dist) + 1
 
-        self.time.resize(new_size)
+        try:
+            self.time.resize(new_size)
+        except ValueError:  # Value Error gets raised on py37, assume its ok
+            self.time.resize(refcheck=False)
+
         self.time[index + 1:] = self.time[index:-1]
         self.time[index] = 0
 

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -8,6 +8,8 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
+import warnings
+
 import numpy as np
 
 from .c_wrappers import clibtau
@@ -487,5 +489,9 @@ class TauBranch(object):
         try:
             arr.resize(new_size)
         except ValueError:
+            msg = ('Resizing a TauP array inplace failed due to the existence'
+                   ' of other references to the array, creating a new array. '
+                   'See Obspy #2280.')
+            warnings.warn(msg)
             arr = np.resize(arr, new_size)
         return arr


### PR DESCRIPTION
### What does this PR do?
I am attempting to fix the python 3.7 TauP failure on Travis in the least invasive way possible. 

### Why was it initiated?  Any relevant Issues?
#2269 fixed a lot of failures on master but we weren't sure how to fix this one.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
