### PR TITLE
Fix gcf reading at Py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: PYTHON_VERSION=3.6
     - os: linux
       env: PYTHON_VERSION=3.7
+    - os: linux
+      env: PYTHON_VERSION=3.8
     # - os: linux
     #   env: PYTHON_VERSION=3.5 ARCHITECTURE_32BIT="True"
     #   addons:
@@ -38,6 +40,8 @@ matrix:
       env: PYTHON_VERSION=3.6
     - os: osx
       env: PYTHON_VERSION=3.7
+    - os: osx
+      env: PYTHON_VERSION=3.8
 
 # mimick travis fast fail and rolling build setup from:
 # https://github.com/JuliaLang/julia/blob/master/.travis.yml

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -84,6 +84,8 @@ master:
      Python2 (see #2413)
    * fix an issue that could make small landmasses not get plotted in basemap
      plots (see #2471, #2477)
+ - obspy.io.gcf:
+   * Fixes Python 3.8 compatibility of GCF reader. (see #2505)
  - obspy.io.mseed:
    * Add ability to write int64 data to mseed if it can safely be downcast
      to int32 data, otherwise raises ObsPyMSEEDError. (see #2356)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,6 +66,14 @@ environment:
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Miniconda38"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Miniconda38-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+
 matrix:
     allow_failures:
       - PYTHON_VERSION: "3.5"

--- a/obspy/io/gcf/libgcf.py
+++ b/obspy/io/gcf/libgcf.py
@@ -55,7 +55,7 @@ def decode36(data):
             pos = imed - 10 + ord('A')
         else:
             pos = imed + ord('0')
-        c = chr(pos[0])
+        c = chr(pos)
         s = c + s
         data = data // 36
     return s
@@ -93,10 +93,18 @@ def read_data_block(f, headonly=False, channel_prefix="HH", **kwargs):
     sysid = np.frombuffer(sysid, count=1, dtype='>u4')
     if sysid >> 31 & 0b1 > 0:
         sysid = (sysid << 6) >> 6
-    sysid = decode36(sysid)
+    if isinstance(sysid, np.ndarray) and sysid.shape is (1,):
+        sysid = sysid[0]
+    else:
+        raise ValueError('sysid should be a single element np.ndarray')
+    sysid = decode36(sysid[0])
     # get Stream ID
     stid = np.frombuffer(f.read(4), count=1, dtype='>u4')
-    stid = decode36(stid)
+    if isinstance(stid, np.ndarray) and stid.shape is (1,):
+        stid = stid[0]
+    else:
+        raise ValueError('stid should be a single element np.ndarray')
+    stid = decode36(stid[0])
     # get Date & Time
     data = np.frombuffer(f.read(4), count=1, dtype='>u4')
     starttime = decode_date_time(data)

--- a/obspy/io/gcf/libgcf.py
+++ b/obspy/io/gcf/libgcf.py
@@ -93,18 +93,18 @@ def read_data_block(f, headonly=False, channel_prefix="HH", **kwargs):
     sysid = np.frombuffer(sysid, count=1, dtype='>u4')
     if sysid >> 31 & 0b1 > 0:
         sysid = (sysid << 6) >> 6
-    if isinstance(sysid, np.ndarray) and sysid.shape is (1,):
+    if isinstance(sysid, np.ndarray) and sysid.shape == (1,):
         sysid = sysid[0]
     else:
         raise ValueError('sysid should be a single element np.ndarray')
-    sysid = decode36(sysid[0])
+    sysid = decode36(sysid)
     # get Stream ID
     stid = np.frombuffer(f.read(4), count=1, dtype='>u4')
-    if isinstance(stid, np.ndarray) and stid.shape is (1,):
+    if isinstance(stid, np.ndarray) and stid.shape == (1,):
         stid = stid[0]
     else:
         raise ValueError('stid should be a single element np.ndarray')
-    stid = decode36(stid[0])
+    stid = decode36(stid)
     # get Date & Time
     data = np.frombuffer(f.read(4), count=1, dtype='>u4')
     starttime = decode_date_time(data)

--- a/obspy/io/gcf/libgcf.py
+++ b/obspy/io/gcf/libgcf.py
@@ -52,9 +52,10 @@ def decode36(data):
     while data:
         imed = data % 36
         if imed > 9:
-            c = chr(imed - 10 + ord('A'))
+            pos = imed - 10 + ord('A')
         else:
-            c = chr(imed + ord('0'))
+            pos = imed + ord('0')
+        c = chr(pos[0])
         s = c + s
         data = data // 36
     return s

--- a/setup.py
+++ b/setup.py
@@ -801,6 +801,7 @@ def setupPackage():
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Physics'],
         keywords=KEYWORDS,


### PR DESCRIPTION
As #2469 shown, in Py38 gcf reading was failing. It turned out that `char()` do not allow anymore to pass as an argument a list which is the case here. So I changed it to pass only first and only element of the list.

I tested on 3.8 and 3.6 on my machine, let's see what Travis will say.

Based on branch ci_py38, rebased on current master.

Closes #2469