### PR TITLE
Steam/Trace almost_equal method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install:
   - conda info -a
   - |
       if [[ "$MINIMUM_DEPENDENCIES" == 'True' ]]; then
-        NUMPY="numpy=1.7.0"
+        NUMPY="numpy=1.7.2"
         SCIPY="scipy=0.11.0"
         MATPLOTLIB="matplotlib=1.1.1"
         # no basemap version works with this old numpy, so leave out

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install:
   - conda info -a
   - |
       if [[ "$MINIMUM_DEPENDENCIES" == 'True' ]]; then
-        NUMPY="numpy=1.6.2"
+        NUMPY="numpy=1.7.0"
         SCIPY="scipy=0.11.0"
         MATPLOTLIB="matplotlib=1.1.1"
         # no basemap version works with this old numpy, so leave out

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ master:
  - obspy.core:
    * Fixed "==" comparison for Stream and Trace which was very slow in case of
      traces with >1e6 samples (see #2377)
+   * Added almost_equal method for Stream and Trace classes (see #2286).
    * Casting FDSN identifiers to strings upon setting in the stats dictionary
      (see #1997).
    * UTCDateTime objects will now always evaluate equal if their string

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -662,7 +662,7 @@ class Stream(object):
         return self.__class__(traces=self.traces[max(0, i):max(0, j):k])
 
     def almost_equal(self, other, default_stats=True, rtol=1e-05, atol=1e-08,
-                     equal_nan=False):
+                     equal_nan=True):
         """
         Return True if the stream is approximately equal to another stream.
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -653,15 +653,17 @@ class Stream(object):
         # see also https://docs.python.org/3/reference/datamodel.html
         return self.__class__(traces=self.traces[max(0, i):max(0, j):k])
 
-    def almost_equal(self, other, processing=False, rtol=1e-05, atol=1e-08,
+    def almost_equal(self, other, default_stats=True, rtol=1e-05, atol=1e-08,
                      equal_nan=False):
         """
         Return True if the stream is approximately equal to another stream.
 
         :param other: Another :class:`~obspy.core.stream.Stream` object.
-        :param processing:
-            If True also compare the ``processing`` attribute of each trace's
-            :class:`~obspy.core.trace.Stats` object.
+        :param default_stats:
+            If True only compare the default stats on the traces, such as seed
+            identification codes, start/end times, sampling_rates, etc. If
+            False also compare extra stats attributes such as processing and
+            format specific information.
         :param rtol: The relative tolerance parameter passed to
             :func:`~numpy.allclose` for comparing time series.
         :param atol: The absolute tolerance parameter passed to
@@ -672,7 +674,7 @@ class Stream(object):
         :return: bool
         """
         # Kwargs to pass trace's almost_equal method.
-        tr_kwargs = dict(processing=processing, rtol=rtol, atol=atol,
+        tr_kwargs = dict(processing=default_stats, rtol=rtol, atol=atol,
                          equal_nan=equal_nan)
         # Ensure the streams are sorted (as done with the __equal__ method)
         self_sorted = self.select()

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -721,6 +721,9 @@ class Stream(object):
             >>> st1[0].data *= 10
             >>> assert not st1.almost_equal(st2)
         """
+        # Return False if other is not a stream or not the same length.
+        if not isinstance(other, Stream) or not len(self) == len(other):
+            return False
         # Kwargs to pass trace's almost_equal method.
         tr_kwargs = dict(default_stats=default_stats, rtol=rtol, atol=atol,
                          equal_nan=equal_nan)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -693,7 +693,7 @@ class Stream(object):
             >>> st2 = read()
             >>> # The traces should, of course, be equal.
             >>> assert st1 == st2
-            >>> # Perform detrending on st1 twice so that processing stats differ.
+            >>> # Perform detrending on st1 twice so processing stats differ.
             >>> st1 = st1.detrend('linear')
             >>> st1 = st1.detrend('linear')
             >>> st2 = st2.detrend('linear')

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -550,7 +550,7 @@ class Stream(object):
         This function strictly compares the data and stats objects of each
         trace contained by the streams. If less strict behavior is desired,
         which may be the case for testing, consider using the
-        :meth:`~obspy.core.stream.Stream.almost_equal` method.
+        :func:`~obspy.core.util.testing.stream_almost_equal` function.
 
         :type other: :class:`~obspy.core.stream.Stream`
         :param other: Stream object for comparison.
@@ -660,83 +660,6 @@ class Stream(object):
         """
         # see also https://docs.python.org/3/reference/datamodel.html
         return self.__class__(traces=self.traces[max(0, i):max(0, j):k])
-
-    def almost_equal(self, other, default_stats=True, rtol=1e-05, atol=1e-08,
-                     equal_nan=True):
-        """
-        Return True if the stream is approximately equal to another stream.
-
-        :param other: Another :class:`~obspy.core.stream.Stream` object.
-        :param default_stats:
-            If True only compare the default stats on the traces, such as seed
-            identification codes, start/end times, sampling_rates, etc. If
-            False also compare extra stats attributes such as processing and
-            format specific information.
-        :param rtol: The relative tolerance parameter passed to
-            :func:`~numpy.allclose` for comparing time series.
-        :param atol: The absolute tolerance parameter passed to
-            :func:`~numpy.allclose` for comparing time series.
-        :param equal_nan:
-            If ``True`` NaNs are evaluated equal when comparing the time
-            series.
-        :return: bool
-
-        .. rubric:: Example
-
-        1) Changes to the non-default parameters of the
-            :class:`~obspy.core.trace.Stats` objects of the stream's contained
-            :class:`~obspy.core.trace.Trace` objects will cause the streams to
-            be considered unequal, but they will be considered almost equal.
-
-            >>> from obspy import read
-            >>> st1 = read()
-            >>> st2 = read()
-            >>> # The traces should, of course, be equal.
-            >>> assert st1 == st2
-            >>> # Perform detrending on st1 twice so processing stats differ.
-            >>> st1 = st1.detrend('linear')
-            >>> st1 = st1.detrend('linear')
-            >>> st2 = st2.detrend('linear')
-            >>> # The traces are no longer equal, but are almost equal.
-            >>> assert st1 != st2
-            >>> assert st1.almost_equal(st2)
-
-
-        2) Slight differences in each trace's data will cause the streams
-            to be considered unequal, but they will be almost equal if the
-            differences don't exceed the limits set by the ``rtol`` and
-            ``atol`` parameters.
-
-            >>> from obspy import read
-            >>> st1 = read()
-            >>> st2 = read()
-            >>> # Perturb the trace data in st2 slightly.
-            >>> for tr in st2:
-            ...     tr.data *= (1 + 1e-6)
-            >>> # The streams are no longer equal.
-            >>> assert st1 != st2
-            >>> # But they are almost equal.
-            >>> assert st1.almost_equal(st2)
-            >>> # Unless, of course, there is a large change.
-            >>> st1[0].data *= 10
-            >>> assert not st1.almost_equal(st2)
-        """
-        # Return False if other is not a stream or not the same length.
-        if not isinstance(other, Stream) or not len(self) == len(other):
-            return False
-        # Kwargs to pass trace's almost_equal method.
-        tr_kwargs = dict(default_stats=default_stats, rtol=rtol, atol=atol,
-                         equal_nan=equal_nan)
-        # Ensure the streams are sorted (as done with the __equal__ method)
-        self_sorted = self.select()
-        self_sorted.sort()
-        other_sorted = other.select()
-        other_sorted.sort()
-        # Iterate over sorted trace pairs and determine they are almost equal.
-        for tr1, tr2 in zip(self_sorted, other_sorted):
-            if not tr1.almost_equal(tr2, **tr_kwargs):
-                return False  # If any are not almost equal return None.
-        return True
 
     def append(self, trace):
         """

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -653,6 +653,37 @@ class Stream(object):
         # see also https://docs.python.org/3/reference/datamodel.html
         return self.__class__(traces=self.traces[max(0, i):max(0, j):k])
 
