### PR TITLE
seedlink client: add option to fetch available stations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -68,8 +68,12 @@ master:
    * Properly handle fetching poles and zeros in presence of multiple metadata
      files for a given station (see #2411)
  - obspy.clients.seedlink:
-   * add method "get_stations()" to fetch list of network/stations for which
-     streams are available (see #2405)
+   * add method "get_info()" to fetch information on what
+     networks/stations/locations/channels are served by the seedlink server
+     (see #2405)
+   * "get_waveforms()" can now be used with '*' and '?' wildcards in any part
+     of requested SEED ID, i.e. network, station, location and channel (see
+     #2405)
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what
      to plot after scanning data (see #2227)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,6 +67,9 @@ master:
  - obspy.clients.seishub:
    * Properly handle fetching poles and zeros in presence of multiple metadata
      files for a given station (see #2411)
+ - obspy.clients.seedlink:
+   * add method "get_stations()" to fetch list of network/stations for which
+     streams are available (see #2405)
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what
      to plot after scanning data (see #2227)

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -259,7 +259,9 @@ class Client(object):
             info = [(net, sta, loc, cha) for net, sta, loc, cha in
                     self._station_cache if
                     fnmatch.fnmatch(net, network or '*') and
-                    fnmatch.fnmatch(sta, station or '*')]
+                    fnmatch.fnmatch(sta, station or '*') and
+                    fnmatch.fnmatch(loc, location or '*') and
+                    fnmatch.fnmatch(cha, channel or '*')]
             return sorted(info)
 
         self._init_client()
@@ -295,8 +297,9 @@ class Client(object):
         # change results to an Inventory object
         self._station_cache = station_cache
         self._station_cache_level = level
-        return self.get_info(network=network, station=station, cache=True,
-                             level=level)
+        return self.get_info(
+            network=network, station=station, location=location,
+            channel=channel, cache=True, level=level)
 
     def _packet_handler(self, count, slpack):
         """

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -49,10 +49,19 @@ class Client(object):
         """
         self.timeout = timeout
         self.debug = debug
-        self._slclient = SLClient(loglevel=debug and "DEBUG" or "CRITICAL",
-                                  timeout=self.timeout)
+        self.loglevel = debug and "DEBUG" or "CRITICAL"
         self._server_url = "%s:%i" % (server, port)
         self._station_cache = None
+        self._station_cache_level = None
+
+    def _init_client(self):
+        """
+        Make fresh connection to seedlink server
+
+        Should be done before any request to server, since SLClient keeps
+        things like multiselect etc for subsequent requests
+        """
+        self._slclient = SLClient(loglevel=self.loglevel, timeout=self.timeout)
 
     def _connect(self):
         """
@@ -120,6 +129,7 @@ class Client(object):
         else:
             loccha = channel
         seedlink_id = "%s_%s:%s" % (network, station, loccha)
+        self._init_client()
         self._slclient.multiselect = seedlink_id
         self._slclient.begin_time = starttime
         self._slclient.end_time = endtime
@@ -166,6 +176,7 @@ class Client(object):
                         fnmatch.fnmatch(sta, station or '*')]
             return sorted(stations)
 
+        self._init_client()
         self._slclient.infolevel = "STATIONS"
         self._slclient.verbose = 1
         self._connect()

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -129,8 +129,23 @@ class Client(object):
         else:
             loccha = channel
         seedlink_id = "%s_%s:%s" % (network, station, loccha)
+        return self._multiselect_request(seedlink_id, starttime, endtime)
+
+    def _multiselect_request(self, multiselect, starttime, endtime):
+        """
+        Make a multiselect request to underlying seedlink client
+
+        Multiselect string is one or more comma separated
+        network/station/location/channel combinations as defined by seedlink
+        standard, e.g.
+        "NETWORK_STATION:LOCATIONCHANNEL,NETWORK_STATION:LOCATIONCHANNEL"
+        where location+channel may contain '?' characters but should be exactly
+        5 characters long.
+
+        :rtype: :class:`~obspy.core.stream.Stream`
+        """
         self._init_client()
-        self._slclient.multiselect = seedlink_id
+        self._slclient.multiselect = multiselect
         self._slclient.begin_time = starttime
         self._slclient.end_time = endtime
         self._connect()

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -203,9 +203,12 @@ class Client(object):
         >>> info = client.get_info(station="FDF")
         >>> print(info)
         [('G', 'FDF')]
-        >>> netsta = client.get_info(station="FDF", level='channel')
-        >>> print(info)
-        [('G', 'FDF')]
+        >>> info = client.get_info(station="FD?", channel='*Z',
+        ...                        level='channel')
+        >>> print(info)  # doctest: +NORMALIZE_WHITESPACE
+        [('G', 'FDF', '00', 'BHZ'),
+         ('G', 'FDF', '00', 'HNZ'),
+         ('G', 'FDF', '00', 'LHZ')]
 
         Available station information is cached after the first request to the
         server, so use ``cache=False`` on subsequent requests if there is a
@@ -229,8 +232,8 @@ class Client(object):
             to force fetching station metadata again from the server.
         :rtype: list
         :returns: list of 2-tuples (or 4-tuples with ``level='channel'``) with
-            network/station (network/station/location/channel) code
-            combinations for which data is served by the server.
+            network/station (network/station/location/channel, respectively)
+            code combinations for which data is served by the server.
         """
         if level not in ('station', 'channel'):
             msg = "Invalid option for 'level': '%s'" % str(level)

--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -114,6 +114,7 @@ class SeedLinkConnection(object):
     """
 
     SEEDLINK_PROTOCOL_PREFIX = "seedlink://"
+    SEEDLINK_DEFAULT_PORT = 18000
     UNISTATION = b"UNISTATION"
     UNINETWORK = b"UNINETWORK"
     DFT_READBUF_SIZE = 1024
@@ -220,7 +221,10 @@ class SeedLinkConnection(object):
         """
         prefix = SeedLinkConnection.SEEDLINK_PROTOCOL_PREFIX
         if sladdr.startswith(prefix):
-            self.sladdr = len(sladdr[prefix:])
+            sladdr = len(sladdr[prefix:])
+        # use default port 18000
+        if ':' not in sladdr:
+            sladdr += ':%d' % self.SEEDLINK_DEFAULT_PORT
         self.sladdr = sladdr
         # set logger format
         name = " obspy.clients.seedlink [%s]" % (sladdr)

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -41,6 +41,20 @@ class ClientTestCase(unittest.TestCase):
         for offset in (3600, 2000, 1000, 500):
             _test_offset_from_realtime(offset)
 
+    def test_get_station(self):
+        """
+        Test fetching station information
+        """
+        client = self.client
+
+        stations = client.get_stations(station='F*')
+        self.assertIn(('G', 'FDF'), stations)
+        # should have at least 7 stations
+        self.assertTrue(len(stations) > 2)
+        # only fetch one station
+        stations = client.get_stations(network='G', station='FDF')
+        self.assertEqual([('G', 'FDF')], stations)
+
 
 def suite():
     return unittest.makeSuite(ClientTestCase, 'test')

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -39,7 +39,14 @@ class ClientTestCase(unittest.TestCase):
         # buffer stores data and how close to realtime the data is available,
         # so check some different offsets and see if we get some data
         for offset in (3600, 2000, 1000, 500):
-            _test_offset_from_realtime(offset)
+            try:
+                _test_offset_from_realtime(offset)
+            except AssertionError:
+                continue
+            else:
+                break
+        else:
+            raise
 
     def test_get_station(self):
         """

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -48,19 +48,71 @@ class ClientTestCase(unittest.TestCase):
         else:
             raise
 
-    def test_get_station(self):
+    def test_get_info(self):
         """
         Test fetching station information
         """
         client = self.client
 
-        stations = client.get_stations(station='F*')
-        self.assertIn(('G', 'FDF'), stations)
+        info = client.get_info(station='F*')
+        self.assertIn(('G', 'FDF'), info)
         # should have at least 7 stations
-        self.assertTrue(len(stations) > 2)
+        self.assertTrue(len(info) > 2)
         # only fetch one station
-        stations = client.get_stations(network='G', station='FDF')
-        self.assertEqual([('G', 'FDF')], stations)
+        info = client.get_info(network='G', station='FDF')
+        self.assertEqual([('G', 'FDF')], info)
+        # check that we have a cache on station level
+        self.assertIn(('G', 'FDF'), client._station_cache)
+        self.assertTrue(len(client._station_cache) > 20)
+        self.assertEqual(client._station_cache_level, "station")
+
+    def test_multiple_waveform_requests_with_multiple_info_requests(self):
+        """
+        This test a combination of waveform requests that internally do
+        multiple info requests on increasing detail levels
+        """
+        def _test_offset_from_realtime(offset):
+            # need to reinit to clean out any caches
+            self.setUp()
+            t = UTCDateTime() - offset
+            # first do a request that needs an info request on station level
+            # only
+            st = self.client.get_waveforms("*", "F?F", "??", "B??", t, t + 5)
+            self.assertGreater(len(st), 2)
+            self.assertTrue(len(self.client._station_cache) > 20)
+            station_cache_size = len(self.client._station_cache)
+            self.assertIn(("G", "FDF"), self.client._station_cache)
+            self.assertEqual(self.client._station_cache_level, "station")
+            for tr in st:
+                self.assertEqual(tr.stats.network, "G")
+                self.assertEqual(tr.stats.station, "FDF")
+                self.assertEqual(tr.stats.channel[0], "B")
+            # now make a subsequent request that needs an info request on
+            # channel level
+            st = self.client.get_waveforms("*", "F?F", "*", "B*", t, t + 5)
+            self.assertGreater(len(st), 2)
+            self.assertTrue(
+                len(self.client._station_cache) > station_cache_size)
+            self.assertIn(("G", "FDF", "00", "BHZ"),
+                          self.client._station_cache)
+            self.assertEqual(self.client._station_cache_level, "channel")
+            for tr in st:
+                self.assertEqual(tr.stats.network, "G")
+                self.assertEqual(tr.stats.station, "FDF")
+                self.assertEqual(tr.stats.channel[0], "B")
+
+        # getting a result depends on two things.. how long backwards the ring
+        # buffer stores data and how close to realtime the data is available,
+        # so check some different offsets and see if we get some data
+        for offset in (3600, 2000, 1000, 500):
+            try:
+                _test_offset_from_realtime(offset)
+            except AssertionError:
+                continue
+            else:
+                break
+        else:
+            raise
 
 
 def suite():


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Adds a method to seedlink client to be able to fetch a list of network/stations for which waveform streams are provided.

### Why was it initiated?  Any relevant Issues?

This can help in applications to resolve wildcards in stations/networks, e.g. when using `seedlink-plotter` with `"GR_*:HHZ"` as seedlink string because the realtime version of the seedlink client can not handle wildcards in network/station.

###  PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.seedlink"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
