### PR TITLE
_discover_services keyword in FDSN Client

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,10 @@ master:
    * Added wildcard and url support to read_inventory (see #2326).
    * Modified stream.get_gaps() to deal with overlaps correctly (see #1403)
  - obspy.clients.fdsn:
+   * Add new `_discover_services` boolean flag to the Client, which allows the
+     Client to skip the initial services query at instantiation.  This can
+     reduce the load on service providers, but skips checks against unsupported
+     query parameters.
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).
    * The mass downloader now raises a warning if all channels from a station

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -140,7 +140,7 @@ class Client(object):
     def __init__(self, base_url="IRIS", major_versions=None, user=None,
                  password=None, user_agent=DEFAULT_USER_AGENT, debug=False,
                  timeout=120, service_mappings=None, force_redirect=False,
-                 eida_token=None):
+                 eida_token=None, discover_services=True):
         """
         Initializes an FDSN Web Service client.
 
@@ -202,11 +202,19 @@ class Client(object):
             used. This mechanism is only available on select EIDA nodes. The
             token can be provided in form of the PGP message as a string, or
             the filename of a local file with the PGP message in it.
+        :type discover_services: bool
+        :param discover_services: By default the client will query information
+            about the FDSN endpoint when it is instantiated.  This is cached per
+            Python process, but in cases where many clients are instantiated in
+            seperate processes, this initial querying can place a heavy load on
+            the FDSN service provider.  If set to ``False``, no initial service
+            discover is performed and default parameter support is assumed.
         """
         self.debug = debug
         self.user = user
         self.timeout = timeout
         self._force_redirect = force_redirect
+        self.discover_services = discover_services
 
         # Cache for the webservice versions. This makes interactive use of
         # the client more convenient.
@@ -253,7 +261,10 @@ class Client(object):
                     print("\t%s: '%s'" % (key, value))
             print("Request Headers: %s" % str(self.request_headers))
 
-        self._discover_services()
+        if self.discover_services:
+            self._discover_services()
+        else:
+            self.services = DEFAULT_PARAMETERS.copy()
 
         # Use EIDA token if provided - this requires setting new url openers.
         #
@@ -501,7 +512,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if "event" not in self.services:
+        if self.discover_services and "event" not in self.services:
             msg = "The current client does not have an event service."
             raise ValueError(msg)
 
@@ -699,7 +710,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if "station" not in self.services:
+        if self.discover_services and "station" not in self.services:
             msg = "The current client does not have a station service."
             raise ValueError(msg)
 
@@ -812,7 +823,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if "dataselect" not in self.services:
+        if self.discover_services and "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
             raise ValueError(msg)
 
@@ -994,7 +1005,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if "dataselect" not in self.services:
+        if self.discover_services and "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
             raise ValueError(msg)
 
@@ -1140,7 +1151,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if "station" not in self.services:
+        if self.discover_services and "station" not in self.services:
             msg = "The current client does not have a station service."
             raise ValueError(msg)
 

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -205,10 +205,10 @@ class Client(object):
         :type _discover_services: bool
         :param _discover_services: By default the client will query information
             about the FDSN endpoint when it is instantiated.  In certain cases,
-            this may place a heavy load on the FDSN service provider.  If set to
-            ``False``, no service discovery is performed and default parameter
-            support is assumed. This parameter is experimental and will likely
-            be removed in the future.
+            this may place a heavy load on the FDSN service provider.  If set
+            to ``False``, no service discovery is performed and default
+            parameter support is assumed. This parameter is experimental and
+            will likely be removed in the future.
         """
         self.debug = debug
         self.user = user

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -33,8 +33,8 @@ from obspy import UTCDateTime, read_inventory
 from obspy.core.compatibility import urlparse
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES, URL_MAPPINGS,
-                     WADL_PARAMETERS_NOT_TO_BE_PARSED, FDSNException,
-                     FDSNRedirectException, FDSNNoDataException)
+                     WADL_PARAMETERS_NOT_TO_BE_PARSED, DEFAULT_SERVICES,
+                     FDSNException, FDSNRedirectException, FDSNNoDataException)
 from .wadl_parser import WADLParser
 
 if PY2:
@@ -140,7 +140,7 @@ class Client(object):
     def __init__(self, base_url="IRIS", major_versions=None, user=None,
                  password=None, user_agent=DEFAULT_USER_AGENT, debug=False,
                  timeout=120, service_mappings=None, force_redirect=False,
-                 eida_token=None, discover_services=True):
+                 eida_token=None, _discover_services=True):
         """
         Initializes an FDSN Web Service client.
 