+    def almost_equal(self, other, processing=False, rtol=1e-05, atol=1e-08,
+                     equal_nan=False):
+        """
+        Return True if the stream is approximately equal to another stream.
+
+        :param other: Another :class:`~obspy.core.stream.Stream` object.
+        :param processing:
+            If True also compare the ``processing`` attribute of each trace's
+            :class:`~obspy.core.trace.Stats` object.
+        :param rtol: The relative tolerance parameter passed to
+            :func:`~numpy.allclose` for comparing time series.
+        :param atol: The absolute tolerance parameter passed to
+            :func:`~numpy.allclose` for comparing time series.
+        :param equal_nan:
+            If ``True`` NaNs are evaluated equal when comparing the time
+            series.
+        :return: bool
+        """
+        # Kwargs to pass trace's almost_equal method.
+        tr_kwargs = dict(processing=processing, rtol=rtol, atol=atol,
+                         equal_nan=equal_nan)
+        # Ensure the streams are sorted (as done with the __equal__ method)
+        self_sorted = self.select()
+        self_sorted.sort()
+        other_sorted = other.select()
+        other_sorted.sort()
+        for tr1, tr2 in zip(self_sorted, other_sorted):
+            if not tr1.almost_equal(tr2, **tr_kwargs):
+                return False
+        return True
+
     def append(self, trace):
         """
         Append a single Trace object to the current Stream object.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -544,6 +544,14 @@ class Stream(object):
         """
         Implements rich comparison of Stream objects for "==" operator.
 
