### PR TITLE
fix Trace.__eq__ (was super slow in case of >1e6 samples)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,7 @@
 master:
  - obspy.core:
+   * Fixed "==" comparison for Stream and Trace which was very slow in case of
+     traces with >1e6 samples (see #2377)
    * Casting FDSN identifiers to strings upon setting in the stats dictionary
      (see #1997).
    * UTCDateTime objects will now always evaluate equal if their string

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -324,7 +324,7 @@ class Trace(object):
         if not self.stats == other.stats:
             return False
         # comparison of ndarrays is supported by NumPy
-        if not np.array_equal(self, other):
+        if not np.array_equal(self.data, other.data):
             return False
 
         return True


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix a speed issue when comparing traces/streams with lots of samples in them.

### Why was it initiated?  Any relevant Issues?

We had an ugly bug in `Trace.__eq__` which caused incredibly long CPU time for `tr1 == tr2` becaus numpy comparison wasn't run on `Trace.data` but rather `Trace` itself. I can't imagine how nobody stumbled over this one before. Maybe numpy made a change so that this only surfaced now??

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
