### PR TITLE
Units in identity stage

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -768,7 +768,7 @@ class Response(ComparingObject):
             msg = "response_stages must be an iterable."
             raise ValueError(msg)
 
-    def _add_units_to_identity_stages(self):
+    def _attempt_to_fix_units(self):
         """
         Internal helper function that will add units to gain only stages based
         on the units of surrounding stages.
@@ -778,6 +778,27 @@ class Response(ComparingObject):
         """
         previous_output_units = None
         previous_output_units_description = None
+
+        # Potentially set the input units of the first stage to the units of
+        # the overall sensitivity and the output units of the second stage.
+        if self.response_stages and self.response_stages[0] and \
+                hasattr(self, "instrument_sensitivity"):
+            s = self.instrument_sensitivity
+
+            if s:
+                if self.response_stages[0].input_units is None:
+                    self.response_stages[0].input_units = s.input_units
+                if self.response_stages[0].input_units_description is None:
+                    self.response_stages[0].input_units_description = \
+                        s.input_units_description
+
+            if len(self.response_stages) >= 2 and self.response_stages[1]:
+                if self.response_stages[0].output_units is None:
+                    self.response_stages[0].output_units = \
+                        self.response_stages[1].input_units
+                if self.response_stages[0].output_units_description is None:
+                    self.response_stages[0].output_units_description = \
+                        self.response_stages[1].input_units_description
 
         # Front to back.
         for r in self.response_stages:

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -768,6 +768,57 @@ class Response(ComparingObject):
             msg = "response_stages must be an iterable."
             raise ValueError(msg)
 
+    def _add_units_to_identity_stages(self):
+        """
+        Internal helper function that will add units to gain only stages based
+        on the units of surrounding stages.
+
+        Should be called when parsing from file formats that don't have units
+        for identity stages.
+        """
+        previous_output_units = None
+        previous_output_units_description = None
+
+        # Front to back.
+        for r in self.response_stages:
+            # Only for identity/stage only.
+            if type(r) is ResponseStage:
+                if not r.input_units and not r.output_units and \
+                        previous_output_units:
+                    r.input_units = previous_output_units
+                    r.output_units = previous_output_units
+                if not r.input_units_description and \
+                        not r.output_units_description \
+                        and previous_output_units_description:
+                    r.input_units_description = \
+                        previous_output_units_description
+                    r.output_units_description = \
+                        previous_output_units_description
+
+            previous_output_units = r.output_units
+            previous_output_units_description = r.output_units_description
+
+        # Back to front.
+        previous_input_units = None
+        previous_input_units_description = None
+        for r in reversed(self.response_stages):
+            # Only for identity/stage only.
+            if type(r) is ResponseStage:
+                if not r.input_units and not r.output_units and \
+                        previous_input_units:
+                    r.input_units = previous_input_units
+                    r.output_units = previous_input_units
+                if not r.input_units_description and \
+                        not r.output_units_description \
+                        and previous_input_units_description:
+                    r.input_units_description = \
+                        previous_input_units_description
+                    r.output_units_description = \
+                        previous_input_units_description
+
+            previous_input_units = r.input_units
+            previous_input_units_description = r.input_units_description
+
     def get_sampling_rates(self):
         """
         Computes the input and output sampling rates of each stage.

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -24,7 +24,7 @@ from obspy import UTCDateTime
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .util import (BaseNode, Equipment, Operator, Distance, Latitude,
-                   Longitude, _unified_content_strings, _textwrap)
+                   Longitude, _unified_content_strings, _textwrap, Site)
 
 
 @python_2_unicode_compatible
@@ -108,7 +108,7 @@ class Station(BaseNode):
         self.longitude = longitude
         self.elevation = elevation
         self.channels = channels or []
-        self.site = site
+        self.site = site if site is not None else Site()
         self.vault = vault
         self.geology = geology
         self.equipments = equipments or []

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -563,7 +563,7 @@ class Site(ComparingObject):
         Description of a site location using name and optional geopolitical
         boundaries (country, city, etc.).
     """
