### PR TITLE
Deprecate ResourceIdentifier methods which mutate resource string

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,10 @@ master:
    * Modified stream.get_gaps() to deal with overlaps correctly (see #1403)
    * Added option "label_epoch_dates" to Inventory/Network.plot_response() to
      optionally add channel epoch start/end dates to legend labels (see #2309)
+   * Deprecated the convert_id_to_quakeml_uri, regenerate_uuid, and
+     get_quakeml_uri methods of the ResourceIdentifier class (see #2303).
+   * Added get_quakeml_uri_str and get_quakeml_id methods to the
+     ResourceIdentifier class (see #2303).
  - obspy.clients.fdsn:
    * Add new `_discover_services` boolean flag to the Client, which allows the
      Client to skip the initial services query at instantiation.  This can

--- a/obspy/core/event/resourceid.py
+++ b/obspy/core/event/resourceid.py
@@ -21,6 +21,8 @@ from copy import deepcopy
 from uuid import uuid4
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
+from obspy.core.util.decorator import deprecated
+
 
 class _ResourceKey(object):
     """
@@ -459,27 +461,71 @@ class ResourceIdentifier(object):
             id_order[self._resource_key] = []
         id_order[self._resource_key].append(self._object_key)
 
+    @deprecated()
     def convert_id_to_quakeml_uri(self, authority_id="local"):
         """
         Converts the current ID to a valid QuakeML URI.
 
+        This method is deprecated, use get_quakeml_id instead.
+
         Only an invalid QuakeML ResourceIdentifier string it will be converted
         to a valid one.  Otherwise nothing will happen but after calling this
         method the user can be sure that the ID is a valid QuakeML URI.
+
         The resulting ID will be of the form
             smi:authority_id/prefix/resource_id
+
         :type authority_id: str, optional
         :param authority_id: The base url of the resulting string. Defaults to
             ``"local"``.
         """
-        self.id = self.get_quakeml_uri(authority_id=authority_id)
+        self.id = self.get_quakeml_uri_str(authority_id=authority_id)
 
+    def get_quakeml_id(self, authority_id="local"):
+        """
+        Returns a resource id with a valid QuakeML URI.
+
+        Only an invalid QuakeML ResourceIdentifier string it will be converted
+        to a valid one.  Otherwise the returned resource id will be identical
+        to the original.
+
+        The new resource id will have the same referred object as the
+        original.
+
+        The resulting ID will be of the form
+            smi:authority_id/prefix/resource_id
+
+        :type authority_id: str, optional
+        :param authority_id: The base url of the resulting string. Defaults to
+            ``"local"``.
+        :return: A new ResourceIdentifier instance with a valid quakeml uri.
+        """
+        new_id = self.get_quakeml_uri_str(authority_id=authority_id)
+        rid = ResourceIdentifier(new_id)
+        referred_obj = self.get_referred_object()
+        if referred_obj is not None:
+            rid.set_referred_object(referred_obj, warn=False,
+                                    parent=self._parent_key)
+        return rid
+
+    @deprecated()
     def get_quakeml_uri(self, authority_id="local"):
         """
-        Returns the ID as a valid QuakeML URI if possible. Does not
-        change the ID itself.
+        Deprecated, use get_quakeml_uri_str instead.
+        """
+        return self.get_quakeml_uri_str(authority_id=authority_id)
+
+    def get_quakeml_uri_str(self, authority_id="local"):
+        """
+        Returns the ID as a valid QuakeML URI if possible else raise ValueError.
+
+        :type authority_id: str, optional
+        :param authority_id: The base url of the resulting string. Defaults to
+            ``"local"``.
+        :return: A new ResourceIdentifier instance with a valid quakeml uri.
+
         >>> res_id = ResourceIdentifier("some_id")
-        >>> print(res_id.get_quakeml_uri())
+        >>> print(res_id.get_quakeml_uri_str())
         smi:local/some_id
         >>> # Did not change the actual resource id.
         >>> print(res_id.id)
@@ -664,6 +710,7 @@ class ResourceIdentifier(object):
     # return the referred object, if in scope, else None.
     __call__ = get_referred_object
 
+    @deprecated()
     def regenerate_uuid(self):
         """
         Regenerates the uuid part of the ID. Does nothing for resource

--- a/obspy/core/event/resourceid.py
+++ b/obspy/core/event/resourceid.py
@@ -517,7 +517,9 @@ class ResourceIdentifier(object):
 
     def get_quakeml_uri_str(self, authority_id="local"):
         """
-        Returns the ID as a valid QuakeML URI if possible else raise ValueError.
+        Returns an id with a valid QuakeML URI.
+
+        If no valid QuakeML is possible a ValueError is raised.
 
         :type authority_id: str, optional
         :param authority_id: The base url of the resulting string. Defaults to

--- a/obspy/core/event/resourceid.py
+++ b/obspy/core/event/resourceid.py
@@ -466,7 +466,7 @@ class ResourceIdentifier(object):
         """
         Converts the current ID to a valid QuakeML URI.
 
-        This method is deprecated, use get_quakeml_id instead.
+        This method is deprecated, use :meth:`get_quakeml_id` instead.
 
         Only an invalid QuakeML ResourceIdentifier string it will be converted
         to a valid one.  Otherwise nothing will happen but after calling this
@@ -511,7 +511,7 @@ class ResourceIdentifier(object):
     @deprecated()
     def get_quakeml_uri(self, authority_id="local"):
         """
-        Deprecated, use get_quakeml_uri_str instead.
+        This method is deprecated, use :meth:`get_quakeml_uri_str` instead.
         """
         return self.get_quakeml_uri_str(authority_id=authority_id)
 

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -25,6 +25,7 @@ from obspy import UTCDateTime, read_events
 from obspy.core import event as event
 from obspy.core.event.resourceid import ResourceIdentifier, _ResourceKey
 from obspy.core.util.misc import _yield_obj_parent_attr
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.core.util.testing import (create_diverse_catalog,
                                      setup_context_testcase,
                                      WarningsCapture)
@@ -183,28 +184,28 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             "1234567890-.*()_~'/abcdefghijklmnopqrstuvwxyzABCDEFGHIKLMNOPQR"
             "STUVWXYZ0123456789-.*()_~'+?=,;&")
         res = ResourceIdentifier(res_id)
-        self.assertEqual(res_id, res.get_quakeml_uri())
+        self.assertEqual(res_id, res.get_quakeml_uri_str())
         # The id has to valid from start to end. Due to the spaces this cannot
         # automatically be converted to a correct one.
         res_id = "something_before smi:local/something  something_after"
         res = ResourceIdentifier(res_id)
-        self.assertRaises(ValueError, res.get_quakeml_uri)
+        self.assertRaises(ValueError, res.get_quakeml_uri_str)
         # A colon is an invalid character.
         res_id = "smi:local/hello:yea"
         res = ResourceIdentifier(res_id)
-        self.assertRaises(ValueError, res.get_quakeml_uri)
+        self.assertRaises(ValueError, res.get_quakeml_uri_str)
         # Space as well
         res_id = "smi:local/hello yea"
         res = ResourceIdentifier(res_id)
-        self.assertRaises(ValueError, res.get_quakeml_uri)
+        self.assertRaises(ValueError, res.get_quakeml_uri_str)
         # Dots are fine
         res_id = "smi:local/hello....yea"
         res = ResourceIdentifier(res_id)
-        self.assertEqual(res_id, res.get_quakeml_uri())
+        self.assertEqual(res_id, res.get_quakeml_uri_str())
         # Hats not
         res_id = "smi:local/hello^^yea"
         res = ResourceIdentifier(res_id)
-        self.assertRaises(ValueError, res.get_quakeml_uri)
+        self.assertRaises(ValueError, res.get_quakeml_uri_str)
 
     def test_resource_id_valid_quakemluri(self):
         """
@@ -212,7 +213,7 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         __init__()) gets set up with a QUAKEML conform ID.
         """
         rid = ResourceIdentifier()
-        self.assertEqual(rid.id, rid.get_quakeml_uri())
+        self.assertEqual(rid.id, rid.get_quakeml_uri_str())
 
     def test_de_referencing_when_object_goes_out_of_scope(self):
         """
@@ -263,7 +264,7 @@ class ResourceIdentifierTestCase(unittest.TestCase):
         invalid_id = "http://example.org"
         rid = ResourceIdentifier(invalid_id)
         with self.assertRaises(ValueError) as e:
-            rid.get_quakeml_uri()
+            rid.get_quakeml_uri_str()
         self.assertEqual(
             e.exception.args[0],
             "The id 'http://example.org' is not a valid QuakeML resource "
@@ -658,6 +659,42 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             # But rid1 should have been bound to new_obj1 (so it no longer
             # needs to call get_object_hook to find it
             self.assertIs(rid1.get_referred_object(), new_obj1)
+
+    def test_mutative_methods_depreciated(self):
+        """
+        Because Resource ids are hashable they should be immutable. Make
+        sure any methods that mutate resource_ids are depreciated. Currently
+        there are two:
+
+        1. `convert_id_to_quakeml_uri`
+        2. `regnerate_uuid`
+        """
+        rid = ResourceIdentifier('not_a_valid_quakeml_uri')
+        with WarningsCapture() as w:
+            rid.convert_id_to_quakeml_uri()
+        self.assertGreaterEqual(len(w), 1)
+        self.assertTrue([isinstance(x, ObsPyDeprecationWarning) for x in w])
+
+        rid = ResourceIdentifier()
+        with WarningsCapture() as w:
+            rid.regenerate_uuid()
+        self.assertGreaterEqual(len(w), 1)
+        self.assertTrue([isinstance(x, ObsPyDeprecationWarning) for x in w])
+
+    def test_get_quakeml_id(self):
+        """
+        Tests for returning valid quakeml ids using the get_quakeml_id method.
+        """
+        obj = UTCDateTime('2017-09-17')
+        rid1 = ResourceIdentifier('invalid_id', referred_object=obj)
+        rid2 = rid1.get_quakeml_id(authority_id='remote')
+        # The resource ids should not be equal but should refer to the same
+        # object.
+        self.assertNotEqual(rid2, rid1)
+        self.assertIs(rid1.get_referred_object(), rid2.get_referred_object())
+        # A valid resource id should return a resource id that is equal.
+        rid3 = rid2.get_quakeml_id()
+        self.assertEqual(rid2, rid3)
 
 
 def get_instances(obj, cls=None, is_attr=None, has_attr=None):

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -660,10 +660,10 @@ class ResourceIdentifierTestCase(unittest.TestCase):
             # needs to call get_object_hook to find it
             self.assertIs(rid1.get_referred_object(), new_obj1)
 
-    def test_mutative_methods_depreciated(self):
+    def test_mutative_methods_deprecation(self):
         """
         Because Resource ids are hashable they should be immutable. Make
-        sure any methods that mutate resource_ids are depreciated. Currently
+        sure any methods that mutate resource_ids are deprecated. Currently
         there are two:
 
         1. `convert_id_to_quakeml_uri`

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -1096,7 +1096,7 @@ class Pickler(object):
 
     def _id(self, obj):
         try:
-            return obj.get_quakeml_uri()
+            return obj.get_quakeml_uri_str()
         except Exception:
             msg = ("'%s' is not a valid QuakeML URI. It will be in the final "
                    "file but note that the file will not be a valid QuakeML "


### PR DESCRIPTION
### What does this PR do?

1) Depreciates methods of `ResourceIdentifier` which mutate the resource string in place.
2) Adds a method `get_quakeml_id` for returning a *new* `ResourceIdentifier` instance with a valid quakeml uri.
3) Rename `get_quakeml_uri` to `get_quakeml_uri_str` and depreciated the old methods usage
4) Updated docs not to use the depreciated methods.

### Why was it initiated?  Any relevant Issues?

The `ResourceIdentifier` is hashable and as such any mutation of the resource string should be discouraged. Doing so already raises a warning so any internal methods that mutate the string should also be depreciated. 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
