### PR TITLE
Add support for the "today" argument for UTCDateTime

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1522,6 +1522,15 @@ class UTCDateTimeTestCase(unittest.TestCase):
             msg = "'%s' does not start with a 4 digit year" % value
             self.assertEqual(msg, e.exception.args[0])
 
+    def test_today(self):
+        """
+        Tests the parsing of 'today' as argument.
+        """
+        now = UTCDateTime.now()
+        t = UTCDateTime(now.year, now.month, now.day)
+        nt = UTCDateTime("today")
+        self.assertEqual(t, nt)
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -207,6 +207,11 @@ class UTCDateTime(object):
         >>> UTCDateTime(year=1970, month=1, day=1, hour=48, strict=False)
         UTCDateTime(1970, 1, 3, 0, 0)
 
+    (8) Using the magic "today" argument to get the UTCDatetime for the
+        beginning of today:
+
+        >>> today = UTCDateTime("today")
+
     .. rubric:: _`Precision`
 
     The :class:`UTCDateTime` class works with a default precision of ``6``
@@ -322,6 +327,12 @@ class UTCDateTime(object):
                     value = value.decode()
                 # got a string instance
                 value = value.strip()
+
+                if value == "today":
+                    value = self.now()
+                    dt = datetime.datetime(value.year, value.month, value.day)
+                    self._from_datetime(dt)
+                    return
 
                 # Raising in the case where the leading string is less than 4
                 # chars; linked to #2167


### PR DESCRIPTION
### What does this PR do?

It adds the possibility to pass "today" to UTCDateTime in order to obtain a UTCDateTime object initialised at the beginning of the current day. The result is similar as:

```python
UTCDateTime(UTCDateTime.date))
```

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: + DOCS
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