@@ -202,19 +202,18 @@ class Client(object):
             used. This mechanism is only available on select EIDA nodes. The
             token can be provided in form of the PGP message as a string, or
             the filename of a local file with the PGP message in it.
-        :type discover_services: bool
-        :param discover_services: By default the client will query information
-            about the FDSN endpoint when it is instantiated.  This is cached per
-            Python process, but in cases where many clients are instantiated in
-            seperate processes, this initial querying can place a heavy load on
-            the FDSN service provider.  If set to ``False``, no initial service
-            discover is performed and default parameter support is assumed.
+        :type _discover_services: bool
+        :param _discover_services: By default the client will query information
+            about the FDSN endpoint when it is instantiated.  In certain cases,
+            this may place a heavy load on the FDSN service provider.  If set to
+            ``False``, no service discovery is performed and default parameter
+            support is assumed. This parameter is experimental and will likely
+            be removed in the future.
         """
         self.debug = debug
         self.user = user
         self.timeout = timeout
         self._force_redirect = force_redirect
-        self.discover_services = discover_services
 
         # Cache for the webservice versions. This makes interactive use of
         # the client more convenient.
@@ -261,10 +260,10 @@ class Client(object):
                     print("\t%s: '%s'" % (key, value))
             print("Request Headers: %s" % str(self.request_headers))
 
-        if self.discover_services:
+        if _discover_services:
             self._discover_services()
         else:
-            self.services = DEFAULT_PARAMETERS.copy()
+            self.services = DEFAULT_SERVICES
 
         # Use EIDA token if provided - this requires setting new url openers.
         #
@@ -512,7 +511,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if self.discover_services and "event" not in self.services:
+        if "event" not in self.services:
             msg = "The current client does not have an event service."
             raise ValueError(msg)
 
@@ -710,7 +709,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if self.discover_services and "station" not in self.services:
+        if "station" not in self.services:
             msg = "The current client does not have a station service."
             raise ValueError(msg)
 
@@ -823,7 +822,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if self.discover_services and "dataselect" not in self.services:
+        if "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
             raise ValueError(msg)
 
@@ -1005,7 +1004,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if self.discover_services and "dataselect" not in self.services:
+        if "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
             raise ValueError(msg)
 
@@ -1151,7 +1150,7 @@ class Client(object):
         non-default parameters that the webservice does not support will raise
         an error.
         """
