### PR TITLE
Pass SAC byteorder flag correctly

### DIFF
--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -354,7 +354,7 @@ def _read_sac(filename, headonly=False, debug_headers=False, fsize=True,
 
 
 def _internal_read_sac(buf, headonly=False, debug_headers=False, fsize=True,
-                       **kwargs):  # @UnusedVariable
+                       byteorder=None, **kwargs):  # @UnusedVariable
     """
     Reads an SAC file and returns an ObsPy Stream object.
 
@@ -377,6 +377,11 @@ def _internal_read_sac(buf, headonly=False, debug_headers=False, fsize=True,
     :param fsize: Check if file size is consistent with theoretical size
         from header. Defaults to ``True``.
     :type fsize: bool
+    :param byteorder: If omitted or None, automatic byte-order checking is
+        done, starting with native order. If byteorder is specified and
+        incorrect, a :class:`SacIOError` is raised. Only valid for binary
+        files.
+    :type byteorder: str {'little', 'big'}, optional
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: A ObsPy Stream object.
     """
@@ -386,7 +391,8 @@ def _internal_read_sac(buf, headonly=False, debug_headers=False, fsize=True,
 
     # read SAC file
     sac = SACTrace.read(buf, headonly=headonly, ascii=False,
-                        checksize=fsize, encoding=encoding_str)
+                        byteorder=byteorder, checksize=fsize,
+                        encoding=encoding_str)
     # assign all header entries to a new dictionary compatible with an ObsPy
     tr = sac.to_obspy_trace(debug_headers=debug_headers, encoding=encoding_str)
 


### PR DESCRIPTION
### What does this PR do?

This correctly passes the `byteorder` keyword argument from `obspy.read(..., format='SAC')` through `_internal_read_sac` to `SACTrace.read`.

### Why was it initiated?  Any relevant Issues?

~~Follows #2285~~ . Closes #2285

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
