### PR TITLE
Rotate stream to uvw #1992 and #2372

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2596,8 +2596,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 Trims common channels used in rotation to time spans that are
                 available for all three channels (i.e. cuts away parts for
                 which one or two channels used in rotation do not have data).
-            ``'->UVW'``: Rotates data from three components into UVW (Galperin 
-                orientation).
+            ``'->UVW'``: Rotates data from three components into UVW components 
+                (Galperin orientation).
             ``'NE->RT'``: Rotates the North- and East-components of a
                 seismogram to radial and transverse components.
             ``'RT->NE'``: Rotates the radial and transverse components of a
@@ -2638,13 +2638,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 raise ValueError(msg)
             return self._rotate_to_zne(inventory, **kwargs)
         elif method == "->UVW":
+            from obspy.signal.rotate import rotate2zne
             # First rotate to ZNE as above, then rotate zne to uvw:
             zne_stream = self._rotate_to_zne(inventory, **kwargs)
             z = zne_stream[0]
             n = zne_stream[1]
             e = zne_stream[2]
-            return obspy.signal.rotate.rotate2zne(z, 90, -35.3, n, 330, \
-                -35.3, e, 210, -35.3, inverse=True)
+            return rotate2zne(z, 90, -35.3, n, 330, -35.3, e, 210, -35.3, inverse=True)
         elif method == "NE->RT":
             func = "rotate_ne_rt"
         elif method == "RT->NE":

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2638,10 +2638,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 raise ValueError(msg)
             return self._rotate_to_zne(inventory, **kwargs)
         elif method == "->UVW":
-            #first rotate incoming information to ZNE as above
-            self._rotate_to_zne(inventory, **kwargs)
-            #rotate from ZNE to UVW which should be constant transformation 
-            return obspy.signal.rotate.rotate2zne(data1,90,-35.3,data2,330,-35.3,data3,210,-35.3,inverse=True)
+            # First rotate to ZNE as above, then rotate zne to uvw:
+            zne_stream = self._rotate_to_zne(inventory, **kwargs)
+            z = zne_stream[0]
+            n = zne_stream[1]
+            e = zne_stream[2]
+            return obspy.signal.rotate.rotate2zne(z, 90, -35.3, n, 330, \
+                -35.3, e, 210, -35.3, inverse=True)
         elif method == "NE->RT":
             func = "rotate_ne_rt"
         elif method == "RT->NE":
@@ -3321,10 +3324,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         st = self.select(network=network, station=station, location=location)
         st = (st.select(channel=channels[0]) + st.select(channel=channels[1]) +
               st.select(channel=channels[2]))
-        # remove the original unrotated traces from the stream
-        for tr in st.traces:
-            self.remove(tr)
-        # cut data so that we end up with a set of matching pieces for the tree
+        # Store original traces to be replaced if everything passes 
+        unrotated_traces = Stream()
+        for tr in st:
+            unrotated_traces.append(tr)
+        # cut data so that we end up with a set of matching pieces for the three
         # components (i.e. cut away any parts where one of the three components
         # has no data)
         st._trim_common_channels()
@@ -3358,6 +3362,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 tr.data = new_data
                 tr.stats.channel = tr.stats.channel[:-1] + component
             self.traces += traces
+        # remove the original unrotated traces from the stream
+        for tr in unrotated_traces.traces:
+            self.remove(tr)
         return self
 
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2596,6 +2596,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 Trims common channels used in rotation to time spans that are
                 available for all three channels (i.e. cuts away parts for
                 which one or two channels used in rotation do not have data).
+            ``'->UVW'``: Rotates data from three components into UVW (Galperin 
+                orientation).
             ``'NE->RT'``: Rotates the North- and East-components of a
                 seismogram to radial and transverse components.
             ``'RT->NE'``: Rotates the radial and transverse components of a
@@ -2635,6 +2637,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                        "provided as 'inventory' parameter.")
                 raise ValueError(msg)
             return self._rotate_to_zne(inventory, **kwargs)
+        elif method == "->UVW":
+            #first rotate incoming information to ZNE as above
+            self._rotate_to_zne(inventory, **kwargs)
+            #rotate from ZNE to UVW which should be constant transformation 
+            return obspy.signal.rotate.rotate2zne(data1,90,-35.3,data2,330,-35.3,data3,210,-35.3,inverse=True)
         elif method == "NE->RT":
             func = "rotate_ne_rt"
         elif method == "RT->NE":

--- a/obspy/core/tests/data/uvw_inventory.xml
+++ b/obspy/core/tests/data/uvw_inventory.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0">
+  <Source>http://examples.obspy.org/step_table_galperin_and_xyz.txt</Source>
+  <Module>ObsPy 1.1.0</Module>
+  <ModuleURI>https://www.obspy.org</ModuleURI>
+  <Created>2019-05-01T14:53:33.925291</Created>
+  <Network code="XX">
+    <Station code="TRC1">
+      <Latitude unit="DEGREES">1.0</Latitude>
+      <Longitude unit="DEGREES">2.0</Longitude>
+      <Elevation unit="METERS">3.0</Elevation>
+      <Site>
+        <Name>UVW Station</Name>
+      </Site>
+      <CreationDate>2016-01-02T00:00:00</CreationDate>
+      <Channel code="HHU" locationCode="">
+        <Latitude unit="DEGREES">1.0</Latitude>
+        <Longitude unit="DEGREES">2.0</Longitude>
+        <Elevation unit="METERS">3.0</Elevation>
+        <Depth unit="METERS">5.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">-35.3</Dip>
+      </Channel>
+      <Channel code="HHV" locationCode="">
+        <Latitude unit="DEGREES">1.0</Latitude>
+        <Longitude unit="DEGREES">2.0</Longitude>
+        <Elevation unit="METERS">3.0</Elevation>
+        <Depth unit="METERS">5.0</Depth>
+        <Azimuth unit="DEGREES">330.0</Azimuth>
+        <Dip unit="DEGREES">-35.3</Dip>
+      </Channel>
+      <Channel code="HHW" locationCode="">
+        <Latitude unit="DEGREES">1.0</Latitude>
+        <Longitude unit="DEGREES">2.0</Longitude>
+        <Elevation unit="METERS">3.0</Elevation>
+        <Depth unit="METERS">5.0</Depth>
+        <Azimuth unit="DEGREES">210.0</Azimuth>
+        <Dip unit="DEGREES">-35.3</Dip>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2604,15 +2604,14 @@ class StreamTestCase(unittest.TestCase):
         t1 = UTCDateTime('2017-10-11T12:33:15')
         t2 = UTCDateTime('2017-10-11T12:33:40')
         st.trim(t1,t2)