-        if self.discover_services and "station" not in self.services:
+        if "station" not in self.services:
             msg = "The current client does not have a station service."
             raise ValueError(msg)
 

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -174,7 +174,82 @@ DEFAULT_TYPES = {
     "orderby": str,
     "catalog": str,
     "contributor": str,
-    "updatedafter": UTCDateTime}
+    "updatedafter": UTCDateTime,
+    'format': str}
+
+DEFAULT_VALUES = {
+    "starttime": None,
+    "endtime": None,
+    "network": None,
+    "station": None,
+    "location": None,
+    "channel": None,
+    "quality": 'B',
+    "minimumlength": 0.0,
+    "longestonly": False,
+    "startbefore": None,
+    "startafter": None,
+    "endbefore": None,
+    "endafter": None,
+    "maxlongitude": 180.0,
+    "minlongitude": -180.0,
+    "longitude": 0.0,
+    "maxlatitude": 90.0,
+    "minlatitude": -90.0,
+    "latitude": 0.0,
+    "maxdepth": None,
+    "mindepth": None,
+    "maxmagnitude": None,
+    "minmagnitude": None,
+    "magnitudetype": None,
+    "maxradius": 180.0,
+    "minradius": 0.0,
+    "level": 'station',
+    "includerestricted": True,
+    "includeavailability": False,
+    "includeallorigins": False,
+    "includeallmagnitudes": False,
+    "includearrivals": False,
+    "matchtimeseries": False,
+    "eventid": None,
+    "limit": None,
+    "offset": 1,
+    "orderby": 'time',
+    "catalog": None,
+    "contributor": None,
+    "updatedafter": None,
+}
+
+# This creates a services dictionary containing default and optional services,
+# with reasonable types and default values, but none are required. Its purpose
+# is to look like what would be returned from an actual services query on a
+# minimal and very permissive service provider, without actually having to
+# do the query.
+DEFAULT_SERVICES = {}
+for service in ["dataselect", "event", "station"]:
+    DEFAULT_SERVICES[service] = {}
+
+    for default_param in DEFAULT_PARAMETERS[service]:
+        DEFAULT_SERVICES[service][default_param] = {
+            'default_value': DEFAULT_VALUES[default_param],
+            'type': DEFAULT_TYPES[default_param],
+            'required': False,
+        }
+
+    for optional_param in OPTIONAL_PARAMETERS[service]:
+        if optional_param == 'format':
+            if service == 'dataselect':
+                default_val = 'miniseed'
+            else:
+                default_val = 'xml'
+        else:
+            default_val = DEFAULT_VALUES[optional_param]
+
+        DEFAULT_SERVICES[service][optional_param] = {
+            'default_value': default_val,
+            'type': DEFAULT_TYPES[optional_param],
+            'required': False,
+        }
 
 # This list collects WADL parameters that will not be parsed because they are
 # not useful for the ObsPy client.

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -175,7 +175,7 @@ DEFAULT_TYPES = {
     "catalog": str,
     "contributor": str,
     "updatedafter": UTCDateTime,
-    'format': str}
+    "format": str}
 
 DEFAULT_VALUES = {
     "starttime": None,
@@ -184,7 +184,7 @@ DEFAULT_VALUES = {
     "station": None,
     "location": None,
     "channel": None,
-    "quality": 'B',
+    "quality": "B",
     "minimumlength": 0.0,
     "longestonly": False,
     "startbefore": None,
@@ -204,7 +204,7 @@ DEFAULT_VALUES = {
     "magnitudetype": None,
     "maxradius": 180.0,
     "minradius": 0.0,
-    "level": 'station',
+    "level": "station",
     "includerestricted": True,
     "includeavailability": False,
     "includeallorigins": False,
@@ -214,7 +214,7 @@ DEFAULT_VALUES = {
     "eventid": None,
     "limit": None,
     "offset": 1,
-    "orderby": 'time',
+    "orderby": "time",
     "catalog": None,
     "contributor": None,
     "updatedafter": None,
@@ -231,24 +231,24 @@ for service in ["dataselect", "event", "station"]:
 
     for default_param in DEFAULT_PARAMETERS[service]:
         DEFAULT_SERVICES[service][default_param] = {
-            'default_value': DEFAULT_VALUES[default_param],
-            'type': DEFAULT_TYPES[default_param],
-            'required': False,
+            "default_value": DEFAULT_VALUES[default_param],
+            "type": DEFAULT_TYPES[default_param],
+            "required": False,
         }
 
     for optional_param in OPTIONAL_PARAMETERS[service]:
-        if optional_param == 'format':
-            if service == 'dataselect':
-                default_val = 'miniseed'
+        if optional_param == "format":
+            if service == "dataselect":
+                default_val = "miniseed"
             else:
-                default_val = 'xml'
+                default_val = "xml"
         else:
             default_val = DEFAULT_VALUES[optional_param]
 
         DEFAULT_SERVICES[service][optional_param] = {
-            'default_value': default_val,
-            'type': DEFAULT_TYPES[optional_param],
-            'required': False,
+            "default_value": default_val,
+            "type": DEFAULT_TYPES[optional_param],
+            "required": False,
         }
 
 # This list collects WADL parameters that will not be parsed because they are

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -38,7 +38,8 @@ from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import build_url, parse_simple_xml
 from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
                                        FDSNException, FDSNRedirectException,
-                                       FDSNNoDataException, DEFAULT_PARAMETERS)
+                                       FDSNNoDataException, DEFAULT_PARAMETERS,
+                                       DEFAULT_SERVICES)
 from obspy.core.inventory import Response
 from obspy.geodetics import locations2degrees
 
@@ -393,16 +394,13 @@ class ClientTestCase(unittest.TestCase):
 
     def test_discover_services_defaults(self):
         """
-        A Client initialized with discover_services=False shouldn't perform any
+        A Client initialized with _discover_services=False shouldn't perform any
         services/WADL queries on the endpoint, and should show only the default
         service parameters.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
-                        discover_services=False)
-        self.assertEqual(set(client.services.keys()),
-                         set(DEFAULT_PARAMETERS.keys()))
-        # XXX: this is a bad test.  DEFAULT_PARAMETERS.values() aren't the same
-        # as expected for a normal client.services.values()
+                        _discover_services=False)
+        self.assertEqual(client.services, DEFAULT_SERVICES)
 
     def test_simple_xml_parser(self):
         """
@@ -618,7 +616,7 @@ class ClientTestCase(unittest.TestCase):
         now tests if the queries return what was asked for.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
-                        discover_services=False)
+                        _discover_services=False)
 
         # Event id query.
         cat = client.get_events(eventid=609301)
