### PR TITLE
flake8 config: only set verbose mode in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,6 @@ jobs:
       - run:
           name: run linting
           command: |
+            echo 'verbosity = 1' >> .flake8
             /opt/conda/bin/flake8 --version
             /opt/conda/bin/flake8 obspy

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-verbose = 1
 # hang-closing allows valid indented closing brackets, see https://github.com/PyCQA/pycodestyle/issues/103#issuecomment-17366719
 hang-closing = True
 


### PR DESCRIPTION
### What does this PR do?

flake8 config: only set verbose mode in CircleCI: Otherwise a lot of warnings from ignored warnings/errors shows locally for me when I run it

### Why was it initiated?  Any relevant Issues?

Follow up to #2463 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
