### PR TITLE
Add high-precision pick time support and long-phase name support

### DIFF
--- a/obspy/io/nordic/tests/data/sfile_high_precision_picks
+++ b/obspy/io/nordic/tests/data/sfile_high_precision_picks
@@ -1,0 +1,14 @@
+ 2010 1126 0128 45.1 L  37.324 -32.293  2.0  MWW  4 0.0                        1
+ GAP=249        0.34       2.0     0.7  2.3 -0.4033E+00 -0.2372E+00  0.3948E+01E
+ 2010 1126 0128 45.148  37.32390  -32.29291    2.000  0.022                    H
+ ACTION:UP  19-02-22 14:32 OP:pb   STATUS:               ID:20101126012841     I
+ OLDACT:REG 19-02-22 14:31 OP:pb   STATUS:               ID:20101126012841     3
+ 2010-11-26-0128-41S.NSN___020                                                 6
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSd1 SZ EPg       12846.859                             148    0.0110 1.34 110 
+ LSd3 SZ EPg       12848.132                             121    0.0310 3.81 163 
+ LSd2 SZ EPg       12848.183                             115   -0.0110 4.13 221 
+ LSd4 SZ EPg       12849.744                             106   -0.03 9 6.66 136 
+
+                                                                                                                                                               
+ 

--- a/obspy/io/nordic/tests/data/sfile_long_phase
+++ b/obspy/io/nordic/tests/data/sfile_long_phase
@@ -1,0 +1,6 @@
+ 2010 1126 0128 45.1 L  37.324 -32.293  2.0  MWW  4 0.0                        1
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSd1 SZ1EPKiKP    12846.859                                    0.0110 1.34 110 
+
+                                                                                                                                                               
+ 


### PR DESCRIPTION
### What does this PR do?
Adds support for high(er)-precision timing in Nordic pick files (closes #2348) and add support for long phase names - from the seisan manual:
> Long phase names: An 8 character phase can be used in column 11-18. There is then not room for polarity information. the weight is then put into column 9. This format is recognised by HYP and MULPLT

### Why was it initiated?  Any relevant Issues?
Seconds can run in columns 23-28 - I misread the indexing and was reading columns 23-28 rather than 22-28. #2348 pointed out that this is used when seisan is run in "high-accuracy" mode.

Note, pick times are now written out by default in high-accuracy from obspy now. **I need to confirm that seisan is always happy with this**, if not then a flag option for high-accuracy should be implemented.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
