### PR TITLE
UTCDateTime support for numpy datetime64

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -300,6 +300,19 @@ class UTCDateTimeTestCase(unittest.TestCase):
             a + -0.5, UTCDateTime(1969, 12, 31, 23, 59, 59, 500000))
         td = datetime.timedelta(seconds=1)
         self.assertEqual(a + td, UTCDateTime(1970, 1, 1, 0, 0, 1))
+        # Test that ns precision is maintained (time delta has us precision).
+        start = UTCDateTime(ns=1111111111)
+        self.assertEqual(start.ns + int(1e9), (start + td).ns)
+
+    def test_add_numpy_datetime_delta(self):
+        """
+        Numpy datetimedelta and UTCDateTime should be able to be added
+        and subtracted.
+        """
+        utc = UTCDateTime('2019-09-18 18-00-00')
+        td = np.timedelta64(6, 'h')
+        expected_utc = UTCDateTime('2019-09-19 00-00-00')
+        self.assertEqual(utc + td, expected_utc)
 
     def test_sub(self):
         # 1
@@ -318,6 +331,19 @@ class UTCDateTimeTestCase(unittest.TestCase):
         start = UTCDateTime(2000, 1, 1, 0, 0, 0, 999999)
         end = UTCDateTime(2000, 1, 1, 0, 0, 1, 1)
         self.assertAlmostEqual(end - start, 0.000002, 6)
+        # Test that ns precision is maintained (time delta has us precision).
+        start = UTCDateTime(ns=1111111111)
+        self.assertEqual(start.ns - int(1e9), (start - td).ns)
+
+    def test_sub_numpy_datetime_delta(self):
+        """
+        Numpy datetimedelta and UTCDateTime should be able to be added
+        and subtracted.
+        """
+        utc = UTCDateTime('2019-09-18 18-00-00')
+        td = np.timedelta64(6, 'h')
+        expected_utc = UTCDateTime('2019-09-18 12-00-00')
+        self.assertEqual(utc - td, expected_utc)
 
     def test_negative_timestamp(self):
         dt = UTCDateTime(-1000.1)
@@ -391,6 +417,14 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(str(dt), "2008-01-01T12:00:00.005000Z")
         # without parameters returns current date time
         UTCDateTime()
+
+    def test_init_utcdatetime_datetime64(self):
+        """
+        It should be possible to init a UTCDateTime from a numpy datetime64.
+        """
+        utc = UTCDateTime('2017-09-18 18:25:12.1111')
+        out = UTCDateTime(utc.datetime64)
+        self.assertEqual(utc, out)
 
     def test_init_utcdatetime_mixing_keyworks_with_arguments(self):
         # times
@@ -951,6 +985,30 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(max(times), dt3)
         self.assertEqual(min(times), dt1)  # expected
         self.assertEqual(min(times), dt2)  # due to precision
+
+    def test_rich_comparisons_datetimes(self):
+        """
+        Ensure rich comparisons work with datetime.datetime.
+        """
+        # Init 3 UTCDateTime objects for use in testing and other dtypes.
+        utc = UTCDateTime('2017-09-18T18:00:00')
+        dts = [x.datetime for x in [utc - 1, utc, utc + 1]]
+        # first test equality-like operators
+        utc.__eq__(dts[1])
+        self.assertEqual(utc, dts[1])
+        self.assertEqual(dts[1], utc)
+        self.assertLessEqual(utc, dts[1])
+        self.assertGreaterEqual(dts[1], utc)
+        # then less than
+        self.assertLess(utc, dts[2])
+        self.assertLessEqual(utc, dts[2])
+        self.assertLess(dts[0], utc)
+        self.assertLessEqual(dts[0], utc)
+        # then greater than
+        self.assertGreater(utc, dts[0])
+        self.assertGreaterEqual(utc, dts[0])
+        self.assertGreater(dts[2], utc)
+        self.assertGreaterEqual(dts[2], utc)
 
     def test_datetime_with_timezone(self):
         """
@@ -1569,6 +1627,14 @@ class UTCDateTimeTestCase(unittest.TestCase):
         # skip ISO8601 mode
         self.assertEqual(UTCDateTime('2019-01-01T02-02:33', iso8601=False),
                          UTCDateTime(2019, 1, 1, 2, 2, 33))
+
+    def test_convert_to_numpy_datetime64(self):
+        """
+        UTCDateTime should be convertible to numpy datetime64.
+        """
+        utc = UTCDateTime('2019-09-18 18-00-00.102020201')
+        dt64 = utc.datetime64
+        self.assertEqual(utc.ns, dt64.astype(int))
 
 
 def suite():

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -68,6 +68,9 @@ YMDHMS = ('year', 'month', 'day', 'hour', 'minute', 'second')
 YJHMS = ('year', 'julday', 'hour', 'minute', 'second')
 YMDHMS_FORMAT = "%04d-%02d-%02dT%02d:%02d:%02d"
 
+# types which define other packages datetime representation
+OTHER_TIME_TYPES = (datetime.datetime, datetime.date, np.datetime64)
+
 
 class UTCDateTime(object):
     """
