### PR TITLE
Characteristic function bk

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,7 +67,8 @@ master:
     * added read support for FOCMEC 'out' and 'lst' files (see #2156)
  - obspy.signal.trigger:
     * fix a bug in AR picker (see #2157)
-    * function added (see #2341)
+    * option to return Baer-Kradolfer characteristic function from pk_mbaer
+      function added (see #2341)
  - obspy.signal.PPSD:
    * Fixed exact trace cutting for PSD segments (see #2040).
    * Timestamp representations internally and in npz I/O were changed to use

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,8 +67,7 @@ master:
     * added read support for FOCMEC 'out' and 'lst' files (see #2156)
  - obspy.signal.trigger:
     * fix a bug in AR picker (see #2157)
-    * option to return Baer-Kradolfer characteristic function from pk_mbaer
-      function added
+    * function added (see #2341)
  - obspy.signal.PPSD:
    * Fixed exact trace cutting for PSD segments (see #2040).
    * Timestamp representations internally and in npz I/O were changed to use

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,6 +67,8 @@ master:
     * added read support for FOCMEC 'out' and 'lst' files (see #2156)
  - obspy.signal.trigger:
     * fix a bug in AR picker (see #2157)
+    * option to return Baer-Kradolfer characteristic function from pk_mbaer
+      function added
  - obspy.signal.PPSD:
    * Fixed exact trace cutting for PSD segments (see #2040).
    * Timestamp representations internally and in npz I/O were changed to use

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -92,3 +92,4 @@ Winkelman, Andrew
 Zaccarelli, Riccardo
 Zad, Seyed Kasra Hosseini
 Zhu, Lijun
+Bagagli, Matteo

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Allgeyer, Sebastien
 Ammon, Charles J.
 Antunes, Emanuel
 Arnarsson, Ólafur St.
+Bagagli, Matteo
 Bank, Markus
 Barsch, Robert
 Behr, Yannik
@@ -92,4 +93,3 @@ Winkelman, Andrew
 Zaccarelli, Riccardo
 Zad, Seyed Kasra Hosseini
 Zhu, Lijun
-Bagagli, Matteo

--- a/obspy/signal/src/pk_mbaer.c
+++ b/obspy/signal/src/pk_mbaer.c
@@ -3,9 +3,6 @@
 #  Purpose: C-Version of Baer Picker based on Fortran code of Baer
 #   Author: Andreas Rietbrock, Joachim Wassermann
 # Copyright (C) A. Rietbrock, J. Wassermann
-#
-# Modified: M.Bagagli 02-2019
-            - The function now returns also the characteristic function
 #---------------------------------------------------------------------*/
 #include "platform.h"
 #include <stdio.h>
@@ -85,7 +82,7 @@ c preset_len  | no of points taken for the estimation of variance of
 
 *******************************************************************************
 int ppick (reltrc,npts,pptime,pfm,
-     samplespersec,tdownmax,tupevent,thrshl1,thrshl2,preset_len,p_dur)
+     samplespersec,tdownmax,tupevent,thrshl1,thrshl2,preset_len,p_dur,cf)
 float *reltrc;
 int npts;
 int *pptime;
@@ -95,11 +92,10 @@ int tdownmax,tupevent;
 float thrshl1,thrshl2;
 int preset_len;
 int p_dur;
-float *CF  //MB
-
+float *cf
 */
 
-int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec, int tdownmax, int tupevent, float thrshl1, float thrshl2, int preset_len, int p_dur,float *CF){
+int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec, int tdownmax, int tupevent, float thrshl1, float thrshl2, int preset_len, int p_dur,float *cf){
       int len2;
       int *trace = NULL;
       int ipkflg;
@@ -121,7 +117,7 @@ int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec,
       float min,max;
       float scale;
 
-      int CF_COUNTER=0;    //MB
+      int cf_counter=0;
 
 
       len2 = 2*preset_len;  /*
@@ -276,9 +272,9 @@ label160:
           edev= (edat-mean)/sdev;  /* corresponds to CF(t), mean corresponds
                                       to S(t)
                                    */
-          CF[CF_COUNTER]=edev ;    //MB
-          CF_COUNTER++ ;           //MB
-      }                            //MB add brackets {}.
+          cf[cf_counter]=edev;
+          cf_counter++;
+      }
 
       iamp = (int) (abs(trace[i]) + 0.5);
       if(iamp > amp)

--- a/obspy/signal/src/pk_mbaer.c
+++ b/obspy/signal/src/pk_mbaer.c
@@ -1,6 +1,6 @@
 /*--------------------------------------------------------------------
 # Filename: pk_mbaer.c
-#  Purpose: C-Verions of Baer Picker based on Fortran code of Baer
+#  Purpose: C-Version of Baer Picker based on Fortran code of Baer
 #   Author: Andreas Rietbrock, Joachim Wassermann
 # Copyright (C) A. Rietbrock, J. Wassermann
 #---------------------------------------------------------------------*/
@@ -10,8 +10,8 @@
 #include <math.h>
 #include <string.h>
 
-
 static void preset(float *, int , float *, float *, float *, /*@out@*/ float *, /*@out@*/ float *, float *, int *, /*@out@*/ int *, /*@out@*/ int *, /*@out@*/ int *, char *, /*@out@*/ int *, float );
+
 /*
 *******************************************************************************
 c====================================================================
@@ -92,10 +92,11 @@ int tdownmax,tupevent;
 float thrshl1,thrshl2;
 int preset_len;
 int p_dur;
-{
+float *CF  //MB
+
 */
 
-int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec, int tdownmax, int tupevent, float thrshl1, float thrshl2, int preset_len, int p_dur){
+int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec, int tdownmax, int tupevent, float thrshl1, float thrshl2, int preset_len, int p_dur,float *CF){
       int len2;
       int *trace = NULL;
       int ipkflg;
@@ -116,6 +117,9 @@ int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec,
       int ii;
       float min,max;
       float scale;
+
+      int CF_COUNTER=0;    //MB
+
 
       len2 = 2*preset_len;  /*
                             the variance of SF(t) is updated as long as
@@ -160,7 +164,7 @@ int ppick (float *reltrc, int npts, int *pptime, char *pfm, float samplespersec,
       mean = 0;
       dtime = 0;
 
-      preset(reltrc,preset_len,&rawold,&y2,&yt,&ssx,&ssx2,&sdev,&num,&itar,
+      preset(/*@IN@*/reltrc,preset_len,&rawold,&y2,&yt,/*@OUT@*/&ssx,&ssx2,&sdev,&num,&itar,
          &ptime,&preptime,pfm,&ipkflg,samplespersec);
 
       omega = y2/yt;    /* set weighting factor */
@@ -265,10 +269,13 @@ label160:
       edat= edat*edat;         /* corresponds to SF(t) */
       omega= y2/yt;
 
-      if(sdev > 0)
+      if(sdev > 0) {
           edev= (edat-mean)/sdev;  /* corresponds to CF(t), mean corresponds
                                       to S(t)
                                    */
+          CF[CF_COUNTER]=edev ;    //MB
+          CF_COUNTER++ ;           //MB
+      }                            //MB add brackets {}.
 
       iamp = (int) (abs(trace[i]) + 0.5);
       if(iamp > amp)

--- a/obspy/signal/src/pk_mbaer.c
+++ b/obspy/signal/src/pk_mbaer.c
@@ -3,6 +3,9 @@
 #  Purpose: C-Version of Baer Picker based on Fortran code of Baer
 #   Author: Andreas Rietbrock, Joachim Wassermann
 # Copyright (C) A. Rietbrock, J. Wassermann
+#
+# Modified: M.Bagagli 02-2019
+            - The function now returns also the characteristic function
 #---------------------------------------------------------------------*/
 #include "platform.h"
 #include <stdio.h>

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -79,6 +79,22 @@ class TriggerTestCase(unittest.TestCase):
         self.assertEqual(nptime, 17545)
         self.assertEqual(pfm, 'IPU0')
 
+    def test_pk_baer_CF(self):
+        """
+        Test pk_baer against implementation for UNESCO short course
+        """
+        filename = os.path.join(self.path, 'manz_waldk.a01.gz')
+        with gzip.open(filename) as f:
+            data = np.loadtxt(f, dtype=np.float32)
+        df, ntdownmax, ntupevent, thr1, thr2, npreset_len, np_dur = \
+            (200.0, 20, 60, 7.0, 12.0, 100, 100)
+        nptime, pfm, cf = pk_baer(data, df, ntdownmax, ntupevent,
+                                  thr1, thr2, npreset_len, np_dur,
+                                  return_cf=True)
+        self.assertEqual(nptime, 17545)
+        self.assertEqual(pfm, 'IPU0')
+        self.assertEqual(len(cf), 119999)
+
     def test_ar_pick(self):
         """
         Test ar_pick against implementation for UNESCO short course

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -79,7 +79,7 @@ class TriggerTestCase(unittest.TestCase):
         self.assertEqual(nptime, 17545)
         self.assertEqual(pfm, 'IPU0')
 
-    def test_pk_baer_CF(self):
+    def test_pk_baer_cf(self):
         """
         Test pk_baer against implementation for UNESCO short course
         """

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -406,16 +406,20 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
     pfm = C.create_string_buffer(b"     ", 5)
     # be nice and adapt type if necessary
     reltrc = np.ascontiguousarray(reltrc, np.float32)
+    # Initiliaze CF array (MB)
+    c_float_p = C.POINTER(C.c_float)
+    CF = np.ascontiguousarray(np.zeros(len(reltrc) - 1), np.float32)
+    data_p = CF.ctypes.data_as(c_float_p)
     # index in pk_mbaer.c starts with 1, 0 index is lost, length must be
     # one shorter
     args = (len(reltrc) - 1, C.byref(pptime), pfm, samp_int,
-            tdownmax, tupevent, thr1, thr2, preset_len, p_dur)
+            tdownmax, tupevent, thr1, thr2, preset_len, p_dur, data_p)
     errcode = clibsignal.ppick(reltrc, *args)
     if errcode != 0:
         raise MemoryError("Error in function ppick of mk_mbaer.c")
     # add the sample to the time which is not taken into account
     # pfm has to be decoded from byte to string
-    return pptime.value + 1, pfm.value.decode('utf-8')
+    return pptime.value + 1, pfm.value.decode('utf-8'), CF
 
 
 def ar_pick(a, b, c, samp_rate, f1, f2, lta_p, sta_p, lta_s, sta_s, m_p, m_s,

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -395,12 +395,10 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
     :param p_dur: p_dur defines the time interval for which the maximum
         amplitude is evaluated Originally set to 6 secs
     :type return_cf: bool
-    :param return_cf: If ``True``, also return the charachteristic function
-        calculated by the C-routine.
+    :param return_cf: If ``True``, also return the characteristic function.
     :return: (pptime, pfm [,cf]) pptime sample number of parrival;
         pfm direction of first motion (U or D), optionally also the
-        numpy.ndarray float32 containing the values of the characteristic
-        function.
+        characteristic function.
     .. note:: currently the first sample is not taken into account
 
     .. seealso:: [Baer1987]_
@@ -412,7 +410,7 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
     reltrc = np.ascontiguousarray(reltrc, np.float32)
     # Initiliaze CF array (MB)
     c_float_p = C.POINTER(C.c_float)
-    cf_arr = np.ascontiguousarray(np.zeros(len(reltrc) - 1), np.float32)
+    cf_arr = np.zeros(len(reltrc) - 1, dtype=np.float32, order="C")
     cf_p = cf_arr.ctypes.data_as(c_float_p)
     # index in pk_mbaer.c starts with 1, 0 index is lost, length must be
     # one shorter

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -412,8 +412,8 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
     reltrc = np.ascontiguousarray(reltrc, np.float32)
     # Initiliaze CF array (MB)
     c_float_p = C.POINTER(C.c_float)
-    CF = np.ascontiguousarray(np.zeros(len(reltrc) - 1), np.float32)
-    cf_p = CF.ctypes.data_as(c_float_p)
+    cf_arr = np.ascontiguousarray(np.zeros(len(reltrc) - 1), np.float32)
+    cf_p = cf_arr.ctypes.data_as(c_float_p)
     # index in pk_mbaer.c starts with 1, 0 index is lost, length must be
     # one shorter
     args = (len(reltrc) - 1, C.byref(pptime), pfm, samp_int,
@@ -421,11 +421,11 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
     errcode = clibsignal.ppick(reltrc, *args)
     if errcode != 0:
         raise MemoryError("Error in function ppick of mk_mbaer.c")
-    # Switch CF param (MB)
+    # Switch cf_arr param (MB)
     # add the sample to the time which is not taken into account
     # pfm has to be decoded from byte to string
     if return_cf:
-        return pptime.value + 1, pfm.value.decode('utf-8'), CF
+        return pptime.value + 1, pfm.value.decode('utf-8'), cf_arr
     else:
         return pptime.value + 1, pfm.value.decode('utf-8')
 


### PR DESCRIPTION
### What does this PR do?
This simple PR wants to add the option of returning the Characteristic Function of the Baer-Kradolfer picker implementation inside obspy (obspy.signal.trigger.pk_baer). I modified the C-source code and the python wrapper accordingly to obtain it.

### Why was it initiated?  Any relevant Issues?
No major issue, or problem. Just needed this ability for a project myself, I think it would be useful to the community as well.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
