### PR TITLE
Changed Stream.get_gaps() to identify gaps within masked Traces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ install:
   # "conda install -c conda-forge --no-update-dependencies pyshp", because the
   # pyshp conda package lists 0 dependencies, anyway, so use "--no-deps" to
   # really avoid installing/updating any other packages
-  - conda install -c conda-forge --no-update-dependencies --no-deps pyshp
+  - conda install -c conda-forge --no-update-deps --no-deps pyshp
   # install packages not available via conda
   - pip install codecov
   - pip install geographiclib

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,8 +21,9 @@ master:
      resource_ids which are not found via the normal means (see #2279).
    * Calling Stream.write(...) on an empty stream will now raise an
      ObsPyException consistently across all I/O plugins (see #2201)
-   * Stream.get_gaps() will now check for gaps within Traces that have masked
-     arrays (i.e., Traces that have been merged without a fill value).
+   * Stream.get_gaps() will now properly report gaps within Traces that
+     have masked arrays (i.e. Traces that have been merged without a fill
+     value, see #2299 and #2300).
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,7 +21,8 @@ master:
      resource_ids which are not found via the normal means (see #2279).
    * Calling Stream.write(...) on an empty stream will now raise an
      ObsPyException consistently across all I/O plugins (see #2201)
-   * Stream.get_gaps() will now check for gaps within previously merged Traces.
+   * Stream.get_gaps() will now check for gaps within Traces that have masked
+     arrays (i.e., Traces that have been merged without a fill value).
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ master:
      resource_ids which are not found via the normal means (see #2279).
    * Calling Stream.write(...) on an empty stream will now raise an
      ObsPyException consistently across all I/O plugins (see #2201)
+   * Stream.get_gaps() will now check for gaps within previously merged Traces.
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -10,6 +10,7 @@ Bernardi, Fabrizio
 Bernauer, Felix
 Bes de Berc, Maxime
 Beyreuther, Moritz
+Boltz, Shawn
 Bonaimé, Sébastien
 Carothers, Lloyd
 Chamberlain, Calum

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -796,7 +796,8 @@ class Stream(object):
         self.sort()
         gap_list = []
         for _i in range(len(self.traces)):
-            # if the trace is masked, break it up and run get_gaps on the stream
+            # if the trace is masked, break it up and run get_gaps on the 
+            # stream
             if isinstance(self.traces[_i].data, np.ma.masked_array):
                 gap_list.extend(self.traces[_i].split().get_gaps())
             if _i + 1 == len(self.traces):

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -795,7 +795,13 @@ class Stream(object):
         copied_traces = copy.copy(self.traces)
         self.sort()
         gap_list = []
-        for _i in range(len(self.traces) - 1):
+        for _i in range(len(self.traces)):
+            # if the trace is masked, break it up and run get_gaps on the stream
+            if isinstance(self.traces[_i].data, np.ma.masked_array):
+                gap_list.extend(self.traces[_i].split().get_gaps())
+            if _i + 1 == len(self.traces):
+                # reached the last trace
+                break
             # skip traces with different network, station, location or channel
             if self.traces[_i].id != self.traces[_i + 1].id:
                 continue

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -758,7 +758,7 @@ class Stream(object):
 
         Please be aware that no sorting and checking of stations, channels, ...
         is done. This method only compares the start and end times of the
-        Traces.
+        Traces and gaps within Traces.
 
         .. rubric:: Example
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -758,7 +758,8 @@ class Stream(object):
 
         Please be aware that no sorting and checking of stations, channels, ...
         is done. This method only compares the start and end times of the
-        Traces and gaps within Traces.
+        Traces and the start and end times of segments within Traces that contain
+        masked arrays (i.e., Traces that were merged without a fill value).
 
         .. rubric:: Example
 
@@ -796,8 +797,8 @@ class Stream(object):
         self.sort()
         gap_list = []
         for _i in range(len(self.traces)):
-            # if the trace is masked, break it up and run get_gaps on the 
-            # stream
+            # if the trace is masked, break it up and run get_gaps on the
+            # resulting stream
             if isinstance(self.traces[_i].data, np.ma.masked_array):
                 gap_list.extend(self.traces[_i].split().get_gaps())
             if _i + 1 == len(self.traces):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -363,6 +363,33 @@ class StreamTestCase(unittest.TestCase):
             st.append(Trace(data=data, header={'network': network}))
         self.assertEqual(len(st.get_gaps()), 0)
 
+    def test_get_gaps_masked(self):
+        """
+        Test get_gaps method of the Stream objects (Issue #2299)
+        """
+        # Create a Stream with a masked array (analogous to a merged Stream)
+        st = Stream()
+        data = np.ma.array(np.arange(0, 100, step=1))
+        data.mask = np.zeros(data.shape)
+        data.mask[50:60] = 1
+        st.append(Trace(data=data))
+        # Expected gap
+        gap = ["", "", "", "",
+               UTCDateTime(1970, 1, 1, 0, 0, 49),
+               UTCDateTime(1970, 1, 1, 0, 1, 0),
+               10., 10]
+        # Get the gaps
+        gaps = st.get_gaps()
+        # Assert the number of gaps
+        self.assertEqual(len(gaps), 1)
+        # Verify the resulting gap list matches what is expected
+        for _i in range(6):
+            self.assertEqual(gaps[0][_i], gap[_i])
+        self.assertAlmostEqual(float(gaps[0][6]), float(gap[6]), places=3)
+        self.assertAlmostEqual(float(gaps[0][7]), float(gap[7]))
+        # Double-check that the initial Stream is unmodified
+        self.assertEqual(len(st), 1)
+
     def test_pop(self):
         """
         Test the pop method of the Stream object.


### PR DESCRIPTION
### What does this PR do?
This PR adds logic to `Stream.get_gaps()` to identify gaps in Streams that have Traces with masked arrays (previously merged Streams).

### Why was it initiated?  Any relevant Issues?
This PR was initiated to address issue #2299.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