-    def __init__(self, name, description=None, town=None, county=None,
+    def __init__(self, name="", description=None, town=None, county=None,
                  region=None, country=None):
         """
         :type name: str

--- a/obspy/core/tests/data/stationxml_no_units_in_stage_1.xml
+++ b/obspy/core/tests/data/stationxml_no_units_in_stage_1.xml
@@ -30,8 +30,8 @@
             <Value>3141.49</Value>
             <Frequency>0.0001</Frequency>
             <InputUnits>
-              <Name>COUNTS</Name>
-              <Description>DIGITAL COUNTS</Description>
+              <Name>M/S</Name>
+              <Description>Meters per second</Description>
             </InputUnits>
             <OutputUnits>
               <Name>COUNTS</Name>

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -275,8 +275,20 @@ class ResponseTestCase(unittest.TestCase):
         inv = read_inventory(os.path.join(
             self.data_dir, "stationxml_no_units_in_stage_1.xml"))
         r = inv[0][0][0].response
-        self.assertIsNone(r.response_stages[0].input_units)
-        self.assertIsNone(r.response_stages[0].output_units)
+
+        # The units should already have been fixed from reading the StationXML
+        # files...
+        self.assertEqual(r.response_stages[0].input_units, "M/S")
+        self.assertEqual(r.response_stages[0].input_units_description,
+                         "Meters per second")
+        self.assertEqual(r.response_stages[0].output_units, "V")
+        self.assertEqual(r.response_stages[0].output_units_description,
+                         "VOLTS")
+
+        # We have to set the units to None here as there is some other logic in
+        # reading the StationXML files that sets them based on other units...
+        r.response_stages[0].input_units = None
+        r.response_stages[0].output_units = None
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -388,7 +388,7 @@ def _read_channel(cha_element, _ns):
     response = cha_element.find(_ns("Response"))
     if response is not None:
         channel.response = _read_response(response, _ns)
-        channel.response._add_units_to_identity_stages()
+        channel.response._attempt_to_fix_units()
     return channel
 
 

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -388,6 +388,7 @@ def _read_channel(cha_element, _ns):
     response = cha_element.find(_ns("Response"))
     if response is not None:
         channel.response = _read_response(response, _ns)
+        channel.response._add_units_to_identity_stages()
     return channel
 
 

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -1159,6 +1159,10 @@ class StationXMLTestCase(unittest.TestCase):
             inv_2 = obspy.read_inventory(buf)
 
         response_2 = inv_2.get_response("BW.RJOB..EHZ", t)
+        # Set these to None manually as the autocorrection during parsing will
+        # set it.
+        response_2.response_stages[0].input_units = None
+        response_2.response_stages[0].input_units_description = None
 
         self.assertEqual(response, response_2)
         self.assertEqual(response_2.response_stages[1].input_units, "V")

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -1134,6 +1134,46 @@ class StationXMLTestCase(unittest.TestCase):
         self.assertEqual(
             response_2.response_stages[2].output_units_description, "Volts")
 
+        # Also try from the other side.
+        inv = obspy.read_inventory().select(station="RJOB", channel="EHZ",
+                                            time=t)
+        response = inv.get_response("BW.RJOB..EHZ", t)
+        response.response_stages[0].input_units = None
+        response.response_stages[0].output_units = None
+        response.response_stages[0].input_units_description = None
+        response.response_stages[0].output_units_description = None
+        rstage_2 = ResponseStage(2, 1, 1, "V", "V",
+                                 input_units_description="Volts",
+                                 output_units_description="Volts")
+        rstage_3 = ResponseStage(3, 1, 1, "V", "V",
+                                 input_units_description="Volts",
+                                 output_units_description="Volts")
+        response.response_stages.insert(1, rstage_2)
+        response.response_stages.insert(2, rstage_3)
+        for i, rstage in enumerate(response.response_stages[3:]):
+            rstage.stage_sequence_number = i + 4
+
+        with io.BytesIO() as buf:
+            inv.write(buf, format="stationxml")
+            buf.seek(0, 0)
+            inv_2 = obspy.read_inventory(buf)
+
+        response_2 = inv_2.get_response("BW.RJOB..EHZ", t)
+
+        self.assertEqual(response, response_2)
+        self.assertEqual(response_2.response_stages[1].input_units, "V")
+        self.assertEqual(response_2.response_stages[1].output_units, "V")
+        self.assertEqual(
+            response_2.response_stages[1].input_units_description, "Volts")
+        self.assertEqual(
+            response_2.response_stages[1].output_units_description, "Volts")
+        self.assertEqual(response_2.response_stages[2].input_units, "V")
+        self.assertEqual(response_2.response_stages[2].output_units, "V")
+        self.assertEqual(
+            response_2.response_stages[2].input_units_description, "Volts")
+        self.assertEqual(
+            response_2.response_stages[2].output_units_description, "Volts")
+
 
 def suite():
     return unittest.makeSuite(StationXMLTestCase, "test")


### PR DESCRIPTION
Fixes #2250.

The issue is that StationXML cannot store units for gain only stages. Thus, upon reading StationXML, there is now a post-processing step to assign the units of surrounding to gain only response stages. I think this should be save and we can now round-trip these types of response stages.