### PR TITLE
Importing ABCs through compatibility layer and fix of proj_version check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,4 +20,4 @@ jobs:
           name: run linting
           command: |
             /opt/conda/bin/flake8 --version
-            /opt/conda/bin/flake8 --verbose --ignore=E402,$(python -c 'import pycodestyle; print(pycodestyle.DEFAULT_IGNORE)') --exclude=__init__.py obspy
+            /opt/conda/bin/flake8 --verbose --ignore=E402,E504,W504,$(python -c 'import pycodestyle; print(pycodestyle.DEFAULT_IGNORE)') --exclude=__init__.py obspy

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,9 +133,9 @@ install:
         NUMPY="numpy"
         SCIPY="scipy"
         MATPLOTLIB="matplotlib"
-        BASEMAP="basemap=1.2.1"
+        BASEMAP="basemap>=1.2.1"
         PYPROJ="pyproj"
-        PROJ4="proj4=4.9.3"
+        PROJ4="proj4"
         GFORTRAN=""
       else
         NUMPY="numpy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,16 @@ install:
         PYPROJ="pyproj"
         PROJ4="proj4=4.9.3"
         GFORTRAN=""
+      elif [[ "${PYTHON_VERSION}" == '3.7' ]]; then
+        # Pin proj4 to 4.9.3 for map testing - see basemap #433
+        # Let conda resolve to the latest versions otherwise.
+        NUMPY="numpy"
+        SCIPY="scipy"
+        MATPLOTLIB="matplotlib"
+        BASEMAP="basemap=1.2.1"
+        PYPROJ="pyproj"
+        PROJ4="proj4=4.9.3"
+        GFORTRAN=""
       else
         NUMPY="numpy"
         SCIPY="scipy"

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -14,7 +14,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import collections
+from obspy.core import compatibility
 
 import obspy
 
@@ -240,13 +240,13 @@ class Restrictions(object):
         self.sanitize = bool(sanitize)
 
         # These must be iterables, but not strings.
-        if not isinstance(channel_priorities, collections.Iterable) \
+        if not isinstance(channel_priorities, compatibility.collections_abc.Iterable) \
                 or isinstance(channel_priorities, (str, native_str)):
             msg = "'channel_priorities' must be a list or other iterable " \
                   "container."
             raise TypeError(msg)
 
-        if not isinstance(location_priorities, collections.Iterable) \
+        if not isinstance(location_priorities, compatibility.collections_abc.Iterable) \
                 or isinstance(location_priorities, (str, native_str)):
             msg = "'location_priorities' must be a list or other iterable " \
                   "container."

--- a/obspy/clients/fdsn/mass_downloader/restrictions.py
+++ b/obspy/clients/fdsn/mass_downloader/restrictions.py
@@ -14,7 +14,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-from obspy.core import compatibility
+from obspy.core.compatibility import collections_abc
 
 import obspy
 
@@ -240,13 +240,13 @@ class Restrictions(object):
         self.sanitize = bool(sanitize)
 
         # These must be iterables, but not strings.
-        if not isinstance(channel_priorities, compatibility.collections_abc.Iterable) \
+        if not isinstance(channel_priorities, collections_abc.Iterable) \
                 or isinstance(channel_priorities, (str, native_str)):
             msg = "'channel_priorities' must be a list or other iterable " \
                   "container."
             raise TypeError(msg)
 
-        if not isinstance(location_priorities, compatibility.collections_abc.Iterable) \
+        if not isinstance(location_priorities, collections_abc.Iterable) \
                 or isinstance(location_priorities, (str, native_str)):
             msg = "'location_priorities' must be a list or other iterable " \
                   "container."

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -385,7 +385,7 @@ def get_proj_version(raw_string=False):
     _proj = Proj(proj='utm', zone=10, ellps='WGS84')
     if hasattr(_proj, 'proj_version_str'):
         version_string = str(getattr(_proj, 'proj_version_str'))
-    elif hasattr(_proj, 'proj_version')::
+    elif hasattr(_proj, 'proj_version'):
         version_string = str(getattr(_proj, 'proj_version'))
     else:
         from pyproj import proj_version_str

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -383,9 +383,7 @@ def get_proj_version(raw_string=False):
     # of the Proj class that is only set when the projection is made. Make
     # a dummy projection and get the version
     _proj = Proj(proj='utm', zone=10, ellps='WGS84')
-    if hasattr(_proj, 'proj_version_str'):
-        version_string = str(getattr(_proj, 'proj_version_str'))
-    elif hasattr(_proj, 'proj_version'):
+    if hasattr(_proj, 'proj_version'):
         version_string = str(getattr(_proj, 'proj_version'))
     else:
         from pyproj import proj_version_str

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -383,7 +383,10 @@ def get_proj_version(raw_string=False):
     # of the Proj class that is only set when the projection is made. Make
     # a dummy projection and get the version
     _proj = Proj(proj='utm', zone=10, ellps='WGS84')
-    version_string = str(getattr(_proj, 'proj_version_str', 'proj_version'))
+    if hasattr(_proj, 'proj_version_str'):
+        version_string = str(getattr(_proj, 'proj_version_str'))
+    else:
+        version_string = str(getattr(_proj, 'proj_version'))
     if raw_string:
         return version_string
     version_list = [to_int_or_zero(no) for no in version_string.split(".")]

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -385,8 +385,12 @@ def get_proj_version(raw_string=False):
     _proj = Proj(proj='utm', zone=10, ellps='WGS84')
     if hasattr(_proj, 'proj_version_str'):
         version_string = str(getattr(_proj, 'proj_version_str'))
-    else:
+    elif hasattr(_proj, 'proj_version')::
         version_string = str(getattr(_proj, 'proj_version'))
