### PR TITLE
seishub: fix fetching paz for stations with multiple metadata files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,6 +56,9 @@ master:
      clients (see #2342 and #2344)
    * make it possible to use signed EIDA tokens and also skip token validation
      completely (see #2297)
+ - obspy.clients.seishub:
+   * Properly handle fetching poles and zeros in presence of multiple metadata
+     files for a given station (see #2411)
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what
      to plot after scanning data (see #2227)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix fetching poles and zeros when there are multiple metadata files on the server for a given station. 

### Why was it initiated?  Any relevant Issues?

Before this was only looking at the first found metadata file which in many cases doesn't hold the desired response info.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
