### PR TITLE
docs: dont advertize Stream.attach_response() in API docs landing page

### DIFF
--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -174,8 +174,6 @@ method will call some functions within evalresp to generate the response.
 Some convenience methods to perform an instrument correction on
 :class:`~obspy.core.stream.Stream` (and :class:`~obspy.core.trace.Trace`)
 objects are available and most users will want to use those. The
-:meth:`~obspy.core.stream.Stream.attach_response()` method will attach matching
-responses to each trace if they are available within the inventory object. The
 :meth:`~obspy.core.stream.Stream.remove_response()` method deconvolves the
 instrument response in-place. As always see the corresponding docs pages for a
 full list of options and a more detailed explanation.
@@ -183,9 +181,8 @@ full list of options and a more detailed explanation.
 >>> from obspy import read
 >>> st = read()
 >>> inv = read_inventory("/path/to/BW_RJOB.xml")
->>> st.attach_response(inv)  # doctest: +NORMALIZE_WHITESPACE
- []
->>> st.remove_response(output="VEL", water_level=20)  # doctest: +ELLIPSIS
+>>> st.remove_response(
+...     inventory=inv, output="VEL", water_level=20)  # doctest: +ELLIPSIS
 <obspy.core.stream.Stream object at 0x...>
 
 Writing


### PR DESCRIPTION
### What does this PR do?

Removes `Stream.attach_response()` being advertized in API docs front page.

+DOCS

### Why was it initiated?  Any relevant Issues?

...


### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
