### PR TITLE
io.shapefile: support for writing extra fields with Inventory objects

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,8 +57,8 @@ master:
  - obspy.io.sh:
    * Add read support for SeismicHandler EVT event files (see #2109)
  - obspy.io.shapefile:
-   * Add possibility to add custom database columns when writing catalog
-     objects to shapefile (see #2012)
+   * Add possibility to add custom database columns when writing catalog or
+     inventory objects to shapefile (see #2012 and #2305)
  - obspy.io
     * added read support for receiver gather format v. 1.6 (see #2070)
  - obspy.signal.trigger:

--- a/obspy/io/shapefile/__init__.py
+++ b/obspy/io/shapefile/__init__.py
@@ -14,7 +14,7 @@ Write support works via the ObsPy plugin structure for
 >>> cat = read_events()  # load example data
 >>> cat.write("my_events.shp", format="SHAPEFILE")  # doctest: +SKIP
 
-Additional information for events can be written to the shapefile as custom
+Additional information can be written to the shapefile as custom
 database columns. In this toy example we add the Flinn Engdahl region as a
 database column (see :func:`obspy.io.shapefile.core._write_shapefile()`):
 
@@ -26,6 +26,10 @@ database column (see :func:`obspy.io.shapefile.core._write_shapefile()`):
 >>> extra_fields = [('Region', 'C', 100, None, regions)]
 >>> cat.write("my_events.shp", format="SHAPEFILE",
 ...           extra_fields=extra_fields)  # doctest: +SKIP
+
+Note that the number of values given for each custom database column must be
+equal to the number of events in a given catalog or equal to the total number
+of stations combined across all networks in a given inventory.
 
 .. seealso::
 

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -92,6 +92,17 @@ expected_catalog_fields_with_region.append(['Region', 'C', 50, 0])
 expected_catalog_records_with_region = copy.deepcopy(expected_catalog_records)
 expected_catalog_records_with_region[0].append('SOUTHEAST OF HONSHU, JAPAN')
 expected_catalog_records_with_region[1].append('GERMANY')
+# set up expected results with extra 'Comment' field
+expected_inventory_fields_with_comment = copy.deepcopy(
+    expected_inventory_fields)
+expected_inventory_fields_with_comment.append(['Comment', 'C', 50, 0])
+expected_inventory_records_with_comment = copy.deepcopy(
+    expected_inventory_records)
+expected_inventory_records_with_comment[0].append('Abc')
+expected_inventory_records_with_comment[1].append('123')
+expected_inventory_records_with_comment[2].append(None)
+expected_inventory_records_with_comment[3].append('Some comment')
+expected_inventory_records_with_comment[4].append('')
 
 
 def _assert_records_and_fields(got_fields, got_records, expected_fields,
@@ -266,6 +277,54 @@ class ShapefileTestCase(unittest.TestCase):
                     got_fields=shp.fields, got_records=shp.records(),
                     expected_fields=expected_catalog_fields_with_region,
                     expected_records=expected_catalog_records_with_region)
+                self.assertEqual(shp.shapeType, shapefile.POINT)
+                _close_shapefile_reader(shp)
+            # For some reason, on windows the files are still in use when
+            # TemporaryWorkingDirectory tries to remove the directory.
+            self.assertTrue(fh_shp.closed)
+            self.assertTrue(fh_dbf.closed)
+            self.assertTrue(fh_shx.closed)
+
+    def test_write_inventory_shapefile_with_extra_field(self):
+        """
+        Tests writing an inventory with an additional custom database column
+        """
+        inv = read_inventory()
+        extra_fields = [('Comment', 'C', 50, None,
+                        ['Abc', '123', None, 'Some comment', ''])]
+        bad_extra_fields_wrong_length = [('Comment', 'C', 50, None, ['ABC'])]
+        bad_extra_fields_name_clash = [('Station', 'C', 50, None, ['ABC'])]
+
+        with TemporaryWorkingDirectory():
+            # test some bad calls that should raise an Exception
+            with self.assertRaises(ValueError) as cm:
+                _write_shapefile(
+                    inv, "inventory.shp",
+                    extra_fields=bad_extra_fields_wrong_length)
+            self.assertEqual(
+                str(cm.exception), "list of values for each item in "
+                "'extra_fields' must have same length as all Stations "
+                "combined across all Networks.")
+            with self.assertRaises(ValueError) as cm:
+                _write_shapefile(
+                    inv, "inventory.shp",
+                    extra_fields=bad_extra_fields_name_clash)
+            self.assertEqual(
+                str(cm.exception), "Conflict with existing field named "
+                "'Station'.")
+            # now test a good call that should work
+            _write_shapefile(inv, "inventory.shp", extra_fields=extra_fields)
+            for suffix in SHAPEFILE_SUFFIXES:
+                self.assertTrue(os.path.isfile("inventory" + suffix))
+            with open("inventory.shp", "rb") as fh_shp, \
+                    open("inventory.dbf", "rb") as fh_dbf, \
+                    open("inventory.shx", "rb") as fh_shx:
+                shp = shapefile.Reader(shp=fh_shp, shx=fh_shx, dbf=fh_dbf)
+                # check contents of shapefile that we just wrote
+                _assert_records_and_fields(
+                    got_fields=shp.fields, got_records=shp.records(),
+                    expected_fields=expected_inventory_fields_with_comment,
+                    expected_records=expected_inventory_records_with_comment)
                 self.assertEqual(shp.shapeType, shapefile.POINT)
                 _close_shapefile_reader(shp)
             # For some reason, on windows the files are still in use when

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -99,8 +99,8 @@ expected_inventory_fields_with_comment.append(['Comment', 'C', 50, 0])
 expected_inventory_records_with_comment = copy.deepcopy(
     expected_inventory_records)
 expected_inventory_records_with_comment[0].append('Abc')
-expected_inventory_records_with_comment[1].append('123')
-expected_inventory_records_with_comment[2].append(None)
+expected_inventory_records_with_comment[1].append(None)
+expected_inventory_records_with_comment[2].append('123')
 expected_inventory_records_with_comment[3].append('Some comment')
 expected_inventory_records_with_comment[4].append('')
 
@@ -291,7 +291,7 @@ class ShapefileTestCase(unittest.TestCase):
         """
         inv = read_inventory()
         extra_fields = [('Comment', 'C', 50, None,
-                        ['Abc', '123', None, 'Some comment', ''])]
+                        ['Abc', None, '123', 'Some comment', ''])]
         bad_extra_fields_wrong_length = [('Comment', 'C', 50, None, ['ABC'])]
         bad_extra_fields_name_clash = [('Station', 'C', 50, None, ['ABC'])]
 
@@ -303,8 +303,8 @@ class ShapefileTestCase(unittest.TestCase):
                     extra_fields=bad_extra_fields_wrong_length)
             self.assertEqual(
                 str(cm.exception), "list of values for each item in "
-                "'extra_fields' must have same length as all Stations "
-                "combined across all Networks.")
+                "'extra_fields' must have same length as the count of all "
+                "Stations combined across all Networks.")
             with self.assertRaises(ValueError) as cm:
                 _write_shapefile(
                     inv, "inventory.shp",


### PR DESCRIPTION
### What does this PR do?

Adds support for writing extra fields also for inventory objects, similar to what is already possible for catalogs. See #2012

### Why was it initiated?  Any relevant Issues?

--

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
