### PR TITLE
Fix reading from buffer not at start of file and using autodetection

### DIFF
--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -129,6 +129,19 @@ class WaveformPluginsTestCase(unittest.TestCase):
                             st = read(temp, format=format)
                             self.assertEqual(len(st), 1)
                             self.assertEqual(st[0].stats._format, format)
+                            # BytesIO with an offset (additional data in front
+                            # but file pointer at right position in file), with
+                            # and without autodetection
+                            for autodetect in (format, None):
+                                temp.seek(0)
+                                temp2 = io.BytesIO()
+                                dummy_bytes = b'123456'
+                                temp2.write(dummy_bytes)
+                                temp2.write(temp.read())
+                                temp2.seek(len(dummy_bytes))
+                                st = read(outfile, format=autodetect)
+                                self.assertEqual(len(st), 1)
+                                self.assertEqual(st[0].stats._format, format)
                         # Q files consist of two files - deleting additional
                         # file
                         if format == 'Q':

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -440,7 +440,7 @@ def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
             # check format
             is_format = is_format(filename)
             if position is not None:
-                filename.seek(0, 0)
+                filename.seek(position, 0)
             if is_format:
                 break
         else:

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -63,27 +63,27 @@ def _internal_is_sac(buf):
         delta_bin = buf.read(4)
         delta = struct.unpack(native_str('<f'), delta_bin)[0]
         # read nvhdr (70 header floats, 6 position in header integers)
-        buf.seek(4 * 70 + 4 * 6)
+        buf.seek(starting_pos + 4 * 70 + 4 * 6, 0)
         nvhdr_bin = buf.read(4)
         nvhdr = struct.unpack(native_str('<i'), nvhdr_bin)[0]
         # read leven (70 header floats, 35 header integers, 0 position in
         # header bool)
-        buf.seek(4 * 70 + 4 * 35)
+        buf.seek(starting_pos + 4 * 70 + 4 * 35, 0)
         leven_bin = buf.read(4)
         leven = struct.unpack(native_str('<i'), leven_bin)[0]
         # read lpspol (70 header floats, 35 header integers, 1 position in
         # header bool)
-        buf.seek(4 * 70 + 4 * 35 + 4 * 1)
+        buf.seek(starting_pos + 4 * 70 + 4 * 35 + 4 * 1, 0)
         lpspol_bin = buf.read(4)
         lpspol = struct.unpack(native_str('<i'), lpspol_bin)[0]
         # read lovrok (70 header floats, 35 header integers, 2 position in
         # header bool)
-        buf.seek(4 * 70 + 4 * 35 + 4 * 2)
+        buf.seek(starting_pos + 4 * 70 + 4 * 35 + 4 * 2, 0)
         lovrok_bin = buf.read(4)
         lovrok = struct.unpack(native_str('<i'), lovrok_bin)[0]
         # read lcalda (70 header floats, 35 header integers, 3 position in
         # header bool)
-        buf.seek(4 * 70 + 4 * 35 + 4 * 3)
+        buf.seek(starting_pos + 4 * 70 + 4 * 35 + 4 * 3, 0)
         lcalda_bin = buf.read(4)
         lcalda = struct.unpack(native_str('<i'), lcalda_bin)[0]
         # check if file is big-endian


### PR DESCRIPTION
I am pretty sure we have a bug in our reading routines when
 - auto fileformat detection is used
 - a binary buffer is passed
 - that buffer is not at start of file

To reproduce, add some random bytes into a buffer and fill the rest with a valid waveform files data:

```python
from obspy import read
filename = 'LMOW.BHE.SAC'  # file is in io/sac/tests/data
import io
bio = io.BytesIO()
bio.write(b'123456')
data = open(filename, 'rb').read()
bio.write(data)
bio.seek(6)
st = read(bio)
```

The last line will call `_is_mseed()` first, and then goes over to `_is_sac()` and should eventually read it as a sac file starting at the initial offset position of 6 bytes.

This might be a real edge case, especially since some `is_xxx()` check routines might not be clean about keeping file handles open (did not check all of them..) but still should be fixed eventually.

The fix should be simple, but I found more code that breaks when not at position 0 in buffer (in sac file check) and there might be many more locations with problems of that kind, but still better to fix at least some of them. We probably need a `_generic_is_file_format` routine that consistently handles open file handles etc like was done in #2326 not sure..

```diff
diff --git a/obspy/core/util/base.py b/obspy/core/util/base.py
index 9c81efe17..0a9ffbcea 100644
--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -433,7 +434,7 @@ def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
             # check format
             is_format = is_format(filename)
             if position is not None:
-                filename.seek(0, 0)
+                filename.seek(position, 0)
             if is_format:
                 break
         else:
```

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
