### PR TITLE
ImportError with custom plugin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 master:
  - obspy.core:
+   * Fixed import of custom plugins (see #2423)
    * Fixed "==" comparison for Stream and Trace which was very slow in case of
      traces with >1e6 samples (see #2377)
    * Added almost_equal method for Stream and Trace classes (see #2286).

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -54,42 +54,15 @@ __all__ = [native_str(i) for i in __all__]
 
 
 # insert supported read/write format plugin lists dynamically in docstrings
-from obspy.core.util.base import make_format_plugin_table
+from obspy.core.util.base import _add_format_plugin_table
 
 
-def _add_table(func, namespace, name, numspaces):
-    """
-    A function to populate the docstring of func with its plugin table.
-    """
-    table = make_format_plugin_table(namespace, name, numspaces=numspaces)
-    # When obspy is re-imported this can raise an error since the doc strings
-    # have already been formatted. Simply return docstring if this happens.
-    try:
-        return func.__doc__ % table
-    except TypeError:
-        return func.__doc__
-
-
-read.__doc__ = _add_table(read, "waveform", "read", numspaces=4)
-read_events.__doc__ = _add_table(read_events, "event", "read", numspaces=4)
-read_inventory.__doc__ =\
-    _add_table(read_inventory, "inventory", "read", numspaces=4)
-
-
-if PY2:
-    Stream.write.im_func.func_doc = \
-        _add_table(Stream.write, "waveform", "write", numspaces=8)
-    Catalog.write.im_func.func_doc = \
-        _add_table(Catalog.write, "event", "write", numspaces=8)
-    Inventory.write.im_func.func_doc = \
-        _add_table(Inventory.write, "inventory", "write", numspaces=8)
-else:
-    Stream.write.__doc__ = \
-        _add_table(Stream.write, "waveform", "write", numspaces=8)
-    Catalog.write.__doc__ = \
-        _add_table(Catalog.write, "event", "write", numspaces=8)
-    Inventory.write.__doc__ = \
-        _add_table(Inventory.write, "Inventory", "write", numspaces=8)
+_add_format_plugin_table(read, "waveform", "read", numspaces=4)
+_add_format_plugin_table(read_events, "event", "read", numspaces=4)
+_add_format_plugin_table(read_inventory, "inventory", "read", numspaces=4)
+_add_format_plugin_table(Stream.write, "waveform", "write", numspaces=8)
+_add_format_plugin_table(Catalog.write, "event", "write", numspaces=8)
+_add_format_plugin_table(Inventory.write, "inventory", "write", numspaces=8)
 
 
 if requests.__version__ in ('2.12.0', '2.12.1', '2.12.2'):

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -55,36 +55,41 @@ __all__ = [native_str(i) for i in __all__]
 
 # insert supported read/write format plugin lists dynamically in docstrings
 from obspy.core.util.base import make_format_plugin_table
-read.__doc__ = \
-    read.__doc__ % make_format_plugin_table("waveform", "read", numspaces=4)
-read_events.__doc__ = \
-    read_events.__doc__ % make_format_plugin_table("event", "read",
-                                                   numspaces=4)
-read_inventory.__doc__ = \
-    read_inventory.__doc__ % make_format_plugin_table("inventory", "read",
-                                                      numspaces=4)
+
+
+def _add_table(func, namespace, name, numspaces):
+    """
+    A function to populate the docstring of func with its plugin table.
+    """
+    table = make_format_plugin_table(namespace, name, numspaces=numspaces)
+    # When obspy is re-imported this can raise an error since the doc strings
+    # have already been formatted. Simply return docstring if this happens.
+    try:
+        return func.__doc__ % table
+    except TypeError:
+        return func.__doc__
+
+
+read.__doc__ = _add_table(read, "waveform", "read", numspaces=4)
+read_events.__doc__ = _add_table(read_events, "event", "read", numspaces=4)
+read_inventory.__doc__ =\
+    _add_table(read_inventory, "inventory", "read", numspaces=4)
 
 
 if PY2:
     Stream.write.im_func.func_doc = \
-        Stream.write.__doc__ % make_format_plugin_table("waveform", "write",
-                                                        numspaces=8)
+        _add_table(Stream.write, "waveform", "write", numspaces=8)
     Catalog.write.im_func.func_doc = \
-        Catalog.write.__doc__ % make_format_plugin_table("event", "write",
-                                                         numspaces=8)
+        _add_table(Catalog.write, "event", "write", numspaces=8)
     Inventory.write.im_func.func_doc = \
-        Inventory.write.__doc__ % make_format_plugin_table(
-            "inventory", "write", numspaces=8)
+        _add_table(Inventory.write, "inventory", "write", numspaces=8)
 else:
     Stream.write.__doc__ = \
-        Stream.write.__doc__ % make_format_plugin_table("waveform", "write",
-                                                        numspaces=8)
+        _add_table(Stream.write, "waveform", "write", numspaces=8)
     Catalog.write.__doc__ = \
-        Catalog.write.__doc__ % make_format_plugin_table("event", "write",
-                                                         numspaces=8)
+        _add_table(Catalog.write, "event", "write", numspaces=8)
     Inventory.write.__doc__ = \
-        Inventory.write.__doc__ % make_format_plugin_table(
-            "inventory", "write", numspaces=8)
+        _add_table(Inventory.write, "Inventory", "write", numspaces=8)
 
 
 if requests.__version__ in ('2.12.0', '2.12.1', '2.12.2'):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -29,7 +29,7 @@ import numpy as np
 import pkg_resources
 import requests
 from future.utils import native_str
-from pkg_resources import iter_entry_points
+from pkg_resources import get_entry_info, iter_entry_points
 
 from obspy.core.util.misc import to_int_or_zero, buffered_load_entry_point
 
@@ -519,8 +519,8 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     for name, ep in eps.items():
         module_short = ":mod:`%s`" % ".".join(ep.module_name.split(".")[:3])
         ep_list = [ep.dist.key, "obspy.plugin.%s.%s" % (group, name), method]
-        func = buffered_load_entry_point(*ep_list)
-        func_str = ':func:`%s`' % ".".join((ep.module_name, func.__name__))
+        entry_info = str(get_entry_info(*ep_list))
+        func_str = ':func:`%s`' % entry_info.split(' = ')[1].replace(':','.')
         mod_list.append((name, module_short, func_str))
 
     mod_list = sorted(mod_list)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -546,6 +546,19 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     return ret
 
 
+def _add_format_plugin_table(func, group, method, numspaces=4):
+    """
+    A function to populate the docstring of func with its plugin table.
+    """
+    if '%s' in func.__doc__:
+        if PY2 and method == "write":
+            func.im_func.func_doc = func.__doc__ % make_format_plugin_table(
+                group, method, numspaces=numspaces)
+        else:
+            func.__doc__ = func.__doc__ % make_format_plugin_table(
+                group, method, numspaces=numspaces)
+
+
 class ComparingObject(object):
     """
     Simple base class that implements == and != based on self.__dict__

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -100,6 +100,7 @@ class NamedTemporaryFile(io.BufferedIOBase):
     >>> os.path.exists(tf.name)
     False
     """
+
     def __init__(self, dir=None, suffix='.tmp', prefix='obspy-'):
         fd, self.name = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
         self._fileobj = os.fdopen(fd, 'w+b', 0)  # 0 -> do not buffer
@@ -520,7 +521,7 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
         module_short = ":mod:`%s`" % ".".join(ep.module_name.split(".")[:3])
         ep_list = [ep.dist.key, "obspy.plugin.%s.%s" % (group, name), method]
         entry_info = str(get_entry_info(*ep_list))
-        func_str = ':func:`%s`' % entry_info.split(' = ')[1].replace(':','.')
+        func_str = ':func:`%s`' % entry_info.split(' = ')[1].replace(':', '.')
         mod_list.append((name, module_short, func_str))
 
     mod_list = sorted(mod_list)
@@ -549,6 +550,7 @@ class ComparingObject(object):
     """
     Simple base class that implements == and != based on self.__dict__
     """
+
     def __eq__(self, other):
         return (isinstance(other, self.__class__)
                 and self.__dict__ == other.__dict__)


### PR DESCRIPTION
For illustration I use obspyh5 as custom plugin, but I guess it would be the same for other plugins.

Consider the following setup:

```
conda create -n test obspy h5py
conda activate test
pip install obspyh5
```

The following script is working:

```
import obspy
import obspyh5
```

The following script is not working in obspy master.

```
import obspyh5
```

```
Traceback (most recent call last):
  File "/home/eule/anaconda/envs/workhorse/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2442, in resolve
    return functools.reduce(getattr, self.attrs, module)
AttributeError: module 'obspyh5' has no attribute 'readh5'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 1, in <module>
    import obspyh5
  File "/home/eule/dev/obspyh5/obspyh5.py", line 26, in <module>
    from obspy.core import Trace, Stream, UTCDateTime as UTC
  File "/home/eule/dev/obspy/obspy/__init__.py", line 59, in <module>
    read.__doc__ % make_format_plugin_table("waveform", "read", numspaces=4)
  File "/home/eule/dev/obspy/obspy/core/util/base.py", line 522, in make_format_plugin_table
    func = buffered_load_entry_point(*ep_list)
  File "/home/eule/dev/obspy/obspy/core/util/misc.py", line 644, in buffered_load_entry_point
    _ENTRY_POINT_CACHE[hash_str] = load_entry_point(dist, group, name)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.6/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/eule/anaconda/envs/workhorse/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2843, in load_entry_point
    return ep.load()
  File "/home/eule/anaconda/envs/workhorse/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2434, in load
    return self.resolve()
  File "/home/eule/anaconda/envs/workhorse/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2444, in resolve
    raise ImportError(str(exc))
ImportError: module 'obspyh5' has no attribute 'readh5'
```

@medlin01GA Thanks for spotting this mysterious bug.