### PR TITLE
Refactor stack

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3172,7 +3172,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             a copy of your stream object.
         """
         from obspy.signal.util import stack as stack_func
-        groups = self._group_by(group_by)
+        groups = self._groupby(group_by)
         stacks = []
         for groupid, traces in groups.items():
             header = {k: v for k, v in traces[0].stats.items()
@@ -3295,7 +3295,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     "channels": channels_}
         return all_channels
 
-    def _group_by(self, group_by):
+    def _groupby(self, group_by):
         """
         Group traces by same metadata.
 

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3171,11 +3171,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             original data, use :meth:`~obspy.core.stream.Stream.copy` to create
             a copy of your stream object.
         """
-        if group_by == 'id':
-            group_by = '{network}.{station}.{location}.{channel}'
-        groups = collections.defaultdict(list)
-        for tr in self:
-            groups[group_by.format(**tr.stats)].append(tr)
+        groups = self._group_by(group_by)
         stacks = []
         for groupid, traces in groups.items():
             header = {k: v for k, v in traces[0].stats.items()
@@ -3313,6 +3309,26 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     "start": start, "end": end, "gaps": gaps,
                     "channels": channels_}
         return all_channels
+
+    def _group_by(self, group_by):
+        """
+        Group traces by same metadata.
+
+        :param group_by: Group traces together which have the same metadata
+            given by this parameter. The parameter should name the
+            corresponding keys of the stats object,
+            e.g. ``'{network}.{station}'``
+            This parameter can take the value
+            ``'id'`` which stacks groups the traces by SEED id
+
+        :return: dictionary {group: stream}
+        """
+        if group_by == 'id':
+            group_by = '{network}.{station}.{location}.{channel}'
+        groups = collections.defaultdict(self.__class__)
+        for tr in self:
+            groups[group_by.format(**tr.stats)].append(tr)
+        return dict(groups)
 
     def _trim_common_channels(self):
         """

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3146,9 +3146,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type stack_type: str or tuple
         :param stack_type: Type of stack, one of the following:
             ``'linear'``: average stack (default),
-            ``('pw', order)``: phase weighted stack of given order,
-            see [Schimmel1997]_,
-            ``('root', order)``: root stack of given order.
+            ``('pw', order)``: phase weighted stack of given order
+            (see [Schimmel1997]_, order 0 corresponds to linear stack),
+            ``('root', order)``: root stack of given order
+            (order 1 corresponds to linear stack).
         :type npts_tol: int
         :param npts_tol: Tolerate traces with different number of points
             with a difference up to this value. Surplus samples are discarded.

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3176,7 +3176,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         stacks = []
         for groupid, traces in groups.items():
             header = {k: v for k, v in traces[0].stats.items()
-                      if all(tr.stats.get(k) == v for tr in traces)}
+                      if all(np.all(tr.stats.get(k) == v) for tr in traces)}
             header.pop('endtime', None)
             if 'sampling_rate' not in header:
                 msg = 'Sampling rate of traces to stack is different'

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2714,12 +2714,19 @@ class StreamTestCase(unittest.TestCase):
         # check correct setting of metadata
         st = read()
         st[0].stats.back_azimuth -= 10
+        st[0].stats.array1 = np.array([1, 2])
+        st[1].stats.array1 = np.array([1, 2, 3])
+        st[2].stats.array1 = 'no array here'
+        for tr in st:
+            tr.stats.array2 = np.array([3, 4])
         st2 = st.copy().stack()
         self.assertEqual(st2[0].stats.station, st[0].stats.station)
         self.assertEqual(st2[0].stats.inclination, st[0].stats.inclination)
         self.assertEqual(st2[0].stats.starttime, st[0].stats.starttime)
         self.assertEqual(st2[0].stats.channel, '')
         self.assertNotIn('back_azimuth', st2[0].stats)
+        self.assertNotIn('array1', st2[0].stats)
+        self.assertIn('array2', st2[0].stats)
         st[1].stats.starttime += 10
         st2 = st.copy().stack()
         self.assertEqual(st2[0].stats.starttime, UTCDateTime(0))

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -304,9 +304,10 @@ def stack(data, stack_type='linear'):
     :type stack_type: str or tuple
     :param stack_type: Type of stack, one of the following:
         ``'linear'``: average stack (default),
-        ``('pw', order)``: phase weighted stack of given order,
-        see [Schimmel1997]_,
-        ``('root', order)``: root stack of given order.
+        ``('pw', order)``: phase weighted stack of given order
+        (see [Schimmel1997]_, order 0 corresponds to linear stack),
+        ``('root', order)``: root stack of given order
+        (order 1 corresponds to linear stack).
     """
     if stack_type == 'linear':
         stack = np.mean(data, axis=0)

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -313,7 +313,10 @@ def stack(data, stack_type='linear'):
         stack = np.mean(data, axis=0)
     elif stack_type[0] == 'pw':
         from scipy.signal import hilbert
-        from scipy.fftpack import next_fast_len
+        try:
+            from scipy.fftpack import next_fast_len
+        except ImportError:  # scipy < 0.18
+            next_fast_len = next_pow_2
         npts = np.shape(data)[1]
         nfft = next_fast_len(npts)
         anal_sig = hilbert(data, N=nfft)[:, :npts]


### PR DESCRIPTION
I refactored Stream.stack a bit and moved the grouping to ``Stream._group_by()`` and the data stacking to ``obspy.signal.utils.stack()`` so that it can be used with a simple numpy array as well.

Follow-up to #2440.