@@ -233,7 +236,15 @@ class UTCDateTime(object):
         >>> UTCDateTime(dt)
         UTCDateTime(2009, 5, 24, 8, 28, 12, 5001)
 
-    (7) Using strict=False the limits of hour, minute, and second become more
+    (7) Using a numpy :class:`numpy.datetime64` object.
+
+        >>> dt = np.datetime64('2009-05-24T08:28:12', 'ns')
+        >>> UTCDateTime(dt)
+        UTCDateTime(2009, 5, 24, 8, 28, 12)
+
+        Note: all datetime64
+
+    (8) Using strict=False the limits of hour, minute, and second become more
         flexible:
 
         >>> UTCDateTime(year=1970, month=1, day=1, hour=48, strict=False)
@@ -329,12 +340,15 @@ class UTCDateTime(object):
                         (value.__dict__['timestamp'] % 1.0) * 1e6)
                     dt_ = datetime.datetime.utcfromtimestamp(timestamp_seconds)
                     dt_ = dt_.replace(microsecond=timestamp_microseconds)
-                    self._from_datetime(dt_)
+                    self._from_other_time(dt_)
                 return
             # check types
             # The string instance check is mainly needed to not convert
             # numpy strings as these can be converted to floats on
             # numpy >= 1.14.
+            if isinstance(value, OTHER_TIME_TYPES):
+                self._from_other_time(value)
+                return
             if not isinstance(value, (str, bytes)):
                 try:
                     # got a timestamp
@@ -342,15 +356,6 @@ class UTCDateTime(object):
                     return
                 except Exception:
                     pass
-            if isinstance(value, datetime.datetime):
-                # got a Python datetime.datetime object
-                self._from_datetime(value)
-                return
-            elif isinstance(value, datetime.date):
-                # got a Python datetime.date object
-                dt = datetime.datetime(value.year, value.month, value.day)
-                self._from_datetime(dt)
-                return
             elif isinstance(value, (bytes, str)):
                 if not isinstance(value, (str, native_str)):
                     value = value.decode()
@@ -419,11 +424,11 @@ class UTCDateTime(object):
                 # patterns and pass it directly to Python's  datetime.datetime
                 if not ''.join(parts).isdigit():
                     dt = datetime.datetime(*args, **kwargs)
-                    self._from_datetime(dt)
+                    self._from_other_time(dt)
                     return
                 dt = datetime.datetime.strptime(value, pattern)
                 dt += datetime.timedelta(seconds=ms)
-                self._from_datetime(dt)
+                self._from_other_time(dt)
                 return
         # check for ordinal/julian date kwargs
         if 'julday' in kwargs:
@@ -470,7 +475,7 @@ class UTCDateTime(object):
             else:
                 raise
         else:
-            self._from_datetime(dt)
+            self._from_other_time(dt)
 
     def _handle_overflow(self, year, month, day, hour=0, minute=0, second=0,
                          microsecond=0):
@@ -544,14 +549,21 @@ class UTCDateTime(object):
     _ns = property(_get_ns, _set_ns)
     ns = property(_get_ns, _set_ns)
 
-    def _from_datetime(self, dt):
+    def _from_other_time(self, dt):
         """
-        Use Python datetime object to set current time.
+        Set ns from an external time representation.
 
-        :type dt: :class:`datetime.datetime`
-        :param dt: Python datetime object.
+        :type dt: :class:`datetime.datetime`, or :class:`numpy.datetime64`
+        :param dt: A non-ObsPy time object.
         """
-        self._ns = _datetime_to_ns(dt)
+        if isinstance(dt, datetime.datetime):
+            self.__ns = _datetime_to_ns(dt)
+        elif isinstance(dt, datetime.date):
+            dt = datetime.datetime(dt.year, dt.month, dt.day)
+            self.__ns = _datetime_to_ns(dt)
+        elif isinstance(dt, np.datetime64):
+            # Note: need extra int call here to ensure python int not numpy.
+            self.__ns = int(dt.astype('datetime64[ns]').astype(int))
 
     def _from_timestamp(self, value):
         """
@@ -644,7 +656,7 @@ class UTCDateTime(object):
                                         date_pattern + 'T' + time_pattern)
         # add microseconds and eventually correct time zone
         dt += datetime.timedelta(seconds=float(delta) + ms)
-        self._from_datetime(dt)
+        self._from_other_time(dt)
 
     def _get_timestamp(self):
         """
@@ -677,6 +689,17 @@ class UTCDateTime(object):
         1222864235.123456
         """
         return self.timestamp
+
+    def _get_datetime64(self):
+        """
+        Return a numpy datetime64 object.
+
+        :rtype: :class:`numpy.datetime64`
+        :return: Numpy datetime64 object.
+        """
+        return np.datetime64(self.ns, 'ns')
+
+    datetime64 = property(_get_datetime64)
 
     def _get_datetime(self):
         """
