### PR TITLE
core: Unify "_is_xxx()" file format checks regarding file handling

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -29,8 +29,8 @@ from obspy.core.trace import Trace
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util.base import (ENTRY_POINTS, _get_function_from_entry_point,
                                   _read_from_plugin, _generic_reader)
-from obspy.core.util.decorator import (map_example_filename,
-                                       raise_if_masked, uncompress_file)
+from obspy.core.util.decorator import (map_example_filename, raise_if_masked,
+                                       uncompress_file, file_format_check)
 from obspy.core.util.misc import get_window_times, buffered_load_entry_point
 from obspy.core.util.obspy_types import ObsPyException
 
@@ -3372,12 +3372,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         return self
 
 
-def _is_pickle(filename):  # @UnusedVariable
+@file_format_check
+def _is_pickle(filename, **kwargs):  # @UnusedVariable
     """
     Check whether a file is a pickled ObsPy Stream file.
 
-    :type filename: str
-    :param filename: Name of the pickled ObsPy Stream file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if pickled file.
 
@@ -3386,17 +3387,11 @@ def _is_pickle(filename):  # @UnusedVariable
     >>> _is_pickle('/path/to/pickle.file')  # doctest: +SKIP
     True
     """
-    if isinstance(filename, (str, native_str)):
-        try:
-            with open(filename, 'rb') as fp:
-                st = pickle.load(fp)
-        except Exception:
-            return False
-    else:
-        try:
-            st = pickle.load(filename)
-        except Exception:
-            return False
+    fh = filename
+    try:
+        st = pickle.load(fh)
+    except Exception:
+        return False
     return isinstance(st, Stream)
 
 

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -508,10 +508,11 @@ class CatalogTestCase(unittest.TestCase):
         # create event and save to disk
         origin = Origin(time=UTCDateTime('2016-01-01'))
         event1 = Event(origins=[origin])
-        bio = io.BytesIO()
-        event1.write(bio, 'quakeml')
-        # read from disk
-        event2 = read_events(bio)[0]
+        with io.BytesIO() as bio:
+            event1.write(bio, 'quakeml')
+            # read from disk
+            bio.seek(0)
+            event2 = read_events(bio, format='QUAKEML')[0]
         # saved and loaded event should be equal
         self.assertEqual(event1, event2)
 

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -749,9 +749,9 @@ def make_diverse_catalog_list(*args):  # NOQA
         cat1.write(bytes_io, 'quakeml')
         # get a few copies from reading from bytes
         bytes_io.seek(0)
-        cat2 = read_events(bytes_io)
+        cat2 = read_events(bytes_io, format='QUAKEML')
         bytes_io.seek(0)
-        cat3 = read_events(bytes_io)
+        cat3 = read_events(bytes_io, format='QUAKEML')
     # make more catalogs with copy method
     cat4 = cat1.copy()
     cat5 = cat4.copy()

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -745,11 +745,13 @@ def make_diverse_catalog_list(*args):  # NOQA
     """
     # create a complex catalog
     cat1 = create_diverse_catalog()
-    bytes_io = io.BytesIO()
-    cat1.write(bytes_io, 'quakeml')
-    # get a few copies from reading from bytes
-    cat2 = read_events(bytes_io)
-    cat3 = read_events(bytes_io)
+    with io.BytesIO() as bytes_io:
+        cat1.write(bytes_io, 'quakeml')
+        # get a few copies from reading from bytes
+        bytes_io.seek(0)
+        cat2 = read_events(bytes_io)
+        bytes_io.seek(0)
+        cat3 = read_events(bytes_io)
     # make more catalogs with copy method
     cat4 = cat1.copy()
     cat5 = cat4.copy()

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -267,6 +267,10 @@ def file_format_check(func, filename, **kwargs):
     """
     # Open filehandle or..
     if not hasattr(filename, 'read'):
+        if not os.path.exists(filename):
+            msg = 'File not found: ' + filename
+            # we can raise FileNotFoundError after dropping Python2
+            raise Exception(msg)
         file_size = os.path.getsize(filename)
         kwargs['_file_size'] = file_size
         with io.open(filename, 'rb') as fh:

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -285,25 +285,32 @@ def file_format_check(func, filename, **kwargs):
         finally:
             # Reset pointer.
             fh.seek(initial_pos, 0)
+        return
+    # Do not accept directories
+    try:
+        is_local_path = os.path.exists(filename)
+    except TypeError:
+        is_local_path = False
+    if is_local_path and os.path.isdir(filename):
+        return False
     # Or open it if it is a local file
-    elif os.path.exists(filename):
+    if is_local_path:
         file_size = os.path.getsize(filename)
         kwargs['_file_size'] = file_size
         with io.open(filename, 'rb') as fh:
             return func(fh, **kwargs)
     # Or initialize a BytesIO object
-    elif isinstance(filename, (bytes, native_bytes)):
+    if isinstance(filename, (bytes, native_bytes)):
         kwargs['_file_size'] = len(filename)
         with io.BytesIO(filename) as fh:
             return func(fh, **kwargs)
     # Or initialize a TextIO object
-    elif isinstance(filename, (str, native_str)):
+    if isinstance(filename, (str, native_str)):
         kwargs['_file_size'] = len(filename)
         with io.StringIO(filename) as fh:
             return func(fh, **kwargs)
-    # Any other cases: raise Exception
-    msg = 'Invalid input: ' + str(filename)[:100]
-    raise Exception(msg)
+    # Any other cases: return False
+    return False
 
 
 def map_example_filename(arg_kwarg_name):

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -283,6 +283,14 @@ def file_format_check(func, filename, **kwargs):
             kwargs['_file_size'] = file_size
             return func(fh, **kwargs)
         finally:
+            # if we attached a TextIOWrapper by means of
+            # core.util.misc._text_buffer_wrapper and saved it from garbage
+            # collection by attaching it as a variable, detach it now and clear
+            # the reference so it can be garbage collected
+            if hasattr(fh, '__text_io_wrapper') and \
+                    isinstance(fh.__text_io_wrapper, io.TextIOWrapper):
+                fh.__text_io_wrapper.detach()
+                del fh.__text_io_wrapper
             # Reset pointer.
             fh.seek(initial_pos, 0)
         return

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -377,6 +377,29 @@ def map_example_filename(arg_kwarg_name):
     return _map_example_filename
 
 
+@decorator
+def _open_file(func, *args, **kwargs):
+    """
+    Ensure a file buffer is passed as first argument to the
+    decorated function.
+
+    :param func: callable that takes at least one argument;
+        the first argument must be treated as a buffer.
+    :return: callable
+    """
+    first_arg = args[0]
+    try:
+        with open(first_arg, 'rb') as fi:
+            args = tuple([fi] + list(args[1:]))
+            return func(*args, **kwargs)
+    except TypeError:  # assume we have been passed a buffer
+        if not hasattr(args[0], 'read'):
+            raise  # type error was in function call, not in opening file
+        out = func(*args, **kwargs)
+        first_arg.seek(0)  # reset position to start of file
+    return out
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -799,6 +799,20 @@ def _xml_doc_from_anything(source):
     return xml_doc
 
 
+def _text_buffer_wrapper(buf, encoding):
+    """
+    Derives a text buffer from a (potentially open) binary or text buffer
+
+    :type buf: :class:`io.BufferedIOBase` or :class:`io.TextIOBase`
+    :param buf: An open file-like object open in binary or text mode or a
+        BytesIO/StringIO object.
+    :rtype: :class:`io.TextIOWrapper`
+    """
+    if not isinstance(buf, (io.BufferedIOBase, io.TextIOBase)):
+        raise TypeError()
+    return io.TextIOWrapper(buf, encoding=encoding)
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -28,6 +28,7 @@ from subprocess import STDOUT, CalledProcessError, check_output
 
 
 import numpy as np
+from lxml import etree
 from pkg_resources import load_entry_point
 
 WIN32 = sys.platform.startswith('win32')
