### PR TITLE
More robust ISO8601 detection + option to disable auto detection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,8 @@ master:
    * fixed UTCDateTime(..., julday=366) for non-leap years. This was returning
      January 1st of the next year in case of non-leap years being used. Now it
      properly raises an out-of-bounds ValueError (see #2369)
+   * better ISO8601 detection for UTCDateTime objects and UTCDateTime(...,
+     iso8601=False) now completely disables ISO8601 handling (see #2447)
    * Added replace method to UTCDateTime class (see #2077).
    * Added remove method to Inventory class (see #2088).
    * Added id property to WaveformStreamID (see #2131).

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1552,6 +1552,24 @@ class UTCDateTimeTestCase(unittest.TestCase):
         expected = UTCDateTime(2016, 12, 31)
         self.assertEqual(got, expected)
 
+    def test_issue_2447(self):
+        """
+        Setting iso8601=False should disable ISO8601 parsing.
+
+        See issue #2447.
+        """
+        # auto detection
+        self.assertEqual(UTCDateTime('2019-01-01T02-02:33'),
+                         UTCDateTime(2019, 1, 1, 4, 33, 0))
+        self.assertEqual(UTCDateTime('2019-01-01 02-02:33'),
+                         UTCDateTime(2019, 1, 1, 2, 2, 33))
+        # enforce ISO8601 mode
+        self.assertEqual(UTCDateTime('2019-01-01T02-02:33', iso8601=True),
+                         UTCDateTime(2019, 1, 1, 4, 33, 0))
+        # skip ISO8601 mode
+        self.assertEqual(UTCDateTime('2019-01-01T02-02:33', iso8601=False),
+                         UTCDateTime(2019, 1, 1, 2, 2, 33))
+
 
 def suite():
     return unittest.makeSuite(UTCDateTimeTestCase, 'test')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -343,8 +343,8 @@ class UTCDateTime(object):
                         self._from_iso8601_string(value)
                         return
                     except Exception:
-                        # if iso8601 is enforce raise here otherwise fallback
-                        # to non iso8601
+                        # raise here if iso8601 is enforced otherwise fallback
+                        # to non iso8601 detection by continuing below
                         if iso8601:
                             raise
 

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -30,6 +30,12 @@ from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 # is called a lot. Thus pre-compile it.
 _YEAR0REGEX = re.compile(r"^(\d{1,3}[-/,])(.*)$")
 
+_ISO8601_REGEX = re.compile(
+    r"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?"
+    r"|W([0-4]\d|5[0-3])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6"
+    r"])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17"
+    r"[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$")
+
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 # XXX the strftime problem seems to be specific to Python < 3.2
 # XXX so this can be removed after dropping Python 2 support
@@ -66,9 +72,9 @@ class UTCDateTime(object):
     :param args: The creation of a new `UTCDateTime` object depends from the
         given input parameters. All possible options are summarized in the
         `Examples`_ section below.
-    :type iso8601: bool, optional
-    :param iso8601: Enforce `ISO8601:2004`_ detection. Works only with a string
-        as first input argument.
+    :type iso8601: bool or None, optional
+    :param iso8601: Enforce/disable `ISO8601:2004`_ mode. Defaults to ``None``
+        for auto detection. Works only with a string as first input argument.
     :type strict: bool, optional
     :param strict: If True, Conform to `ISO8601:2004`_ limits on positional
         and keyword arguments. If False, allow hour, minute, second, and
@@ -268,7 +274,7 @@ class UTCDateTime(object):
             self._ns = ns
             return
         # iso8601 flag
-        iso8601 = kwargs.pop('iso8601', False) is True
+        iso8601 = kwargs.pop('iso8601', None)
         # check parameter
         if len(args) == 0 and len(kwargs) == 0:
             # use current date/time if no argument is given
@@ -331,13 +337,17 @@ class UTCDateTime(object):
                         "'%s' does not start with a 4 digit year" % value)
 
                 # check for ISO8601 date string
-                if value.count("T") == 1 or iso8601:
+                if iso8601 is True or (iso8601 is None and
+                                       re.match(_ISO8601_REGEX, value)):
                     try:
                         self._from_iso8601_string(value)
                         return
                     except Exception:
+                        # if iso8601 is enforce raise here otherwise fallback
+                        # to non iso8601
                         if iso8601:
                             raise
+
                 # try to apply some standard patterns
                 value = value.replace('T', ' ')
                 value = value.replace('_', ' ')

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -30,11 +30,24 @@ from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 # is called a lot. Thus pre-compile it.
 _YEAR0REGEX = re.compile(r"^(\d{1,3}[-/,])(.*)$")
 
-_ISO8601_REGEX = re.compile(
-    r"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?"
-    r"|W([0-4]\d|5[0-3])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6"
-    r"])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17"
-    r"[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$")
+# based on https://www.myintervals.com/blog/2009/05/20/iso-8601, w/ week 53 fix
+_ISO8601_REGEX = re.compile(r"""
+    ^
+    ([\+-]?\d{4}(?!\d{2}\b))
+    ((-?)
+     ((0[1-9]|1[0-2])
+      (\3([12]\d|0[1-9]|3[01]))?
+      |W([0-4]\d|5[0-3])(-?[1-7])?
+      |(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6]))
+     )
+     ([T\s]
+      ((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?
+      (\17[0-5]\d([\.,]\d+)?)?
+      ([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?
+     )?
+    )?
+    $
+    """, re.VERBOSE)
 
 TIMESTAMP0 = datetime.datetime(1970, 1, 1, 0, 0)
 # XXX the strftime problem seems to be specific to Python < 3.2


### PR DESCRIPTION
### What does this PR do?

Improves ISO8601 detection

### Why was it initiated?  Any relevant Issues?

#2447

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS: ALL"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [N/A] First time contributors have added your name to `CONTRIBUTORS.txt` .
