### PR TITLE
Allow writing of zero-sampling rate MiniSEED files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -101,6 +101,7 @@ master:
      to int32 data, otherwise raises ObsPyMSEEDError. (see #2356)
    * The recordanalyzer can now detect calibration blockettes 300, 310,
      and 320 (see #2370).
+   * Can now write zero sampling-rate traces. (see #2488, 2509)
  - obspy.io.nordic:
    * Add ability to read and write focal mechanisms and moment tensor
      information. (see #1924)

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -637,8 +637,9 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
         # of more than 100 microseconds, or if timing quality is set, \
         # Blockette 1001 will be written for every record.
         starttime = util._convert_datetime_to_mstime(trace.stats.starttime)
-        if starttime % 100 != 0 or \
-           (1.0 / trace.stats.sampling_rate * HPTMODULUS) % 100 != 0:
+        if starttime % 100 != 0 or (
+                trace.stats.sampling_rate and
+                (1.0 / trace.stats.sampling_rate * HPTMODULUS) % 100 != 0):
             use_blkt_1001 = True
 
         if hasattr(trace.stats, 'mseed') and \

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1609,8 +1609,11 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         with io.BytesIO() as buf:
             tr.write(buf, format="mseed")
             buf.seek(0, 0)
-            tr2 = read(buf)
+            tr2 = read(buf)[0]
 
+        # Delete meta-data that gets added during reading.
+        del tr2.stats["_format"]
+        del tr2.stats["mseed"]
         self.assertEqual(tr, tr2)
 
 

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1595,6 +1595,24 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         self.assertEqual(''.join(tr.data.astype(str)),
                          '001:00:00:00 REF TEK 130\r\n')
 
+    def test_reading_and_writing_zero_sampling_rate_traces(self):
+        """
+        LOG channels for example usually have sampling rates of zero.
+        """
+        tr = Trace(
+            data=np.linspace(0, 1, 10),
+            header={
+                "sampling_rate": 0.0,
+                "network": "AA",
+                "station": "CC",
+                "channel": "LOG"})
+        with io.BytesIO() as buf:
+            tr.write(buf, format="mseed")
+            buf.seek(0, 0)
+            tr2 = read(buf)
+
+        self.assertEqual(tr, tr2)
+
 
 def suite():
     return unittest.makeSuite(MSEEDReadingAndWritingTestCase, 'test')


### PR DESCRIPTION
Fixes #2488

Very simple fix as proposed by @megies. Also includes a test.