### PR TITLE
Change time_error default for Catalog to NLLOC_OBS #2371

### DIFF
--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -403,8 +403,8 @@ def write_nlloc_obs(catalog, filename, **kwargs):
         date = pick.time.strftime("%Y%m%d")
         hourminute = pick.time.strftime("%H%M")
         seconds = pick.time.second + pick.time.microsecond * 1e-6
-        time_error = pick.time_errors.uncertainty or -1
-        if time_error == -1:
+        time_error = pick.time_errors.uncertainty or 0.0
+        if time_error == 0.0:
             try:
                 time_error = (pick.time_errors.upper_uncertainty +
                               pick.time_errors.lower_uncertainty) / 2.0


### PR DESCRIPTION
This Pull Request changes the default time_error to 0.0 instead of -1 so that error will no longer be interpreted as 1 second.

It was initiated based on issue #2371 .

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
