### PR TITLE
Fix mseed test

### DIFF
--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -223,7 +223,7 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
 
     def test_invalid_data_type(self):
         """
-        Writing data of type int64 and int16 are not supported.
+        Writing data of type int64 and int8 are not supported.
 
         int64 data can now be written since #2356 if it can be downcast to
         int32.

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -224,6 +224,9 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
     def test_invalid_data_type(self):
         """
         Writing data of type int64 and int16 are not supported.
+
+        int64 data can now be written since #2356 if it can be downcast to
+        int32.
         """
         npts = 6000
         np.random.seed(815)  # make test reproducible
@@ -231,6 +234,9 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             tempfile = tf.name
             # int64
             data = np.random.randint(-1000, 1000, npts).astype(np.int64)
+            # add a data point that can not be downcast (even though we have a
+            # separate test for this)
+            data[4] = np.iinfo(np.int32).max + 2
             st = Stream([Trace(data=data)])
             self.assertRaises(Exception, st.write, tempfile, format="MSEED")
             # int8


### PR DESCRIPTION
### What does this PR do?

Adjust one MSEED test case, int64 can now be written if safe to downcast to int32, see #2373 

### Why was it initiated?  Any relevant Issues?

see above

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
