### PR TITLE
Geographic selection of inventory/network/station

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -95,7 +95,7 @@ master:
  - obspy.clients.iris:
    * results of distaz method are now returned as native floats (see #2499)
  - obspy.geodetics:
-   * new utility function `inside_geobounds()` to check wether an object is
+   * new utility function `inside_geobounds()` to check whether an object is
      inside a geographic bound (see #2515)
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,9 @@ master:
      #2405)
  - obspy.clients.iris:
    * results of distaz method are now returned as native floats (see #2499)
+ - obspy.geodetics:
+   * new utility function `inside_geobounds()` to check wether an object is
+     inside a geographic bound (see #2515)
  - obspy.imaging:
    * obspy-scan can now be used with wildcarded SEED IDs when specifying what
      to plot after scanning data (see #2227)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ master:
    * Fix a bug that was causing an exception being raised in `Response.plot()`
      because a float was being passed down to numpy.linspace as length of array
      (see #2533)
+   * Geographic select of inventory/network/station (see #2515)
  - obspy.clients.fdsn:
    * Add new `_discover_services` boolean flag to the Client, which allows the
      Client to skip the initial services query at instantiation.  This can

--- a/misc/docs/source/packages/obspy.geodetics.rst
+++ b/misc/docs/source/packages/obspy.geodetics.rst
@@ -10,8 +10,10 @@
        :nosignatures:
 
        ~base.calc_vincenty_inverse
+       ~base.degrees2kilometers
        ~base.gps2dist_azimuth
-       ~base.kilometer2degrees
+       ~base.inside_geobounds
+       ~base.kilometers2degrees
        ~base.locations2degrees
        ~flinnengdahl.FlinnEngdahl
 
@@ -27,4 +29,3 @@
        flinnengdahl
 
     .. comment to end block
-

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -531,7 +531,9 @@ class Inventory(ComparingObject):
 
     def select(self, network=None, station=None, location=None, channel=None,
                time=None, starttime=None, endtime=None, sampling_rate=None,
-               keep_empty=False):
+               keep_empty=False, minlatitude=None, maxlatitude=None,
+               minlongitude=None, maxlongitude=None, latitude=None,
+               longitude=None, minradius=None, maxradius=None):
         r"""
         Return a copy of the inventory filtered on various parameters.
 
@@ -597,10 +599,39 @@ class Inventory(ComparingObject):
             or at given point in time (i.e. channels starting after given time
             will not be shown).
         :type sampling_rate: float
+        :param sampling_rate: Only include channels whose sampling rate
+            matches the given sampling rate, in Hz (within absolute tolerance
+            of 1E-8 Hz and relative tolerance of 1E-5)
         :type keep_empty: bool
         :param keep_empty: If set to `True`, networks/stations that match
             themselves but have no matching child elements (stations/channels)
             will be included in the result.
+        :type minlatitude: float
+        :param minlatitude: Only include stations/channels with a latitude
+            larger than the specified minimum.
+        :type maxlatitude: float
+        :param maxlatitude: Only include stations/channels with a latitude
+            smaller than the specified maximum.
+        :type minlongitude: float
+        :param minlongitude: Only include stations/channels with a longitude
+            larger than the specified minimum.
+        :type maxlongitude: float
+        :param maxlongitude: Only include stations/channels with a longitude
+            smaller than the specified maximum.
+        :type latitude: float
+        :param latitude: Specify the latitude to be used for a radius
+            selection.
+        :type longitude: float
+        :param longitude: Specify the longitude to be used for a radius
+            selection.
+        :type minradius: float
+        :param minradius: Only include stations/channels within the specified
+            minimum number of degrees from the geographic point defined by the
+            latitude and longitude parameters.
+        :type maxradius: float
+        :param maxradius: Only include stations/channels within the specified
+            maximum number of degrees from the geographic point defined by the
+            latitude and longitude parameters.
         """
         networks = []
         for net in self.networks:
@@ -619,7 +650,11 @@ class Inventory(ComparingObject):
             net_ = net.select(
                 station=station, location=location, channel=channel, time=time,
                 starttime=starttime, endtime=endtime,
-                sampling_rate=sampling_rate, keep_empty=keep_empty)
+                sampling_rate=sampling_rate, keep_empty=keep_empty,
+                minlatitude=minlatitude, maxlatitude=maxlatitude,
+                minlongitude=minlongitude, maxlongitude=maxlongitude,
+                latitude=latitude, longitude=longitude,
+                minradius=minradius, maxradius=maxradius)
 
             # If the network previously had stations but no longer has any
             # and keep_empty is False: Skip the network.

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -477,8 +477,9 @@ class Network(BaseNode):
                 minlongitude=minlongitude, maxlongitude=maxlongitude,
                 latitude=latitude, longitude=longitude, minradius=minradius,
                 maxradius=maxradius)
-            if not inside_geobounds(sta, **geo_filters):
-                continue
+            if any(value is not None for value in geo_filters.values()):
+                if not inside_geobounds(sta, **geo_filters):
+                    continue
 
             has_channels = bool(sta.channels)
 

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -472,11 +472,12 @@ class Network(BaseNode):
                 if not sta.is_active(time=time, starttime=starttime,
                                      endtime=endtime):
                     continue
-            geo_filters = (minlatitude, maxlatitude,
-                           minlongitude, maxlongitude,
-                           latitude, longitude,
-                           minradius, maxradius)
-            if not inside_geobounds(sta, *geo_filters):
+            geo_filters = dict(
+                minlatitude=minlatitude, maxlatitude=maxlatitude,
+                minlongitude=minlongitude, maxlongitude=maxlongitude,
+                latitude=latitude, longitude=longitude, minradius=minradius,
+                maxradius=maxradius)
+            if not inside_geobounds(sta, **geo_filters):
                 continue
 
             has_channels = bool(sta.channels)

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -459,11 +459,12 @@ class Station(BaseNode):
                 if not cha.is_active(time=time, starttime=starttime,
                                      endtime=endtime):
                     continue
-            geo_filters = (minlatitude, maxlatitude,
-                           minlongitude, maxlongitude,
-                           latitude, longitude,
-                           minradius, maxradius)
-            if not inside_geobounds(cha, *geo_filters):
+            geo_filters = dict(
+                minlatitude=minlatitude, maxlatitude=maxlatitude,
+                minlongitude=minlongitude, maxlongitude=maxlongitude,
+                latitude=latitude, longitude=longitude, minradius=minradius,
+                maxradius=maxradius)
+            if not inside_geobounds(cha, **geo_filters):
                 continue
 
             channels.append(cha)

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -464,8 +464,9 @@ class Station(BaseNode):
                 minlongitude=minlongitude, maxlongitude=maxlongitude,
                 latitude=latitude, longitude=longitude, minradius=minradius,
                 maxradius=maxradius)
-            if not inside_geobounds(cha, **geo_filters):
-                continue
+            if any(value is not None for value in geo_filters.values()):
+                if not inside_geobounds(cha, **geo_filters):
+                    continue
 
             channels.append(cha)
         sta = copy.copy(self)

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -440,6 +440,23 @@ class InventoryTestCase(unittest.TestCase):
         self.assertEqual(
             sum(len(sta) for net in inv.select(station="R?O*") for sta in net),
             9)
+        self.assertEqual(
+            sum(len(sta) for net in inv.select(
+                minlatitude=47.5, maxlatitude=47.9,
+                minlongitude=11.9, maxlongitude=13.3) for sta in net),
+            9)
+        self.assertEqual(
+            sum(len(sta) for net in inv.select(
+                latitude=48, longitude=13,
+                maxradius=0.5) for sta in net),
+            9)
+
+        # Only WET Station.
+        self.assertEqual(
+            sum(len(sta) for net in inv.select(
+                latitude=48, longitude=13,
+                minradius=0.5, maxradius=1.15) for sta in net),
+            9)
 
         # Most parameters are just passed to the Network.select() method.
         select_kwargs = {
@@ -450,7 +467,15 @@ class InventoryTestCase(unittest.TestCase):
             "time": UTCDateTime(2001, 1, 1),
             "sampling_rate": 123.0,
             "starttime": UTCDateTime(2002, 1, 1),
-            "endtime": UTCDateTime(2003, 1, 1)}
+            "endtime": UTCDateTime(2003, 1, 1),
+            "minlatitude": None,
+            "maxlatitude": None,
+            "minlongitude": None,
+            "maxlongitude": None,
+            "latitude": None,
+            "longitude": None,
+            "minradius": None,
+            "maxradius": None}
         with mock.patch("obspy.core.inventory.network.Network.select") as p:
             p.return_value = obspy.core.inventory.network.Network("BW")
             inv.select(**select_kwargs)

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -211,6 +211,14 @@ class NetworkTestCase(unittest.TestCase):
                              net.select(station="F*", keep_empty=True)), 12)
         self.assertEqual(sum(len(i) for i in
                              net.select(station="WET", keep_empty=True)), 9)