+        Trace order does not effect the comparison because the traces are
+        sorted beforehand.
+
+        This function strictly compares the data and stats objects of each
+        trace contained by the streams. If less strict behavior is desired,
+        which may be the case for testing, consider using the
+        :meth:`~obspy.core.stream.Stream.almost_equal` method.
+
         :type other: :class:`~obspy.core.stream.Stream`
         :param other: Stream object for comparison.
         :rtype: bool

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2656,21 +2656,6 @@ class StreamTestCase(unittest.TestCase):
             self.assertEqual(e.exception.args[0],
                              'Can not write empty stream to file.')
 
-    def test_almost_equal(self):
-        """
-        Basic tests for almost equal. More rigorous testing is done on the
-        Trace's almost_equal method, which gets called by this one.
-        """
-        # identical streams should be almost equal
-        st1, st2 = read(), read()
-        self.assertTrue(st1.almost_equal(st2))
-        # passing something other than a stream should not be almost equal
-        self.assertFalse(st1.almost_equal(None))
-        self.assertFalse(st1.almost_equal(1.1))
-        # passing streams of different lengths should not be almost equal
-        st2 = st2[1:]
-        self.assertFalse(st1.almost_equal(st2))
-
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2658,10 +2658,18 @@ class StreamTestCase(unittest.TestCase):
 
     def test_almost_equal(self):
         """
-        Identical Streams should be almost_equal.
+        Basic tests for almost equal. More rigorous testing is done on the
+        Trace's almost_equal method, which gets called by this one.
         """
+        # identical streams should be almost equal
         st1, st2 = read(), read()
         self.assertTrue(st1.almost_equal(st2))
+        # passing something other than a stream should not be almost equal
+        self.assertFalse(st1.almost_equal(None))
+        self.assertFalse(st1.almost_equal(1.1))
+        # passing streams of different lengths should not be almost equal
+        st2 = st2[1:]
+        self.assertFalse(st1.almost_equal(st2))
 
 
 def suite():

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2656,9 +2656,18 @@ class StreamTestCase(unittest.TestCase):
             self.assertEqual(e.exception.args[0],
                              'Can not write empty stream to file.')
 
+    def test_almost_equal(self):
+        """
+        Identical Streams should be almost_equal.
+        """
+        st1, st2 = read(), read()
+        self.assertTrue(st1.almost_equal(st2))
+
 
 def suite():
