### PR TITLE
Check Python 3.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: PYTHON_VERSION=3.6
     - os: linux
       env: PYTHON_VERSION=3.7
+    - os: linux
+      env: PYTHON_VERSION=3.8
     # - os: linux
     #   env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
     #   addons:
@@ -38,6 +40,8 @@ matrix:
       env: PYTHON_VERSION=3.6
     - os: osx
       env: PYTHON_VERSION=3.7
+    - os: osx
+      env: PYTHON_VERSION=3.8
 
 # mimick travis fast fail and rolling build setup from:
 # https://github.com/JuliaLang/julia/blob/master/.travis.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,6 +66,14 @@ environment:
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Miniconda38"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Miniconda38-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+
 matrix:
     allow_failures:
       - PYTHON_VERSION: "3.5"


### PR DESCRIPTION
Python 3.8.0rc1 is out, we should check if there are any issues with our master branch before releasing 1.2.0.

Hopefull there will be packages on conda-forge, then we could simply add it to the CI build matrix. See conda-forge/python-feedstock#270