### PR TITLE
Fix dependency version number comparison in tests

### DIFF
--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -347,7 +347,7 @@ def get_dependency_version(package_name, raw_string=False):
     try:
         version_string = pkg_resources.get_distribution(package_name).version
     except pkg_resources.DistributionNotFound:
-        return None
+        return []
     if raw_string:
         return version_string
     version_list = version_string.split("rc")[0].strip("~")


### PR DESCRIPTION
### What does this PR do?

Fix execution of `core` test suite on Python 3 when basemap is not installed. 

### Why was it initiated?  Any relevant Issues?

See http://tests.obspy.org/101698/

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
