### PR TITLE
Generalize Inventory, Catalog and Stream reading - allow wildcards

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ master:
    * Added copy method to Inventory class (see #2322).
    * The Response.recalculate_overall_sensitivity() method now accepts integers
      (see #2338, #2343).
+   * Added wildcard and url support to read_inventory (see #2326).
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -152,9 +152,7 @@ class Catalog(object):
         """
         if not isinstance(other, Catalog):
             return False
-        if self.events != other.events:
-            return False
-        return True
+        return self.events == other.events
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -815,7 +813,7 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
         # if no pathname or URL specified, return example catalog
         return _create_example_catalog()
     else:
-        return _generic_reader(pathname_or_url, format, _read, **kwargs)
+        return _generic_reader(pathname_or_url, _read, format=format, **kwargs)
 
 
 @uncompress_file

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -33,7 +33,7 @@ import numpy as np
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile, _read_from_plugin
 from obspy.core.util.base import (ENTRY_POINTS, download_to_file,
-                                  sanitize_filename)
+                                  sanitize_filename, _generic_reader)
 from obspy.core.util.decorator import map_example_filename, uncompress_file
 from obspy.core.util.misc import buffered_load_entry_point
 from obspy.imaging.cm import obspy_sequential
@@ -814,47 +814,8 @@ def read_events(pathname_or_url=None, format=None, **kwargs):
     if pathname_or_url is None:
         # if no pathname or URL specified, return example catalog
         return _create_example_catalog()
-    elif not isinstance(pathname_or_url, (str, native_str)):
-        # not a string - we assume a file-like object
-        try:
-            # first try reading directly
-            catalog = _read(pathname_or_url, format, **kwargs)
-        except TypeError:
-            # if this fails, create a temporary file which is read directly
-            # from the file system
-            pathname_or_url.seek(0)
-            with NamedTemporaryFile() as fh:
-                fh.write(pathname_or_url.read())
-                catalog = _read(fh.name, format, **kwargs)
-        return catalog
-    elif isinstance(pathname_or_url, bytes) and \
-            pathname_or_url.strip().startswith(b'<'):
-        # XML string
-        return _read(io.BytesIO(pathname_or_url), format, **kwargs)
-    elif "://" in pathname_or_url[:10]:
-        # URL
-        # extract extension if any
-        suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
-        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
-            download_to_file(url=pathname_or_url, filename_or_buffer=fh)
-            catalog = _read(fh.name, format, **kwargs)
-        return catalog
     else:
-        pathname = pathname_or_url
-        # File name(s)
-        pathnames = sorted(glob.glob(pathname))
-        if not pathnames:
-            # try to give more specific information why the stream is empty
-            if glob.has_magic(pathname) and not glob.glob(pathname):
-                raise Exception("No file matching file pattern: %s" % pathname)
-            elif not glob.has_magic(pathname) and not os.path.isfile(pathname):
-                raise IOError(2, "No such file or directory", pathname)
-
-        catalog = _read(pathnames[0], format, **kwargs)
-        if len(pathnames) > 1:
-            for filename in pathnames[1:]:
-                catalog.extend(_read(filename, format, **kwargs).events)
-        return catalog
+        return _generic_reader(pathname_or_url, format, _read, **kwargs)
 
 
 @uncompress_file

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -22,18 +22,14 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import glob
-import io
 import copy
-import os
 import warnings
 
 import numpy as np
 
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util import NamedTemporaryFile, _read_from_plugin
-from obspy.core.util.base import (ENTRY_POINTS, download_to_file,
-                                  sanitize_filename, _generic_reader)
+from obspy.core.util import _read_from_plugin
+from obspy.core.util.base import ENTRY_POINTS, _generic_reader
 from obspy.core.util.decorator import map_example_filename, uncompress_file
 from obspy.core.util.misc import buffered_load_entry_point
 from obspy.imaging.cm import obspy_sequential

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -50,9 +50,12 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
     """
     Function to read inventory files.
 
-    :param path_or_file_object: File name or file like object. If this
-        attribute is omitted, an example :class:`Inventory`
-        object will be returned.
+    :type path_or_file_object: str or StringIO.StringIO
+    :param path_or_file_object: String containing a file name or a URL or a open
+        file-like object. Wildcards are allowed for a file name. If this
+        attribute is omitted, an example
+        :class:`~obspy.core.inventory.inventory.Inventory` object will be
+        returned.
     :type format: str
     :param format: Format of the file to read (e.g. ``"STATIONXML"``). See the
         `Supported Formats`_ section below for a list of supported formats.

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -50,7 +50,7 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
     """
     Function to read inventory files.
 
-    :type path_or_file_object: str or StringIO.StringIO
+    :type path_or_file_object: str or file-like object.
     :param path_or_file_object: String containing a file name or a URL or a open
         file-like object. Wildcards are allowed for a file name. If this
         attribute is omitted, an example
@@ -88,7 +88,8 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         # if no pathname or URL specified, return example catalog
         return _create_example_inventory()
     else:
-        return _generic_reader(path_or_file_object, format, _read, **kwargs)
+        return _generic_reader(path_or_file_object, _read, format=format,
+                               **kwargs)
 
 
 @uncompress_file
@@ -97,7 +98,7 @@ def _read(filename, format=None, **kwargs):
     Reads a single event file into a ObsPy Catalog object.
     """
     inventory, format = _read_from_plugin('inventory', filename, format=format,
-                                  **kwargs)
+                                          **kwargs)
     return inventory
 
 @python_2_unicode_compatible
@@ -148,12 +149,12 @@ class Inventory(ComparingObject):
 
     def __eq__(self, other):
         """
-        __eq__ method of the Catalog object.
+        __eq__ method of the Inventory object.
 
         :type other: :class:`~obspy.core.inventory.Inventory`
         :param other: Inventory object for comparison.
         :rtype: bool
-        :return: ``True`` if both Inventories contain the same networks.
+        :return: ``True`` if both Inventories are equal.
 
         .. rubric:: Example
 
@@ -167,9 +168,7 @@ class Inventory(ComparingObject):
         """
         if not isinstance(other, Inventory):
             return False
-        if self.networks != other.networks:
-            return False
-        return True
+        return self.networks == other.networks
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -12,19 +12,16 @@ Provides the Inventory class.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import python_2_unicode_compatible, native_str
+from future.utils import python_2_unicode_compatible
 
 import copy
 import fnmatch
-import os
 import textwrap
 import warnings
 
 import obspy
 from obspy.core.util.base import (ENTRY_POINTS, ComparingObject,
-                                  _read_from_plugin, NamedTemporaryFile,
-                                  download_to_file, sanitize_filename,
-                                  _generic_reader)
+                                  _read_from_plugin, _generic_reader)
 from obspy.core.util.decorator import map_example_filename, uncompress_file
 from obspy.core.util.misc import buffered_load_entry_point
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
@@ -100,6 +97,7 @@ def _read(filename, format=None, **kwargs):
     inventory, format = _read_from_plugin('inventory', filename, format=format,
                                           **kwargs)
     return inventory
+
 
 @python_2_unicode_compatible
 class Inventory(ComparingObject):

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -48,8 +48,8 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
     Function to read inventory files.
 
     :type path_or_file_object: str or file-like object.
-    :param path_or_file_object: String containing a file name or a URL or a open
-        file-like object. Wildcards are allowed for a file name. If this
+    :param path_or_file_object: String containing a file name or a URL or a
+        open file-like object. Wildcards are allowed for a file name. If this
         attribute is omitted, an example
         :class:`~obspy.core.inventory.inventory.Inventory` object will be
         returned.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -27,10 +27,8 @@ import numpy as np
 from obspy.core import compatibility
 from obspy.core.trace import Trace
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
-                                  _read_from_plugin, download_to_file,
-                                  sanitize_filename, _generic_reader)
+                                  _read_from_plugin, _generic_reader)
 from obspy.core.util.decorator import (map_example_filename,
                                        raise_if_masked, uncompress_file)
 from obspy.core.util.misc import get_window_times, buffered_load_entry_point

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -30,7 +30,7 @@ from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
 from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
                                   _read_from_plugin, download_to_file,