+        self.assertEqual(sum(len(i) for i in
+                             net.select(
+                                minlatitude=47.89, maxlatitude=48.39,
+                                minlongitude=10.88, maxlongitude=11.98)), 12)
+        self.assertEqual(sum(len(i) for i in
+                             net.select(
+                                latitude=48.12, longitude=12.24,
+                                maxradius=1)), 12)
 
         # Test the keep_empty flag.
         net_2 = net.select(time=UTCDateTime(2000, 1, 1))
@@ -222,15 +230,23 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(len(net_2), 1)
         self.assertEqual(sum(len(i) for i in net_2), 0)
 
-        # location, channel, time, starttime, endtime, and sampling_rate are
-        # also passed on to the station selector.
+        # location, channel, time, starttime, endtime, and sampling_rate
+        # and geographic parameters are also passed on to the station selector.
         select_kwargs = {
             "location": "00",
             "channel": "EHE",
             "time": UTCDateTime(2001, 1, 1),
             "sampling_rate": 123.0,
             "starttime": UTCDateTime(2002, 1, 1),
-            "endtime": UTCDateTime(2003, 1, 1)}
+            "endtime": UTCDateTime(2003, 1, 1),
+            "minlatitude": None,
+            "maxlatitude": None,
+            "minlongitude": None,
+            "maxlongitude": None,
+            "latitude": None,
+            "longitude": None,
+            "minradius": None,
+            "maxradius": None}
 
         with mock.patch("obspy.core.inventory.station.Station.select") as p:
             p.return_value = obspy.core.inventory.station.Station("FUR", 1,

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -182,6 +182,21 @@ class StationTestCase(unittest.TestCase):
         self.assertEqual(len(sta.select(sampling_rate=1.0 + 1E-6)), 3)
         self.assertEqual(len(sta.select(sampling_rate=0.1 - 1E-6)), 3)
 
+        # Artificially set different coordinates for a channel of RJOB.
+        sta = read_inventory()[1][0]
+        sta[0].latitude = 47.9
+        sta[0].longitude = 12.9
+        self.assertEqual(len(sta.select(
+            minlatitude=47.8, maxlatitude=48,
+            minlongitude=12.8, maxlongitude=13)), 1)
+        self.assertEqual(len(sta.select(
+            latitude=47.95, longitude=12.95, maxradius=0.1)), 1)
+        self.assertEqual(len(sta.select(
+            latitude=47.95, longitude=12.95, minradius=0.1)), 2)
+        self.assertEqual(len(sta.select(
+            latitude=47.95, longitude=12.95,
+            minradius=0.08, maxradius=0.1)), 0)
+
 
 def suite():
     return unittest.makeSuite(StationTestCase, 'test')

--- a/obspy/geodetics/__init__.py
+++ b/obspy/geodetics/__init__.py
@@ -13,7 +13,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-from .base import (calc_vincenty_inverse, degrees2kilometers, gps2dist_azimuth,
+from .base import (calc_vincenty_inverse, degrees2kilometers,
+                   gps2dist_azimuth, inside_geobounds,
                    kilometer2degrees, kilometers2degrees, locations2degrees)
 from .flinnengdahl import FlinnEngdahl
 

--- a/obspy/geodetics/base.py
+++ b/obspy/geodetics/base.py
@@ -398,7 +398,7 @@ def mean_longitude(longitudes):
     return mean_longitude
 
 
-def inside_geobounds(object, minlatitude=None, maxlatitude=None,
+def inside_geobounds(obj, minlatitude=None, maxlatitude=None,
                      minlongitude=None, maxlongitude=None,
                      latitude=None, longitude=None,
                      minradius=None, maxradius=None):
@@ -409,8 +409,8 @@ def inside_geobounds(object, minlatitude=None, maxlatitude=None,
     The object must have ``latitude`` and ``longitude`` attributes, expressed
     in degrees.
 
-    :type object: object
-    :param object: An object with `latitude` and `longitude` attributes.
+    :type obj: object
+    :param obj: An object with `latitude` and `longitude` attributes.
     :type minlatitude: float
     :param minlatitude: Minimum latitude in degrees.
     :type maxlatitude: float
@@ -451,16 +451,16 @@ def inside_geobounds(object, minlatitude=None, maxlatitude=None,
     ...                  minradius=1, maxradius=10)
     True
     """
-    if not hasattr(object, 'latitude') or not hasattr(object, 'longitude'):
+    if not hasattr(obj, 'latitude') or not hasattr(obj, 'longitude'):
         raise AttributeError(
             'Object must have "latitude" and "longitude" attributes.')
-    olatitude = object.latitude
-    _check_latitude(olatitude, 'object.latitude')
+    olatitude = obj.latitude
+    _check_latitude(olatitude, 'obj.latitude')
     _check_latitude(minlatitude, 'minlatitude')
     _check_latitude(maxlatitude, 'maxlatitude')
     _check_latitude(latitude, 'latitude')
     # Make sure longitudes are between -180 to 180 degrees
-    olongitude = _normalize_longitude(object.longitude)
+    olongitude = _normalize_longitude(obj.longitude)
     minlongitude = _normalize_longitude(minlongitude)
     maxlongitude = _normalize_longitude(maxlongitude)
     longitude = _normalize_longitude(longitude)


### PR DESCRIPTION

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Add geographic options to `[Inventory,Network,Station].select()`, following
the same syntax of `Client.get_stations()`.

Also add documentation to "sampling_rate" parameter.

### Why was it initiated?  Any relevant Issues?

Sometimes datacenter provides preassembled datasets with data and metadata for all the stations in the network (ex.: http://cnt.rm.ingv.it/event/23558121 --> Download). This PR adds possibility of filtering metadata based on geographic parameters, following the same syntax of `Client.get_stations()`.
Not covered by this PR is the possibility of selecting data in stream based on the inventory content (next time ;-)

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .