### PR TITLE
Move origin-time uncertainty to origin.time_errors for Nordic IO

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -104,6 +104,8 @@ master:
    * Include AIN as takeoff-angle when reading and writing nordic files
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
+   * Include origin time uncertainty as QuantityError on origin.time_errors
+     and RMS as origin.quality.standard_error (see # )
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -105,7 +105,7 @@ master:
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
    * Include origin time uncertainty as QuantityError on origin.time_errors
-     and RMS as origin.quality.standard_error (see # )
+     and RMS as origin.quality.standard_error (see #2502)
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -104,8 +104,6 @@ master:
    * Include AIN as takeoff-angle when reading and writing nordic files
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
-   * Include origin time uncertainty as QuantityError on origin.time_errors
-     and RMS as origin.quality.standard_error (see #2502)
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -482,10 +482,17 @@ def _read_uncertainty(tagged_lines, event):
             _km_to_deg_lon(errors['x_err'], orig.latitude))
         orig.depth_errors = QuantityError(errors['z_err'] * 1000.)
     try:
-        orig.quality = OriginQuality(
-            azimuthal_gap=int(line[5:8]), standard_error=float(line[14:20]))
+        gap = int(line[5:8])
+    except ValueError:
+        gap = None
+    try:
+        orig.time_errors = QuantityError(float(line[14:20]))
     except ValueError:
         pass
+    if orig.quality:
+        orig.quality.azimuthal_gap = gap
+    else:
+        orig.quality = OriginQuality(azimuthal_gap=gap)
     return event
 
 
@@ -1463,7 +1470,7 @@ def nordpick(event, high_accuracy=True):
                 polarity.rjust(1) + ' ')
         pick_string_formatter = (
             " {station:5s}{instrument:1s}{component:1s}{phase_info:10s}"
-            "{hour:2d}{minute:2d}{seconds:6s}{coda:5s}{amp:7s}{period:5s}"
+            "{hour:2d}{minute:2d}{seconds:>6s}{coda:5s}{amp:7s}{period:5s}"
             "{azimuth:6s}{velocity:5s}{ain:4s}{azimuthres:3s}{timeres:5s}  "
             "{distance:5s}{caz:4s} ")
         # Note that pick seconds rounding only works because SEISAN does not


### PR DESCRIPTION
### What does this PR do?

Previously the time-uncertainty in origin-time was over-writing the event RMS (in origin.quality.standard_error), this PR moves the time-uncertainty to origin.time_errors.  Note that this is a bug-fix, but it is a bug in master, hence pulling to master.

This also fixes a small pick-time formatting bug, that didn't cause issues with SEISAN, but looked a little ugly: the seconds of pick-time was left-justified rather than right-justified.

### Why was it initiated?  Any relevant Issues?

I spotted it when trying to get at the RMS.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
