### PR TITLE
Get rid of deprecation warning `from collections import `

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -23,7 +23,6 @@ from socket import timeout as socket_timeout
 import textwrap
 import threading
 import warnings
-from collections import OrderedDict
 
 from lxml import etree
 
@@ -40,10 +39,13 @@ if PY2:
     from urllib import urlencode
     import urllib2 as urllib_request
     import Queue as queue  # NOQA
+    from collections import OrderedDict
+
 else:
     from urllib.parse import urlencode
     import urllib.request as urllib_request
     import queue
+    from collections.abc import OrderedDict
 
 
 DEFAULT_SERVICE_VERSIONS = {'dataselect': 1, 'station': 1, 'event': 1}

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -15,10 +15,15 @@ and should be removed once the datacenters are fully standard compliant.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
 import io
 import warnings
-from collections import defaultdict
+
+if PY2:
+    from collections import defaultdict
+else:
+    from collections.abc import defaultdict
 
 from lxml import etree
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -12,10 +12,14 @@ Classes related to instrument responses.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
 import copy
 import ctypes as C  # NOQA
-from collections import defaultdict
+if PY2:
+    from collections import defaultdict
+else:
+    from collections.abc import defaultdict
 from copy import deepcopy
 import itertools
 from math import pi

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -23,7 +23,10 @@ import re
 import sys
 import tempfile
 import unicodedata
-from collections import OrderedDict
+if PY2:
+    from collections import OrderedDict
+else:
+    from collections.abc import OrderedDict
 
 import numpy as np
 import pkg_resources

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -11,12 +11,13 @@ Various types used in ObsPy.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
 if PY2:
     from collections import OrderedDict
 else:
     from collections.abc import OrderedDict
-    
+
 try:
     import __builtin__
     list = __builtin__.list

--- a/obspy/core/util/obspy_types.py
+++ b/obspy/core/util/obspy_types.py
@@ -12,8 +12,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-from collections import OrderedDict
-
+if PY2:
+    from collections import OrderedDict
+else:
+    from collections.abc import OrderedDict
+    
 try:
     import __builtin__
     list = __builtin__.list

--- a/obspy/io/mseed/scripts/recordanalyzer.py
+++ b/obspy/io/mseed/scripts/recordanalyzer.py
@@ -21,12 +21,16 @@ A command-line tool to analyze Mini-SEED records.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import native_str
+from future.utils import PY2, native_str
+
 
 import sys
 import string
 from argparse import ArgumentParser
-from collections import OrderedDict
+if PY2:
+    from collections import OrderedDict
+else:
+    from collections.abc import OrderedDict
 from copy import deepcopy
 from struct import unpack
 

--- a/obspy/io/nordic/utils.py
+++ b/obspy/io/nordic/utils.py
@@ -11,9 +11,13 @@ Utility functions for Nordic file format support for ObsPy
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA @UnusedWildImport
+from future.utils import PY2
 
 import warnings
-from collections import defaultdict
+if PY2:
+    from collections import defaultdict
+else:
+    from collections.abc import defaultdict
 
 from obspy.io.nordic import NordicParsingError
 

--- a/obspy/io/rg16/core.py
+++ b/obspy/io/rg16/core.py
@@ -4,8 +4,12 @@ Receiver Gather (version 1.6-1) bindings to ObsPy core module.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
-from collections import namedtuple
+if PY2:
+    from collections import namedtuple
+else:
+    from collections.abc import namedtuple
 
 import numpy as np
 

--- a/obspy/io/sh/evt.py
+++ b/obspy/io/sh/evt.py
@@ -12,8 +12,12 @@ SeismicHandler evt file bindings to ObsPy core module.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
-from collections import defaultdict
+if PY2:
+    from collections import defaultdict
+else:
+    from collections.abc import defaultdict
 import io
 from math import cos, pi
 from warnings import warn

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -28,8 +28,12 @@ characteristic functions and a coincidence triggering routine.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
+from future.utils import PY2
 
-from collections import deque
+if PY2:
+    from collections import deque
+else:
+    from collections.abc import deque
 import ctypes as C  # NOQA
 import warnings
 

--- a/obspy/taup/helper_classes.py
+++ b/obspy/taup/helper_classes.py
@@ -7,8 +7,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 from future.utils import native_str
+from future.utils import PY2
 
-from collections import namedtuple
+if PY2:
+    from collections import namedtuple
+else:
+    from collections.abc import namedtuple
 
 import numpy as np
 

--- a/obspy/taup/tau_model.py
+++ b/obspy/taup/tau_model.py
@@ -6,9 +6,12 @@ Internal TauModel class.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import native_str
+from future.utils import PY2, native_str
 
-from collections import OrderedDict
+if PY2:
+    from collections import OrderedDict
+else:
+    from collections.abc import OrderedDict
 import os
 from copy import deepcopy
 from itertools import count

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -6,14 +6,17 @@ Tests the high level obspy.taup.tau interface.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import native_str
+from future.utils import PY2,native_str
 
 import collections
 import inspect
 import os
 import unittest
 import warnings
-from collections import OrderedDict
+if PY2:
+    from collections import OrderedDict
+else:
+    from collections.abc import OrderedDict
 
 import numpy as np
 

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -6,7 +6,7 @@ Tests the high level obspy.taup.tau interface.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
-from future.utils import PY2,native_str
+from future.utils import PY2, native_str
 
 import collections
 import inspect


### PR DESCRIPTION
I changed all imports `from collections import smth` to be PY2 constant dependent.
That way of importing will de removed in Py3.8 in favour of `from collections.abc import smth`.
Since in the codebase there are already existing imports based on `future.utils.PY2` constant I decided to use that approach. 

I change all occurences of that kind of an import apart of one code snippet in the documentation. which is located here:
`obspy\misc\docs\source\tutorial\code_snippets\quakeml_custom_tags.rst`
I decided to leave that as is because currently that snippet works on all Python versions and adding if would make it more complicated. We could change that when we will be dropping support for PY2.