### PR TITLE
Nordic high accuracy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,9 @@ master:
    * Fix mapping of magnitude-types between MS to S and Ms to s.
    * Output preferred origin when writing to Nordic format instead of using
      the first origin (see #2195)
+   * Include high-accuracy phase-pick reading and writing - high-accuracy is
+     now the default phase-writing format.
+   * Allow long-phase names (both reading and writing) - longer than 4 char.
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,7 +45,8 @@ master:
    * Output preferred origin when writing to Nordic format instead of using
      the first origin (see #2195)
    * Include high-accuracy phase-pick reading and writing - high-accuracy is
-     now the default phase-writing format.
+     now the default phase-writing format, a boolean flag `high_accuracy`
+     has been added to turn this off.
    * Allow long-phase names (both reading and writing) - longer than 4 char.
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,

--- a/obspy/io/nordic/__init__.py
+++ b/obspy/io/nordic/__init__.py
@@ -12,3 +12,11 @@ obspy.io.nordic - Nordic file format support for ObsPy
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+
+
+class NordicParsingError(Exception):
+    """
+    Internal general error for IO operations in obspy.core.io.nordic.
+    """
+    def __init__(self, value):
+        self.value = value

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -1512,9 +1512,9 @@ def nordpick(event):
             period=_str_conv(peri, rounded=peri_round).rjust(5)[0:5],
             azimuth=_str_conv(azimuth).rjust(6)[0:6],
             velocity=_str_conv(velocity).rjust(5)[0:5],
-            azimuthres= _str_conv(azimuthres).rjust(3)[0:3],
-            timeres= _str_conv(timeres, rounded=2).rjust(5)[0:5],
-            distance= distance.rjust(5)[0:5],
+            azimuthres=_str_conv(azimuthres).rjust(3)[0:3],
+            timeres=_str_conv(timeres, rounded=2).rjust(5)[0:5],
+            distance=distance.rjust(5)[0:5],
             caz=_str_conv(caz).rjust(4)[0:4]))
         # Note that currently finalweight is unsupported, nor is velocity, or
         # angle of incidence.  This is because obspy.event stores slowness in

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -732,11 +732,7 @@ def _read_picks(tagged_lines, new_event):
             polarity = line[16]
             if weight == ' ':
                 weight = 0
-        polarity_maps = {"": "undecidable", "C": "positive", "D": "negative"}
-        try:
-            polarity = polarity_maps[polarity]
-        except KeyError:
-            polarity = "undecidable"
+        polarity = POLARITY_MAPPING.get(polarity, "undecidable")
         # It is valid nordic for the origin to be hour 23 and picks to be hour
         # 00 or 24: this signifies a pick over a day boundary.
         pick_hour = int(line[18:20])
@@ -770,10 +766,7 @@ def _read_picks(tagged_lines, new_event):
             pick.onset = ONSET_MAPPING[line[9]]
         except KeyError:
             pass
-        if line[15] == 'A':
-            pick.evaluation_mode = 'automatic'
-        else:
-            pick.evaluation_mode = 'manual'
+        pick.evaluation_mode = EVALUATION_MAPPING.get(line[15], "manual")
         # Note these two are not always filled - velocity conversion not yet
         # implemented, needs to be converted from km/s to s/deg
         # if not velocity == 999.0:

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -34,10 +34,16 @@ from obspy.core.event import (
     Tensor, ResourceIdentifier)
 
 