@@ -669,7 +667,7 @@ class ClientTestCase(unittest.TestCase):
         returned inventory in different ways.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
-                        discover_services=False)
+                        _discover_services=False)
 
         # Radial query.
         inv = client.get_stations(latitude=-56.1, longitude=-26.7,
@@ -739,7 +737,7 @@ class ClientTestCase(unittest.TestCase):
         without discovering services first.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
-                        discover_services=False)
+                        _discover_services=False)
 
         queries = [
             ("IU", "ANMO", "00", "BHZ",

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -38,8 +38,7 @@ from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import build_url, parse_simple_xml
 from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
                                        FDSNException, FDSNRedirectException,
-                                       FDSNNoDataException, DEFAULT_PARAMETERS,
-                                       DEFAULT_SERVICES)
+                                       FDSNNoDataException, DEFAULT_SERVICES)
 from obspy.core.inventory import Response
 from obspy.geodetics import locations2degrees
 
@@ -394,9 +393,9 @@ class ClientTestCase(unittest.TestCase):
 
     def test_discover_services_defaults(self):
         """
-        A Client initialized with _discover_services=False shouldn't perform any
-        services/WADL queries on the endpoint, and should show only the default
-        service parameters.
+        A Client initialized with _discover_services=False shouldn't perform
+        any services/WADL queries on the endpoint, and should show only the
+        default service parameters.
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
                         _discover_services=False)
@@ -606,8 +605,7 @@ class ClientTestCase(unittest.TestCase):
             del tr.stats._fdsnws_dataselect_url
         self.assertEqual(got, expected, failmsg(got, expected))
 
-
-    def test_iris_example_queries_event_discover_services_False(self):
+    def test_iris_example_queries_event_discover_services_false(self):
         """
         Tests the (sometimes modified) example queries given on the IRIS
         web page, without service discovery.
@@ -657,7 +655,7 @@ class ClientTestCase(unittest.TestCase):
             # does not only check the preferred magnitude..
             self.assertTrue(any(m.mag >= 3.999 for m in event.magnitudes))
 
-    def test_iris_example_queries_station_discover_services_False(self):
+    def test_iris_example_queries_station_discover_services_false(self):
         """
         Tests the (sometimes modified) example queries given on IRIS webpage,
         without service discovery.
@@ -731,7 +729,7 @@ class ClientTestCase(unittest.TestCase):
                 self.assertEqual(net.code, "IU")
                 self.assertTrue(sta.code.startswith("A"))
 
-    def test_iris_example_queries_dataselect_discover_services_False(self):
+    def test_iris_example_queries_dataselect_discover_services_false(self):
         """
         Tests the (sometimes modified) example queries given on IRIS webpage,
         without discovering services first.
@@ -1571,7 +1569,6 @@ class ClientTestCase(unittest.TestCase):
             client = Client(
                 'GFZ', eida_token=os.path.join(self.datapath,
                                                'event_helpstring.txt'))
-        
 
 
 def suite():


### PR DESCRIPTION
### What does this PR do?

This PR adds a `discover_services` boolean keyword to `obspy.clients.fdsn.Client.__init__`.

`Client._discover_services()` can be an expensive operation for a data
center, but it was run on `Client.__init__` even if it wasn't used.  This
keyword bypasses the service discover/query, and instead assumes the
default services at the data center.  This is helpful for distributed
applications that instantiate many clients in seperate Python processes.

### Why was it initiated?  Any relevant Issues?

See #2094 for a short discussion.  (Note: an additional PR is necessary to end that issue.)

This PR branches from a recent `master` branch.  

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
