### PR TITLE
nordic: Add support for AIN:takeoff_angle

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,7 +69,8 @@ master:
      has been added to turn this off. (see #2351 and #2348)
    * Allow long-phase names (both reading and writing) - longer than 4 char.
      (see #2351)
-   * Include AIN as takeoff-angle when reading and writing nordic files.
+   * Include AIN as takeoff-angle when reading and writing nordic files
+     (see #2404).
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,7 @@ master:
      has been added to turn this off. (see #2351 and #2348)
    * Allow long-phase names (both reading and writing) - longer than 4 char.
      (see #2351)
+   * Include AIN as takeoff-angle when reading and writing nordic files.
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -637,7 +637,7 @@ class TestNordicMethods(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', UserWarning)
                 event_back = read_events(tf.name)
-        _assert_similarity(event, event_back[0], verbose=True)
+        _assert_similarity(event, event_back[0])
 
     def test_write_preferred_origin(self):
         event = full_test_event()

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -637,7 +637,7 @@ class TestNordicMethods(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', UserWarning)
                 event_back = read_events(tf.name)
-        _assert_similarity(event, event_back[0])
+        _assert_similarity(event, event_back[0], verbose=True)
 
     def test_write_preferred_origin(self):
         event = full_test_event()
@@ -989,11 +989,11 @@ def full_test_event():
         Arrival(time_weight=2, phase=test_event.picks[3].phase_hint,
                 pick_id=test_event.picks[3].resource_id,
                 backazimuth_residual=5, time_residual=0.2, distance=15,
-                azimuth=25),
+                azimuth=25, takeoff_angle=10),
         Arrival(time_weight=2, phase=test_event.picks[4].phase_hint,
                 pick_id=test_event.picks[4].resource_id,
                 backazimuth_residual=5, time_residual=0.2, distance=15,
-                azimuth=25)]
+                azimuth=25, takeoff_angle=170)]
     # Add in error info (line E)
     test_event.origins[0].quality = OriginQuality(
         standard_error=0.01, azimuthal_gap=36)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This PR *turns on* reading AIN from Nordic files to takeoff_angle (and writing the reverse) and turns off the warnings.

### Why was it initiated?  Any relevant Issues?

It turns out I misunderstood what AIN was (angle of incidence), I wrongly assumed it was angle of incidence at the seismometer, but it is in fact takeoff angle. As this is supported in quakeml and `Event`s I thought I should read it.

This PR is created on master because lots of changes have been made in master to nordic IO that are not in maintenance_1.1.x. This isn't really a feature though.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
~~- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"~~
~~- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)~~
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~~