-                                  sanitize_filename)
+                                  sanitize_filename, _generic_reader)
 from obspy.core.util.decorator import (map_example_filename,
                                        raise_if_masked, uncompress_file)
 from obspy.core.util.misc import get_window_times, buffered_load_entry_point
@@ -202,51 +202,30 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     kwargs['endtime'] = endtime
     kwargs['nearest_sample'] = nearest_sample
     kwargs['check_compression'] = check_compression
-    # create stream
-    st = Stream()
+    kwargs['headonly'] = headonly
+    kwargs['format'] = format
+
     if pathname_or_url is None:
         # if no pathname or URL specified, return example stream
         st = _create_example_stream(headonly=headonly)
-    elif not isinstance(pathname_or_url, (str, native_str)):
-        # not a string - we assume a file-like object
-        pathname_or_url.seek(0)
-        try:
-            # first try reading directly
-            stream = _read(pathname_or_url, format, headonly, **kwargs)
-            st.extend(stream.traces)
-        except TypeError:
-            # if this fails, create a temporary file which is read directly
-            # from the file system
-            pathname_or_url.seek(0)
-            with NamedTemporaryFile() as fh:
-                fh.write(pathname_or_url.read())
-                st.extend(_read(fh.name, format, headonly, **kwargs).traces)
-        pathname_or_url.seek(0)
-    elif "://" in pathname_or_url:
-        # some URL
-        # extract extension if any
-        suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
-        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
-            download_to_file(url=pathname_or_url, filename_or_buffer=fh)
-            st.extend(_read(fh.name, format, headonly, **kwargs).traces)
     else:
