### PR TITLE
fix two issues if plain numbers are used with trim

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1504,15 +1504,20 @@ class Stream(object):
         # select start/end time fitting to a sample point of the first trace
         if nearest_sample:
             tr = self.traces[0]
-            if starttime:
-                delta = compatibility.round_away(
-                    (starttime - tr.stats.starttime) * tr.stats.sampling_rate)
-                starttime = tr.stats.starttime + delta * tr.stats.delta
-            if endtime:
-                delta = compatibility.round_away(
-                    (endtime - tr.stats.endtime) * tr.stats.sampling_rate)
-                # delta is negative!
-                endtime = tr.stats.endtime + delta * tr.stats.delta
+            try:
+                if starttime is not None:
+                    delta = compatibility.round_away(
+                        (starttime - tr.stats.starttime) * tr.stats.sampling_rate)
+                    starttime = tr.stats.starttime + delta * tr.stats.delta
+                if endtime is not None:
+                    delta = compatibility.round_away(
+                        (endtime - tr.stats.endtime) * tr.stats.sampling_rate)
+                    # delta is negative!
+                    endtime = tr.stats.endtime + delta * tr.stats.delta
+            except TypeError:
+                msg = ('starttime and endtime have to be UTCDateTime objects '
+                       'or None for this call to Stream.trim()')
+                raise TypeError(msg)
         for trace in self.traces:
             trace.trim(starttime, endtime, pad=pad,
                        nearest_sample=nearest_sample, fill_value=fill_value)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1507,7 +1507,8 @@ class Stream(object):
             try:
                 if starttime is not None:
                     delta = compatibility.round_away(
-                        (starttime - tr.stats.starttime) * tr.stats.sampling_rate)
+                        (starttime - tr.stats.starttime) *
+                        tr.stats.sampling_rate)
                     starttime = tr.stats.starttime + delta * tr.stats.delta
                 if endtime is not None:
                     delta = compatibility.round_away(

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1515,7 +1515,7 @@ class Stream(object):
                     # delta is negative!
                     endtime = tr.stats.endtime + delta * tr.stats.delta
             except TypeError:
-                msg = ('starttime and endtime have to be UTCDateTime objects '
+                msg = ('starttime and endtime must be UTCDateTime objects '
                        'or None for this call to Stream.trim()')
                 raise TypeError(msg)
         for trace in self.traces:

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1131,7 +1131,8 @@ class Trace(object):
         array([2, 3, 4, 5, 6, 7, 8])
         """
         # check time order and swap eventually
-        if starttime and endtime and starttime > endtime:
+        if (isinstance(starttime, UTCDateTime) and
+                isinstance(endtime, UTCDateTime) and starttime > endtime):
             raise ValueError("startime is larger than endtime")
         # cut it
         if starttime:


### PR DESCRIPTION
This solves the following issues, when using numbers in trim (undocumented behavior!)

```py
In [2]: read()[0].trim(5, 4)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-550a8a88d1ce> in <module>()
----> 1 read()[0].trim(5, 4)

<decorator-gen-121> in trim(self, starttime, endtime, pad, nearest_sample, fill_value)

~/dev/obspy/obspy/core/trace.py in _add_processing_info(func, *args, **kwargs)
    243     info = info % "::".join(arguments)
    244     self = args[0]
--> 245     result = func(*args, **kwargs)
    246     # Attach after executing the function to avoid having it attached
    247     # while the operation failed.

~/dev/obspy/obspy/core/trace.py in trim(self, starttime, endtime, pad, nearest_sample, fill_value)
   1143         # check time order and swap eventually
   1144         if starttime and endtime and starttime > endtime:
-> 1145             raise ValueError("startime is larger than endtime")
   1146         # cut it
   1147         if starttime:

ValueError: startime is larger than endtime
```

```
In [3]: read().trim(5, 5)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-b3e119b0d653> in <module>()
----> 1 read().trim(5, 5)

~/dev/obspy/obspy/core/stream.py in trim(self, starttime, endtime, pad, nearest_sample, fill_value)
   1520             if starttime:
   1521                 delta = compatibility.round_away(
-> 1522                     (starttime - tr.stats.starttime) * tr.stats.sampling_rate)
   1523                 starttime = tr.stats.starttime + delta * tr.stats.delta
   1524             if endtime:

TypeError: unsupported operand type(s) for -: 'int' and 'UTCDateTime'
```

The first call is OK now. The second call raises a more meaningful error message:

```
In [1]: read().trim(5, None)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/dev/obspy/obspy/core/stream.py in trim(self, starttime, endtime, pad, nearest_sample, fill_value)
   1509                     delta = compatibility.round_away(
-> 1510                         (starttime - tr.stats.starttime) * tr.stats.sampling_rate)
   1511                     starttime = tr.stats.starttime + delta * tr.stats.delta

TypeError: unsupported operand type(s) for -: 'int' and 'UTCDateTime'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-1-5c96aaaae7dd> in <module>()
----> 1 read().trim(5, None)

~/dev/obspy/obspy/core/stream.py in trim(self, starttime, endtime, pad, nearest_sample, fill_value)
   1518                 msg = ('starttime and endtime have to be UTCDateTime objects '
   1519                        'or None for this call to Stream.trim()')
-> 1520                 raise TypeError(msg)
   1521         for trace in self.traces:
   1522             trace.trim(starttime, endtime, pad=pad,

TypeError: starttime and endtime have to be UTCDateTime objects or None for this call to Stream.trim()
```

IMO, this PR does not need an extra test.