@@ -768,6 +769,30 @@ def _seed_id_map(
     if user_id_map is not None:
         id_map.update(user_id_map)
     return id_map
+
+
+def _xml_doc_from_anything(source):
+    """
+    Helper function attempting to create an xml etree element from either a
+    filename, a file-like object, or a (byte)string.
+
+    Will raise a ValueError if it fails.
+    """
+    if isinstance(source, etree._Element):
+        return source
+
+    try:
+        xml_doc = etree.parse(source).getroot()
+    except Exception:
+        try:
+            xml_doc = etree.fromstring(source)
+        except Exception:
+            try:
+                xml_doc = etree.fromstring(source.encode())
+            except Exception:
+                raise ValueError("Could not parse '%s' to an etree element." %
+                                 source)
+    return xml_doc
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -813,7 +813,14 @@ def _text_buffer_wrapper(buf, encoding):
     :rtype: :class:`io.TextIOWrapper` or :class:`io.TextIOBase`
     """
     if isinstance(buf, io.BufferedIOBase):
-        return io.TextIOWrapper(buf, encoding=encoding)
+        tbuf = io.TextIOWrapper(buf, encoding=encoding)
+        # we need to attach the TextIOWrapper as a variable to save it from
+        # garbage collection. if we don't it closes the underlying bytes
+        # buffer, which we don't want to happen, open file-like objects should
+        # stay open and be able to return to initial position during automatic
+        # file format detection
+        buf.__text_io_wrapper = tbuf
+        return tbuf
     elif isinstance(buf, io.TextIOBase):
         return buf
     raise TypeError()

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -801,16 +801,22 @@ def _xml_doc_from_anything(source):
 
 def _text_buffer_wrapper(buf, encoding):
     """
-    Derives a text buffer from a (potentially open) binary or text buffer
+    Derives a text buffer from a (potentially open) binary buffer
+
+    If a text buffer is given it is returned as is, since there are some
+    problems e.g. calling readline() on a TextIOWrapper if it is wrapping
+    another TextIOBase object it seems.
 
     :type buf: :class:`io.BufferedIOBase` or :class:`io.TextIOBase`
     :param buf: An open file-like object open in binary or text mode or a
         BytesIO/StringIO object.
-    :rtype: :class:`io.TextIOWrapper`
+    :rtype: :class:`io.TextIOWrapper` or :class:`io.TextIOBase`
     """
-    if not isinstance(buf, (io.BufferedIOBase, io.TextIOBase)):
-        raise TypeError()
-    return io.TextIOWrapper(buf, encoding=encoding)
+    if isinstance(buf, io.BufferedIOBase):
+        return io.TextIOWrapper(buf, encoding=encoding)
+    elif isinstance(buf, io.TextIOBase):
+        return buf
+    raise TypeError()
 
 
 if __name__ == '__main__':

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -780,6 +780,8 @@ def _xml_doc_from_anything(source):
     """
     if isinstance(source, etree._Element):
         return source
+    if isinstance(source, etree._ElementTree):
+        return source.getroot()
 
     try:
         xml_doc = etree.parse(source).getroot()
@@ -792,6 +794,8 @@ def _xml_doc_from_anything(source):
             except Exception:
                 raise ValueError("Could not parse '%s' to an etree element." %
                                  source)
+    if isinstance(xml_doc, etree._ElementTree):
+        return xml_doc.getroot()
     return xml_doc
 
 

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -826,6 +826,37 @@ def _text_buffer_wrapper(buf, encoding):
     raise TypeError()
 
 
+def _buffer_proxy(filename_or_buf, function, reset_fp=True,
+                  file_mode="rb", *args, **kwargs):
+    """
+    Calls a function with an open file or file-like object as the first
+    argument. If the file originally was a filename, the file will be
+    opened, otherwise it will just be passed to the underlying function.
+
+    :param filename_or_buf: File to pass.
+    :type filename_or_buf: str, open file, or file-like object.
+    :param function: The function to call.
+    :param reset_fp: If True, the file pointer will be set to the initial
+        position after the function has been called.
+    :type reset_fp: bool
+    :param file_mode: Mode to open file in if necessary.
+    """
+    try:
+        position = filename_or_buf.tell()
+        is_buffer = True
+    except AttributeError:
+        is_buffer = False
+
+    if is_buffer is True:
+        ret_val = function(filename_or_buf, *args, **kwargs)
+        if reset_fp:
+            filename_or_buf.seek(position, 0)
+        return ret_val
+    else:
+        with open(filename_or_buf, file_mode) as fh:
+            return function(fh, *args, **kwargs)
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(exclude_empty=True)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -633,11 +633,13 @@ def buffered_load_entry_point(dist, group, name):
     """
     Return `name` entry point of `group` for `dist` or raise ImportError
     :type dist: str
-    :param dist: The name of the distribution containing the entry point.
+    :param dist: The name of the distribution containing the entry point
+        (e.g. ``"obspy"``).
     :type group: str
-    :param group: The name of the group containing the entry point.
+    :param group: The name of the group containing the entry point
+        (e.g. ``"obspy.plugin.waveform.MSEED"``).
     :type name: str
-    :param name: The name of the entry point.
+    :param name: The name of the entry point (e.g. ``"isFormat"``)
     :return: The loaded entry point
     """
     hash_str = '/'.join([dist, group, name])

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -42,6 +42,7 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
 from obspy.core.util import AttribDict, loadtxt
+from obspy.core.util.decorator import file_format_check
 
 
 HEADER = ("TIMESERIES {network}_{station}_{location}_{channel}_{dataquality}, "
@@ -61,12 +62,13 @@ def _format_header(stats, format, dataquality, dtype, unit):
     return header
 
 
-def _is_slist(filename):
+@file_format_check
+def _is_slist(filename, **kwargs):
     """
     Checks whether a file is ASCII SLIST format.
 
-    :type filename: str
-    :param filename: Name of the ASCII SLIST file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if ASCII SLIST file.
 
@@ -75,24 +77,22 @@ def _is_slist(filename):
     >>> _is_slist('/path/to/slist.ascii')  # doctest: +SKIP
     True
     """
-    try:
-        with open(filename, 'rt') as f:
-            temp = f.readline()
-    except Exception:
+    fh = filename
+    temp = fh.readline()
+    if not temp.startswith(b'TIMESERIES'):
         return False
-    if not temp.startswith('TIMESERIES'):
-        return False
-    if 'SLIST' not in temp:
+    if b'SLIST' not in temp:
         return False
     return True
 
 
-def _is_tspair(filename):
+@file_format_check
+def _is_tspair(filename, **kwargs):
     """
     Checks whether a file is ASCII TSPAIR format.
 
-    :type filename: str
-    :param filename: Name of the ASCII TSPAIR file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if ASCII TSPAIR file.
 
@@ -101,14 +101,11 @@ def _is_tspair(filename):
     >>> _is_tspair('/path/to/tspair.ascii')  # doctest: +SKIP
     True
     """
-    try:
-        with open(filename, 'rt') as f:
-            temp = f.readline()
-    except Exception:
+    fh = filename
+    temp = fh.readline()
+    if not temp.startswith(b'TIMESERIES'):
         return False
-    if not temp.startswith('TIMESERIES'):
-        return False
-    if 'TSPAIR' not in temp:
+    if b'TSPAIR' not in temp:
         return False
     return True
 

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -44,6 +44,7 @@ from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
 from obspy.core.util import AttribDict, loadtxt
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _text_buffer_wrapper
 
 
 HEADER = ("TIMESERIES {network}_{station}_{location}_{channel}_{dataquality}, "
@@ -70,6 +71,10 @@ def _is_slist(filename, **kwargs):
 
     :type filename: :class:`io.BytesIOBase`
     :param filename: Open file or file-like object to be checked
+    :type encoding: str
+    :param encoding: Encoding of the file. Given setting is ignored if the
+        input is already a Text stream with a set encoding (default: default
+        system encoding)
     :rtype: bool
     :return: ``True`` if ASCII SLIST file.
 
@@ -79,14 +84,14 @@ def _is_slist(filename, **kwargs):
     True
     """
     fh = filename
-    temp = fh.readline()
+    # mimic old behavior of decoding bytes input using default encoding if
+    # nothing else was specified explicitly
+    encoding = kwargs.pop('encoding', locale.getpreferredencoding())
+    fh = _text_buffer_wrapper(fh, encoding)
     try:
-        # mimic old behavior of decoding bytes input using default encoding
-        temp = temp.decode(locale.getpreferredencoding())
+        temp = fh.readline()
     except UnicodeError:
         return False
-    except AttributeError:
-        pass
     if not temp.startswith('TIMESERIES'):
         return False
     if 'SLIST' not in temp:
@@ -101,6 +106,10 @@ def _is_tspair(filename, **kwargs):
 
     :type filename: :class:`io.BytesIOBase`
     :param filename: Open file or file-like object to be checked
+    :type encoding: str
+    :param encoding: Encoding of the file. Given setting is ignored if the
+        input is already a Text stream with a set encoding (default: default
+        system encoding)
     :rtype: bool
     :return: ``True`` if ASCII TSPAIR file.
 
@@ -110,14 +119,14 @@ def _is_tspair(filename, **kwargs):
     True
     """
     fh = filename
-    temp = fh.readline()
+    # mimic old behavior of decoding bytes input using default encoding if
+    # nothing else was specified explicitly
+    encoding = kwargs.pop('encoding', locale.getpreferredencoding())
+    fh = _text_buffer_wrapper(fh, encoding)
     try:
-        # mimic old behavior of decoding bytes input using default encoding
-        temp = temp.decode(locale.getpreferredencoding())
+        temp = fh.readline()
     except UnicodeError:
         return False
-    except AttributeError:
-        pass
     if not temp.startswith('TIMESERIES'):
         return False
     if 'TSPAIR' not in temp:

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -36,6 +36,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 import io
+import locale
 
 import numpy as np
 
@@ -79,9 +80,16 @@ def _is_slist(filename, **kwargs):
     """
     fh = filename
     temp = fh.readline()
-    if not temp.startswith(b'TIMESERIES'):
+    try:
+        # mimic old behavior of decoding bytes input using default encoding
+        temp = temp.decode(locale.getpreferredencoding())
+    except UnicodeError:
         return False
-    if b'SLIST' not in temp:
+    except AttributeError:
+        pass
+    if not temp.startswith('TIMESERIES'):
+        return False
+    if 'SLIST' not in temp:
         return False
     return True
 
@@ -103,9 +111,16 @@ def _is_tspair(filename, **kwargs):
     """
     fh = filename
     temp = fh.readline()
-    if not temp.startswith(b'TIMESERIES'):
+    try:
+        # mimic old behavior of decoding bytes input using default encoding
+        temp = temp.decode(locale.getpreferredencoding())
+    except UnicodeError:
         return False
-    if b'TSPAIR' not in temp:
+    except AttributeError:
+        pass
+    if not temp.startswith('TIMESERIES'):
+        return False
+    if 'TSPAIR' not in temp:
         return False
     return True
 

--- a/obspy/io/cmtsolution/core.py
+++ b/obspy/io/cmtsolution/core.py
@@ -22,6 +22,7 @@ from obspy.core.event import (Catalog, Comment, Event, EventDescription,
                               Origin, Magnitude, FocalMechanism, MomentTensor,
                               Tensor, SourceTimeFunction)
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _buffer_proxy
 from obspy.geodetics import FlinnEngdahl
 
 
@@ -36,37 +37,6 @@ def _get_resource_id(cmtname, res_type, tag=None):
     if tag is not None:
         res_id += "#" + tag
     return res_id
-
-
-def _buffer_proxy(filename_or_buf, function, reset_fp=True,
-                  file_mode="rb", *args, **kwargs):
-    """
-    Calls a function with an open file or file-like object as the first
-    argument. If the file originally was a filename, the file will be
-    opened, otherwise it will just be passed to the underlying function.
-
-    :param filename_or_buf: File to pass.
-    :type filename_or_buf: str, open file, or file-like object.
-    :param function: The function to call.
-    :param reset_fp: If True, the file pointer will be set to the initial
-        position after the function has been called.
-    :type reset_fp: bool
-    :param file_mode: Mode to open file in if necessary.
-    """
-    try:
-        position = filename_or_buf.tell()
-        is_buffer = True
-    except AttributeError:
-        is_buffer = False
-
-    if is_buffer is True:
-        ret_val = function(filename_or_buf, *args, **kwargs)
-        if reset_fp:
-            filename_or_buf.seek(position, 0)
-        return ret_val
-    else:
-        with open(filename_or_buf, file_mode) as fh:
-            return function(fh, *args, **kwargs)
 
 
 @file_format_check

--- a/obspy/io/cmtsolution/core.py
+++ b/obspy/io/cmtsolution/core.py
@@ -21,6 +21,7 @@ from obspy import UTCDateTime
 from obspy.core.event import (Catalog, Comment, Event, EventDescription,
                               Origin, Magnitude, FocalMechanism, MomentTensor,
                               Tensor, SourceTimeFunction)
+from obspy.core.util.decorator import file_format_check
 from obspy.geodetics import FlinnEngdahl
 
 
@@ -68,16 +69,18 @@ def _buffer_proxy(filename_or_buf, function, reset_fp=True,
             return function(fh, *args, **kwargs)
 
 
-def _is_cmtsolution(filename_or_buf):
+@file_format_check
+def _is_cmtsolution(filename_or_buf, **kwargs):
     """
     Checks if the file is a CMTSOLUTION file.
 
-    :param filename_or_buf: File to test.
-    :type filename_or_buf: str or file-like object.
+    :type filename_or_buf: :class:`io.BytesIOBase`
+    :param filename_or_buf: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if CMTSOLUTION file.
     """
     try:
-        return _buffer_proxy(filename_or_buf, _internal_is_cmtsolution,
-                             reset_fp=True)
+        return _internal_is_cmtsolution(filename_or_buf)
     # Happens for example when passing the data as a string which would be
     # interpreted as a filename.
     except OSError:

--- a/obspy/io/css/core.py
+++ b/obspy/io/css/core.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.decorator import file_format_check
 
 
 DTYPE = {
@@ -38,71 +39,73 @@ DTYPE = {
 }
 
 
-def _is_css(filename):
+@file_format_check
+def _is_css(filename, **kwargs):
     """
     Checks whether a file is CSS waveform data (header) or not.
 
-    :type filename: str
-    :param filename: CSS file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a CSS waveform header file.
     """
+    fh = filename
     # Fixed file format.
     # Tests:
     #  - the length of each line (283 chars)
     #  - two epochal time fields
     #    (for position of dot and if they convert to UTCDateTime)
     #  - supported data type descriptor
-    try:
-        with open(filename, "rb") as fh:
-            lines = fh.readlines()
-            # check for empty file
-            if not lines:
-                return False
-            # check every line
-            for line in lines:
-                assert(len(line.rstrip(b"\n\r")) == 283)
-                assert(b"." in line[26:28])
-                UTCDateTime(float(line[16:33]))
-                assert(b"." in line[71:73])
-                UTCDateTime(float(line[61:78]))
-                assert(line[143:145] in DTYPE)
-    except Exception:
+    lines = fh.readlines()
+    # check for empty file
+    if not lines:
         return False
+    # check every line
+    for line in lines:
+        try:
+            assert(len(line.rstrip(b"\n\r")) == 283)
+            assert(b"." in line[26:28])
+            UTCDateTime(float(line[16:33]))
+            assert(b"." in line[71:73])
+            UTCDateTime(float(line[61:78]))
+            assert(line[143:145] in DTYPE)
+        except Exception:
+            return False
     return True
 
 
-def _is_nnsa_kb_core(filename):
+@file_format_check
+def _is_nnsa_kb_core(filename, **kwargs):
     """
     Checks whether a file is NNSA KB Core waveform data (header) or not.
 
-    :type filename: str
-    :param filename: NNSA KB Core file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a NNSA KB Core waveform header file.
     """
+    fh = filename
     # Fixed file format.
     # Tests:
     #  - the length of each line (287 chars)
     #  - two epochal time fields
     #    (for position of dot and if they convert to UTCDateTime)
     #  - supported data type descriptor
-    try:
-        with open(filename, "rb") as fh:
-            lines = fh.readlines()
-            # check for empty file
-            if not lines:
-                return False
-            # check every line
-            for line in lines:
-                assert(len(line.rstrip(b"\n\r")) == 287)
-                assert(line[27:28] == b".")
-                UTCDateTime(float(line[16:33]))
-                assert(line[73:74] == b".")
-                UTCDateTime(float(line[62:79]))
-                assert(line[144:146] in DTYPE)
-    except Exception:
+    lines = fh.readlines()
+    # check for empty file
+    if not lines:
         return False
+    # check every line
+    for line in lines:
+        try:
+            assert(len(line.rstrip(b"\n\r")) == 287)
+            assert(line[27:28] == b".")
+            UTCDateTime(float(line[16:33]))
+            assert(line[73:74] == b".")
+            UTCDateTime(float(line[62:79]))
+            assert(line[144:146] in DTYPE)
+        except Exception:
+            return False
     return True
 
 

--- a/obspy/io/focmec/core.py
+++ b/obspy/io/focmec/core.py
@@ -21,6 +21,7 @@ import numpy as np
 from obspy import UTCDateTime, Catalog, __version__
 from obspy.core.event import (
     Event, FocalMechanism, NodalPlanes, NodalPlane, Comment, CreationInfo)
+from obspy.core.util.decorator import file_format_check
 
 
 # XXX some current PR was doing similar, should be merged to
@@ -43,13 +44,19 @@ POLARITIES_EMERGENT = '+-lrfb'
 POLARITIES = POLARITIES_IMPULSIVE + POLARITIES_EMERGENT
 
 
-def _is_focmec(filename):
+@file_format_check
+def _is_focmec(filename, **kwargs):
     """
     Checks that a file is actually a FOCMEC output data file
+
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if FOCMEC file.
     """
+    fh = filename
     try:
-        with open(filename, 'rb') as fh:
-            line = fh.readline()
+        line = fh.readline()
     except Exception:
         return False
     # first line should be ASCII only, something like:

--- a/obspy/io/gcf/core.py
+++ b/obspy/io/gcf/core.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 
 from obspy import Stream, Trace, UTCDateTime
+from obspy.core.util.decorator import file_format_check
 
 from . import libgcf
 
@@ -40,18 +41,19 @@ def merge_gcf_stream(st):
     return Stream(traces=traces)
 
 
-def _is_gcf(filename):
+@file_format_check
+def _is_gcf(filename, **kwargs):
     """
     Checks whether a file is GCF or not.
 
-    :type filename: str
-    :param filename: GCF file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a GCF file.
     """
+    fh = filename
     try:
-        with open(filename, 'rb') as f:
-            libgcf.is_gcf(f)
+        libgcf.is_gcf(fh)
     except Exception:
         return False
     return True

--- a/obspy/io/gse2/bulletin.py
+++ b/obspy/io/gse2/bulletin.py
@@ -26,6 +26,7 @@ from obspy.core.event.header import (
     EvaluationMode, EventDescriptionType, EventType, EventTypeCertainty,
     OriginDepthType, OriginUncertaintyDescription, PickOnset, PickPolarity)
 from obspy.core.utcdatetime import UTCDateTime
+from obspy.core.util.decorator import file_format_check
 
 
 # Convert GSE2 depth flag to ObsPy depth type
@@ -103,18 +104,19 @@ class GSE2BulletinSyntaxError(Exception):
     """Raised when the file is not a valid GSE2 file"""
 
 
-def _is_gse2(filename):
+@file_format_check
+def _is_gse2(filename, **kwargs):
     """
     Checks whether a file is GSE2.0 format.
 
-    :type filename: str
-    :param filename: Name of the GSE2.0 file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if GSE2.0 file.
     """
+    fh = filename
     try:
-        with open(filename, 'rb') as fh:
-            temp = fh.read(12)
+        temp = fh.read(12)
     except Exception:
         return False
     if temp != b'BEGIN GSE2.0':

--- a/obspy/io/gse2/core.py
+++ b/obspy/io/gse2/core.py
@@ -9,22 +9,24 @@ from future.builtins import *  # NOQA
 import numpy as np
 
 from obspy import Stream, Trace
+from obspy.core.util.decorator import file_format_check
+
 from . import libgse1, libgse2
 
 
-def _is_gse2(filename):
+@file_format_check
+def _is_gse2(filename, **kwargs):
     """
     Checks whether a file is GSE2 or not.
 
-    :type filename: str
-    :param filename: GSE2 file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a GSE2 file.
     """
-    # Open file.
+    fh = filename
     try:
-        with open(filename, 'rb') as f:
-            libgse2.is_gse2(f)
+        libgse2.is_gse2(fh)
     except Exception:
         return False
     return True
@@ -111,21 +113,21 @@ def _write_gse2(stream, filename, inplace=False, **kwargs):  # @UnusedVariable
             libgse2.write(trace.stats, trace.data, f, inplace)
 
 
-def _is_gse1(filename):
+@file_format_check
+def _is_gse1(filename, **kwargs):
     """
     Checks whether a file is GSE1 or not.
 
-    :type filename: str
-    :param filename: GSE1 file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a GSE1 file.
     """
-    # Open file.
-    with open(filename, 'rb') as f:
-        try:
-            data = f.readline()
-        except Exception:
-            return False
+    fh = filename
+    try:
+        data = fh.readline()
+    except Exception:
+        return False
     if data.startswith(b'WID1') or data.startswith(b'XW01'):
         return True
     return False

--- a/obspy/io/hypodd/pha.py
+++ b/obspy/io/hypodd/pha.py
@@ -17,6 +17,7 @@ from obspy import UTCDateTime
 from obspy.core.event import (
     Catalog, Event, Origin, Magnitude, Pick, WaveformStreamID, Arrival,
     OriginQuality)
+from obspy.core.util.decorator import file_format_check
 from obspy.core.util.misc import _seed_id_map
 
 
@@ -58,10 +59,17 @@ def _block2event(block, seed_map, id_default, ph2comp):
     return event
 
 
-def _is_pha(filename):
+@file_format_check
+def _is_pha(filename, **kwargs):
+    """
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if HYPODD PHA file.
+    """
+    f = filename
     try:
-        with open(filename, 'rb') as f:
-            line = f.readline()
+        line = f.readline()
         assert line.startswith(b'#')
         assert len(line.split()) == 15
         yr, mo, dy, hr, mn, sc = line.split()[1:7]

--- a/obspy/io/iaspei/core.py
+++ b/obspy/io/iaspei/core.py
@@ -22,6 +22,7 @@ from obspy.core.event import (
     Catalog, Event, Origin, Comment, EventDescription, OriginUncertainty,
     QuantityError, OriginQuality, CreationInfo, Magnitude, ResourceIdentifier,
     Pick, StationMagnitude, WaveformStreamID, Amplitude)
+from obspy.core.util.decorator import file_format_check
 from obspy.core.util.obspy_types import ObsPyReadingError
 from .util import (
     float_or_none, int_or_none, fixed_flag, evaluation_mode_and_status,
@@ -643,19 +644,18 @@ def __read_ims10_bulletin(fh, **kwargs):  # NOQA
     return ISFReader(fh, **kwargs).deserialize()
 
 
+@file_format_check
 def _is_ims10_bulletin(filename_or_buf, **kwargs):
     """
     Checks whether a file is ISF IMS1.0 bulletin format.
 
-    :type filename_or_buf: str or file
-    :param filename_or_buf: name of the file to be checked or open file-like
-        object.
+    :type filename_or_buf: :class:`io.BytesIOBase`
+    :param filename_or_buf: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if ISF IMS1.0 bulletin file.
     """
     try:
-        return _buffer_proxy(filename_or_buf, __is_ims10_bulletin,
-                             reset_fp=True, **kwargs)
+        return __is_ims10_bulletin(filename_or_buf, **kwargs)
     # Happens for example when passing the data as a string which would be
     # interpreted as a filename.
     except OSError:

--- a/obspy/io/iaspei/core.py
+++ b/obspy/io/iaspei/core.py
@@ -23,6 +23,7 @@ from obspy.core.event import (
     QuantityError, OriginQuality, CreationInfo, Magnitude, ResourceIdentifier,
     Pick, StationMagnitude, WaveformStreamID, Amplitude)
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _buffer_proxy
 from obspy.core.util.obspy_types import ObsPyReadingError
 from .util import (
     float_or_none, int_or_none, fixed_flag, evaluation_mode_and_status,
@@ -585,37 +586,6 @@ class ISFReader(object):
 
     def _parse_generic_comment(self, line):
         return self._make_comment(line)
-
-
-def _buffer_proxy(filename_or_buf, function, reset_fp=True,
-                  file_mode="rb", *args, **kwargs):
-    """
-    Calls a function with an open file or file-like object as the first
-    argument. If the file originally was a filename, the file will be
-    opened, otherwise it will just be passed to the underlying function.
-
-    :param filename_or_buf: File to pass.
-    :type filename_or_buf: str, open file, or file-like object.
-    :param function: The function to call.
-    :param reset_fp: If True, the file pointer will be set to the initial
-        position after the function has been called.
-    :type reset_fp: bool
-    :param file_mode: Mode to open file in if necessary.
-    """
-    try:
-        position = filename_or_buf.tell()
-        is_buffer = True
-    except AttributeError:
-        is_buffer = False
-
-    if is_buffer is True:
-        ret_val = function(filename_or_buf, *args, **kwargs)
-        if reset_fp:
-            filename_or_buf.seek(position, 0)
-        return ret_val
-    else:
-        with open(filename_or_buf, file_mode) as fh:
-            return function(fh, *args, **kwargs)
 
 
 def _read_ims10_bulletin(filename_or_buf, **kwargs):

--- a/obspy/io/kinemetrics/core.py
+++ b/obspy/io/kinemetrics/core.py
@@ -12,48 +12,31 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+from obspy.core.util.decorator import file_format_check
+
 from . import evt
 from .evt_base import EvtBaseError
 
 
-def is_evt(filename_or_object):
+@file_format_check
+def is_evt(filename_or_object, **kwargs):
     """
     Checks whether a file is Evt or not.
 
-    :type filename_or_object: filename or file-like object
-    :param filename_or_object: Evt file to be checked
+    :type filename_or_object: :class:`io.BytesIOBase`
+    :param filename_or_object: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a Evt file, ``False`` otherwise
     """
-    if hasattr(filename_or_object, "seek") and \
-            hasattr(filename_or_object, "tell") and \
-            hasattr(filename_or_object, "read"):
-        is_fileobject = True
-        pos = filename_or_object.tell()
-    else:
-        is_fileobject = False
-
+    fh = filename_or_object
     tag = evt.EvtTag()
-
-    if is_fileobject:
-        try:
-            tag.read(filename_or_object)
-            if tag.verify(verbose=False) is False:
-                return False
-            return True
-        except EvtBaseError:
+    try:
+        tag.read(fh)
+        if tag.verify(verbose=False) is False:
             return False
-        finally:
-            filename_or_object.seek(pos, 0)
-    else:
-        with open(filename_or_object, "rb") as file_obj:
-            try:
-                tag.read(file_obj)
-                if tag.verify(verbose=False) is False:
-                    return False
-                return True
-            except (EvtBaseError, IOError):
-                return False
+        return True
+    except EvtBaseError:
+        return False
 
 
 def read_evt(filename_or_object, **kwargs):

--- a/obspy/io/nied/fnetmt.py
+++ b/obspy/io/nied/fnetmt.py
@@ -22,6 +22,7 @@ from obspy.core.event import (Catalog, Comment, Event,
                               Origin, Magnitude, FocalMechanism, MomentTensor,
                               Tensor, NodalPlane, NodalPlanes)
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _buffer_proxy
 from . import util
 
 
@@ -37,37 +38,6 @@ def _get_resource_id(name, res_type, tag=None):
     if tag is not None:
         res_id += "#" + tag
     return res_id
-
-
-def _buffer_proxy(filename_or_buf, function, reset_fp=True,
-                  file_mode="rb", *args, **kwargs):
-    """
-    Calls a function with an open file or file-like object as the first
-    argument. If the file originally was a filename, the file will be
-    opened, otherwise it will just be passed to the underlying function.
-
-    :param filename_or_buf: File to pass.
-    :type filename_or_buf: str, open file, or file-like object.
-    :param function: The function to call.
-    :param reset_fp: If True, the file pointer will be set to the initial
-        position after the function has been called.
-    :type reset_fp: bool
-    :param file_mode: Mode to open file in if necessary.
-    """
-    try:
-        position = filename_or_buf.tell()
-        is_buffer = True
-    except AttributeError:
-        is_buffer = False
-
-    if is_buffer is True:
-        ret_val = function(filename_or_buf, *args, **kwargs)
-        if reset_fp:
-            filename_or_buf.seek(position, 0)
-        return ret_val
-    else:
-        with open(filename_or_buf, file_mode) as fh:
-            return function(fh, *args, **kwargs)
 
 
 @file_format_check

--- a/obspy/io/nied/fnetmt.py
+++ b/obspy/io/nied/fnetmt.py
@@ -21,6 +21,7 @@ from obspy import UTCDateTime
 from obspy.core.event import (Catalog, Comment, Event,
                               Origin, Magnitude, FocalMechanism, MomentTensor,
                               Tensor, NodalPlane, NodalPlanes)
+from obspy.core.util.decorator import file_format_check
 from . import util
 
 
@@ -69,16 +70,18 @@ def _buffer_proxy(filename_or_buf, function, reset_fp=True,
             return function(fh, *args, **kwargs)
 
 
-def _is_fnetmt_catalog(filename_or_buf):
+@file_format_check
+def _is_fnetmt_catalog(filename_or_buf, **kwargs):
     """
     Checks if the file is an F-net moment tensor file.
 
-    :param filename_or_buf: File to test.
-    :type filename_or_buf: str or file-like object.
+    :type filename_or_buf: :class:`io.BytesIOBase`
+    :param filename_or_buf: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if F-net moment tensor file.
     """
     try:
-        return _buffer_proxy(filename_or_buf, _internal_is_fnetmt_catalog,
-                             reset_fp=True)
+        return _internal_is_fnetmt_catalog(filename_or_buf)
     # Happens for example when passing the data as a string which would be
     # interpreted as a filename.
     except (OSError):

--- a/obspy/io/nied/knet.py
+++ b/obspy/io/nied/knet.py
@@ -17,41 +17,11 @@ import numpy as np
 from obspy import UTCDateTime, Stream, Trace
 from obspy.core.trace import Stats
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _buffer_proxy
 
 
 class KNETException(Exception):
     pass
-
-
-def _buffer_proxy(filename_or_buf, function, reset_fp=True,
-                  file_mode="rb", *args, **kwargs):
-    """
-    Calls a function with an open file or file-like object as the first
-    argument. If the file originally was a filename, the file will be
-    opened, otherwise it will just be passed to the underlying function.
-
-    :param filename_or_buf: File to pass.
-    :type filename_or_buf: str, open file, or file-like object.
-    :param function: The function to call.
-    :param reset_fp: If True, the file pointer will be set to the initial
-        position after the function has been called.
-    :type reset_fp: bool
-    :param file_mode: Mode to open file in if necessary.
-    """
-    try:
-        position = filename_or_buf.tell()
-        is_buffer = True
-    except AttributeError:
-        is_buffer = False
-
-    if is_buffer is True:
-        ret_val = function(filename_or_buf, *args, **kwargs)
-        if reset_fp:
-            filename_or_buf.seek(position, 0)
-        return ret_val
-    else:
-        with open(filename_or_buf, file_mode) as fh:
-            return function(fh, *args, **kwargs)
 
 
 @file_format_check

--- a/obspy/io/nied/knet.py
+++ b/obspy/io/nied/knet.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from obspy import UTCDateTime, Stream, Trace
 from obspy.core.trace import Stats
+from obspy.core.util.decorator import file_format_check
 
 
 class KNETException(Exception):
@@ -53,16 +54,16 @@ def _buffer_proxy(filename_or_buf, function, reset_fp=True,
             return function(fh, *args, **kwargs)
 
 
-def _is_knet_ascii(filename_or_buf):
+@file_format_check
+def _is_knet_ascii(filename_or_buf, **kwargs):
     """
     Checks if the file is a valid K-NET/KiK-net ASCII file.
 
-    :param filename_or_buf: File to test.
-    :type filename_or_buf: str or file-like object.
+    :type filename_or_buf: :class:`io.BytesIOBase`
+    :param filename_or_buf: Open file or file-like object to be checked
     """
     try:
-        return _buffer_proxy(filename_or_buf, _internal_is_knet_ascii,
-                             reset_fp=True)
+        return _internal_is_knet_ascii(filename_or_buf)
     # Happens for example when passing the data as a string which would be
     # interpreted as a filename.
     except (OSError, UnicodeDecodeError):

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -22,6 +22,7 @@ from obspy import Catalog, UTCDateTime, __version__
 from obspy.core.event import (Arrival, Comment, CreationInfo, Event, Origin,
                               OriginQuality, OriginUncertainty, Pick,
                               WaveformStreamID)
+from obspy.core.util.decorator import file_format_check
 from obspy.geodetics import kilometer2degrees
 
 
@@ -31,13 +32,19 @@ POLARITIES = {"c": "positive", "u": "positive", "d": "negative"}
 POLARITIES_REVERSE = {"positive": "u", "negative": "d"}
 
 
-def is_nlloc_hyp(filename):
+@file_format_check
+def is_nlloc_hyp(filename, **kwargs):
     """
     Checks that a file is actually a NonLinLoc Hypocenter-Phase file.
+
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if NLLOC Hypocenter file.
     """
+    fh = filename
     try:
-        with open(filename, 'rb') as fh:
-            temp = fh.read(6)
+        temp = fh.read(6)
     except Exception:
         return False
     if temp != b'NLLOC ':

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -64,15 +64,19 @@ def _is_sfile(sfile, **kwargs):
     :type sfile: :class:`io.BytesIOBase`
     :param sfile: Open file or file-like object to be checked
     :type encoding: str
-    :param encoding: Encoding of the file.
+    :param encoding: Encoding of the file. Given setting is ignored if the
+        input is already a Text stream with a set encoding.
     :rtype: bool
     :return: ``True`` if nordic file.
     """
-    encoding = kwargs.pop('encoding', 'latin-1')
+    if isinstance(sfile, io.BufferedIOBase):
+        encoding = kwargs.pop('encoding', 'latin-1')
+        sfile = _text_buffer_wrapper(sfile, encoding)
+    else:
+        msg = ("'encoding' parameter is being ignored on a Text buffer input "
+               "already having an encoding.")
+        warnings.warn(msg)
     f = sfile
-    # we're getting either a binary buffer or a text buffer, doesn't matter
-    # though, we can always wrap another TextIOWrapper around it
-    f = _text_buffer_wrapper(f, encoding=encoding)
     try:
         tags = _get_line_tags(f=f, report=False)
     except Exception:

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -69,13 +69,8 @@ def _is_sfile(sfile, **kwargs):
     :rtype: bool
     :return: ``True`` if nordic file.
     """
-    if isinstance(sfile, io.BufferedIOBase):
-        encoding = kwargs.pop('encoding', 'latin-1')
-        sfile = _text_buffer_wrapper(sfile, encoding)
-    else:
-        msg = ("'encoding' parameter is being ignored on a Text buffer input "
-               "already having an encoding.")
-        warnings.warn(msg)
+    encoding = kwargs.pop('encoding', 'latin-1')
+    sfile = _text_buffer_wrapper(sfile, encoding)
     f = sfile
     try:
         tags = _get_line_tags(f=f, report=False)

--- a/obspy/io/pdas/core.py
+++ b/obspy/io/pdas/core.py
@@ -16,21 +16,23 @@ import numpy as np
 
 from obspy.core import Stream, Trace, UTCDateTime
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.decorator import file_format_check
 
 
-def _is_pdas(filename):
+@file_format_check
+def _is_pdas(filename, **kwargs):
     """
     Checks whether a file is a PDAS file or not.
 
-    :type filename: str
-    :param filename: Name of file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a PDAS file.
     """
+    fh = filename
     try:
-        with open(filename, "rb") as fh:
-            header_fields = [fh.readline().split()[0].decode()
-                             for i_ in range(11)]
+        header_fields = [fh.readline().split()[0].decode()
+                         for i_ in range(11)]
         expected_headers = ['DATASET', 'FILE_TYPE', 'VERSION', 'SIGNAL',
                             'DATE', 'TIME', 'INTERVAL', 'VERT_UNITS',
                             'HORZ_UNITS', 'COMMENT', 'DATA']

--- a/obspy/io/pde/mchedr.py
+++ b/obspy/io/pde/mchedr.py
@@ -32,7 +32,7 @@ from obspy.core.event import (Amplitude, Arrival, Axis, Catalog, Comment,
                               PrincipalAxes, QuantityError, ResourceIdentifier,
                               StationMagnitude, Tensor, WaveformStreamID)
 from obspy.core.utcdatetime import UTCDateTime
-from obspy.core.util.decorator import map_example_filename
+from obspy.core.util.decorator import map_example_filename, file_format_check
 from obspy.geodetics import FlinnEngdahl
 
 
@@ -41,13 +41,14 @@ res_id_prefix = 'quakeml:us.anss.org'
 
 
 @map_example_filename('filename')
-def _is_mchedr(filename):
+@file_format_check
+def _is_mchedr(filename, **kwargs):
     """
     Checks whether a file format is mchedr
     (machine-readable Earthquake Data Report).
 
-    :type filename: str
-    :param filename: Name of the mchedr file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if mchedr file.
 
@@ -56,18 +57,16 @@ def _is_mchedr(filename):
     >>> _is_mchedr('/path/to/mchedr.dat')  # doctest: +SKIP
     True
     """
-    if not isinstance(filename, (str, native_str)):
-        return False
-    with open(filename, 'rb') as fh:
-        for line in fh.readlines():
-            # skip blank lines at beginning, if any
-            if line.strip() == b'':
-                continue
-            # first record has to be 'HY':
-            if line[0:2] == b'HY':
-                return True
-            else:
-                return False
+    fh = filename
+    for line in fh.readlines():
+        # skip blank lines at beginning, if any
+        if line.strip() == b'':
+            continue
+        # first record has to be 'HY':
+        if line[0:2] == b'HY':
+            return True
+        else:
+            return False
 
 
 class Unpickler(object):

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -45,6 +45,7 @@ from obspy.core.event import (Amplitude, Arrival, Axis, Catalog, Comment,
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict, Enum
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _xml_doc_from_anything
 
 
 NSMAP_QUAKEML = {None: "http://quakeml.org/xmlns/bed/1.2",
@@ -60,30 +61,6 @@ def _get_first_child_namespace(element):
     except IndexError:
         return None
     return etree.QName(element.tag).namespace
-
-
-def _xml_doc_from_anything(source):
-    """
-    Helper function attempting to create an xml etree element from either a
-    filename, a file-like object, or a (byte)string.
-
-    Will raise a ValueError if it fails.
-    """
-    if isinstance(source, etree._Element):
-        return source
-
-    try:
-        xml_doc = etree.parse(source).getroot()
-    except Exception:
-        try:
-            xml_doc = etree.fromstring(source)
-        except Exception:
-            try:
-                xml_doc = etree.fromstring(source.encode())
-            except Exception:
-                raise ValueError("Could not parse '%s' to an etree element." %
-                                 source)
-    return xml_doc
 
 
 @file_format_check

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -44,6 +44,7 @@ from obspy.core.event import (Amplitude, Arrival, Axis, Catalog, Comment,
                               WaveformStreamID)
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict, Enum
+from obspy.core.util.decorator import file_format_check
 
 
 NSMAP_QUAKEML = {None: "http://quakeml.org/xmlns/bed/1.2",
@@ -82,12 +83,13 @@ def _xml_doc_from_anything(source):
     return xml_doc
 
 
-def _is_quakeml(filename):
+@file_format_check
+def _is_quakeml(filename, **kwargs):
     """
     Checks whether a file is QuakeML format.
 
-    :type filename: str
-    :param filename: Name of the QuakeML file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if QuakeML file.
 
@@ -96,20 +98,10 @@ def _is_quakeml(filename):
     >>> _is_quakeml('/path/to/quakeml.xml')  # doctest: +SKIP
     True
     """
-    if hasattr(filename, "tell") and hasattr(filename, "seek") and \
-            hasattr(filename, "read"):
-        file_like_object = True
-        position = filename.tell()
-    else:
-        file_like_object = False
-
     try:
         xml_doc = _xml_doc_from_anything(filename)
     except Exception:
         return False
-    finally:
-        if file_like_object:
-            filename.seek(position, 0)
 
     # check if node "*/eventParameters/event" for the global namespace exists
     try:

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -69,6 +69,9 @@ def _xml_doc_from_anything(source):
 
     Will raise a ValueError if it fails.
     """
+    if isinstance(source, etree._Element):
+        return source
+
     try:
         xml_doc = etree.parse(source).getroot()
     except Exception:

--- a/obspy/io/rg16/core.py
+++ b/obspy/io/rg16/core.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import numpy as np
 
 from obspy.core import Stream, Trace, Stats, UTCDateTime
+from obspy.core.util.decorator import file_format_check
 from obspy.io.rg16.util import _read, _open_file, _quick_merge
 
 
@@ -497,13 +498,13 @@ def _read_trace_header_10(fi, trace_block_start):
     return dict_header_10
 
 
-@_open_file
+@file_format_check
 def _is_rg16(filename, **kwargs):
     """
     Determine if a file is a rg16 file.
 
-    :param filename: a path to a file or a file object
-    :type filename: str, buffer
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: True if the file object is a rg16 file.
     """

--- a/obspy/io/rg16/util.py
+++ b/obspy/io/rg16/util.py
@@ -5,33 +5,11 @@ from future.utils import native_str as nstr
 
 from codecs import encode
 import copy
-import decorator
 
 import numpy as np
 from obspy import Trace
-
-
-@decorator.decorator
-def _open_file(func, *args, **kwargs):
-    """
-    Ensure a file buffer is passed as first argument to the
-    decorated function.
-
-    :param func: callable that takes at least one argument;
-        the first argument must be treated as a buffer.
-    :return: callable
-    """
-    first_arg = args[0]
-    try:
-        with open(first_arg, 'rb') as fi:
-            args = tuple([fi] + list(args[1:]))
-            return func(*args, **kwargs)
-    except TypeError:  # assume we have been passed a buffer
-        if not hasattr(args[0], 'read'):
-            raise  # type error was in function call, not in opening file
-        out = func(*args, **kwargs)
-        first_arg.seek(0)  # reset position to start of file
-    return out
+# keep this import because _open_file used to be defined in here
+from obspy.core.util.decorator import _open_file  # NOQA
 
 
 def _read(fi, position, length, dtype, left_part=True):

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -55,6 +55,7 @@ def _internal_is_sac(buf):
     :return: ``True`` if a SAC file.
     """
     try:
+        starting_pos = buf.tell()
         # read delta (first header float)
         delta_bin = buf.read(4)
         delta = struct.unpack(native_str('<f'), delta_bin)[0]

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -54,7 +54,6 @@ def _internal_is_sac(buf):
     :rtype: bool
     :return: ``True`` if a SAC file.
     """
-    starting_pos = buf.tell()
     try:
         # read delta (first header float)
         delta_bin = buf.read(4)
@@ -106,9 +105,6 @@ def _internal_is_sac(buf):
             return False
     except Exception:
         return False
-    finally:
-        # Reset buffer head position after reading.
-        buf.seek(starting_pos, 0)
     return True
 
 
@@ -143,24 +139,20 @@ def _internal_is_sac_xy(buf):
     :rtype: bool
     :return: ``True`` if a alphanumeric SAC file.
     """
-    cur_pos = buf.tell()
     try:
-        try:
-            hdcards = []
-            # read in the header cards
-            for _i in range(30):
-                hdcards.append(buf.readline())
-            npts = int(hdcards[15].split()[-1])
-            # read in the seismogram
-            seis = buf.read(-1).split()
-        except Exception:
-            return False
-        # check that npts header value and seismogram length are consistent
-        if npts != len(seis):
-            return False
-        return True
-    finally:
-        buf.seek(cur_pos, 0)
+        hdcards = []
+        # read in the header cards
+        for _i in range(30):
+            hdcards.append(buf.readline())
+        npts = int(hdcards[15].split()[-1])
+        # read in the seismogram
+        seis = buf.read(-1).split()
+    except Exception:
+        return False
+    # check that npts header value and seismogram length are consistent
+    if npts != len(seis):
+        return False
+    return True
 
 
 def _read_sac_xy(filename, headonly=False, debug_headers=False,

--- a/obspy/io/sac/core.py
+++ b/obspy/io/sac/core.py
@@ -19,15 +19,17 @@ import struct
 from obspy import Stream
 
 from obspy.core.compatibility import is_bytes_buffer
+from obspy.core.util.decorator import file_format_check
 from .sactrace import SACTrace
 
 
-def _is_sac(filename):
+@file_format_check
+def _is_sac(filename, **kwargs):
     """
     Checks whether a file is a SAC file or not.
 
-    :param filename: SAC file to be checked.
-    :type filename: str, open file, or file-like object
+    :param filename: Open binary file-like object
+    :type filename: :class:`io.BytesIOBase`
     :rtype: bool
     :return: ``True`` if a SAC file.
 
@@ -39,13 +41,8 @@ def _is_sac(filename):
     >>> _is_sac(get_example_file('test.mseed'))
     False
     """
-    if is_bytes_buffer(filename):
-        return _internal_is_sac(filename)
-    elif isinstance(filename, (str, bytes)):
-        with open(filename, "rb") as fh:
-            return _internal_is_sac(fh)
-    else:
-        raise ValueError("Cannot open '%s'." % filename)
+    fh = filename
+    return _internal_is_sac(fh)
 
 
 def _internal_is_sac(buf):
@@ -115,12 +112,13 @@ def _internal_is_sac(buf):
     return True
 
 
-def _is_sac_xy(filename):
+@file_format_check
+def _is_sac_xy(filename, **kwargs):
     """
     Checks whether a file is alphanumeric SAC file or not.
 
-    :param filename: Alphanumeric SAC file to be checked.
-    :type filename: str, open file, or file-like object
+    :param filename: Open alphanumeric SAC file-like object to be checked.
+    :type filename: :class:`io.BytesIOBase`
     :rtype: bool
     :return: ``True`` if a alphanumeric SAC file.
 
@@ -132,13 +130,8 @@ def _is_sac_xy(filename):
     >>> _is_sac_xy(get_example_file('test.sac'))
     False
     """
-    if is_bytes_buffer(filename):
-        return _internal_is_sac_xy(filename)
-    elif isinstance(filename, (str, bytes)):
-        with open(filename, "rb") as fh:
-            return _internal_is_sac_xy(fh)
-    else:
-        raise ValueError("Cannot open '%s'." % filename)
+    fh = filename
+    return _internal_is_sac_xy(fh)
 
 
 def _internal_is_sac_xy(buf):

--- a/obspy/io/scardec/core.py
+++ b/obspy/io/scardec/core.py
@@ -28,6 +28,7 @@ from obspy.core.event import (Catalog, Comment, Event, EventDescription,
                               Origin, Magnitude, FocalMechanism, MomentTensor,
                               Tensor, SourceTimeFunction, NodalPlane,
                               NodalPlanes)
+from obspy.core.util.decorator import file_format_check
 from obspy.geodetics import FlinnEngdahl
 
 
@@ -75,16 +76,18 @@ def _buffer_proxy(filename_or_buf, function, reset_fp=True,
             return function(fh, *args, **kwargs)
 
 
-def _is_scardec(filename_or_buf):
+@file_format_check
+def _is_scardec(filename_or_buf, **kwargs):
     """
     Checks if the file is a SCARDEC file.
 
-    :param filename_or_buf: File to test.
-    :type filename_or_buf: str or file-like object.
+    :type filename_or_buf: :class:`io.BytesIOBase`
+    :param filename_or_buf: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if SCARDEC file.
     """
     try:
-        return _buffer_proxy(filename_or_buf, _internal_is_scardec,
-                             reset_fp=True)
+        return _internal_is_scardec(filename_or_buf)
     # Happens for example when passing the data as a string which would be
     # interpreted as a filename.
     except OSError:

--- a/obspy/io/scardec/core.py
+++ b/obspy/io/scardec/core.py
@@ -29,6 +29,7 @@ from obspy.core.event import (Catalog, Comment, Event, EventDescription,
                               Tensor, SourceTimeFunction, NodalPlane,
                               NodalPlanes)
 from obspy.core.util.decorator import file_format_check
+from obspy.core.util.misc import _buffer_proxy
 from obspy.geodetics import FlinnEngdahl
 
 
@@ -43,37 +44,6 @@ def _get_resource_id(scardecname, res_type, tag=None):
     if tag is not None:
         res_id += "#" + tag
     return res_id
-
-
-def _buffer_proxy(filename_or_buf, function, reset_fp=True,
-                  file_mode="rb", *args, **kwargs):
-    """
-    Calls a function with an open file or file-like object as the first
-    argument. If the file originally was a filename, the file will be
-    opened, otherwise it will just be passed to the underlying function.
-
-    :param filename_or_buf: File to pass.
-    :type filename_or_buf: str, open file, or file-like object.
-    :param function: The function to call.
-    :param reset_fp: If True, the file pointer will be set to the initial
-        position after the function has been called.
-    :type reset_fp: bool
-    :param file_mode: Mode to open file in if necessary.
-    """
-    try:
-        position = filename_or_buf.tell()
-        is_buffer = True
-    except AttributeError:
-        is_buffer = False
-
-    if is_buffer is True:
-        ret_val = function(filename_or_buf, *args, **kwargs)
-        if reset_fp:
-            filename_or_buf.seek(position, 0)
-        return ret_val
-    else:
-        with open(filename_or_buf, file_mode) as fh:
-            return function(fh, *args, **kwargs)
 
 
 @file_format_check

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -24,6 +24,7 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import AttribDict
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.decorator import file_format_check
 from .header import MONTHS
 
 
@@ -339,15 +340,19 @@ class SEG2(object):
             setattr(attrib_dict, key, value)
 
 
-def _is_seg2(filename):
-    if not hasattr(filename, 'write'):
-        file_pointer = open(filename, 'rb')
-    else:
-        file_pointer = filename
+@file_format_check
+def _is_seg2(filename, **kwargs):
+    """
+    Checks whether a file is SEG2 format.
+
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if SEG2 file.
+    """
+    file_pointer = filename
 
     file_descriptor_block = file_pointer.read(4)
-    if not hasattr(filename, 'write'):
-        file_pointer.close()
     try:
         # Determine the endianness and check if the block id is valid.
         if unpack_from(b'2B', file_descriptor_block) == (0x55, 0x3a):

--- a/obspy/io/seisan/core.py
+++ b/obspy/io/seisan/core.py
@@ -19,14 +19,16 @@ import warnings
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.decorator import file_format_check
 
 
-def _is_seisan(filename):
+@file_format_check
+def _is_seisan(filename, **kwargs):
     """
     Checks whether a file is SEISAN or not.
 
-    :type filename: str
-    :param filename: Name of the audio SEISAN file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a SEISAN file.
 
@@ -35,9 +37,9 @@ def _is_seisan(filename):
     >>> _is_seisan("/path/to/1996-06-03-1917-52S.TEST__002")  #doctest: +SKIP
     True
     """
+    fh = filename
     try:
-        with open(filename, 'rb') as f:
-            data = f.read(12 * 80)
+        data = fh.read(12 * 80)
     except Exception:
         return False
     # read some data - contains at least 12 lines a 80 characters

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -22,6 +22,7 @@ from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
 from obspy.core.compatibility import from_buffer
 from obspy.core.util import loadtxt
+from obspy.core.util.decorator import file_format_check
 
 
 MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP',
@@ -71,12 +72,13 @@ SH_KEYS_FLOAT = [k for (k, v) in SH_IDX.items() if v.startswith('R')]
 INVERTED_SH_IDX = {v: k for k, v in SH_IDX.items()}
 
 
-def _is_asc(filename):
+@file_format_check
+def _is_asc(filename, **kwargs):
     """
     Checks whether a file is a Seismic Handler ASCII file or not.
 
-    :type filename: str
-    :param filename: Name of the ASCII file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a Seismic Handler ASCII file.
 
@@ -85,10 +87,10 @@ def _is_asc(filename):
     >>> _is_asc("/path/to/QFILE-TEST-ASC.ASC")  #doctest: +SKIP
     True
     """
+    fh = filename
     # first six chars should contain 'DELTA:'
     try:
-        with open(filename, 'rb') as f:
-            temp = f.read(6)
+        temp = fh.read(6)
     except Exception:
         return False
     if temp != b'DELTA:':
@@ -301,12 +303,13 @@ def _write_asc(stream, filename, included_headers=None, npl=4,
         fh.write(sio.read().encode('ascii', 'strict'))
 
 
-def _is_q(filename):
+@file_format_check
+def _is_q(filename, **kwargs):
     """
     Checks whether a file is a Seismic Handler Q file or not.
 
-    :type filename: str
-    :param filename: Name of the Q file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a Seismic Handler Q file.
 
@@ -315,10 +318,10 @@ def _is_q(filename):
     >>> _is_q("/path/to/QFILE-TEST.QHD")  #doctest: +SKIP
     True
     """
+    fh = filename
     # file must start with magic number 43981
     try:
-        with open(filename, 'rb') as f:
-            temp = f.read(5)
+        temp = fh.read(5)
     except Exception:
         return False
     if temp != b'43981':

--- a/obspy/io/sh/evt.py
+++ b/obspy/io/sh/evt.py
@@ -24,23 +24,26 @@ from obspy.core.event import (Arrival, Catalog, Event,
                               StationMagnitude, WaveformStreamID)
 from obspy.core.event.header import EvaluationMode, EventType, PickOnset
 from obspy.core.util.decorator import file_format_check
-from obspy.core.util.misc import _seed_id_map
+from obspy.core.util.misc import _seed_id_map, _text_buffer_wrapper
 from obspy.io.sh.core import to_utcdatetime
 
 
 @file_format_check
 def _is_evt(filename, **kwargs):
+    """
+    Checks whether a file is EVT format.
+
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :rtype: bool
+    :return: ``True`` if EVT file.
+    """
     f = filename
+    f = _text_buffer_wrapper(f, 'utf-8')
     try:
         temp = f.read(20)
-    except Exception:
-        return False
-    try:
-        temp = temp.decode('utf-8')
     except UnicodeError:
         return False
-    except AttributeError:
-        pass
     return 'Event ID' in temp
 
 

--- a/obspy/io/sh/evt.py
+++ b/obspy/io/sh/evt.py
@@ -23,14 +23,16 @@ from obspy.core.event import (Arrival, Catalog, Event,
                               OriginUncertainty, Pick, ResourceIdentifier,
                               StationMagnitude, WaveformStreamID)
 from obspy.core.event.header import EvaluationMode, EventType, PickOnset
+from obspy.core.util.decorator import file_format_check
 from obspy.core.util.misc import _seed_id_map
 from obspy.io.sh.core import to_utcdatetime
 
 
-def _is_evt(filename):
+@file_format_check
+def _is_evt(filename, **kwargs):
+    f = filename
     try:
-        with open(filename, 'rb') as f:
-            temp = f.read(20)
+        temp = f.read(20)
     except Exception:
         return False
     return b'Event ID' in temp

--- a/obspy/io/sh/evt.py
+++ b/obspy/io/sh/evt.py
@@ -35,7 +35,13 @@ def _is_evt(filename, **kwargs):
         temp = f.read(20)
     except Exception:
         return False
-    return b'Event ID' in temp
+    try:
+        temp = temp.decode('utf-8')
+    except UnicodeError:
+        return False
+    except AttributeError:
+        pass
+    return 'Event ID' in temp
 
 
 def _km2m(km):

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -89,14 +89,14 @@ def is_fdsn_station_text_file(path_or_file_object, **kwargs):
     :rtype: bool
     :return: ``True`` if FDSN StationText file.
     """
-    fh = _text_buffer_wrapper(path_or_file_object, encoding='utf-8')
+    if isinstance(path_or_file_object, io.BufferedIOBase):
+        fh = _text_buffer_wrapper(path_or_file_object, encoding='utf-8')
+    else:
+        fh = path_or_file_object
     try:
         # Attempt to decode.
         first_line = fh.readline()
-    # non intuitively, this can also raise an UnicodeEncodeError, when not a
-    # binary buffer was wrapped for pure decoding, but rather a text buffer
-    # with a different encoding.
-    except (UnicodeDecodeError, UnicodeEncodeError):
+    except UnicodeDecodeError:
         return False
 
     if not first_line.startswith("#"):

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -386,14 +386,16 @@ def _write_stationtxt(inventory, path_or_file_object, level='channel',
         ``'station'`` or ``'channel'``.
     """
     stationtxt = inventory_to_station_text(inventory, level)
+    file_opened = False
     if not hasattr(path_or_file_object, 'write'):
+        file_opened = True
         f = open(path_or_file_object, 'w')
     else:
         f = path_or_file_object
     try:
         f.write(stationtxt)
     finally:
-        if not hasattr(path_or_file_object, 'write'):
+        if file_opened:
             f.close()
 
 

--- a/obspy/io/stationtxt/core.py
+++ b/obspy/io/stationtxt/core.py
@@ -89,10 +89,7 @@ def is_fdsn_station_text_file(path_or_file_object, **kwargs):
     :rtype: bool
     :return: ``True`` if FDSN StationText file.
     """
-    if isinstance(path_or_file_object, io.BufferedIOBase):
-        fh = _text_buffer_wrapper(path_or_file_object, encoding='utf-8')
-    else:
-        fh = path_or_file_object
+    fh = _text_buffer_wrapper(path_or_file_object, encoding='utf-8')
     try:
         # Attempt to decode.
         first_line = fh.readline()

--- a/obspy/io/win/core.py
+++ b/obspy/io/win/core.py
@@ -13,41 +13,45 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.decorator import file_format_check
 
 
-def _is_win(filename, century="20"):  # @UnusedVariable
+@file_format_check
+def _is_win(filename, **kwargs):
     """
     Checks whether a file is WIN or not.
 
-    :type filename: str
-    :param filename: WIN file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
+    :type century: str
+    :param century: two characters for century
     :rtype: bool
     :return: ``True`` if a WIN file.
     """
+    fh = filename
     # as long we don't have full format description we just try to read the
     # file like _read_win and check for errors
     century = "20"  # hardcoded ;(
     try:
-        with open(filename, "rb") as fpin:
-            fpin.read(4)
-            buff = fpin.read(6)
-            yy = "%s%02x" % (century, ord(buff[0:1]))
-            mm = "%x" % ord(buff[1:2])
-            dd = "%x" % ord(buff[2:3])
-            hh = "%x" % ord(buff[3:4])
-            mi = "%x" % ord(buff[4:5])
-            sec = "%x" % ord(buff[5:6])
+        fh.read(4)
+        buff = fh.read(6)
+        yy = "%s%02x" % (century, ord(buff[0:1]))
+        mm = "%x" % ord(buff[1:2])
+        dd = "%x" % ord(buff[2:3])
+        hh = "%x" % ord(buff[3:4])
+        mi = "%x" % ord(buff[4:5])
+        sec = "%x" % ord(buff[5:6])
 
-            # This will raise for invalid dates.
-            UTCDateTime(int(yy), int(mm), int(dd), int(hh), int(mi),
-                        int(sec))
-            buff = fpin.read(4)
-            '%02x' % ord(buff[0:1])
-            '%02x' % ord(buff[1:2])
-            int('%x' % (ord(buff[2:3]) >> 4))
-            ord(buff[3:4])
-            idata00 = fpin.read(4)
-            from_buffer(idata00, native_str('>i'))[0]
+        # This will raise for invalid dates.
+        UTCDateTime(int(yy), int(mm), int(dd), int(hh), int(mi),
+                    int(sec))
+        buff = fh.read(4)
+        '%02x' % ord(buff[0:1])
+        '%02x' % ord(buff[1:2])
+        int('%x' % (ord(buff[2:3]) >> 4))
+        ord(buff[3:4])
+        idata00 = fh.read(4)
+        from_buffer(idata00, native_str('>i'))[0]
     except Exception:
         return False
     return True

--- a/obspy/io/xseed/core.py
+++ b/obspy/io/xseed/core.py
@@ -19,36 +19,26 @@ import warnings
 
 import obspy
 import obspy.core.inventory
+from obspy.core.util.decorator import file_format_check
 
 from . import InvalidResponseError
 from .parser import Parser, is_xseed
 
 
-def _is_seed(filename):
+@file_format_check
+def _is_seed(filename, **kwargs):
     """
     Determine if the file is (dataless) SEED file.
 
     No comprehensive check - it only checks the initial record sequence
     number and the very first blockette.
 
-    :type filename: str
-    :param filename: Path/filename of a local file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
-    :returns: `True` if file seems to be a RESP file, `False` otherwise.
+    :returns: `True` if file seems to be a SEED file, `False` otherwise.
     """
-    try:
-        if hasattr(filename, "read") and hasattr(filename, "seek") and \
-                hasattr(filename, "tell"):
-            pos = filename.tell()
-            try:
-                buf = filename.read(128)
-            finally:
-                filename.seek(pos, 0)
-        else:
-            with io.open(filename, "rb") as fh:
-                buf = fh.read(128)
-    except IOError:
-        return False
+    buf = filename.read(128)
 
     # Minimum record size.
     if len(buf) < 128:
@@ -63,36 +53,32 @@ def _is_seed(filename):
     return True
 
 
-def _is_xseed(filename):
+@file_format_check
+def _is_xseed(filename, **kwargs):
     """
     Determine if the file is an XML-SEED file.
 
     Does not do any schema validation but only check the root tag.
 
-    :type filename: str
-    :param filename: Path/filename of a local file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
-    :returns: `True` if file seems to be a RESP file, `False` otherwise.
+    :returns: `True` if file seems to be a XSEED file, `False` otherwise.
     """
     return is_xseed(filename)
 
 
-def _is_resp(filename):
+@file_format_check
+def _is_resp(filename, **kwargs):
     """
     Check if a file at the specified location appears to be a RESP file.
 
-    :type filename: str
-    :param filename: Path/filename of a local file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :returns: `True` if file seems to be a RESP file, `False` otherwise.
     """
-    if hasattr(filename, "readline"):
-        return _internal_is_resp(filename)
-    try:
-        with open(filename, "rb") as fh:
-            return _internal_is_resp(fh)
-    except (IOError, TypeError):
-        return False
+    return _internal_is_resp(filename)
 
 
 def _internal_is_resp(fh):

--- a/obspy/io/xseed/tests/test_utils.py
+++ b/obspy/io/xseed/tests/test_utils.py
@@ -75,6 +75,8 @@ class UtilsTestCase(unittest.TestCase):
             "RESP.NZ.CRLZ.10.HHZ.windows",
             "RESP.OB.AAA._.BH_"]
         for filename in glob.glob(signal_test_files):
+            if os.path.isdir(filename):
+                continue
             got = _is_resp(filename)
             expected = os.path.basename(filename) in resp_filenames
             self.assertEqual(

--- a/obspy/io/y/core.py
+++ b/obspy/io/y/core.py
@@ -23,6 +23,7 @@ from obspy.core.compatibility import from_buffer
 from obspy.core.trace import Trace
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import AttribDict
+from obspy.core.util.decorator import file_format_check
 
 
 INVALID_CHAR_MSG = (
@@ -105,12 +106,13 @@ def _parse_tag(fh):
     return endian, tag_type, next_tag, next_same
 
 
-def _is_y(filename):
+@file_format_check
+def _is_y(filename, **kwargs):
     """
     Checks whether a file is a Nanometrics Y file or not.
 
-    :type filename: str
-    :param filename: Name of the Nanometrics Y file to be checked.
+    :type filename: :class:`io.BytesIOBase`
+    :param filename: Open file or file-like object to be checked
     :rtype: bool
     :return: ``True`` if a Nanometrics Y file.
 
@@ -119,10 +121,10 @@ def _is_y(filename):
     >>> _is_y("/path/to/YAYT_BHZ_20021223.124800")  #doctest: +SKIP
     True
     """
+    fh = filename
     try:
         # get first tag (16 bytes)
-        with open(filename, 'rb') as fh:
-            _, tag_type, _, _ = _parse_tag(fh)
+        _, tag_type, _, _ = _parse_tag(fh)
     except Exception:
         return False
     # The first tag in a Y-file must be the TAG_Y_FILE tag (tag type 0)

--- a/obspy/io/y/tests/test_core.py
+++ b/obspy/io/y/tests/test_core.py
@@ -8,6 +8,7 @@ import unittest
 import warnings
 
 from obspy.io.y.core import _is_y, _read_y
+from obspy.core.util.base import get_example_file
 
 
 class CoreTestCase(unittest.TestCase):
@@ -24,8 +25,8 @@ class CoreTestCase(unittest.TestCase):
         """
         testfile = os.path.join(self.path, 'data', 'YAYT_BHZ_20021223.124800')
         self.assertEqual(_is_y(testfile), True)
-        self.assertEqual(_is_y("/path/to/slist.ascii"), False)
-        self.assertEqual(_is_y("/path/to/tspair.ascii"), False)
+        self.assertEqual(_is_y(get_example_file("slist.ascii")), False)
+        self.assertEqual(_is_y(get_example_file("tspair.ascii")), False)
 
     def test_read_y_file(self):
         """


### PR DESCRIPTION
### What does this PR do?

This PR aims at unifying I/O handling during file format checks performed in I/O plugins. It introduces a decorator to be used on `_is_xxx_()` file format checker funtions, that unifies opening binary buffers or rewinding already open files or file-like objects to the initial position after the file format check was performed.

Depending if CI looks OK for the first two format checks already migrated (MSEED, SAC), we should also migrate all other check routines.

#### Summary of most important changes

 - new `file_format_check` decorator that (basically taken from the old `_is_mseed` routine)
   - opens bytes buffer from filenames etc. and closes it at the end
   - passes on open file-like objects (and leaves them open at end)
   - creates `BytesIO`/`StringIO` buffers from bytes/string input
 - some is-format checker routines were behaving differently. most of this was unified and all should be. e.g. some were raising exceptions on certain incompatible input while others just always return False. I think they should probably always return False and never raise an Exception, in any case this part is now exclusively in the decorator, the is-format check routines will now **always** receive a bytes or string buffer to work on
 - some is-format checkers used to behave different with decoding things, added a helper method to wrap a `TextIOWrapper` around the bytes buffer handed over by the new decorator

### Why was it initiated?  Any relevant Issues?

Currently this logic is duplicated, present to some extent or sometimes completely missing and spread out across 48 `isFormat` routines. This is aiming in the similar direction as #2326 was for reader routines, so there might be room for further unification with that one later on..

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] purely internal ~~Significant changes have been added to `CHANGELOG.txt` .~~
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .

### TODOS
 - [x] add a test that goes through all `isFormat` functions registered as plugins, passes in an opened `io.BytesIOBase` object, runs format check, makes sure the object is not closed
 - [x] add a test that runs one file format check with an open binary stream not at start of file and makes sure that after format check the decorator properly rewinds the stream to initial position (compare #2419)
 - [x] migrate all other file format checks if PR gets approved
 - [ ] do we need a check on `_file_size` kwarg collision? i.e. if it is problematic when defined in the decorated function as well
 - [ ] maybe rename from `file_format_check` to something more general like `ensure_open_buffer`
 - [ ] `_open_file` helper moved from rg16 to core/util should maybe be integrated with the `file_format_checker` as well
 - [ ] opening remote sources (http) could be integrated as well
 - [ ] integrate `uncompress` decorator into `file_format_checker` as well?
 - [ ] maybe see if the `_generic_reader` and `file_format_checker` can be combined into one thing
 - [ ] should check again if we can wrap a user-provided string buffer with another encoding by wrapping a second Text wrapper around it again. it did not work earlier but it might have been a problem with what was fixed by e6ff5d276c763ea389d2ee44f90748ac5a746b9f
 - [ ] when a open file-like object not at start of file is passed in, what should be reported as "file size" to the file format checker? Total file size (current behavior) or remaining file size from current position in file (might make more sense).

Also, right now, an opened text stream with automatic decoding will be passed down into the plugins' format check function. It might not be possible to do much about this, any ideas?