-    return unittest.makeSuite(StreamTestCase, 'test')
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(StreamTestCase, 'test'))
+    return suite
 
 
 if __name__ == '__main__':

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2740,93 +2740,9 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(tr_orig, tr_pickled)
 
 
-class AlmostEqualTestCase(unittest.TestCase):
-    """
-    Tests for fuzzy equality comparisons for traces.
-    """
-
-    def test_identical_traces(self):
-        """
-        Should return True on identical streams but false if a value is
-        greatly changed.
-        """
-        tr1, tr2 = read()[0], read()[0]
-        self.assertTrue(tr1.almost_equal(tr2))
-        # when one number is changed significantly it should return False
-        tr1.data[0] = (tr1.data[0] + 1) * 1000
-        self.assertFalse(tr1.almost_equal(tr2))
-
-    def test_slightly_modified_data(self):
-        """
-        Traces that are "close" should be considered almost equal.
-        """
-        tr1, tr2 = read()[0], read()[0]
-        # alter one trace's data slightly
-        tr1.data *= (1. + 1e-6)
-        self.assertTrue(tr1.almost_equal(tr2))
-
-    def test_empty_traces(self):
-        """
-        Empty traces should be considered almost equal.
-        """
-        tr1, tr2 = Trace(), Trace()
-        self.assertTrue(tr1.almost_equal(tr2))
-
-    def test_different_stats_no_processing(self):
-        """
-        If only the stats are different traces should not be considered almost
-        equal.
-        """
-        tr1 = Trace(header=dict(network='UU', station='TMU', channel='HHZ'))
-        tr2 = Trace(header=dict(network='UU', station='TMU', channel='HHN'))
-        self.assertFalse(tr1.almost_equal(tr2))
-        self.assertFalse(tr2.almost_equal(tr1))
-
-    def test_processing(self):
-        """
-        Differences in processing attr of stats should only count if
-        processing is True.
-        """
-        tr1, tr2 = read()[0], read()[0]
-        # Detrend each traces once, then second trace twice for two entries
-        # in processing.
-        tr1.detrend()
-        tr2.detrend()
-        tr1.detrend()
-        self.assertTrue(tr1.almost_equal(tr2, default_stats=True))
-        self.assertFalse(tr1.almost_equal(tr2, default_stats=False))
-
-    def test_nan(self):
-        """
-        Ensure NaNs eval equal if equal_nan is used, else they do not.
-        """
-        tr1, tr2 = read()[0], read()[0]
-        tr1.data[0], tr2.data[0] = np.NaN, np.NaN
-        self.assertTrue(tr1.almost_equal(tr2, equal_nan=True))
-        self.assertFalse(tr1.almost_equal(tr2, equal_nan=False))
-
-    def test_unequal_trace_lengths(self):
-        """
-        Ensure traces with different lengths are not almost equal.
-        """
-        tr1, tr2 = read()[0], read()[0]
-        tr2.data = tr2.data[:-1]
-        self.assertFalse(tr1.almost_equal(tr2))
-
-    def test_not_a_trace(self):
-        """
-        Ensure comparing to someething that is not a trace returns False.
-        """
-        tr1 = read()[0]
-        self.assertFalse(tr1.almost_equal(1))
-        self.assertFalse(tr1.almost_equal(None))
-        self.assertFalse(tr1.almost_equal('not a trace'))
-
-
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TraceTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(AlmostEqualTestCase, 'test'))
     return suite
 
 

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2740,8 +2740,59 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(tr_orig, tr_pickled)
 
 
+class AlmostEqualTestCase(unittest.TestCase):
+    """
+    Tests for fuzzy equality comparisons for traces.
+    """
+
+    def test_identical_traces(self):
+        """
+        Should return True on identical streams but false if a value is
+        greatly changed.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        self.assertTrue(tr1.almost_equal(tr2))
+        # when one number is changed significantly it should return False
+        tr1.data[0] = (tr1.data[0] + 1) * 1000
+        self.assertFalse(tr1.almost_equal(tr2))
+
+    def test_empty_traces(self):
+        """
+        Empty traces should be considered almost equal.
+        """
+        tr1, tr2 = Trace(), Trace()
+        self.assertTrue(tr1.almost_equal(tr2))
+
+    def test_different_stats_no_processing(self):
+        """
+        If only the stats are different traces should not be considered almost
+        equal.
+        """
+        tr1 = Trace(header=dict(network='UU', station='TMU', channel='HHZ'))
+        tr2 = Trace(header=dict(network='UU', station='TMU', channel='HHN'))
+        self.assertFalse(tr1.almost_equal(tr2))
+        self.assertFalse(tr2.almost_equal(tr1))
+
+    def test_processing(self):
+        """
+        Differences in processing attr of stats should only count if
+        processing is True.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        # Detrend each traces once, then second trace twice for two entries
+        # in processing.
+        tr1.detrend()
+        tr2.detrend()
+        tr1.detrend()
+        self.assertTrue(tr1.almost_equal(tr2, processing=False))
+        self.assertFalse(tr1.almost_equal(tr2, processing=True))
+
+
 def suite():