+        st1 = st.copy()
         # Create inventory for this stream:
-        inv = read_inventory("core/tests/data/uvw_inventory.xml")
+        inv = read_inventory("data/uvw_inventory.xml")
         # use stream.rotate() to rotate to ZNE
-        ZNE_st = st.rotate(method='->ZNE', inventory=inv)
-        # rotate new stream back
-        #rotated_st = ZNE_st.rotate('->UVW', inventory=inv)
-        from obspy.signal.rotate import rotate2zne
-        rotated_st = rotate2zne(st[0], 90, -35.3, st[1], 330, -35.3, st[2], 210, -35.3)
-        # compare data: 
+        ZNE_st = st1.rotate(method='->ZNE', inventory=inv, components='UVW')
+        # rotate new stream back using new method:
+        rotated_st = st1.rotate(method='->UVW', inventory=inv)
+        # compare data to see if the rotated version matched original UVW stream:
         for tr_got, tr_expected in zip(rotated_st, st):
             np.testing.assert_allclose(tr_got, tr_expected)
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2591,6 +2591,38 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(set(tr.stats.channel[-1] for tr in result),
                          set('ZNE'))
 
+
+#    def test_method_rotate_to_UVW(self):
+#        """
+#        Tests rotating all traces to UVW Galperin Coordinates given an inventory. 
+#        Using data from T. Meggies example in 'Bug in rotate2zne with non-orthogonal comps'
+#        """
+#        # Find stream with inventory that is in uvw Galperin coords
+#        inv = read_inventory("/path/to/ffbx.stationxml", format="STATIONXML")
+
+        # Use stream.rotate to rotate to zne coordinates as that method has already been tested 
+        # Use stream.rotate to rotate back to uvw 
+        # Test that rotation to uvw works with self.assertEqual(original_inv, new_uvw)
+
+
+    def test_stream_rotate_Exception(self):
+        """
+        Tests that if an exception is raised when rotating a stream, 
+        the stream is not emptied.
+        """
+        inv1 = read_inventory()
+        inv2 = inv1.select(station = "FUR")
+        stream = read()
+        with self.assertRaises(Exception):
+            stream.rotate("->ZNE", inventory = inv2, components = ("ZNE"))
+            self.assertEqual(len(stream),3)
+        # test another method:
+        with self.assertRaises(Exception):
+            tr = st.select(component='E')
+            stream.remove(tr)
+            stream.rotate("NE->RT", inventory = inv2, components = ("ZNE"))
+            self.assertEqual(len(stream),2)
+
     def test_write_empty_stream(self):
         """
         Tests error message when trying to write an empty stream

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2592,17 +2592,23 @@ class StreamTestCase(unittest.TestCase):
                          set('ZNE'))
 
 
-#    def test_method_rotate_to_UVW(self):
-#        """
-#        Tests rotating all traces to UVW Galperin Coordinates given an inventory. 
-#        Using data from T. Meggies example in 'Bug in rotate2zne with non-orthogonal comps'
-#        """
-#        # Find stream with inventory that is in uvw Galperin coords
-#        inv = read_inventory("/path/to/ffbx.stationxml", format="STATIONXML")
-
-        # Use stream.rotate to rotate to zne coordinates as that method has already been tested 
-        # Use stream.rotate to rotate back to uvw 
-        # Test that rotation to uvw works with self.assertEqual(original_inv, new_uvw)
+    def test_method_rotate_to_UVW(self):
+        """
+        Tests rotating all traces to UVW Galperin Coordinates given an inventory. 
+        Using data from T. Meggies example in 'Bug in rotate2zne with non-orthogonal comps'
+        """
+        # Find stream and inventory in uvw Galperin coords 
+        #inv = read_inventory('some inventory with things in uvw')
+        st = read('http://examples.obspy.org/step_table_galperin_and_xyz.mseed')
+        st = st.select(station='TRC*')
+        st = st[0:3]
+        # use stream.rotate() to rotate to ZNE
+        ZNE_st = st.rotate('->ZNE')
+        # rotate new stream back
+        rotated_st = ZNE_st.rotate('->UVW')
+        # compare data: 
+        for tr_got, tr_expected in zip(rotated_st, st):
+            np.testing.assert_allclose(tr_got.data, tr_expected.data)
 
 
     def test_stream_rotate_Exception(self):


### PR DESCRIPTION
This pull request adds a method to stream.rotate so that streams can be rotated from any coordinates to UVW coordinates. It also fixes an issue in stream.rotate where previously if stream.rotate failed, the stream would be emptied, this has been adjusted so that if there is an error, the stream is not returned empty. 

This pull request was initiated to fix issues #1992 and #2372 so that it will be possible to use stream.rotate to rotate to UVW coordinates, and so that if an error occurs while a stream is being rotated it is not emptied. 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
