### PR TITLE
add timezone examples to `UTCDateTime` docs

### DIFF
--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -131,8 +131,9 @@ class UTCDateTime(object):
         >>> UTCDateTime(1240561632.5)
         UTCDateTime(2009, 4, 24, 8, 27, 12, 500000)
 
-    (2) Using a `ISO8601:2004`_ string. The detection may be enforced by
-        setting the ``iso8601`` parameter to True.
+    (2) Using a `ISO8601:2004`_ string. The detection may be enabled/disabled
+        using the``iso8601`` parameter, the default is to attempt to
+        auto-detect ISO8601 compliant strings.
 
         * Calendar date representation.
 
@@ -169,6 +170,17 @@ class UTCDateTime(object):
 
             >>> UTCDateTime("2009W011", iso8601=True)      # enforce ISO8601
             UTCDateTime(2008, 12, 29, 0, 0)
+
+        * Specifying time zones.
+
+            >>> UTCDateTime('2019-09-18T+06')  # time zone is UTC+6
+            UTCDateTime(2019, 9, 17, 18, 0)
+
+            >>> UTCDateTime('2019-09-18T02-02')  # time zone is UTC-2
+            UTCDateTime(2019, 9, 18, 4, 0)
+
+            >>> UTCDateTime('2019-09-18T18:23:10.22-01')  # time zone is UTC-1
+            UTCDateTime(2019, 9, 18, 19, 23, 10, 220000)
 
     (3) Using not ISO8601 compatible strings.
 
@@ -244,7 +256,8 @@ class UTCDateTime(object):
 
     You may change that behavior either by,
 
-    (1) using the ``precision`` keyword during object initialization:
+    (1) using the ``precision`` keyword during object initialization
+        (preferred):
 
         >>> dt = UTCDateTime(0, precision=4)
         >>> dt2 = UTCDateTime(0.00001, precision=4)
@@ -253,8 +266,9 @@ class UTCDateTime(object):
         >>> dt == dt2
         True
 
-    (2) or set it the class attribute ``DEFAULT_PRECISION`` for all new
-        :class:`UTCDateTime` objects using a monkey patch:
+    (2) or by setting the class attribute ``DEFAULT_PRECISION`` to the desired
+        precision to affect all new :class:`UTCDateTime` objects
+        (not recommended):
 
         >>> UTCDateTime.DEFAULT_PRECISION = 4
         >>> dt = UTCDateTime(0)


### PR DESCRIPTION
### What does this PR do?

Adds examples of using ISO8601 to specify time zones in input strings.

### Why was it initiated?  Any relevant Issues?

#2447

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
