### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -14,7 +14,6 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import PY2, native_str
 
-import collections
 import copy
 import gzip
 import io
@@ -30,7 +29,7 @@ from lxml import etree
 
 import obspy
 from obspy import UTCDateTime, read_inventory
-from obspy.core.compatibility import urlparse
+from obspy.core.compatibility import urlparse, collections_abc
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES, URL_MAPPINGS,
                      WADL_PARAMETERS_NOT_TO_BE_PARSED, DEFAULT_SERVICES,
@@ -1879,7 +1878,7 @@ def parse_simple_xml(xml_string):
 def get_bulk_string(bulk, arguments):
     # If its an iterable, we build up the query string from it
     # StringIO objects also have __iter__ so check for 'read' as well
-    if isinstance(bulk, collections.Iterable) \
+    if isinstance(bulk, collections_abc.Iterable) \
             and not hasattr(bulk, "read") \
             and not isinstance(bulk, (str, native_str)):
         tmp = ["%s=%s" % (key, convert_to_string(value))

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -29,6 +29,7 @@ else:
     from urllib.error import HTTPError, URLError
 
 import obspy
+from obspy.core import compatibility
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn.client import FDSNException
 from obspy.io.mseed.util import get_record_information
@@ -497,7 +498,7 @@ def get_stationxml_filename(str_or_fct, network, station, channels,
     if isinstance(path, (str, bytes)):
         return path
 
-    elif isinstance(path, collections.Container):
+    elif isinstance(path, compatibility.collections_abc.Container):
         if "available_channels" not in path or \
                 "missing_channels" not in path or \
                 "filename" not in path:
@@ -505,9 +506,10 @@ def get_stationxml_filename(str_or_fct, network, station, channels,
                 "The dictionary returned by the stationxml filename function "
                 "must contain the following keys: 'available_channels', "
                 "'missing_channels', and 'filename'.")
-        if not isinstance(path["available_channels"], collections.Iterable) or\
+        if not isinstance(path["available_channels"],
+                          compatibility.collections_abc.Iterable) or\
                 not isinstance(path["missing_channels"],
-                               collections.Iterable) or \
+                               compatibility.collections_abc.Iterable) or \
                 not isinstance(path["filename"], (str, bytes)):
             raise ValueError("Return types must be two lists of channels and "
                              "a string for the filename.")

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -32,7 +32,7 @@ import numpy as np
 import requests
 
 from obspy import UTCDateTime, read, read_inventory, Stream, Trace
-from obspy.core.compatibility import mock
+from obspy.core.compatibility import mock, RegExTextCase
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import build_url, parse_simple_xml
@@ -93,7 +93,7 @@ def normalize_version_number(string):
     return [l.strip() for l in repl.splitlines()]
 
 
-class ClientTestCase(unittest.TestCase):
+class ClientTestCase(RegExTextCase):
     """
     Test cases for obspy.clients.fdsn.client.Client.
     """
@@ -1570,11 +1570,11 @@ class ClientTestCase(unittest.TestCase):
                     endtime=UTCDateTime("2010-02-27T06:40:00.000"))
 
         # test invalid token/token file
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'EIDA token does not seem to be a valid PGP message'):
             client = Client('GFZ', eida_token="spam")
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 "Read EIDA token from file '[^']*event_helpstring.txt' but it "
                 "does not seem to contain a valid PGP message."):

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -32,7 +32,7 @@ import numpy as np
 import requests
 
 from obspy import UTCDateTime, read, read_inventory, Stream, Trace
-from obspy.core.compatibility import mock, RegExTextCase
+from obspy.core.compatibility import mock, RegExTestCase
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import build_url, parse_simple_xml
@@ -93,7 +93,7 @@ def normalize_version_number(string):
     return [l.strip() for l in repl.splitlines()]
 
 
-class ClientTestCase(RegExTextCase):
+class ClientTestCase(RegExTestCase):
     """
     Test cases for obspy.clients.fdsn.client.Client.
     """

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -24,7 +24,7 @@ import requests
 
 import obspy
 from obspy.core.compatibility import (
-    configparser, get_text_from_response, urlparse)
+    ConfigParser, get_text_from_response, urlparse)
 from obspy.core.inventory.util import _textwrap
 
 
@@ -277,7 +277,7 @@ class LocalNRL(NRL):
         """
         Returns a configparser from a path to an index.txt
         """
-        cp = configparser.ConfigParser()
+        cp = ConfigParser()
         with codecs.open(path, mode='r', encoding='UTF-8') as f:
             if sys.version_info.major == 2:  # pragma: no cover
                 cp.readfp(f)
