### PR TITLE
testing: mpl backend switch context manager: add close option

### DIFF
--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -543,13 +543,17 @@ class MatplotlibBackend(object):
         successfully. If ``False``, additionally tries to use
         :func:`matplotlib.use` first and also shows a warning if the backend
         was not switched successfully.
+    :type close: bool
+    :param close: Whether to close all matplotlib figures when exiting the
+        context manager.
     """
 
-    def __init__(self, backend, sloppy=True):
+    def __init__(self, backend, sloppy=True, close=False):
         self.temporary_backend = backend
         self.sloppy = sloppy
         import matplotlib
         self.previous_backend = matplotlib.get_backend()
+        self.close = close
 
     def __enter__(self):
         if self.temporary_backend is None:
@@ -557,6 +561,9 @@ class MatplotlibBackend(object):
         self.switch_backend(backend=self.temporary_backend, sloppy=self.sloppy)
 
     def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
+        if self.close:
+            import matplotlib.pyplot as plt
+            plt.close('all')
         if self.temporary_backend is None:
             return
         self.switch_backend(backend=self.previous_backend, sloppy=self.sloppy)


### PR DESCRIPTION
### What does this PR do?

Add an option to close all figures when exiting `MatplotlibBackend` helper context manager, which is used to temporarily switch the backend.


### Why was it initiated?  Any relevant Issues?

*Please fill in*

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
