### PR TITLE
fix a problem in Scanner when loading npz on Python3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -62,6 +62,8 @@ master:
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what
      to plot after scanning data (see #2227)
+   * fix a problem in Scanner when loading npz on Python3 that was written on
+     Python2 (see #2413)
  - obspy.io.mseed:
    * The recordanalyzer can now detect calibration blockettes 300, 310,
      and 320 (see #2370).

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -186,6 +186,16 @@ def load_npz(file_, data_dict, samp_int_dict):
     # check obspy version the npz was done with
     if "__version__" in npz_dict:
         version_string = npz_dict["__version__"].item()
+        # saw some error loading a npz written on Py2 when loading on Py3 with
+        # the version string being bytes so that the following `split(".")`
+        # raises an Exception. Not sure what is going on and no time to track
+        # it down properly right now, in any case the following hack should not
+        # cause any problems and it's only used to check if a warning needs to
+        # be shown at the moment
+        try:
+            version_string = version_string.decode('ASCII')
+        except Exception:
+            pass
     else:
         version_string = None
     # npz data computed with obspy < 1.1.0 are slightly different


### PR DESCRIPTION



<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix a problem in Scanner when loading npz on Python3 when the npz was written on Python2.

This is just fixing the symptoms, but no time to look into this deeper right now and I'm pretty sure this fix won't cause other problems.

### Why was it initiated?  Any relevant Issues?

Encountered an exception during loading a npz on Python3.


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