@@ -318,7 +318,7 @@ class RemoteNRL(NRL):
         '''
         Returns a configparser from a path to an index.txt
         '''
-        cp = configparser.SafeConfigParser()
+        cp = ConfigParser()
         with io.StringIO(self._download(path)) as buf:
             if sys.version_info.major == 2:  # pragma: no cover
                 cp.readfp(buf)

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -14,7 +14,6 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import collections
 import io
 import zipfile
 
@@ -572,7 +571,7 @@ class Client(WaveformClient, HTTPClient):
             # Write the bulk content.
             for item in bulk:
                 # Dictionary like items.
-                if isinstance(item, collections.Mapping):
+                if isinstance(item, compatibility.collections_abc.Mapping):
                     if "latitude" in item or "longitude" in item:
                         if not ("latitude" in item and "longitude" in item):
                             raise ValueError(
@@ -591,7 +590,7 @@ class Client(WaveformClient, HTTPClient):
                         raise ValueError("Item '%s' in bulk is malformed." %
                                          str(item))
                 # Iterable items.
-                elif isinstance(item, collections.Container):
+                elif isinstance(item, compatibility.collections_abc.Container):
                     if len(item) != 2:
                         raise ValueError("Item '%s' in bulk must have two "
                                          "entries." % str(item))

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -41,9 +41,9 @@ else:
 
 # Importing the ABCs from collections will no longer work with Python 3.8.
 if PY2:
-    collections_abc = collections
+    collections_abc = collections  # NOQA
 else:
-    collections_abc = collections.abc
+    collections_abc = collections.abc  # NOQA
 
 
 if PY2:
@@ -70,7 +70,6 @@ if PY2:
             return np.frombuffer(data, dtype=dtype).copy()
         else:
             return np.array([], dtype=dtype)
-    import ConfigParser as configparser  # NOQA
 else:
     def from_buffer(data, dtype):
         try:
@@ -78,7 +77,12 @@ else:
         except Exception:
             pass
         return np.array(memoryview(data)).view(dtype).copy()  # NOQA
-    import configparser  # NOQA
+
+
+if PY2:
+    from ConfigParser import SaveConfigParser as ConfigParser  # NOQA
+else:
+    from configparser import ConfigParser  # NOQA
 
 
 def is_text_buffer(obj):

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -11,6 +11,7 @@ import collections
 import io
 import json
 import sys
+import unittest
 
 import numpy as np
 
@@ -43,6 +44,15 @@ if PY2:
     collections_abc = collections
 else:
     collections_abc = collections.abc
+
+
+if PY2:
+    class RegExTextCase(unittest.TestCase):
+        def assertRaisesRegex(self, exception, regex):
+            return self.assertRaisesRegexp(exception, regex)
+else:
+    class RegExTextCase(unittest.TestCase):
+        pass
 
 
 # NumPy does not offer the from_buffer method under Python 3 and instead

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -7,6 +7,7 @@ it work with various versions of our dependencies.
 """
 from future.utils import PY2
 
+import collections
 import io
 import json
 import sys
@@ -35,6 +36,13 @@ if PY2:
     string_types = (basestring,)  # NOQA
 else:
     string_types = (str,)  # NOQA
+
+
+# Importing the ABCs from collections will no longer work with Python 3.8.
+if PY2:
+    collections_abc = collections
+else:
+    collections_abc = collections.abc
 
 
 # NumPy does not offer the from_buffer method under Python 3 and instead

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -48,8 +48,10 @@ else:
 
 if PY2:
     class RegExTestCase(unittest.TestCase):
-        def assertRaisesRegex(self, exception, regex):  # NOQA
-            return self.assertRaisesRegexp(exception, regex)
+        def assertRaisesRegex(self, exception, regex, callable,  # NOQA
+                              *args, **kwargs):
+            return self.assertRaisesRegexp(exception, regex, callable,
+                                           *args, **kwargs)
 else:
     class RegExTestCase(unittest.TestCase):
         pass

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -47,11 +47,11 @@ else:
 
 
 if PY2:
-    class RegExTextCase(unittest.TestCase):
+    class RegExTestCase(unittest.TestCase):
         def assertRaisesRegex(self, exception, regex):
             return self.assertRaisesRegexp(exception, regex)
 else:
-    class RegExTextCase(unittest.TestCase):
+    class RegExTestCase(unittest.TestCase):
         pass
 
 
@@ -80,7 +80,7 @@ else:
 
 
 if PY2:
-    from ConfigParser import SaveConfigParser as ConfigParser  # NOQA
+    from ConfigParser import SafeConfigParser as ConfigParser  # NOQA
 else:
     from configparser import ConfigParser  # NOQA
 

--- a/obspy/core/compatibility.py
+++ b/obspy/core/compatibility.py
@@ -48,7 +48,7 @@ else:
 
 if PY2:
     class RegExTestCase(unittest.TestCase):
-        def assertRaisesRegex(self, exception, regex):
+        def assertRaisesRegex(self, exception, regex):  # NOQA
             return self.assertRaisesRegexp(exception, regex)
 else:
     class RegExTestCase(unittest.TestCase):

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -15,7 +15,7 @@ from future.builtins import *  # NOQA
 
 import copy
 import ctypes as C  # NOQA
-from collections import defaultdict, Iterable
+from collections import defaultdict
 from copy import deepcopy
 import itertools
 from math import pi
@@ -24,6 +24,7 @@ import warnings
 import numpy as np
 import scipy.interpolate
 
+from .. import compatibility
 from obspy.core.util.base import ComparingObject
 from obspy.core.util.obspy_types import (ComplexWithUncertainties,
                                          FloatWithUncertainties,
@@ -402,7 +403,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if value == []:
             self._numerator = []
             return
-        value = list(value) if isinstance(value, Iterable) else [value]
+        value = list(value) if isinstance(
+            value, compatibility.collections_abc.Iterable) else [value]
         for _i, x in enumerate(value):
             if not isinstance(x, FloatWithUncertaintiesAndUnit):
                 value[_i] = FloatWithUncertaintiesAndUnit(x)
@@ -417,7 +419,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if value == []:
             self._denominator = []
             return
-        value = list(value) if isinstance(value, Iterable) else [value]
+        value = list(value) if isinstance(
+            value, compatibility.collections_abc.Iterable) else [value]
         for _i, x in enumerate(value):
             if not isinstance(x, FloatWithUncertaintiesAndUnit):
                 value[_i] = FloatWithUncertaintiesAndUnit(x)

--- a/obspy/core/tests/test_stats.py
+++ b/obspy/core/tests/test_stats.py
@@ -269,7 +269,8 @@ class StatsTestCase(unittest.TestCase):
         """
         stats = Stats()
         for val in self.nslc:
-            setattr(stats, val, None)
+            with warnings.catch_warnings(record=True):
+                setattr(stats, val, None)
             self.assertEqual(getattr(stats, val), 'None')
 
     def test_casted_stats_nscl_writes_to_mseed(self):
@@ -283,8 +284,9 @@ class StatsTestCase(unittest.TestCase):
         stats_items = set(Stats())
         new_stats = Stats()
         new_stats.__dict__.update({x: st[0].stats[x] for x in stats_items})
-        new_stats.network = 1
-        new_stats.station = 1.1
+        with warnings.catch_warnings(record=True):
+            new_stats.network = 1
+            new_stats.station = 1.1
         new_stats.channel = 'Non'
         st[0].stats = new_stats
         # try writing stream to bytes buffer
@@ -314,7 +316,8 @@ class StatsTestCase(unittest.TestCase):
 
         for a_str in the_strs:
             for nslc in self.nslc:
-                setattr(stats, nslc, a_str)
+                with warnings.catch_warnings(record=True):
+                    setattr(stats, nslc, a_str)
                 self.assertIsInstance(getattr(stats, nslc), (str, native_str))
 
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1920,7 +1920,7 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(tr2.stats.endtime, tr.stats.endtime - 2)
         # headonly
         tr = read('https://examples.obspy.org/test.sac', headonly=True)[0]
-        self.assertFalse(tr.data)
+        self.assertEqual(tr.data.size, 0)
 
     def test_copy(self):
         """

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -12,12 +12,13 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
 
-import collections
 import copy
 import warnings
 
+from .. import compatibility
 
-class AttribDict(collections.MutableMapping):
+
+class AttribDict(compatibility.collections_abc.MutableMapping):
     """
     A class which behaves like a dictionary.
 
@@ -98,7 +99,8 @@ class AttribDict(collections.MutableMapping):
         if key in self._types and not isinstance(value, self._types[key]):
             value = self._cast_type(key, value)
 
-        mapping_instance = isinstance(value, collections.Mapping)
+        mapping_instance = isinstance(value,
+                                      compatibility.collections_abc.Mapping)
         attr_dict_instance = isinstance(value, AttribDict)
         if mapping_instance and not attr_dict_instance:
             self.__dict__[key] = AttribDict(value)
@@ -182,7 +184,8 @@ class AttribDict(collections.MutableMapping):
         :return: value cast to correct type.
         """
         typ = self._types[key]
-        new_type = typ[0] if isinstance(typ, collections.Sequence) else typ
+        new_type = typ[0] if isinstance(
+            typ, compatibility.collections_abc.Sequence) else typ
         msg = ('Attribute "%s" must be of type %s, not %s. Attempting to '
                'cast %s to %s') % (key, typ, type(value), value, new_type)
         warnings.warn(msg)

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -184,8 +184,9 @@ class AttribDict(compatibility.collections_abc.MutableMapping):
         :return: value cast to correct type.
         """
         typ = self._types[key]
-        new_type = typ[0] if isinstance(
-            typ, compatibility.collections_abc.Sequence) else typ
+        new_type = (
+            typ[0] if isinstance(typ, compatibility.collections_abc.Sequence)
+            else typ)
         msg = ('Attribute "%s" must be of type %s, not %s. Attempting to '
                'cast %s to %s') % (key, typ, type(value), value, new_type)
         warnings.warn(msg)

--- a/obspy/db/db.py
+++ b/obspy/db/db.py
@@ -124,7 +124,7 @@ class WaveformChannel(Base):
 
     def get_preview(self, apply_calibration=False):
         try:
-            data = np.loads(self.preview)
+            data = pickle.loads(self.preview)
         except Exception:
             data = np.array([])
         if apply_calibration:

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -29,9 +29,9 @@ import io
 import os
 import warnings
 
-from collections import Mapping
 from lxml import etree
 
+from obspy.core import compatibility
 from obspy.core.event import (Amplitude, Arrival, Axis, Catalog, Comment,
                               CompositeTime, ConfidenceEllipsoid, CreationInfo,
                               DataUsed, Event, EventDescription,
@@ -1218,7 +1218,7 @@ class Pickler(object):
                 element.attrib[tag] = str(value)
             elif type_.lower() == "element":
                 # check if value is dictionary-like
-                if isinstance(value, Mapping):
+                if isinstance(value, compatibility.collections_abc.Mapping):
                     subelement = etree.SubElement(element, tag, attrib=attrib)
                     self._custom(value, subelement)
                 elif isinstance(value, bool):

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -21,10 +21,10 @@ import os
 import re
 import warnings
 
-from collections import Mapping
 from lxml import etree
 
 import obspy
+from obspy.core import compatibility
 from obspy.core.util import AttribDict
 from obspy.core.util.obspy_types import (ComplexWithUncertainties,
                                          FloatWithUncertaintiesAndUnit)
@@ -1427,7 +1427,9 @@ def _write_element(parent, element, name):
         parent.set(custom_name, element['value'])
     else:  # if not a attribute, then create a tag
         sub = etree.SubElement(parent, custom_name, attrib=attrib)
-        if isinstance(element['value'], Mapping):  # nested extra tags
+        if isinstance(
+                element['value'],
+                compatibility.collections_abc.Mapping):  # nested extra tags
             for tagname, tag_element in element['value'].items():
                 _write_element(sub, tag_element, tagname)
         else:

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -6,7 +6,6 @@ The Rotate test suite.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2
 
 import gzip
 import itertools
@@ -15,12 +14,13 @@ import unittest
 
 import numpy as np
 
+from obspy.core.compatibility import RegExTextCase
 from obspy.signal.rotate import (rotate_lqt_zne, rotate_ne_rt, rotate_rt_ne,
                                  rotate_zne_lqt, _dip_azimuth2zne_base_vector,
                                  rotate2zne)
 
 
-class RotateTestCase(unittest.TestCase):
+class RotateTestCase(RegExTextCase):
     """
     Test cases for Rotate.
     """
@@ -163,11 +163,7 @@ class RotateTestCase(unittest.TestCase):
         dip_1, dip_2, dip_3 = 0.0, 30.0, 60.0
         azi_1, azi_2, azi_3 = 0.0, 170.0, 35.0
 
-        if PY2:
-            testmethod = self.assertRaisesRegexp
-        else:
-            testmethod = self.assertRaisesRegex
-        testmethod(
+        self.assertRaisesRegex(
             ValueError, 'All three data arrays must be of same length.',
             rotate2zne, z, azi_1, dip_1, n, azi_2, dip_2, e, azi_3, dip_3)
 

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -14,13 +14,13 @@ import unittest
 
 import numpy as np
 
-from obspy.core.compatibility import RegExTextCase
+from obspy.core.compatibility import RegExTestCase
 from obspy.signal.rotate import (rotate_lqt_zne, rotate_ne_rt, rotate_rt_ne,
                                  rotate_zne_lqt, _dip_azimuth2zne_base_vector,
                                  rotate2zne)
 
 
-class RotateTestCase(RegExTextCase):
+class RotateTestCase(RegExTestCase):
     """
     Test cases for Rotate.
     """


### PR DESCRIPTION
Fixes #2357.

Also catches a couple more warnings. We can remove the whole compatibility layer once 1.2 is released.