-    return unittest.makeSuite(TraceTestCase, 'test')
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TraceTestCase, 'test'))
+    suite.addTest(unittest.makeSuite(AlmostEqualTestCase, 'test'))
+    return suite
 
 
 if __name__ == '__main__':

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2796,6 +2796,32 @@ class AlmostEqualTestCase(unittest.TestCase):
         self.assertTrue(tr1.almost_equal(tr2, default_stats=True))
         self.assertFalse(tr1.almost_equal(tr2, default_stats=False))
 
+    def test_nan(self):
+        """
+        Ensure NaNs eval equal if equal_nan is used, else they do not.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        tr1.data[0], tr2.data[0] = np.NaN, np.NaN
+        self.assertTrue(tr1.almost_equal(tr2, equal_nan=True))
+        self.assertFalse(tr1.almost_equal(tr2, equal_nan=False))
+
+    def test_unequal_trace_lengths(self):
+        """
+        Ensure traces with different lengths are not almost equal.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        tr2.data = tr2.data[:-1]
+        self.assertFalse(tr1.almost_equal(tr2))
+
+    def test_not_a_trace(self):
+        """
+        Ensure comparing to someething that is not a trace returns False.
+        """
+        tr1 = read()[0]
+        self.assertFalse(tr1.almost_equal(1))
+        self.assertFalse(tr1.almost_equal(None))
+        self.assertFalse(tr1.almost_equal('not a trace'))
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2756,6 +2756,15 @@ class AlmostEqualTestCase(unittest.TestCase):
         tr1.data[0] = (tr1.data[0] + 1) * 1000
         self.assertFalse(tr1.almost_equal(tr2))
 
+    def test_slightly_modified_data(self):
+        """
+        Traces that are "close" should be considered almost equal.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        # alter one trace's data slightly
+        tr1.data *= (1. + 1e-6)
+        self.assertTrue(tr1.almost_equal(tr2))
+
     def test_empty_traces(self):
         """
         Empty traces should be considered almost equal.
@@ -2784,8 +2793,8 @@ class AlmostEqualTestCase(unittest.TestCase):
         tr1.detrend()
         tr2.detrend()
         tr1.detrend()
-        self.assertTrue(tr1.almost_equal(tr2, processing=False))
-        self.assertFalse(tr1.almost_equal(tr2, processing=True))
+        self.assertTrue(tr1.almost_equal(tr2, default_stats=True))
+        self.assertFalse(tr1.almost_equal(tr2, default_stats=False))
 
 
 def suite():

