### PR TITLE
QuakeML reading: Elements of "http://quakeml.org" native namespace in custom tags section ignored

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -128,6 +128,9 @@ master:
      (see #2106, #2098, #2095)
    * Catalogs with empty event description objects can be round-tripped (see
      #2339, #2340).
+   * Correctly handle QuakeML native namespaces (if they are not matching the
+     document root's namespace) as custom namespaces and parse them into
+     `.extra` (see #2466)
  - obspy.io.sac:
    * Fix bug writing inventory with SOH channels to SACPZ (see #2200).
  - obspy.io.segy:

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -92,7 +92,9 @@ class QuakeMLTestCase(unittest.TestCase):
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
             catalog = _read_quakeml(filename)
-        assert_no_extras(catalog)
+        # there are some custom namespace attributes
+        self.assertTrue(len(catalog[0].extra) == 3)
+        self.assertTrue(len(catalog[0].origins[0].extra) == 4)
         self.assertEqual(len(catalog), 1)
         self.assertEqual(catalog[0].event_type, 'quarry blast')
 

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1129,6 +1129,33 @@ class QuakeMLTestCase(unittest.TestCase):
         # the two catalogs should be equal
         self.assertEqual(cat1, cat2)
 
+    def test_native_namespace_in_extra(self):
+        """
+        Make sure that QuakeML tags that are not the same as the document
+        root's namespaces still are handled as custom tags (coming
+        after any expected/mandatory tags) and get parsed into extras section
+        properly.
+        """
+        custom1 = {
+            'value': u'11111',
+            'namespace': 'http://quakeml.org/xmlns/bed/9.99'}
+        custom2 = {
+            'value': u'22222',
+            'namespace': 'http://quakeml.org/xmlns/quakeml/8.87'}
+        extra = {'custom1': custom1, 'custom2': custom2}
+
+        cat = Catalog()
+        cat.extra = extra
+
+        with io.BytesIO() as buf:
+            cat.write(buf, format='QUAKEML')
+            buf.seek(0)
+            cat2 = read_events(buf, format='QUAKEML')
+
+        self.assertEqual(extra, cat2.extra)
+        self.assertIn(('custom1', custom1), cat2.extra.items())
+        self.assertIn(('custom2', custom2), cat2.extra.items())
+
 
 def suite():
     return unittest.makeSuite(QuakeMLTestCase, 'test')


### PR DESCRIPTION
When reading QuakeML files that contain custom elements which have a native `http://quakeml.org` namespace, these do not get properly deserialized into `.extra` dictionaries. Writing works, but reading back leaves them out.

```python
from obspy import Catalog, read_events

extra = {'my_tag_1': {'value': u'11111',
                      'namespace': 'http://quakeml.org/xmlns/quakeml/1.2'},
         'my_tag_2': {'value': u'22222',
                      'namespace': 'http://xxx.org/xmlns/quakeml/1.2'}}

cat = Catalog()
cat.extra = extra
cat.write('my_catalog.xml', format='QUAKEML')

cat2 = read_events('my_catalog.xml', format='QUAKEML')
print(cat2.extra)
```

xml output

```xml
<?xml version='1.0' encoding='utf-8'?>
<q:quakeml xmlns:ns0="http://xxx.org/xmlns/quakeml/1.2" xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
  <eventParameters publicID="smi:local/08724e77-3221-4989-ad8e-c6f0fc49d8bf">
    <ns0:my_tag_2>22222</ns0:my_tag_2>
    <q:my_tag_1>11111</q:my_tag_1>
  </eventParameters>
</q:quakeml>                                                                                                                                                                    
```

print output after running the read at end

```
AttribDict({'my_tag_2': AttribDict({'value': '22222', 'namespace': 'http://xxx.org/xmlns/quakeml/1.2'})})
```