-        # some file name
-        pathname = pathname_or_url
-        for file in sorted(glob(pathname)):
-            st.extend(_read(file, format, headonly, **kwargs).traces)
-        if len(st) == 0:
-            # try to give more specific information why the stream is empty
-            if has_magic(pathname) and not glob(pathname):
-                raise Exception("No file matching file pattern: %s" % pathname)
-            elif not has_magic(pathname) and not os.path.isfile(pathname):
-                raise IOError(2, "No such file or directory", pathname)
-            # Only raise error if no start/end time has been set. This
-            # will return an empty stream if the user chose a time window with
-            # no data in it.
-            # XXX: Might cause problems if the data is faulty and the user
-            # set start/end time. Not sure what to do in this case.
-            elif not starttime and not endtime:
-                raise Exception("Cannot open file/files: %s" % pathname)
+        st = _generic_reader(pathname_or_url, _read, **kwargs)
+
+    if len(st) == 0:
+        # try to give more specific information why the stream is empty
+        if has_magic(pathname_or_url) and not glob(pathname_or_url):
+            raise Exception("No file matching file pattern: %s" %
+                            pathname_or_url)
+        elif not has_magic(pathname_or_url) and \
+                not os.path.isfile(pathname_or_url):
+            raise IOError(2, "No such file or directory", pathname_or_url)
+        # Only raise error if no start/end time has been set. This
+        # will return an empty stream if the user chose a time window with
+        # no data in it.
+        # XXX: Might cause problems if the data is faulty and the user
+        # set start/end time. Not sure what to do in this case.
+        elif not starttime and not endtime:
+            raise Exception("Cannot open file/files: %s" % pathname_or_url)
     # Trim if times are given.
     if headonly and (starttime or endtime or dtype):
         warnings.warn(_headonly_warning_msg, UserWarning)

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -127,7 +127,7 @@ class EventTestCase(unittest.TestCase):
 
     @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')
     @unittest.skipIf(
-        BASEMAP_VERSION >= [1, 1, 0] and MATPLOTLIB_VERSION == [3, 0, 1],
+        BASEMAP_VERSION or [] >= [1, 1, 0] and MATPLOTLIB_VERSION == [3, 0, 1],
         'matplotlib 3.0.1 is not campatible with basemap')
     @unittest.skipIf(PROJ4_VERSION and PROJ4_VERSION[0] == 5,
                      'unsupported proj4 library')