@@ -1000,14 +1023,17 @@ class UTCDateTime(object):
         >>> UTCDateTime(1970, 1, 1, 0, 0) + 1.123456
         UTCDateTime(1970, 1, 1, 0, 0, 1, 123456)
         """
-        if isinstance(value, datetime.timedelta):
-            # see datetime.timedelta.total_seconds
-            value = (value.microseconds + (value.seconds + value.days *
-                     86400) * 10**6) / 1e6
-        elif isinstance(value, UTCDateTime):
+        if isinstance(value, UTCDateTime):
             msg = ("unsupported operand type(s) for +: 'UTCDateTime' and "
                    "'UTCDateTime'")
             raise TypeError(msg)
+        elif isinstance(value, datetime.timedelta):
+            # see datetime.timedelta.total_seconds
+            value = (value.microseconds + (value.seconds + value.days *
+                     86400) * 10**6) / 1e6
+        elif isinstance(value, np.timedelta64):
+            return UTCDateTime(self.datetime64 + value)
+
         return UTCDateTime(ns=self._ns + int(round(value * 1e9)))
 
     def __sub__(self, value):
@@ -1038,6 +1064,8 @@ class UTCDateTime(object):
             # see datetime.timedelta.total_seconds
             value = (value.microseconds + (value.seconds + value.days *
                      86400) * 10**6) / 1e6
+        elif isinstance(value, np.timedelta64):
+            return UTCDateTime(self.datetime64 - value)
         return UTCDateTime(ns=self._ns - int(round((value * 1e9))))
 
     def __str__(self):
@@ -1723,16 +1751,19 @@ class UTCDateTime(object):
 
 def _datetime_to_ns(dt):
     """
-    Use Python datetime object to return equivalent nanoseconds.
+    Get equivalent nanoseconds from python's datetime or timedelta.
 
-    :type dt: :class:`datetime.datetime`
-    :param dt: Python datetime object.
+    :type dt: :class:`datetime.datetime` or :class:`datetime.timedelta`
+    :param dt: Python datetime or timedelta object.
     :returns: nanoseconds as an int.
     """
-    try:
-        td = (dt - TIMESTAMP0)
-    except TypeError:
-        td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
+    if isinstance(dt, datetime.datetime):
+        try:
+            td = (dt - TIMESTAMP0)
+        except TypeError:
+            td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
+    elif isinstance(dt, datetime.timedelta):
+        td = dt
     # see datetime.timedelta.total_seconds
     return (td.days * 86400 + td.seconds) * 10**9 + td.microseconds * 1000
 

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -562,8 +562,7 @@ class UTCDateTime(object):
             dt = datetime.datetime(dt.year, dt.month, dt.day)
             self.__ns = _datetime_to_ns(dt)
         elif isinstance(dt, np.datetime64):
-            # Note: need extra int call here to ensure python int not numpy.
-            self.__ns = int(dt.astype('datetime64[ns]').astype(int))
+            self.__ns = _datetime_to_ns(dt)
 
     def _from_timestamp(self, value):
         """
@@ -1753,7 +1752,8 @@ def _datetime_to_ns(dt):
     """
     Get equivalent nanoseconds from python's datetime or timedelta.
 
-    :type dt: :class:`datetime.datetime` or :class:`datetime.timedelta`
+    :type dt: :class:`datetime.datetime`, :class:`datetime.timedelta`, or
+        :class:`numpy.datetime64`.
     :param dt: Python datetime or timedelta object.
     :returns: nanoseconds as an int.
     """
@@ -1764,6 +1764,9 @@ def _datetime_to_ns(dt):
             td = (dt.replace(tzinfo=None) - dt.utcoffset()) - TIMESTAMP0
     elif isinstance(dt, datetime.timedelta):
         td = dt
+    elif isinstance(dt, np.datetime64):
+        # Note: need extra int call here to ensure python int not numpy int.
+        return int(dt.astype('datetime64').astype(int))
     # see datetime.timedelta.total_seconds
     return (td.days * 86400 + td.seconds) * 10**9 + td.microseconds * 1000
 


### PR DESCRIPTION
### What does this PR do?

This PR adds some support for numpy's date time representations. It doesn't solve all the issues but does address most of them without any backwards-incompatible changes.

It also includes some small refactoring of `UTCDateTime` and adds some additional tests for the same.

We will have to bump the min numpy version to 1.7 (released in 2013) before merging this.

### Summary

```python
import numpy as np
from obspy import UTCDateTime

utc = UTCDateTime('2017-09-18T18:00:00')

# convert utc to datetime64 (uses ns as units)
dt64 = utc.datetime64

# can now add np.timedelta64 to utc
utc + np.timedelta64(100, 's')

# comparisons work if UTCDateTime is first
utc == dt64  # True
utc - 1 < dt64  # True
utc + 1 > dt64  # True

# but they wont work at all if datetime64 is first. This is because the numpy ops ends up 
# simply passing an int (with no indication of units) to `UTCDateTime`s dunder methods
# which gets interpreted as a timestamp in seconds. I dont see a way to address this issue.
dt64 == utc  # False 
...
```

### Why was it initiated?  Any relevant Issues?

Issues mentioned in #2479 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
