### PR TITLE
Better support for file-like Seg-Y objects

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -24,6 +24,7 @@ Ermert, Laura
 Eulenfeld, Tom
 Fabbri, Tommaso
 Falco, Nicholas
+Fedorov, Oleksandr
 Fee, Jeremy
 Grellier, Clément
 Grunberg, Marc

--- a/obspy/io/segy/unpack.py
+++ b/obspy/io/segy/unpack.py
@@ -160,3 +160,22 @@ class OnTheFlyDataUnpacker:
             fp.seek(self.seek)
             raw = self.unpack_function(fp, self.count, endian=self.endian)
         return raw
+
+
+class OnTheFlyFileDataUnpacker:
+    """
+    Tie-up a data sample unpack function with its parameters.
+
+    This class allows for data to be read directly from a file-like object
+    as needed, preventing the need to store data in memory.
+    """
+    def __init__(self, unpack_function, file, seek, count, endian='>'):
+        self.unpack_function = unpack_function
+        self.file = file
+        self.seek = seek
+        self.count = count
+        self.endian = endian
+
+    def __call__(self):
+        self.file.seek(self.seek)
+        return self.unpack_function(self.file, self.count, endian=self.endian)

--- a/obspy/io/segy/util.py
+++ b/obspy/io/segy/util.py
@@ -3,6 +3,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import io
+import os
 from struct import unpack
 
 from obspy.core.util.libnames import _load_cdll
@@ -36,3 +38,18 @@ def unpack_header_value(endian, packed_value, length, special_format):
     # Should not happen
     else:
         raise Exception
+
+
+def get_filesize(file):
+    """Get a size of provided file-like object."""
+    try:
+        fileno = file.fileno()
+    except (AttributeError, io.UnsupportedOperation):
+        pos = file.tell()
+        file.seek(0, 2)  # go t end of file
+        filesize = file.tell()
+        file.seek(pos, 0)
+    else:
+        filesize = os.fstat(fileno)[6]
+
+    return filesize


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Provide better support for file-like files for `obspy.io.segy`.

Remove explicit `isinstance` check for `io.BytesIO` in behalf of duck-typing. Provide fallbacks for file objects that do not provide `name` attribute or `fileno()` method functionality.

### Why was it initiated?  Any relevant Issues?

`obspy.io.segy` already supports file-like objects, namely `io.BytesIO`, and methods like `iread_segy` already use duck-typing.

But still it's not enough to handle duck-typed file-like objects like ones provided with [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) or [gcsfs](https://gcsfs.readthedocs.io/en/latest/).

This MR adds such functionality to `obspy.io.segy.segy.SEGYFile` and `obspy.io.segy.segy.iread_segy`.  

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
