### PR TITLE
Fix trimming waveforms after fetching from FDSN Client

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,9 @@ master:
      have been deselected due to the default location priorities setting. This
      is a pure usability improvement as it has been confusing users
      (see #2159).
+   * make sure that streams fetched via FDSN are properly trimmed to user
+     requested times if data center serves additional data around the start/end
+     (see #1887, #2298)
  - obspy.io.nordic:
    * Add ability to read and write focal mechanisms and moment tensor
      information. (see #1924)

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -60,6 +60,7 @@ Meschede, Matthias
 Michelini, Alberto
 Miller, Nathaniel C.
 Morgenstern, Bernhard
+Murray-Bergquist, Louisa
 Nof, Ran Novitsky
 Panning, Mark P.
 Rapagnani, Giovanni

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -839,6 +839,7 @@ class Client(object):
             if attach_response:
                 self._attach_responses(st)
             self._attach_dataselect_url_to_stream(st)
+            st.trim(starttime,endtime)
             return st
 
     def _attach_responses(self, st):

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -839,7 +839,7 @@ class Client(object):
             if attach_response:
                 self._attach_responses(st)
             self._attach_dataselect_url_to_stream(st)
-            st.trim(starttime,endtime)
+            st.trim(starttime, endtime)
             return st
 
     def _attach_responses(self, st):

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -308,7 +308,18 @@ class ClientTestCase(unittest.TestCase):
         """
         Fixes #1887
         """
-        self.assertEqual(1, 0)
+        from obspy.clients import fdsn
+        c = fdsn.client.Client(
+            service_mappings={'dataselect': \
+                    'http://eida.ipgp.fr/fdsnws/dataselect/1'}, debug=True)
+        starttime=UTCDateTime('2016-11-01T00:00:00')
+        endtime=UTCDateTime('2016-11-01T00:00:10')
+        stream = c.get_waveforms('G', 'PEL', '*', 'LHZ', starttime,endtime)
+        trace = stream[0]
+        t1= trace.stats.starttime
+        t2= trace.stats.endtime
+        self.assertEqual(starttime, t1)
+        self.assertEqual(endtime,t2)
 
     def test_service_discovery_iris(self):
         """

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -311,16 +311,12 @@ class ClientTestCase(unittest.TestCase):
         """
         c = Client(
             service_mappings={'dataselect':
-                              'http://eida.ipgp.fr/fdsnws/dataselect/1'},
-            debug=True)
+                              'http://eida.ipgp.fr/fdsnws/dataselect/1'})
         starttime = UTCDateTime('2016-11-01T00:00:00')
         endtime = UTCDateTime('2016-11-01T00:00:10')
         stream = c.get_waveforms('G', 'PEL', '*', 'LHZ', starttime, endtime)
-        trace = stream[0]
-        t1 = trace.stats.starttime
-        t2 = trace.stats.endtime
-        self.assertEqual(starttime, t1)
-        self.assertEqual(endtime, t2)
+        self.assertEqual(starttime, stream[0].stats.starttime)
+        self.assertEqual(endtime, stream[0].stats.endtime)
 
     def test_service_discovery_iris(self):
         """

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -306,20 +306,21 @@ class ClientTestCase(unittest.TestCase):
 
     def test_trim_stream_after_get_waveform(self):
         """
-        Fixes #1887
+        Tests that stream is properly trimmed to user requested times after
+        fetching from datacenter, see #1887
         """
-        from obspy.clients import fdsn
-        c = fdsn.client.Client(
-            service_mappings={'dataselect': \
-                    'http://eida.ipgp.fr/fdsnws/dataselect/1'}, debug=True)
-        starttime=UTCDateTime('2016-11-01T00:00:00')
-        endtime=UTCDateTime('2016-11-01T00:00:10')
-        stream = c.get_waveforms('G', 'PEL', '*', 'LHZ', starttime,endtime)
+        c = Client(
+            service_mappings={'dataselect':
+                              'http://eida.ipgp.fr/fdsnws/dataselect/1'},
+            debug=True)
+        starttime = UTCDateTime('2016-11-01T00:00:00')
+        endtime = UTCDateTime('2016-11-01T00:00:10')
+        stream = c.get_waveforms('G', 'PEL', '*', 'LHZ', starttime, endtime)
         trace = stream[0]
-        t1= trace.stats.starttime
-        t2= trace.stats.endtime
+        t1 = trace.stats.starttime
+        t2 = trace.stats.endtime
         self.assertEqual(starttime, t1)
-        self.assertEqual(endtime,t2)
+        self.assertEqual(endtime, t2)
 
     def test_service_discovery_iris(self):
         """

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -304,6 +304,12 @@ class ClientTestCase(unittest.TestCase):
         # queryauth)
         self.assertEqual(client.user, user)
 
+    def test_trim_stream_after_get_waveform(self):
+        """
+        Fixes #1887
+        """
+        self.assertEqual(1, 0)
+
     def test_service_discovery_iris(self):
         """
         Tests the automatic discovery of services with the IRIS endpoint. The


### PR DESCRIPTION
### What does this PR do?

Fixes trimming of waveforms fetched from FDSN clients to make sure start/endtimes match what user requested and no additional data is present around given time span.

### Why was it initiated?  Any relevant Issues?

Fixes #1887 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
