### PR TITLE
getting ppsd out of a pickle

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -140,10 +140,12 @@ master:
    * Timestamp representations internally and in npz I/O were changed to use
      integer nanosecond POSIX timestamps to avoid any potential floating point
      inaccuracies and since this is also what UTCDateTime is based on nowadays
-     (see #2045)
+     (see #2045).
    * Fixed the check for new PSD slices whether they should be added or whether
-     they would add unwanted duplicated data (see #2229)
-   * Fix `period_lim` option when `xaxis_frequency=True` (see #2246)
+     they would add unwanted duplicated data (see #2229).
+   * Fix `period_lim` option when `xaxis_frequency=True` (see #2246).
+   * Added `allow_pickle` parameter to `PPSD.add_npz` and `PPSD.load_npz` and
+     set its default to `False` (see #2457).
  - obspy.signal.cross_correlation:
    * Add new `correlate_template()` function with 'full' normalization option,
      required for correlations in template-matching

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -227,7 +227,7 @@ class PPSD(object):
     NPZ_SIMPLE_TYPE_MAP = {None: ''}
     NPZ_SIMPLE_TYPE_MAP_R = {v: i for i, v in NPZ_SIMPLE_TYPE_MAP.items()}
     # Add current version as a class attribute to avoid hard coding it.
-    _CURRENT_VERSION = 2
+    _CURRENT_VERSION = 3
 
     def __init__(self, stats, metadata, skip_on_gaps=False,
                  db_bins=(-200, -50, 1.), ppsd_length=3600.0, overlap=0.5,
@@ -1311,7 +1311,7 @@ class PPSD(object):
         :type allow_pickle: bool
         :param allow_pickle:
             Allow the pickle protocol to be used when de-serializing saved
-            PPSDs. This is only required for npz files written by obspy
+            PPSDs. This is only required for npz files written by ObsPy
             versions less than 1.2.0.
         """
         def _load(data):
@@ -1327,7 +1327,7 @@ class PPSD(object):
                 try:
                     data_ = data[key]
                 except ValueError:
-                    msg = ("Loading PPSD results saved with obspy versions < "
+                    msg = ("Loading PPSD results saved with ObsPy versions < "
                            "1.2 requires setting the allow_pickle parameter "
                            "of PPSD.load_npz to True")
                     raise ValueError(msg)
@@ -1384,7 +1384,7 @@ class PPSD(object):
         :type allow_pickle: bool
         :param allow_pickle:
             Allow the pickle protocol to be used when de-serializing saved
-            PPSDs. This is only required for npz files written by obspy
+            PPSDs. This is only required for npz files written by ObsPy
             versions less than 1.2.0.
         """
         for filename in glob.glob(filename):
@@ -1456,9 +1456,9 @@ class PPSD(object):
                 with np.load(filename, allow_pickle=allow_pickle) as data:
                     _add(data)
             except ValueError:
-                msg = ("Loading PPSD results saved with obspy versions < "
+                msg = ("Loading PPSD results saved with ObsPy versions < "
                        "1.2 requires setting the allow_pickle parameter "
-                        "of PPSD.load_npz to True.")
+                       "of PPSD.load_npz to True.")
                 raise ValueError(msg)
         else:
             data = np.load(filename)
@@ -2068,7 +2068,7 @@ def get_nhnm():
 
 
 def _check_npz_ppsd_version(ppsd, npzfile):
-    # add some future-proofing and show a warning if older obspy
+    # add some future-proofing and show a warning if older ObsPy
     # versions should read a more recent ppsd npz file, since this is very
     # like problematic
     if npzfile['ppsd_version'].item() > ppsd.ppsd_version:

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -775,7 +775,7 @@ class PsdTestCase(unittest.TestCase):
         Matplotlib version 3 shifts the x-axis labels but everything else looks
         the same. Skipping test for matplotlib >= 3 on 05/12/2018.
         """
-        ppsd = PPSD.load_npz(self.example_ppsd_npz)
+        ppsd = PPSD.load_npz(self.example_ppsd_npz, allow_pickle=True)
 
         # add some gaps in the middle
         for i in sorted(list(range(30, 40)) + list(range(8, 18)) + [4])[::-1]:

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -351,10 +351,12 @@ class PsdTestCase(unittest.TestCase):
 
         # load expected results, for both only PAZ and full response
         filename_paz = os.path.join(self.path, 'IUANMO_ppsd_paz.npz')
-        results_paz = PPSD.load_npz(filename_paz, metadata=None)
+        results_paz = PPSD.load_npz(filename_paz, metadata=None,
+                                    allow_pickle=True)
         filename_full = os.path.join(self.path,
                                      'IUANMO_ppsd_fullresponse.npz')
-        results_full = PPSD.load_npz(filename_full, metadata=None)
+        results_full = PPSD.load_npz(filename_full, metadata=None,
+                                     allow_pickle=True)
 
         # Calculate the PPSDs and test against expected results
         # first: only PAZ
@@ -722,7 +724,7 @@ class PsdTestCase(unittest.TestCase):
         """
         Test plot of several period bins over time
         """
-        ppsd = PPSD.load_npz(self.example_ppsd_npz)
+        ppsd = PPSD.load_npz(self.example_ppsd_npz, allow_pickle=True)
 
         restrictions = {'starttime': UTCDateTime(2011, 2, 6, 1, 1),
                         'endtime': UTCDateTime(2011, 2, 7, 21, 12),
@@ -818,7 +820,7 @@ class PsdTestCase(unittest.TestCase):
                 PPSD.load_npz(filename)
         self.assertEqual(str(e.exception), msg)
         # 2 - adding a npz
-        ppsd = PPSD.load_npz(self.example_ppsd_npz)
+        ppsd = PPSD.load_npz(self.example_ppsd_npz, allow_pickle=True)
         for method in (ppsd.add_npz, ppsd._add_npz):
             with NamedTemporaryFile() as tf:
                 filename = tf.name
@@ -843,7 +845,7 @@ class PsdTestCase(unittest.TestCase):
         allow np.load the use of pickle. See #2409.
         """
         # Init a test PPSD and empty byte stream.
-        ppsd = PPSD.load_npz(self.example_ppsd_npz)
+        ppsd = PPSD.load_npz(self.example_ppsd_npz, allow_pickle=True)
         byte_me = io.BytesIO()
         # Save PPSD to byte stream and rewind to 0.
         ppsd.save_npz(byte_me)
@@ -851,6 +853,10 @@ class PsdTestCase(unittest.TestCase):
         # Load dict, will raise an exception if pickle is needed.
         loaded_dict = dict(np.load(byte_me, allow_pickle=False))
         self.assertIsInstance(loaded_dict, dict)
+        # A helpful error message is issued when allow_pickle is needed.
+        with self.assertRaises(ValueError) as context:
+            PPSD.load_npz(self.example_ppsd_npz)
+        self.assertIn('Loading PPSD results', str(context.exception))
 
 
 def suite():

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -861,7 +861,7 @@ class PsdTestCase(unittest.TestCase):
 
     def test_can_add_npz_without_pickle(self):
         """
-        Ensure PPSD can be be added without using the pickle protocol, or
+        Ensure PPSD can be added without using the pickle protocol, or
         that a helpful error message is raised if allow_pickle is required.
         See #2409.
         """

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -842,7 +842,8 @@ class PsdTestCase(unittest.TestCase):
     def test_can_read_npz_without_pickle(self):
         """
         Ensures that a default PPSD can be written and read without having to
-        allow np.load the use of pickle. See #2409.
+        allow np.load the use of pickle, or that a helpful error message is
+        raised if allow_pickle is required. See #2409.
         """
         # Init a test PPSD and empty byte stream.
         ppsd = PPSD.load_npz(self.example_ppsd_npz, allow_pickle=True)
@@ -857,6 +858,32 @@ class PsdTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             PPSD.load_npz(self.example_ppsd_npz)
         self.assertIn('Loading PPSD results', str(context.exception))
+
+    def test_can_add_npz_without_pickle(self):
+        """
+        Ensure PPSD can be be added without using the pickle protocol, or
+        that a helpful error message is raised if allow_pickle is required.
+        See #2409.
+        """
+
+        def _save_nps_require_pickle(filename, ppsd):
+            """ Save npz in such a way that requires pickle to load"""
+            out = {}
+            for key in PPSD.NPZ_STORE_KEYS:
+                out[key] = getattr(ppsd, key)
+            np.savez_compressed(filename, **out)
+
+        ppsd = _internal_get_ppsd()
+        # save PPSD in such a way to mock old versions.
+        with NamedTemporaryFile(suffix='.npz') as ntemp:
+            temp_path = ntemp.name
+            _save_nps_require_pickle(temp_path, ppsd)
+            # We should be able to load the files when allowing pickle.
+            ppsd.add_npz(temp_path, allow_pickle=True)
+            # If not allow_pickle,  a helpful error msg should be raised.
+            with self.assertRaises(ValueError) as context:
+                ppsd.add_npz(temp_path)
+            self.assertIn('Loading PPSD results', str(context.exception))
 
 
 def suite():


### PR DESCRIPTION
### What does this PR do?

This PR changes how the `PPSD` class handles saved npz files that require pickle. From the changes made in #2424 `allow_pickle` was used by default, which is not safe. This PR makes the user opt-in to the use of pickle by adding `allow_pickle` keywords to `PPSD.load_npz` and `PPSD.add_npz`. It also catches the `ValueError` issued by numpy when pickle is required and re-issues a (hopefully) helpful message telling the user they must set `allow_pickle` to `True`.

### Why was it initiated?  Any relevant Issues?

#2424 and #2409

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
