### PR TITLE
make interphinx point to latest python version

### DIFF
--- a/misc/docs/source/conf.py
+++ b/misc/docs/source/conf.py
@@ -326,7 +326,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2.7/', None),
+    'python': ('https://docs.python.org/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None),


### PR DESCRIPTION
Intersphinx links in the docs still point to python2.7.
+DOCS