-mag_mapping = {"ML": "L", "MLv": "L", "mB": "B", "Ms": "s", "MS": "S",
+MAG_MAPPING = {"ML": "L", "MLv": "L", "mB": "B", "Ms": "s", "MS": "S",
                "MW": "W", "MbLg": "G", "Mc": "C"}
-
-onsets = {'I': 'impulsive', 'E': 'emergent'}
+INV_MAG_MAPPING = {item: key for key, item in MAG_MAPPING.items()}
+POLARITY_MAPPING = {"": "undecidable", "C": "positive", "D": "negative"}
+INV_POLARITY_MAPPING = {item: key for key, item in POLARITY_MAPPING.items()}
+ONSET_MAPPING = {'I': 'impulsive', 'E': 'emergent'}
+INV_ONSET_MAPPING = {item: key for key, item in ONSET_MAPPING.items()}
+EVALUATION_MAPPING = {'A': 'automatic', ' ': 'manual'}
+INV_EVALUTATION_MAPPING = {
+    item: key for key, item in EVALUATION_MAPPING.items()}
 # List of currently implemented line-endings, which in Nordic mark what format
 # info in that line will be.
 accepted_tags = ['1', '6', '7', 'E', ' ', 'F', 'M', '3']
@@ -183,23 +189,17 @@ def _str_conv(number, rounded=False):
         if number < 100000:
             string = str(number)
         else:
-            exponant = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
-            divisor = 10 ** exponant
-            string = '{0:.1f}'.format(number / divisor) + 'e' + str(exponant)
-    elif rounded == 2 and isinstance(number, (float, int)):
+            exponent = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
+            divisor = 10 ** exponent
+            string = '{0:.1f}'.format(number / divisor) + 'e' + str(exponent)
+    elif rounded and isinstance(number, (float, int)):
         if number < 100000:
-            string = '{0:.2f}'.format(number)
+            string = "{:.{precision}f}".format(number, precision=rounded)
         else:
-            exponant = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
-            divisor = 10 ** exponant
-            string = '{0:.2f}'.format(number / divisor) + 'e' + str(exponant)
-    elif rounded == 1 and isinstance(number, (float, int)):
-        if number < 100000:
-            string = '{0:.1f}'.format(number)
-        else:
-            exponant = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
-            divisor = 10 ** exponant
-            string = '{0:.1f}'.format(number / divisor) + 'e' + str(exponant)
+            exponent = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
+            divisor = 10 ** exponent
+            string = "{:.{precision}f}".format(
+                number / divisor, precision=rounded) + 'e' + str(exponent)
     else:
         return str(number)
     return string
@@ -219,11 +219,9 @@ def _evmagtonor(mag_type):
     if mag_type == 'M':
         warnings.warn('Converting generic magnitude to moment magnitude')
         return "W"
-    try:
-        mag = mag_mapping[mag_type]
-    except KeyError:
+    mag = MAG_MAPPING.get(mag_type, '')
+    if mag == '':
         warnings.warn(mag_type + ' is not convertible')
-        return ''
     return mag
 
 
@@ -238,12 +236,9 @@ def _nortoevmag(mag_type):
     """
     if mag_type.upper() == "L":
         return "ML"
-    inv_mag_mapping = {item: key for key, item in mag_mapping.items()}
-    try:
-        mag = inv_mag_mapping[mag_type]
-    except KeyError:
+    mag = INV_MAG_MAPPING.get(mag_type, '')
+    if mag == '':
         warnings.warn(mag_type + ' is not convertible')
-        return ''
     return mag
 
 
@@ -714,7 +709,11 @@ def _read_picks(tagged_lines, new_event):
         if len(line) < 80:
             line = line.ljust(80)  # Pick-lines without a tag may be short.
         weight = line[14]
-        if weight == '_':
+        if weight not in ' 012349_':  # Long phase name
+            weight = line[8]
+            phase = line[10:17].strip()
+            polarity = ''
+        elif weight == '_':
             phase = line[10:17]
             weight = 0
             polarity = ''
@@ -730,27 +729,19 @@ def _read_picks(tagged_lines, new_event):
             polarity = "undecidable"
         # It is valid nordic for the origin to be hour 23 and picks to be hour
         # 00 or 24: this signifies a pick over a day boundary.
-        if int(line[18:20]) == 0 and evtime.hour == 23:
+        pick_hour = int(line[18:20])
+        pick_minute = int(line[20:22])
+        pick_seconds = float(line[22:28])
+        if pick_hour == 0 and evtime.hour == 23:
             day_add = 86400
-            pick_hour = 0
-        elif int(line[18:20]) == 24:
+        elif pick_hour >= 24:  # Nordic supports up to 48 hours advanced.
             day_add = 86400
-            pick_hour = 0
+            pick_hour -= 24
         else:
             day_add = 0
-            pick_hour = int(line[18:20])
-        try:
-            time = UTCDateTime(evtime.year, evtime.month, evtime.day,
-                               pick_hour, int(line[20:22]),
-                               float(line[23:28])) + day_add
-        except ValueError:
-            time = UTCDateTime(evtime.year, evtime.month, evtime.day,
-                               int(line[18:20]), pick_hour,
-                               float("0." + line[23:38].split('.')[1])) +\
-                60 + day_add
-            # Add 60 seconds on to the time, this copes with s-file
-            # preference to write seconds in 1-60 rather than 0-59 which
-            # datetime objects accept
+        time = UTCDateTime(
+            year=evtime.year, month=evtime.month, day=evtime.day,
+            hour=pick_hour, minute=pick_minute) + (pick_seconds + day_add)
         if header[57:60] == 'AIN':
             ain = _float_conv(line[57:60])
             warnings.warn('AIN: %s in header, currently unsupported' % ain)
@@ -766,7 +757,7 @@ def _read_picks(tagged_lines, new_event):
         pick = Pick(waveform_id=_waveform_id, phase_hint=phase,
                     polarity=polarity, time=time)
         try:
-            pick.onset = onsets[line[9]]
+            pick.onset = ONSET_MAPPING[line[9]]
         except KeyError:
             pass
         if line[15] == 'A':
@@ -1260,17 +1251,17 @@ def _write_moment_tensor_line(focal_mechanism):
     # Sort out the second line
     lines[1][1:3] = 'MT'
     lines[1][3:9] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_rr, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_rr, 3)[0:6].rjust(6)
     lines[1][10:16] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_tt, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_tt, 3)[0:6].rjust(6)
     lines[1][17:23] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_pp, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_pp, 3)[0:6].rjust(6)
     lines[1][24:30] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_rt, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_rt, 3)[0:6].rjust(6)
     lines[1][31:37] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_rp, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_rp, 3)[0:6].rjust(6)
     lines[1][38:44] = _str_conv(
-        focal_mechanism.moment_tensor.tensor.m_tp, 3).rjust(6)
+        focal_mechanism.moment_tensor.tensor.m_tp, 3)[0:6].rjust(6)
     if hasattr(magnitude, 'creation_info') and hasattr(
             magnitude.creation_info, 'agency_id'):
         lines[1][45:48] = magnitude.creation_info.agency_id.rjust(3)[0:3]
@@ -1361,62 +1352,49 @@ def nordpick(event):
         from the values stored in seisan.  Multiple weights are also
         not supported.
     """
+    # Nordic picks do not have a date associated with them - we need time
+    # relative to some origin time.
+    try:
+        origin = event.preferred_origin() or event.origins[0]
+        origin_date = origin.time.date
+    except IndexError:
+        origin = Origin()
+        origin_date = min([p.time for p in event.picks]).date
     pick_strings = []
     for pick in event.picks:
         if not pick.waveform_id:
             msg = ('No waveform id for pick at time %s, skipping' % pick.time)
             warnings.warn(msg)
             continue
-        # Convert string to short sting
-        if pick.onset == 'impulsive':
-            impulsivity = 'I'
-        elif pick.onset == 'emergent':
-            impulsivity = 'E'
-        else:
-            impulsivity = ' '
-
-        # Convert string to short string
-        if pick.polarity == 'positive':
-            polarity = 'C'
-        elif pick.polarity == 'negative':
-            polarity = 'D'
-        else:
-            polarity = ' '
+        impulsivity = _str_conv(INV_ONSET_MAPPING.get(pick.onset))
+        polarity = _str_conv(INV_POLARITY_MAPPING.get(pick.polarity))
         # Extract velocity: Note that horizontal slowness in quakeML is stored
         # as s/deg
-        if pick.horizontal_slowness is not None:
-            # velocity = 1.0 / pick.horizontal_slowness
-            velocity = ' '  # Currently this conversion is unsupported.
-        else:
-            velocity = ' '
-        # Extract azimuth
-        if pick.backazimuth is not None:
-            azimuth = pick.backazimuth
-        else:
-            azimuth = ' '
+        # if pick.horizontal_slowness is not None:
+        #     # velocity = 1.0 / pick.horizontal_slowness
+        #     velocity = ' '  # Currently this conversion is unsupported.
+        # else:
+        #     velocity = ' '
+        velocity = ' '
+        azimuth = _str_conv(pick.backazimuth)
         # Extract the correct arrival info for this pick - assuming only one
         # arrival per pick...
-        try:
-            origin = event.preferred_origin() or event.origins[0]
-            arrival = [arrival for arrival in origin.arrivals
-                       if arrival.pick_id == pick.resource_id]
-        except IndexError:
-            arrival = []
+        arrival = [arrival for arrival in origin.arrivals
+                   if arrival.pick_id == pick.resource_id]
         if len(arrival) > 0:
+            if len(arrival) > 1:
+                warnings.warn("Multiple arrivals for pick - only writing one")
             arrival = arrival[0]
             # Extract weight - should be stored as 0-4, or 9 for seisan.
-            if arrival.time_weight is not None:
-                weight = int(arrival.time_weight)
-            else:
-                weight = '0'
+            weight = _str_conv(int(arrival.time_weight or 0))
             # Extract azimuth residual
             if arrival.backazimuth_residual is not None:
-                azimuthres = int(arrival.backazimuth_residual)
+                azimuthres = _str_conv(int(arrival.backazimuth_residual))
             else:
                 azimuthres = ' '
             # Extract time residual
             if arrival.time_residual is not None:
-                timeres = arrival.time_residual
+                timeres = _str_conv(arrival.time_residual, rounded=2)
             else:
                 timeres = ' '
             # Extract distance
@@ -1425,30 +1403,22 @@ def nordpick(event):
                 if distance >= 100.0:
                     distance = str(_int_conv(distance))
                 elif 10.0 < distance < 100.0:
-                    distance = _str_conv(round(distance, 1), 1)
+                    distance = _str_conv(round(distance, 1), rounded=1)
                 elif distance < 10.0:
-                    distance = _str_conv(round(distance, 2), 2)
+                    distance = _str_conv(round(distance, 2), rounded=2)
                 else:
                     distance = _str_conv(distance, False)
             else:
                 distance = ' '
             # Extract CAZ
             if arrival.azimuth is not None:
-                caz = int(arrival.azimuth)
+                caz = _str_conv(int(arrival.azimuth))
             else:
                 caz = ' '
         else:
-            caz = ' '
-            distance = ' '
-            timeres = ' '
-            azimuthres = ' '
-            azimuth = ' '
-            weight = 0
-        if not pick.phase_hint:
-            # Cope with some authorities not providing phase hints :(
-            phase_hint = ' '
-        else:
-            phase_hint = pick.phase_hint
+            caz, distance, timeres, azimuthres, azimuth, weight = (
+                ' ', ' ', ' ', ' ', ' ', 0)
+        phase_hint = pick.phase_hint or ' '
         # Extract amplitude: note there can be multiple amplitudes, but they
         # should be associated with different picks.
         amplitude = [amplitude for amplitude in event.amplitudes
@@ -1496,38 +1466,50 @@ def nordpick(event):
             peri_round = False
             amp = None
             coda = ' '
-        # If the weight is 0 then we don't need to print it
-        if weight == 0 or weight == '0':
-            weight = None  # this will return an empty string using _str_conv
-        elif weight is not None:
-            weight = int(weight)
-        if pick.evaluation_mode == "automatic":
-            eval_mode = "A"
-        elif pick.evaluation_mode == "manual":
-            eval_mode = " "
-        else:
-            warnings.warn("Evaluation mode %s is not supported"
-                          % pick.evaluation_mode)
-            eval_mode = " "
+        eval_mode = INV_EVALUTATION_MAPPING.get(pick.evaluation_mode, None)
+        if eval_mode is None:
+            warnings.warn("Evaluation mode {0} is not mappable".format(
+                pick.evaluation_mode))
         # Generate a print string and attach it to the list
         channel_code = pick.waveform_id.channel_code or '   '
-        pick_strings.append(
-            " {0}{1}{2} {3}{4}{5}{6}{7} {8}{9}{10}.{11}{12}"
-            "{13}{14}{15}{16}    {17}{18}  {19}{20} ".format(
-                pick.waveform_id.station_code.ljust(5), channel_code[0],
-                channel_code[-1], impulsivity, phase_hint.ljust(4),
-                _str_conv(weight).rjust(1), eval_mode, polarity.rjust(1),
-                str(pick.time.hour).rjust(2), str(pick.time.minute).rjust(2),
-                str(pick.time.second).rjust(3),
-                str(float(pick.time.microsecond) /
-                    (10 ** 4)).split('.')[0].zfill(2),
-                _str_conv(coda).rjust(5)[0:5],
-                _str_conv(amp, rounded=1).rjust(7)[0:7],
-                _str_conv(peri, rounded=peri_round).rjust(5),
-                _str_conv(azimuth).rjust(6), _str_conv(velocity).rjust(5),
-                _str_conv(azimuthres).rjust(3),
-                _str_conv(timeres, rounded=2).rjust(5)[0:5], distance.rjust(5),
-                _str_conv(caz).rjust(4)))
+        pick_hour = pick.time.hour
+        if pick.time.date > origin_date:
+            # pick hours up to 48 are supported
+            days_diff = (pick.time.date - origin_date).days
+            if days_diff > 1:
+                raise NordicParsingError(
+                    "Pick is {0} days from the origin, must be < 48 "
+                    "hours".format(days_diff))
+            pick_hour += 24
+        pick_seconds = pick.time.second + (pick.time.microsecond / 1e6)
+        if len(phase_hint) > 4:
+            # Weight goes in 9 and phase_hint runs through 11-18
+            if polarity != ' ':
+                UserWarning("Polarity not written due to phase hint length")
+            phase_info = (
+                _str_conv(weight).rjust(1) + impulsivity + phase_hint.ljust(8))
+        else:
+            phase_info = (
+                ' ' + impulsivity + phase_hint.ljust(4) +
+                _str_conv(weight).rjust(1) + eval_mode +
+                polarity.rjust(1) + ' ')
+        # TODO: Make this a nice format string that specifically matches seisan
+        pick_strings.append(' ' + pick.waveform_id.station_code.ljust(5) +
+                            channel_code[0] + channel_code[-1] +
+                            phase_info + str(pick_hour).rjust(2) +
+                            str(pick.time.minute).rjust(2) +
+                            _str_conv(pick_seconds, rounded=3).rjust(6) +
+                            _str_conv(coda).rjust(5)[0:5] +
+                            _str_conv(amp, rounded=1).rjust(7)[0:7] +
+                            _str_conv(peri, rounded=peri_round).rjust(5) +
+                            _str_conv(azimuth).rjust(6) +
+                            _str_conv(velocity).rjust(5) +
+                            _str_conv(' ').rjust(4) +
+                            _str_conv(azimuthres).rjust(3) +
+                            _str_conv(timeres, rounded=2).rjust(5)[0:5] +
+                            _str_conv(' ').rjust(2) +
+                            distance.rjust(5) +
+                            _str_conv(caz).rjust(4) + ' ')
         # Note that currently finalweight is unsupported, nor is velocity, or
         # angle of incidence.  This is because obspy.event stores slowness in
         # s/deg and takeoff angle, which would require computation from the

--- a/obspy/io/nordic/tests/data/sfile_high_precision_picks
+++ b/obspy/io/nordic/tests/data/sfile_high_precision_picks
@@ -1,0 +1,14 @@
+ 2010 1126 0128 45.1 L  37.324 -32.293  2.0  MWW  4 0.0                        1
+ GAP=249        0.34       2.0     0.7  2.3 -0.4033E+00 -0.2372E+00  0.3948E+01E
+ 2010 1126 0128 45.148  37.32390  -32.29291    2.000  0.022                    H
+ ACTION:UP  19-02-22 14:32 OP:pb   STATUS:               ID:20101126012841     I
+ OLDACT:REG 19-02-22 14:31 OP:pb   STATUS:               ID:20101126012841     3
+ 2010-11-26-0128-41S.NSN___020                                                 6
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSd1 SZ EPg       12846.859                             148    0.0110 1.34 110 
+ LSd3 SZ EPg       12848.132                             121    0.0310 3.81 163 
+ LSd2 SZ EPg       12848.183                             115   -0.0110 4.13 221 
+ LSd4 SZ EPg       12849.744                             106   -0.03 9 6.66 136 
+
+                                                                                                                                                               
+ 

--- a/obspy/io/nordic/tests/data/sfile_long_phase
+++ b/obspy/io/nordic/tests/data/sfile_long_phase
@@ -1,0 +1,6 @@
+ 2010 1126 0128 45.1 L  37.324 -32.293  2.0  MWW  4 0.0                        1
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSd1 SZ1EPKiKP    12846.859                                    0.0110 1.34 110 
+
+                                                                                                                                                               
+ 

--- a/obspy/io/nordic/tests/data/sfile_seconds_overflow
+++ b/obspy/io/nordic/tests/data/sfile_seconds_overflow
@@ -1,0 +1,8 @@
+ 2009  7 2 0650 38.0 L  37.204 -32.354  8.5  AKR  5 0.1 1.2LAKR                1
+ GAP=325        0.39       3.1     4.2  4.7 -0.2566E+01  0.3577E+01  0.5629E+01E
+ 2009  7 2 0650 37.984  37.20362  -32.35415    8.489  0.142                    H
+ ACTION:ARG 11-03-16 17:12 OP:wcc  STATUS:               ID:20090702065037 L   I
+ 2009-07-02-0649-56M.LSFIR_024                                                 6
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSb2 SZ IP        649 100.24 129                        113    0.0210 10.9  14
+

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -293,8 +293,11 @@ class TestNordicMethods(unittest.TestCase):
                          header_event.origins[0].depth)
 
     def test_header_mapping(self):
-        head_1 = readheader(os.path.join(self.testing_path,
-                                         '01-0411-15L.S201309'))
+        # Raise "UserWarning: Lines of type I..."
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            head_1 = readheader(os.path.join(self.testing_path,
+                                             '01-0411-15L.S201309'))
         with open(os.path.join(self.testing_path,
                                '01-0411-15L.S201309'), 'r') as f:
             # raises "UserWarning: AIN in header, currently unsupported"
@@ -307,7 +310,10 @@ class TestNordicMethods(unittest.TestCase):
     def test_missing_header(self):
         # Check that a suitable error is raised
         with self.assertRaises(NordicParsingError):
-            readheader(os.path.join(self.testing_path, 'Sfile_no_header'))
+            # Raises AIN warning
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                readheader(os.path.join(self.testing_path, 'Sfile_no_header'))
 
     def test_reading_string_io(self):
         filename = os.path.join(self.testing_path, '01-0411-15L.S201309')
@@ -427,19 +433,23 @@ class TestNordicMethods(unittest.TestCase):
         """
         Check that we can read dos formatted, latin1 encoded files.
         """
-        dos_file = os.path.join(self.testing_path, 'dos-file.sfile')
-        self.assertTrue(_is_sfile(dos_file))
-        event = readheader(dos_file)
-        self.assertEqual(event.origins[0].latitude, 60.328)
-        cat = read_events(dos_file)
-        self.assertEqual(cat[0].origins[0].latitude, 60.328)
-        wavefiles = readwavename(dos_file)
-        self.assertEqual(wavefiles[0], "90121311.0851W41")
-        spectral_info = read_spectral_info(dos_file)
-        self.assertEqual(len(spectral_info.keys()), 10)
-        self.assertEqual(spectral_info[('AVERAGE', '')]['stress_drop'], 27.7)
-        with self.assertRaises(UnicodeDecodeError):
-            readheader(dos_file, 'ASCII')
+        with warnings.catch_warnings():
+            # Lots of unsupported line warnings
+            warnings.simplefilter('ignore', UserWarning)
+            dos_file = os.path.join(self.testing_path, 'dos-file.sfile')
+            self.assertTrue(_is_sfile(dos_file))
+            event = readheader(dos_file)
+            self.assertEqual(event.origins[0].latitude, 60.328)
+            cat = read_events(dos_file)
+            self.assertEqual(cat[0].origins[0].latitude, 60.328)
+            wavefiles = readwavename(dos_file)
+            self.assertEqual(wavefiles[0], "90121311.0851W41")
+            spectral_info = read_spectral_info(dos_file)
+            self.assertEqual(len(spectral_info.keys()), 10)
+            self.assertEqual(spectral_info[('AVERAGE', '')]['stress_drop'],
+                             27.7)
+            with self.assertRaises(UnicodeDecodeError):
+                readheader(dos_file, 'ASCII')
 
     def test_read_many_events(self):
         testing_path = os.path.join(self.testing_path, 'select.out')
@@ -457,9 +467,12 @@ class TestNordicMethods(unittest.TestCase):
                 warnings.simplefilter('ignore', UserWarning)
                 write_select(cat, filename=tf.name)
             self.assertTrue(_is_sfile(tf.name))
-            cat_back = read_events(tf.name)
-            for event_1, event_2 in zip(cat, cat_back):
-                _assert_similarity(event_1=event_1, event_2=event_2)
+            with warnings.catch_warnings():
+                # Type I warning
+                warnings.simplefilter('ignore', UserWarning)
+                cat_back = read_events(tf.name)
+        for event_1, event_2 in zip(cat, cat_back):
+            _assert_similarity(event_1=event_1, event_2=event_2)
 
     def test_write_plugin(self):
         cat = read_events()
@@ -534,7 +547,10 @@ class TestNordicMethods(unittest.TestCase):
         Test reading the info from spectral analysis.
         """
         testing_path = os.path.join(self.testing_path, 'automag.out')
-        spec_inf = read_spectral_info(testing_path)
+        with warnings.catch_warnings():
+            # Userwarning, type I
+            warnings.simplefilter('ignore', UserWarning)
+            spec_inf = read_spectral_info(testing_path)
         self.assertEqual(len(spec_inf), 5)
         # This should actually test that what we are reading in is correct.
         average = spec_inf[('AVERAGE', '')]
@@ -615,8 +631,10 @@ class TestNordicMethods(unittest.TestCase):
         event.origins[0].longitude = -120
         with NamedTemporaryFile(suffix=".out") as tf:
             event.write(tf.name, format="NORDIC")
-            event_back = read_events(tf.name)
-            _assert_similarity(event, event_back[0])
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                event_back = read_events(tf.name)
+        _assert_similarity(event, event_back[0])
 
     def test_write_preferred_origin(self):
         event = full_test_event()
@@ -627,15 +645,108 @@ class TestNordicMethods(unittest.TestCase):
         event.preferred_origin_id = preferred_origin.resource_id
         with NamedTemporaryFile(suffix=".out") as tf:
             event.write(tf.name, format="NORDIC")
-            event_back = read_events(tf.name)
-            self.assertEqual(preferred_origin.latitude,
-                             event_back[0].origins[0].latitude)
-            self.assertEqual(preferred_origin.longitude,
-                             event_back[0].origins[0].longitude)
-            self.assertEqual(preferred_origin.depth,
-                             event_back[0].origins[0].depth)
-            self.assertEqual(preferred_origin.time,
-                             event_back[0].origins[0].time)
+            with warnings.catch_warnings():
+                # Type I warning
+                warnings.simplefilter('ignore', UserWarning)
+                event_back = read_events(tf.name)
+        self.assertEqual(preferred_origin.latitude,
+                         event_back[0].origins[0].latitude)
+        self.assertEqual(preferred_origin.longitude,
+                         event_back[0].origins[0].longitude)
+        self.assertEqual(preferred_origin.depth,
+                         event_back[0].origins[0].depth)
+        self.assertEqual(preferred_origin.time,
+                         event_back[0].origins[0].time)
+
+    def test_read_high_precision_pick(self):
+        """
+        Nordic supports writing to milliseconds in high-precision mode,
+        obspy < 1.2.0 did not properly read this, see #2348.
+        """
+        # raises "UserWarning: AIN in header, currently unsupported"
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            cat = read_events(
+                os.path.join(self.testing_path, "sfile_high_precision_picks"))
+        event = cat[0]
+        pick_times = {
+            "LSd1": UTCDateTime(2010, 11, 26, 1, 28, 46.859),
+            "LSd3": UTCDateTime(2010, 11, 26, 1, 28, 48.132),
+            "LSd2": UTCDateTime(2010, 11, 26, 1, 28, 48.183),
+            "LSd4": UTCDateTime(2010, 11, 26, 1, 28, 49.744)}
+        for key, value in pick_times.items():
+            pick = [p for p in event.picks
+                    if p.waveform_id.station_code == key]
+            self.assertEqual(len(pick), 1)
+            self.assertEqual(pick[0].time, value)
+
+    def test_high_precision_read_write(self):
+        """ Test that high-precision writing works. """
+        # raises "UserWarning: AIN in header, currently unsupported"
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            cat = read_events(
+                os.path.join(self.testing_path, "sfile_high_precision_picks"))
+        event = cat[0]
+        pick_times = {
+            "LSd1": UTCDateTime(2010, 11, 26, 1, 28, 46.859),
+            "LSd3": UTCDateTime(2010, 11, 26, 1, 28, 48.132),
+            "LSd2": UTCDateTime(2010, 11, 26, 1, 28, 48.183),
+            "LSd4": UTCDateTime(2010, 11, 26, 1, 28, 49.744)}
+        for key, value in pick_times.items():
+            pick = [p for p in event.picks
+                    if p.waveform_id.station_code == key]
+            self.assertEqual(len(pick), 1)
+            self.assertEqual(pick[0].time, value)
+        with NamedTemporaryFile(suffix=".out") as tf:
+            write_select(cat, filename=tf.name)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                cat_back = read_events(tf.name)
+        self.assertEqual(len(cat_back), 1)
+        for key, value in pick_times.items():
+            pick = [p for p in cat_back[0].picks
+                    if p.waveform_id.station_code == key]
+            self.assertEqual(len(pick), 1)
+            self.assertEqual(pick[0].time, value)
+
+    def test_long_phase_name(self):
+        """ Nordic format supports 8 char phase names, sometimes. """
+        # raises "UserWarning: AIN in header, currently unsupported"
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            cat = read_events(
+                os.path.join(self.testing_path, "sfile_long_phase"))
+        # This file has one event with one pick
+        pick = cat[0].picks[0]
+        arrival = cat[0].origins[0].arrivals[0]
+        self.assertEqual(pick.phase_hint, "PKiKP")
+        self.assertEqual(arrival.time_weight, 1)
+        with NamedTemporaryFile(suffix=".out") as tf:
+            write_select(cat, filename=tf.name)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                cat_back = read_events(tf.name)
+        pick = cat_back[0].picks[0]
+        arrival = cat_back[0].origins[0].arrivals[0]
+        self.assertEqual(pick.phase_hint, "PKiKP")
+        self.assertEqual(arrival.time_weight, 1)
+
+    def test_read_write_over_day(self):
+        """
+        Nordic picks are relative to origin time - check that this works
+        over day boundaries.
+        """
+        event = full_test_event()
+        event.origins[0].time -= 3600
+        self.assertGreater(
+            event.picks[0].time.date, event.origins[0].time.date)
+        with NamedTemporaryFile(suffix=".out") as tf:
+            write_select(Catalog([event]), filename=tf.name)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                event_back = read_events(tf.name)[0]
+        _assert_similarity(event, event_back)
 
 
 def _assert_similarity(event_1, event_2, verbose=False):

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -21,10 +21,13 @@ from obspy.core.event import (
     NodalPlane, NodalPlanes, ResourceIdentifier, Tensor)
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.core.util.misc import TemporaryWorkingDirectory
+
+from obspy.io.nordic import NordicParsingError
 from obspy.io.nordic.core import (
     _is_sfile, read_spectral_info, read_nordic, readwavename, blanksfile,
-    _write_nordic, nordpick, readheader, _int_conv, _readheader, _evmagtonor,
-    write_select, NordicParsingError, _float_conv, _nortoevmag, _str_conv,
+    _write_nordic, nordpick, readheader, _readheader,  write_select)
+from obspy.io.nordic.utils import (
+    _int_conv, _float_conv, _str_conv, _nortoevmag, _evmagtonor,
     _get_line_tags)
 
 

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -846,11 +846,11 @@ def _test_similarity(event_1, event_2, verbose=False):
                                 return False
                     if arr_1["distance"] and round(
                             arr_1["distance"]) != round(arr_2["distance"]):
-                            if verbose:
-                                print('%s does not match %s for key %s' %
-                                      (arr_1[arr_key], arr_2[arr_key],
-                                       arr_key))
-                            return False
+                        if verbose:
+                            print('%s does not match %s for key %s' %
+                                  (arr_1[arr_key], arr_2[arr_key],
+                                   arr_key))
+                        return False
     # Check picks
     if len(event_1.picks) != len(event_2.picks):
         if verbose:

--- a/obspy/io/nordic/utils.py
+++ b/obspy/io/nordic/utils.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+Utility functions for Nordic file format support for ObsPy
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from future.builtins import *  # NOQA @UnusedWildImport
+
+import warnings
+from collections import defaultdict
+
+from obspy.io.nordic import NordicParsingError
+
+
+MAG_MAPPING = {"ML": "L", "MLv": "L", "mB": "B", "Ms": "s", "MS": "S",
+               "MW": "W", "MbLg": "G", "Mc": "C"}
+INV_MAG_MAPPING = {item: key for key, item in MAG_MAPPING.items()}
+# List of currently implemented line-endings, which in Nordic mark what format
+# info in that line will be.
+ACCEPTED_TAGS = ('1', '6', '7', 'E', ' ', 'F', 'M', '3')
+
+
+def _int_conv(string):
+    """
+    Convenience tool to convert from string to integer.
+
+    If empty string return None rather than an error.
+
+    >>> _int_conv('12')
+    12
+    >>> _int_conv('')
+
+    """
+    try:
+        intstring = int(string)
+    except Exception:
+        intstring = None
+    return intstring
+
+
+def _float_conv(string):
+    """
+    Convenience tool to convert from string to float.
+
+    If empty string return None rather than an error.
+
+    >>> _float_conv('12')
+    12.0
+    >>> _float_conv('')
+    >>> _float_conv('12.324')
+    12.324
+    """
+    try:
+        floatstring = float(string)
+    except Exception:
+        floatstring = None
+    return floatstring
+
+
+def _str_conv(number, rounded=False):
+    """
+    Convenience tool to convert a number, either float or int into a string.
+
+    If the int or float is None, returns empty string.
+
+    >>> print(_str_conv(12.3))
+    12.3
+    >>> print(_str_conv(12.34546, rounded=1))
+    12.3
+    >>> print(_str_conv(None))
+    <BLANKLINE>
+    >>> print(_str_conv(1123040))
+    11.2e5
+    """
+    if not number:
+        return str(' ')
+    if not rounded and isinstance(number, (float, int)):
+        if number < 100000:
+            string = str(number)
+        else:
+            exponent = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
+            divisor = 10 ** exponent
+            string = '{0:.1f}'.format(number / divisor) + 'e' + str(exponent)
+    elif rounded and isinstance(number, (float, int)):
+        if number < 100000:
+            string = "{:.{precision}f}".format(number, precision=rounded)
+        else:
+            exponent = int('{0:.2E}'.format(number).split('E+')[-1]) - 1
+            divisor = 10 ** exponent
+            string = "{:.{precision}f}".format(
+                number / divisor, precision=rounded) + 'e' + str(exponent)
+    else:
+        return str(number)
+    return string
+
+
+def _get_line_tags(f, report=True):
+    """
+    Associate lines with a known line-type
+    :param f: File open in read
+    :param report: Whether to report warnings about lines not implemented
+    """
+    f.seek(0)
+    line = f.readline()
+    if len(line.rstrip()) != 80:
+        # Cannot be Nordic
+        raise NordicParsingError(
+            "Lines are not 80 characters long: not a nordic file")
+    f.seek(0)
+    tags = defaultdict(list)
+    for i, line in enumerate(f):
+        try:
+            line_id = line.rstrip()[79]
+        except IndexError:
+            line_id = ' '
+        if line_id in ACCEPTED_TAGS:
+            tags[line_id].append((line, i))
+        elif report:
+            warnings.warn("Lines of type %s have not been implemented yet, "
+                          "please submit a development request" % line_id)
+    return tags
+
+
+def _evmagtonor(mag_type):
+    """
+    Switch from obspy event magnitude types to seisan syntax.
+
+    >>> print(_evmagtonor('mB'))  # doctest: +SKIP
+    B
+    >>> print(_evmagtonor('M'))  # doctest: +SKIP
+    W
+    >>> print(_evmagtonor('bob'))  # doctest: +SKIP
+    <BLANKLINE>
+    """
+    if mag_type == 'M':
+        warnings.warn('Converting generic magnitude to moment magnitude')
+        return "W"
+    mag = MAG_MAPPING.get(mag_type, '')
+    if mag == '':
+        warnings.warn(mag_type + ' is not convertible')
+    return mag
+
+
+def _nortoevmag(mag_type):
+    """
+    Switch from nordic type magnitude notation to obspy event magnitudes.
+
+    >>> print(_nortoevmag('B'))  # doctest: +SKIP
+    mB
+    >>> print(_nortoevmag('bob'))  # doctest: +SKIP
+    <BLANKLINE>
+    """
+    if mag_type.upper() == "L":
+        return "ML"
+    mag = INV_MAG_MAPPING.get(mag_type, '')
+    if mag == '':
+        warnings.warn(mag_type + ' is not convertible')
+    return mag
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
### What does this PR do?

Adds support for high(er)-precision timing in Nordic pick files (closes #2348) and add support for long phase names - from the seisan manual:

> Long phase names: An 8 character phase can be used in column 11-18. There is then not room for polarity information. the weight is then put into column 9. This format is recognised by HYP and MULPLT

### Why was it initiated? Any relevant Issues?
Seconds can run in columns 23-28 - I misread the indexing and was reading columns 23-28 rather than 22-28. #2348 pointed out that this is used when seisan is run in "high-accuracy" mode.

Note, pick times are now written out by default in high-accuracy from obspy now. I need to confirm that seisan is always happy with this, if not then a flag option for high-accuracy should be implemented.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