--- a/obspy/core/tests/test_util_testing.py
+++ b/obspy/core/tests/test_util_testing.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for obspy's testing utilities.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA
+
+import unittest
+
+import numpy as np
+
+from obspy import read, Trace
+from obspy.core.util.testing import streams_almost_equal, traces_almost_equal
+
+
+class AlmostEqualTestCase(unittest.TestCase):
+    """
+    Tests for fuzzy equality comparisons for traces.
+    """
+
+    def test_identical_traces(self):
+        """
+        Should return True on identical streams but false if a value is
+        greatly changed.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        self.assertTrue(traces_almost_equal(tr1, tr2))
+        # when one number is changed significantly it should return False
+        tr1.data[0] = (tr1.data[0] + 1) * 1000
+        self.assertFalse(traces_almost_equal(tr1, tr2))
+
+    def test_slightly_modified_data(self):
+        """
+        Traces that are "close" should be considered almost equal.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        # alter one trace's data slightly
+        tr1.data *= (1. + 1e-6)
+        self.assertTrue(traces_almost_equal(tr1, tr2))
+
+    def test_empty_traces(self):
+        """
+        Empty traces should be considered almost equal.
+        """
+        tr1, tr2 = Trace(), Trace()
+        self.assertTrue(traces_almost_equal(tr1, tr2))
+
+    def test_different_stats_no_processing(self):
+        """
+        If only the stats are different traces should not be considered almost
+        equal.
+        """
+        tr1 = Trace(header=dict(network='UU', station='TMU', channel='HHZ'))
+        tr2 = Trace(header=dict(network='UU', station='TMU', channel='HHN'))
+        self.assertFalse(traces_almost_equal(tr1, tr2))
+        self.assertFalse(traces_almost_equal(tr2, tr1))
+
+    def test_processing(self):
+        """
+        Differences in processing attr of stats should only count if
+        processing is True.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        # Detrend each traces once, then second trace twice for two entries
+        # in processing.
+        tr1.detrend()
+        tr2.detrend()
+        tr1.detrend()
+        self.assertTrue(traces_almost_equal(tr1, tr2, default_stats=True))
+        self.assertFalse(traces_almost_equal(tr1, tr2, default_stats=False))
+
+    def test_nan(self):
+        """
+        Ensure NaNs eval equal if equal_nan is used, else they do not.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        tr1.data[0], tr2.data[0] = np.NaN, np.NaN
+        self.assertTrue(traces_almost_equal(tr1, tr2, equal_nan=True))
+        self.assertFalse(traces_almost_equal(tr1, tr2, equal_nan=False))
+
+    def test_unequal_trace_lengths(self):
+        """
+        Ensure traces with different lengths are not almost equal.
+        """
+        tr1, tr2 = read()[0], read()[0]
+        tr2.data = tr2.data[:-1]
+        self.assertFalse(traces_almost_equal(tr1, tr2))
+
+    def test_not_a_trace(self):
+        """
+        Ensure comparing to someething that is not a trace returns False.
+        """
+        tr1 = read()[0]
+        self.assertFalse(traces_almost_equal(tr1, 1))
+        self.assertFalse(traces_almost_equal(tr1, None))
+        self.assertFalse(traces_almost_equal(tr1, 'not a trace'))
+
+    def test_stream_almost_equal(self):
+        """
+        Basic tests for almost equal. More rigorous testing is done on the
+        Trace's almost_equal method, which gets called by this one.
+        """
+        # identical streams should be almost equal
+        st1, st2 = read(), read()
+        self.assertTrue(streams_almost_equal(st1, st2))
+        # passing something other than a stream should not be almost equal
+        self.assertFalse(streams_almost_equal(st1, None))
+        self.assertFalse(streams_almost_equal(st1, 1.1))
+        # passing streams of different lengths should not be almost equal
+        st2 = st2[1:]
+        self.assertFalse(streams_almost_equal(st1, st2))
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(AlmostEqualTestCase, 'test'))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -819,7 +819,7 @@ class Trace(object):
         return out
 
     def almost_equal(self, tr, default_stats=True, rtol=1e-05, atol=1e-08,
-                     equal_nan=False):
+                     equal_nan=True):
         """
         Return True if the trace is approximately equal to another trace.
 
@@ -839,8 +839,11 @@ class Trace(object):
         :return: bool
         """
         # First compare the array values
-        all_close = np.allclose(self.data, tr.data, rtol=rtol, atol=atol,
-                                equal_nan=equal_nan)
+        try:  # Use equal_nan if available
+            all_close = np.allclose(self.data, tr.data, rtol=rtol, atol=atol,
+                                    equal_nan=equal_nan)
+        except TypeError:  # If on older version of numpy
+            all_close = np.allclose(self.data, tr.data, rtol=rtol, atol=atol)
         # Then compare the stats objects
         stats1 = _make_stats_dict(self, default_stats)
         stats2 = _make_stats_dict(tr, default_stats)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -843,8 +843,8 @@ class Trace(object):
             return False
         # First compare the array values
         try:  # Use equal_nan if available