+    else:
+        from pyproj import proj_version_str
+        version_string = proj_version_str
+
     if raw_string:
         return version_string
     version_list = [to_int_or_zero(no) for no in version_string.split(".")]

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -382,7 +382,8 @@ def get_proj_version(raw_string=False):
     # proj4 is a c library, prproj wraps this.  proj_version is an attribute
     # of the Proj class that is only set when the projection is made. Make
     # a dummy projection and get the version
-    version_string = str(Proj(proj='utm', zone=10, ellps='WGS84').proj_version)
+    _proj = Proj(proj='utm', zone=10, ellps='WGS84')
+    version_string = str(getattr(_proj, 'proj_version_str', 'proj_version'))
     if raw_string:
         return version_string
     version_list = [to_int_or_zero(no) for no in version_string.split(".")]

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -18,7 +18,7 @@ from struct import pack, unpack
 import numpy as np
 
 from obspy import UTCDateTime
-from obspy.core.compatibility import from_buffer
+from obspy.core.compatibility import from_buffer, collections_abc
 from obspy.core.util.decorator import ObsPyDeprecationWarning
 from . import InternalMSEEDParseTimeError
 from .headers import (ENCODINGS, ENDIAN, FIXED_HEADER_ACTIVITY_FLAGS,
@@ -1256,7 +1256,7 @@ def _check_flag_value(flag_value):
         utc_val = UTCDateTime(flag_value)
         corrected_flag = [(utc_val, utc_val)]
 
-    elif isinstance(flag_value, collections.Mapping):
+    elif isinstance(flag_value, collections_abc.Mapping):
         # dict allowed if it has the right format
         corrected_flag = []
         for flag_key in flag_value:
@@ -1268,7 +1268,7 @@ def _check_flag_value(flag_value):
                     # Single value : ensure it's UTCDateTime and store it
                     utc_val = UTCDateTime(inst_values)
                     corrected_flag.append((utc_val, utc_val))
-                elif isinstance(inst_values, collections.Sequence):
+                elif isinstance(inst_values, collections_abc.Sequence):
                     # Several instant values : check their types
                     # and add each of them
                     for value in inst_values:
@@ -1288,7 +1288,7 @@ def _check_flag_value(flag_value):
                 # Expecting either a list of tuples (start, end) or
                 # a list of (start1, end1, start1, end1)
                 dur_values = flag_value[flag_key]
-                if isinstance(dur_values, collections.Sequence):
+                if isinstance(dur_values, collections_abc.Sequence):
                     if len(dur_values) != 0:
                         # Check first item
                         if isinstance(dur_values[0], datetime) or \
@@ -1331,10 +1331,10 @@ def _check_flag_value(flag_value):
                                     raise ValueError(msg)
                                 next(duration_iter)
 
-                        elif isinstance(dur_values[0], collections.Sequence):
+                        elif isinstance(dur_values[0], collections_abc.Sequence):
                             # List of tuples (start, end)
                             for value in dur_values:
-                                if not isinstance(value, collections.Sequence):
+                                if not isinstance(value, collections_abc.Sequence):
                                     msg = "Incorrect type %s for flag duration"
                                     raise ValueError(msg % str(type(value)))
                                 elif len(value) != 2:
@@ -1491,7 +1491,7 @@ def _convert_flags_to_raw_byte(expected_flags, user_flags, recstart, recend):
             if isinstance(user_flags[key], bool) and user_flags[key]:
                 # Boolean value, we accept it for all records
                 use_in_this_record = True
-            elif isinstance(user_flags[key], collections.Sequence):
+            elif isinstance(user_flags[key], collections_abc.Sequence):
                 # List of tuples (start, end)
                 use_in_this_record = False
                 for tuple_value in user_flags[key]:

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -30,6 +30,7 @@ from uuid import uuid4
 
 import numpy as np
 
+from obspy.core import compatibility
 from obspy import Stream, UTCDateTime, read, __version__
 from obspy.core.util.base import get_dependency_version
 from obspy.io.mseed.util import get_flags
@@ -615,7 +616,7 @@ class MSEEDMetadata(object):
 
         # If passed as a dictionary, serialize and derialize to get the
         # mapping from Python object to JSON type.
-        if isinstance(qc_metrics, collections.Mapping):
+        if isinstance(qc_metrics, compatibility.collections_abc.Mapping):
             qc_metrics = json.loads(self.get_json_meta(validate=False))
         elif hasattr(qc_metrics, "read"):
             qc_metrics = json.load(qc_metrics)

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -30,8 +30,8 @@ from uuid import uuid4
 
 import numpy as np
 
-from obspy.core import compatibility
 from obspy import Stream, UTCDateTime, read, __version__
+from obspy.core.compatibility import collections_abc
 from obspy.core.util.base import get_dependency_version
 from obspy.io.mseed.util import get_flags
 
@@ -616,7 +616,7 @@ class MSEEDMetadata(object):
 
         # If passed as a dictionary, serialize and derialize to get the
         # mapping from Python object to JSON type.
-        if isinstance(qc_metrics, compatibility.collections_abc.Mapping):
+        if isinstance(qc_metrics, collections_abc.Mapping):
             qc_metrics = json.loads(self.get_json_meta(validate=False))
         elif hasattr(qc_metrics, "read"):
             qc_metrics = json.load(qc_metrics)


### PR DESCRIPTION
Okay, this time I hope it is done properly...

I replaced bare imports of Abstract Base Classes to go through compatibility layer. It is necessary for compatibility between 2.7 and 3.8 since 3.8 drops possibility of ABC import directly from `collections` and requires import from `collections.abc`.
I substituted imports only for ABCs so `Mapping`, `Iterable` and `Sequence`. There are only so few changes because in other cases the imports were done already in that way.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
