### PR TITLE
Maintenance 1.1.x: fix divide by zero exception issue #2293

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -53,6 +53,7 @@ Lopes, Rui L.
 MacCarthy, Jonathan
 Maggi, Alessia
 Martin, Henri
+Medlin, Andrew
 Megies, Tobias
 Meschede, Matthias
 Michelini, Alberto

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -407,7 +407,9 @@ def _read_channel(inventory_root, cha_element, _ns):
     numerator = _tag2obj(cha_element, _ns("sampleRateNumerator"), int)
     denominator = _tag2obj(cha_element, _ns("sampleRateDenominator"), int)
 
-    rate = numerator / denominator
+    # If numerator is zero, set rate to zero irrespective of the denominator.
+    # If numerator is non-zero and denominator zero, will raise ZeroDivisionError.
+    rate = numerator / denominator if numerator != 0 else 0
 
     channel.sample_rate_ratio_number_samples = numerator
     channel.sample_rate_ratio_number_seconds = denominator

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -408,7 +408,8 @@ def _read_channel(inventory_root, cha_element, _ns):
     denominator = _tag2obj(cha_element, _ns("sampleRateDenominator"), int)
 
     # If numerator is zero, set rate to zero irrespective of the denominator.
-    # If numerator is non-zero and denominator zero, will raise ZeroDivisionError.
+    # If numerator is non-zero and denominator zero, will raise
+    # ZeroDivisionError.
     rate = numerator / denominator if numerator != 0 else 0
 
     channel.sample_rate_ratio_number_samples = numerator

--- a/obspy/io/seiscomp/tests/data/channel_level.sc3ml
+++ b/obspy/io/seiscomp/tests/data/channel_level.sc3ml
@@ -386,8 +386,8 @@
             <dataloggerChannel>0</dataloggerChannel>
             <sensorSerialNumber>yyyy</sensorSerialNumber>
             <sensorChannel>0</sensorChannel>
-            <sampleRateNumerator>40</sampleRateNumerator>
-            <sampleRateDenominator>1</sampleRateDenominator>
+            <sampleRateNumerator>0</sampleRateNumerator>
+            <sampleRateDenominator>0</sampleRateDenominator>
             <depth>4</depth>
             <azimuth>0</azimuth>
             <dip>-90</dip>


### PR DESCRIPTION
### What does this PR do?

When computing the sampling rate while parsing channel data from sc3ml file, if the numerator of the sampling rate is zero then the sampling rate is set to zero regardless of the denominator value. This means that in the special case when both the numerator and denominator are zero, we safely assign zero (new behavior), but if the numerator is non-zero we compute numerator/denominator (same as previous behavior). 

This logic preserves the existing behavior of raising a ZeroDivisionError if the denominator is zero and the numerator is non-zero.

### Why was it initiated?  Any relevant Issues?

Some station metadata delivered by the IRIS web service contains zero values for the numerator and denominator of the channel sampling rate. Trying to ingest such data into obspy was crashing obspy while in read_inventory. Closes #2293 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.  (except those already failing in the branch)
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