@@ -518,7 +518,7 @@ class CatalogTestCase(unittest.TestCase):
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')
 @unittest.skipIf(
-    BASEMAP_VERSION >= [1, 1, 0] and MATPLOTLIB_VERSION == [3, 0, 1],
+    BASEMAP_VERSION or [] >= [1, 1, 0] and MATPLOTLIB_VERSION == [3, 0, 1],
     'matplotlib 3.0.1 is not campatible with basemap')
 class CatalogBasemapTestCase(unittest.TestCase):
     """

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -44,6 +44,10 @@ class InventoryTestCase(unittest.TestCase):
         self.image_dir = os.path.join(os.path.dirname(__file__), 'images')
         self.nperr = np.geterr()
         np.seterr(all='ignore')
+        path = os.path.join(os.path.dirname(__file__), 'data')
+        self.path = path
+        self.station_xml1 = os.path.join(path, 'IU_ANMO_00_BHZ.xml')
+        self.station_xml2 = os.path.join(path, 'IU_ULN_00_LH1.xml')
 
     def tearDown(self):
         np.seterr(**self.nperr)
@@ -610,6 +614,17 @@ class InventoryTestCase(unittest.TestCase):
         self.assertEqual(inv[0][0][0].latitude, original_latitude)
         self.assertEqual(inv2[0][0][0].latitude, original_latitude + 1)
         self.assertNotEqual(inv[0][0][0].latitude, inv2[0][0][0].latitude)
+
+    def test_read_inventory_with_wildcard(self):
+        """
+        Tests the read_inventory() function with a filename wild card.
+        """
+        # without wildcard..
+        expected = read_inventory(self.station_xml1)
+        expected += read_inventory(self.station_xml2)
+        # with wildcard
+        got = read_inventory(os.path.join(self.path, "IU_*_00*.xml"))
+        self.assertEqual(expected, got)
 
 
 @unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -15,6 +15,7 @@ from future.utils import PY2
 
 import builtins
 import doctest
+import glob
 import inspect
 import io
 import os
@@ -635,6 +636,51 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
                     continue
                 fh.write(chunk)
 
+
+def _generic_reader(pathname_or_url=None, format=None, callback_func=None,
+                    **kwargs):
+    if not isinstance(pathname_or_url, (str, native_str)):
+        # not a string - we assume a file-like object
+        try:
+            # first try reading directly
+            generic = callback_func(pathname_or_url, format, **kwargs)
+        except TypeError:
+            # if this fails, create a temporary file which is read directly
+            # from the file system
+            pathname_or_url.seek(0)
+            with NamedTemporaryFile() as fh:
+                fh.write(pathname_or_url.read())
+                generic = callback_func(fh.name, format, **kwargs)
+        return generic
+    elif isinstance(pathname_or_url, bytes) and \
+            pathname_or_url.strip().startswith(b'<'):
+        # XML string
+        return callback_func(io.BytesIO(pathname_or_url), format, **kwargs)
+    elif "://" in pathname_or_url[:10]:
+        # URL
+        # extract extension if any
+        suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
+        with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
+            download_to_file(url=pathname_or_url, filename_or_buffer=fh)
+            generic = callback_func(fh.name, format, **kwargs)
+        return generic
+    else:
+        pathname = pathname_or_url
+        # File name(s)
+        pathnames = sorted(glob.glob(pathname))
+        if not pathnames:
+            # try to give more specific information why the stream is empty
+            if glob.has_magic(pathname) and not glob.glob(pathname):
+                raise Exception("No file matching file pattern: %s" % pathname)
+            elif not glob.has_magic(pathname) and not os.path.isfile(pathname):
+                raise IOError(2, "No such file or directory", pathname)
+
+        generic = callback_func(pathnames[0], format, **kwargs)
+        if len(pathnames) > 1:
+            for filename in pathnames[1:]:
+                generic.extend(callback_func(filename, format, **kwargs))
+        return generic
+    
 
 if __name__ == '__main__':
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -680,7 +680,7 @@ def _generic_reader(pathname_or_url=None, callback_func=None,
             for filename in pathnames[1:]:
                 generic.extend(callback_func(filename, **kwargs))
         return generic
-    
+
 
 if __name__ == '__main__':
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -637,32 +637,32 @@ def download_to_file(url, filename_or_buffer, chunk_size=1024):
                 fh.write(chunk)
 
 
-def _generic_reader(pathname_or_url=None, format=None, callback_func=None,
+def _generic_reader(pathname_or_url=None, callback_func=None,
                     **kwargs):
     if not isinstance(pathname_or_url, (str, native_str)):
         # not a string - we assume a file-like object
         try:
             # first try reading directly
-            generic = callback_func(pathname_or_url, format, **kwargs)
+            generic = callback_func(pathname_or_url, **kwargs)
         except TypeError:
             # if this fails, create a temporary file which is read directly
             # from the file system
             pathname_or_url.seek(0)
             with NamedTemporaryFile() as fh:
                 fh.write(pathname_or_url.read())
-                generic = callback_func(fh.name, format, **kwargs)
+                generic = callback_func(fh.name, **kwargs)
         return generic
     elif isinstance(pathname_or_url, bytes) and \
             pathname_or_url.strip().startswith(b'<'):
         # XML string
-        return callback_func(io.BytesIO(pathname_or_url), format, **kwargs)
+        return callback_func(io.BytesIO(pathname_or_url), **kwargs)
     elif "://" in pathname_or_url[:10]:
         # URL
         # extract extension if any
         suffix = os.path.basename(pathname_or_url).partition('.')[2] or '.tmp'
         with NamedTemporaryFile(suffix=sanitize_filename(suffix)) as fh:
             download_to_file(url=pathname_or_url, filename_or_buffer=fh)
-            generic = callback_func(fh.name, format, **kwargs)
+            generic = callback_func(fh.name, **kwargs)
         return generic
     else:
         pathname = pathname_or_url
@@ -675,10 +675,10 @@ def _generic_reader(pathname_or_url=None, format=None, callback_func=None,
             elif not glob.has_magic(pathname) and not os.path.isfile(pathname):
                 raise IOError(2, "No such file or directory", pathname)
 
-        generic = callback_func(pathnames[0], format, **kwargs)
+        generic = callback_func(pathnames[0], **kwargs)
         if len(pathnames) > 1:
             for filename in pathnames[1:]:
-                generic.extend(callback_func(filename, format, **kwargs))
+                generic.extend(callback_func(filename, **kwargs))
         return generic
     
 


### PR DESCRIPTION
### What does this PR do?

This PR resolves the difference between ``read_events`` and ``read_inventory``. Now both call a generic reader function that accepts ``str``, ``file-like-objects``, ``url`` and wildcards for ``str``. The PR also adds the ``__eq__`` and ``extend`` methods to ``Inventory``.

Resolves #2238 , related to #2322 .

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `master` for new features,
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: + DOCS
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
