### PR TITLE
Inventory.plot_response: add option for epoch times in legend

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ master:
      (see #2338, #2343).
    * Added wildcard and url support to read_inventory (see #2326).
    * Modified stream.get_gaps() to deal with overlaps correctly (see #1403)
+   * Added option "label_epoch_dates" to Inventory/Network.plot_response() to
+     optionally add channel epoch start/end dates to legend labels (see #2309)
  - obspy.clients.fdsn:
    * Adding more location codes to the default priority list in the mass
      downloader (see #2155, #2159).

--- a/misc/docs/source/gallery.rst
+++ b/misc/docs/source/gallery.rst
@@ -195,6 +195,15 @@ Gallery
     inv.plot_response(0.001, station="RJOB")
 
 .. gallery-plot::
+    :target: packages/autogen/obspy.core.inventory.inventory.Inventory.plot_response.html
+    :alt: Bode plot of Inventory indicating different epochs
+
+    from obspy import read_inventory
+    inv = read_inventory()
+    inv = inv.select(station='RJOB', channel='EHZ')
+    inv.plot_response(0.001, label_epoch_dates=True)
+
+.. gallery-plot::
     :target: packages/autogen/obspy.core.inventory.response.Response.plot.html
     :alt: Bode plot of Response class
 

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -156,6 +156,23 @@ For example:
     resp = inv[0][0][0].response
     resp.plot(0.001, output="VEL")
 
+When plotting stations with instrumentation changes, epoch times can be added
+to the legend labels:
+
+.. code-block:: python
+
+    >>> from obspy import read_inventory
+    >>> inv = read_inventory()
+    >>> inv = inv.select(station='RJOB', channel='EHZ')
+    >>> inv.plot_response(0.001, label_epoch_dates=True)  # doctest: +SKIP
+
+.. plot::
+
+    from obspy import read_inventory
+    inv = read_inventory()
+    inv = inv.select(station='RJOB', channel='EHZ')
+    inv.plot_response(0.001, label_epoch_dates=True)
+
 For more examples see the :ref:`Obspy Gallery <gallery>`.
 
 Dealing with the Response information

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -27,7 +27,7 @@ from obspy.core.util.misc import buffered_load_entry_point
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .network import Network
-from .util import _unified_content_strings, _textwrap
+from .util import _unified_content_strings, _textwrap, _response_plot_label
 
 # Make sure this is consistent with obspy.io.stationxml! Importing it
 # from there results in hard to resolve cyclic imports.
@@ -997,7 +997,8 @@ class Inventory(ComparingObject):
     def plot_response(self, min_freq, output="VEL", network="*", station="*",
                       location="*", channel="*", time=None, starttime=None,
                       endtime=None, axes=None, unwrap_phase=False,
-                      plot_degrees=False, show=True, outfile=None):
+                      plot_degrees=False, show=True, outfile=None,
+                      label_epoch_dates=False):
         """
         Show bode plot of instrument response of all (or a subset of) the
         inventory's channels.
@@ -1056,6 +1057,9 @@ class Inventory(ComparingObject):
             also used to automatically determine the output format. Supported
             file formats depend on your matplotlib backend.  Most backends
             support png, pdf, ps, eps and svg. Defaults to ``None``.
+        :type label_epoch_dates: bool
+        :param label_epoch_dates: Whether to add channel epoch dates in the
+            plot's legend labels.
 
         .. rubric:: Basic Usage
 
@@ -1086,11 +1090,11 @@ class Inventory(ComparingObject):
         for net in matching.networks:
             for sta in net.stations:
                 for cha in sta.channels:
+                    label = _response_plot_label(
+                        net, sta, cha, label_epoch_dates=label_epoch_dates)
                     try:
                         cha.plot(min_freq=min_freq, output=output,
-                                 axes=(ax1, ax2),
-                                 label=".".join((net.code, sta.code,
-                                                 cha.location_code, cha.code)),
+                                 axes=(ax1, ax2), label=label,
                                  unwrap_phase=unwrap_phase,
                                  plot_degrees=plot_degrees, show=False,
                                  outfile=None)

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -21,7 +21,8 @@ import warnings
 from obspy.core.util.obspy_types import ObsPyException, ZeroSamplingRate
 
 from .station import Station
-from .util import BaseNode, _unified_content_strings, _textwrap
+from .util import (
+    BaseNode, _unified_content_strings, _textwrap, _response_plot_label)
 
 
 @python_2_unicode_compatible
@@ -566,7 +567,8 @@ class Network(BaseNode):
 
     def plot_response(self, min_freq, output="VEL", station="*", location="*",
                       channel="*", time=None, starttime=None, endtime=None,
-                      axes=None, unwrap_phase=False, show=True, outfile=None):
+                      axes=None, unwrap_phase=False, show=True, outfile=None,
+                      label_epoch_dates=False):
         """
         Show bode plot of instrument response of all (or a subset of) the
         network's channels.
@@ -619,6 +621,9 @@ class Network(BaseNode):
             also used to automatically determine the output format. Supported
             file formats depend on your matplotlib backend.  Most backends
             support png, pdf, ps, eps and svg. Defaults to ``None``.
+        :type label_epoch_dates: bool
+        :param label_epoch_dates: Whether to add channel epoch dates in the
+            plot's legend labels.
 
         .. rubric:: Basic Usage
 
@@ -648,12 +653,12 @@ class Network(BaseNode):
 
         for sta in matching.stations:
             for cha in sta.channels:
+                label = _response_plot_label(
+                    self, sta, cha, label_epoch_dates=label_epoch_dates)
                 try:
                     cha.plot(min_freq=min_freq, output=output, axes=(ax1, ax2),
-                             label=".".join((self.code, sta.code,
-                                             cha.location_code, cha.code)),
-                             unwrap_phase=unwrap_phase, show=False,
-                             outfile=None)
+                             label=label, unwrap_phase=unwrap_phase,
+                             show=False, outfile=None)
                 except ZeroSamplingRate:
                     msg = ("Skipping plot of channel with zero "
                            "sampling rate:\n%s")

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -874,6 +874,24 @@ def _seed_id_keyfunction(x):
     return x
 
 
+def _response_plot_label(network, station, channel, label_epoch_dates):
+    label = ".".join((network.code, station.code,
+                      channel.location_code, channel.code))
+    if label_epoch_dates:
+        start = channel.start_date
+        if start is None:
+            start = 'open'
+        else:
+            start = str(start.date)
+        end = channel.end_date
+        if end is None:
+            end = 'open'
+        else:
+            end = str(end.date)
+        label += '\n{} -- {}'.format(start, end)
+    return label
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -201,6 +201,27 @@ class InventoryTestCase(unittest.TestCase):
                 inv.plot_response(0.01, output="ACC", channel="*N",
                                   station="[WR]*", time=t, outfile=ic.name)
 
+    def test_response_plot_epoch_times_in_label(self):
+        """
+        Tests response plot with epoch times in labels switched on.
+        """
+        import matplotlib.pyplot as plt
+        inv = read_inventory().select(station='RJOB', channel='EHZ')
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore")
+            fig = inv.plot_response(0.01, label_epoch_dates=True, show=False)
+        try:
+            legend = fig.axes[0].get_legend()
+            texts = legend.get_texts()
+            expecteds = ['BW.RJOB..EHZ\n2001-05-15 -- 2006-12-12',
+                         'BW.RJOB..EHZ\n2006-12-13 -- 2007-12-17',
+                         'BW.RJOB..EHZ\n2007-12-17 -- open']
+            self.assertEqual(len(texts), 3)
+            for text, expected in zip(texts, expecteds):
+                self.assertEqual(text.get_text(), expected)
+        finally:
+            plt.close(fig)
+
     def test_inventory_merging_metadata_update(self):
         """
         Tests the metadata update during merging of inventory objects.

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -146,6 +146,27 @@ class NetworkTestCase(unittest.TestCase):
                 net.plot_response(0.002, output="DISP", channel="B*E",
                                   time=t, outfile=ic.name)
 
+    def test_response_plot_epoch_times_in_label(self):
+        """
+        Tests response plot with epoch times in labels switched on.
+        """
+        import matplotlib.pyplot as plt
+        net = read_inventory().select(station='RJOB', channel='EHZ')[0]
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore")
+            fig = net.plot_response(0.01, label_epoch_dates=True, show=False)
+        try:
+            legend = fig.axes[0].get_legend()
+            texts = legend.get_texts()
+            expecteds = ['BW.RJOB..EHZ\n2001-05-15 -- 2006-12-12',
+                         'BW.RJOB..EHZ\n2006-12-13 -- 2007-12-17',
+                         'BW.RJOB..EHZ\n2007-12-17 -- open']
+            self.assertEqual(len(texts), 3)
+            for text, expected in zip(texts, expecteds):
+                self.assertEqual(text.get_text(), expected)
+        finally:
+            plt.close(fig)
+
     def test_len(self):
         """
         Tests the __len__ property.


### PR DESCRIPTION
Add option to include channel epoch start/end date in legend labels of `Inventory.plot_response(.., epoch_dates=False)`. This could make the plot useful for plotting a single NSLC but with multiple epochs (instrumentation changes).