-            all_close = np.allclose(self.data, other.data, rtol=rtol, atol=atol,
-                                    equal_nan=equal_nan)
+            all_close = np.allclose(self.data, other.data, rtol=rtol,
+                                    atol=atol, equal_nan=equal_nan)
         except TypeError:
             # This happens on very old versions of numpy. Essentially
             # we just need to handle NaN detection on our own, if equal_nan.

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -818,15 +818,17 @@ class Trace(object):
         out.data = data
         return out
 
-    def almost_equal(self, tr, processing=False, rtol=1e-05, atol=1e-08,
+    def almost_equal(self, tr, default_stats=True, rtol=1e-05, atol=1e-08,
                      equal_nan=False):
         """
         Return True if the trace is approximately equal to another trace.
 
         :param tr: Another :class:`~obspy.core.trace.Trace` object.
-        :param processing:
-            If True also compare the ``processing`` attribute of each trace's
-            :class:`~obspy.core.trace.Stats` object.
+        :param default_stats:
+            If True only compare the default stats on the traces, such as seed
+            identification codes, start/end times, sampling_rates, etc. If
+            False also compare extra stats attributes such as processing and
+            format specific information.
         :param rtol: The relative tolerance parameter passed to
             :func:`~numpy.allclose` for comparing time series.
         :param atol: The absolute tolerance parameter passed to
@@ -840,8 +842,8 @@ class Trace(object):
         all_close = np.allclose(self.data, tr.data, rtol=rtol, atol=atol,
                                 equal_nan=equal_nan)
         # Then compare the stats objects
-        stats1 = _make_stats_dict(self, processing)
-        stats2 = _make_stats_dict(tr, processing)
+        stats1 = _make_stats_dict(self, default_stats)
+        stats2 = _make_stats_dict(tr, default_stats)
         return all_close and stats1 == stats2
 
     def get_id(self):
@@ -2976,14 +2978,13 @@ def _data_sanity_checks(value):
         raise ValueError(msg)
 
 
-def _make_stats_dict(tr, processing):
+def _make_stats_dict(tr, default_stats):
     """
     Return a dict of stats from trace optionally including processing.
     """
-    out = {i: v for i,v in tr.stats.items() if i != 'processing'}
-    if processing:
-        out['processing'] = getattr(tr.stats, 'processing', None)
-    return out
+    if not default_stats:
+        return dict(tr.stats)
+    return {i: tr.stats[i] for i in Stats.defaults}
 
 
 if __name__ == '__main__':

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -818,47 +818,6 @@ class Trace(object):
         out.data = data
         return out
 
-    def almost_equal(self, other, default_stats=True, rtol=1e-05, atol=1e-08,
-                     equal_nan=True):
-        """
-        Return True if the trace is approximately equal to another trace.
-
-        :param other: Another :class:`~obspy.core.trace.Trace` object.
-        :param default_stats:
-            If True only compare the default stats on the traces, such as seed
-            identification codes, start/end times, sampling_rates, etc. If
-            False also compare extra stats attributes such as processing and
-            format specific information.
-        :param rtol: The relative tolerance parameter passed to
-            :func:`~numpy.allclose` for comparing time series.
-        :param atol: The absolute tolerance parameter passed to
-            :func:`~numpy.allclose` for comparing time series.
-        :param equal_nan:
-            If ``True`` NaNs are evaluated equal when comparing the time
-            series.
-        :return: bool
-        """
-        # If other isnt  a trace, or data is not the same len return False.
-        if not isinstance(other, Trace) or len(self.data) != len(other.data):
-            return False
-        # First compare the array values
-        try:  # Use equal_nan if available
-            all_close = np.allclose(self.data, other.data, rtol=rtol,
-                                    atol=atol, equal_nan=equal_nan)
-        except TypeError:
-            # This happens on very old versions of numpy. Essentially
-            # we just need to handle NaN detection on our own, if equal_nan.
-            is_close = np.isclose(self.data, other.data, rtol=rtol, atol=atol)
-            if equal_nan:
-                isnan = np.isnan(self.data) & np.isnan(other.data)
-            else:
-                isnan = np.zeros(self.data.shape).astype(bool)
-            all_close = np.all(isnan | is_close)
-        # Then compare the stats objects
-        stats1 = _make_stats_dict(self, default_stats)
-        stats2 = _make_stats_dict(other, default_stats)
-        return all_close and stats1 == stats2
-
     def get_id(self):
         """
         Return a SEED compatible identifier of the trace.
@@ -2989,15 +2948,6 @@ def _data_sanity_checks(value):
         msg = ("NumPy array for Trace.data has bad shape ('%s'). Only 1-d "
                "arrays are allowed for initialization.") % str(value.shape)
         raise ValueError(msg)
-
-
-def _make_stats_dict(tr, default_stats):
-    """
-    Return a dict of stats from trace optionally including processing.
-    """
-    if not default_stats:
-        return dict(tr.stats)
-    return {i: tr.stats[i] for i in Stats.defaults}
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -1089,7 +1089,7 @@ def streams_almost_equal(st1, st2, default_stats=True, rtol=1e-05, atol=1e-08,
         >>> st2 = st2.detrend('linear')
         >>> # The traces are no longer equal, but are almost equal.
         >>> assert st1 != st2
-        >>> assert st1.almost_equal(st2)
+        >>> assert streams_almost_equal(st1, st2)
 
 
     2) Slight differences in each trace's data will cause the streams
@@ -1106,10 +1106,10 @@ def streams_almost_equal(st1, st2, default_stats=True, rtol=1e-05, atol=1e-08,
         >>> # The streams are no longer equal.
         >>> assert st1 != st2
         >>> # But they are almost equal.
-        >>> assert st1.almost_equal(st2)
+        >>> assert streams_almost_equal(st1, st2)
         >>> # Unless, of course, there is a large change.
         >>> st1[0].data *= 10
-        >>> assert not st1.almost_equal(st2)
+        >>> assert not streams_almost_equal(st1, st2)
     """
     from obspy.core.stream import Stream
     # Return False if both objects are not streams or not the same length.

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -20,6 +20,7 @@ import numpy as np
 from obspy import Trace, UTCDateTime, read, read_inventory
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.core.util.misc import SuppressOutput
+from obspy.core.util.testing import traces_almost_equal
 from obspy.io.sac import attach_paz
 from obspy.signal.headers import clibevresp
 from obspy.signal.invsim import (
@@ -428,8 +429,7 @@ class InvSimTestCase(unittest.TestCase):
         seedresp['filename'] = stringio
         tr2.data = simulate_seismometer(tr2.data, tr2.stats.sampling_rate,
                                         seedresp=seedresp)
-
-        self.assertTrue(tr1.almost_equal(tr2))
+        self.assertTrue(traces_almost_equal(tr1, tr2))
 
     def test_segfaulting_resp_file(self):
         """

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -429,7 +429,7 @@ class InvSimTestCase(unittest.TestCase):
         tr2.data = simulate_seismometer(tr2.data, tr2.stats.sampling_rate,
                                         seedresp=seedresp)
 
-        self.assertEqual(tr1, tr2)
+        self.assertTrue(tr1.almost_equal(tr2))
 
     def test_segfaulting_resp_file(self):
         """


### PR DESCRIPTION
### What does this PR do?
This PR adds the `almost_equal` method to the `obspy.Stream` and `obspy.Trace` class definitions. These methods allow for a less strict comparison of waveform data in two ways:

1) Optionally, only the default parameters of stats objects are used in the comparisons. This is controlled by the `default_stats` parameter. In my experience the `processing` attribute can sometimes differ slightly between two steams that are otherwise identical, in which case it may still be desirable to consider them equal.

2) The numpy arrays of the traces are compared as "close" using the function `numpy.allclose`. This allows the user to specify relative and absolute tolerances for comparison using the `atol` and `rtol` parameters.  

### Why was it initiated?  Any relevant Issues?

This feature request was mentioned in #2269, and probably in other places before that. It will primarily be useful for obspy's test suite but may find usages in obspy-related projects as well. It will hopefully fix the windows issues the CI is running into.

It would be nice to implement an option that would raise an error if two streams/traces are not equal with a nice message explaining the differences, but that would require a little more energy/time than I currently have so it may be best left for a future PR. 

I am not 100% satisfied with the method name, so if anyone has other ideas please share.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .

+DOCS