### PR TITLE
sc3ml read_inventory performance issue on large files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ obspy/taup/tests/images/testrun/
 misc/docker_tests/temp/
 # Temporary dir for the anaconda builds.
 misc/installer/anaconda/conda_builds
+.vscode/**

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,8 +51,8 @@ master:
      the last character of the SEED channel (see #2484).
    * Fixed a bug in Stream.plot(type='section', reftime=..., ...) that caused
      wrong relative start times of traces relative to given reftime (see #2493)
-   * Fixed path case issue that was causing unit test failure on Windows (see
-     #2296)
+   * Fixed a Windows-specific path case issue in a helper function that returns
+     a list of untracked files in the git repository (see #2296)
  - obspy.clients.fdsn:
    * Add new `_discover_services` boolean flag to the Client, which allows the
      Client to skip the initial services query at instantiation.  This can
@@ -136,11 +136,8 @@ master:
      in it (see #2358, #1393)
  - obspy.io.seiscomp:
    * Very large performance improvement reading large sc3ml inventory files by
-     pre-indexing sensors, dataloggers and responses (see #2296).
-   * Sped up reading sc3ml inventory files by reducing number of calls to
-     element.find (see #2296).
-   * Fixed bug in warnings filters that depended on order of execution (see
-     #2296).
+     pre-indexing sensors, dataloggers and responses and reducing lxml calls
+     (see #2296).
  - obspy.io.quakeml:
    * Allow writing invalid ids but raise a warning
      (see #2104, #2090, #2093, #1872).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,8 @@ master:
      the last character of the SEED channel (see #2484).
    * Fixed a bug in Stream.plot(type='section', reftime=..., ...) that caused
      wrong relative start times of traces relative to given reftime (see #2493)
+   * Fixed path case issue that was causing unit test failure on Windows (see
+     #2296)
  - obspy.clients.fdsn:
    * Add new `_discover_services` boolean flag to the Client, which allows the
      Client to skip the initial services query at instantiation.  This can
@@ -132,6 +134,13 @@ master:
  - obspy.io.segy:
    * show nice error message when trying to write a trace with too many samples
      in it (see #2358, #1393)
+ - obspy.io.seiscomp:
+   * Very large performance improvement reading large sc3ml inventory files by
+     pre-indexing sensors, dataloggers and responses (see #2296).
+   * Sped up reading sc3ml inventory files by reducing number of calls to
+     element.find (see #2296).
+   * Fixed bug in warnings filters that depended on order of execution (see
+     #2296).
  - obspy.io.quakeml:
    * Allow writing invalid ids but raise a warning
      (see #2104, #2090, #2093, #1872).

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -258,7 +258,7 @@ def get_untracked_files_from_git():
         git_root_dir = p.decode().strip()
         if git_root_dir:
             git_root_dir = os.path.abspath(git_root_dir)
-        if git_root_dir != dir_:
+        if os.path.normcase(git_root_dir) != os.path.normcase(dir_):
             raise ValueError('Git root directory (%s) does not match expected '
                              'path (%s).' % (git_root_dir, dir_))
         p = check_output(['git', 'status', '-u', '--porcelain'],

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -465,7 +465,6 @@ def _read_channel(instrumentation_register, cha_element, _ns):
     numerator = _tag2obj(cha_element, _ns("sampleRateNumerator"), int)
     denominator = _tag2obj(cha_element, _ns("sampleRateDenominator"), int)
 
-    # If numerator is zero, set rate to zero irrespective of the denominator.
     # If numerator is non-zero and denominator zero, will raise
     # ZeroDivisionError.
     rate = numerator / denominator if numerator != 0 else 0

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -425,8 +425,8 @@ def _read_channel(instrumentation_register, cha_element, _ns):
 
         for resp_type in instrumentation_register["responses"].keys():
             found_response = instrumentation_register["responses"][resp_type].get(response_id)
-            if found_response:
-                response_elements += found_response
+            if found_response is not None:
+                response_elements.append(found_response)
 
         if len(response_elements) == 0:
             msg = ("Could not find response tag with public ID "

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -186,9 +186,10 @@ def _tag2obj(element, tag, convert):
     try:
         # Single closing tags e.g. <analogueFilterChain/>.text return None
         # and will be converted to a string 'None' when convert is str
-        if element.find(tag).text is None:
+        found_tag_text = element.find(tag).text
+        if found_tag_text is None:
             return None
-        return convert(element.find(tag).text)
+        return convert(found_tag_text)
     except Exception:
         None
 

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -22,6 +22,7 @@ import re
 import warnings
 
 from lxml import etree
+from collections import defaultdict
 
 import obspy
 from obspy.core.util.obspy_types import (ComplexWithUncertainties,
@@ -111,11 +112,58 @@ def _read_sc3ml(path_or_file_object):
     module = None
     module_uri = None
 
+    # Find the inventory root element. (Only finds the first. We expect only one, so any more than
+    # that will be ignored.)
+    inv_element = root.find(_ns("Inventory"))
+
+    # Pre-generate a dictionary of the sensors, dataloggers and responses to avoid costly linear
+    # search when parsing network nodes later.
+    # Register sensors
+    sensors = {}
+    for sensor_element in inv_element.findall(_ns("sensor")):
+        public_id = sensor_element.get("publicID")
+        if public_id:
+            if public_id in sensors:
+                msg = ("Found multiple matching sensor tags with the same publicID '{}'.".format(public_id))
+                raise obspy.ObsPyException(msg)
+            else:
+                sensors[public_id] = sensor_element
+    # Register dataloggers
+    dataloggers = {}
+    for datalogger_element in inv_element.findall(_ns("datalogger")):
+        public_id = datalogger_element.get("publicID")
+        if public_id:
+            if public_id in dataloggers:
+                msg = ("Found multiple matching datalogger tags with the same publicID '{}'.".format(public_id))
+                raise obspy.ObsPyException(msg)
+            else:
+                dataloggers[public_id] = datalogger_element
+    # Register reponses
+    responses = {
+        "responsePAZ": {},
+        "responsePolynomial": {},
+        "responseFIR": {}
+    }
+    for response_type in responses.keys():
+        for response_element in inv_element.findall(_ns(response_type)):
+            public_id = response_element.get("publicID")
+            if public_id:
+                if public_id in responses[response_type]:
+                    msg = ("Found multiple matching {} tags with the same publicID '{}'.".format(response_type, public_id))
+                    raise obspy.ObsPyException(msg)
+                else:
+                    responses[response_type][public_id] = response_element
+    # Organize all the collection instrument information into a unified intrumentation register.
+    instrumentation_register = {
+        "sensors": sensors,
+        "dataloggers": dataloggers,
+        "responses": responses
+    }
+
     # Collect all networks from the sc3ml inventory
     networks = []
-    inv_element = root.find(_ns("Inventory"))
     for net_element in inv_element.findall(_ns("network")):
-        networks.append(_read_network(inv_element, net_element, _ns))
+        networks.append(_read_network(instrumentation_register, net_element, _ns))
 
     return obspy.core.inventory.Inventory(networks=networks, source=source,
                                           sender=sender, created=created,
@@ -141,12 +189,12 @@ def _tag2obj(element, tag, convert):
         None
 
 
-def _read_network(inventory_root, net_element, _ns):
+def _read_network(instrumentation_register, net_element, _ns):
 
     """
     Reads the network structure
 
-    :param inventory_root: base inventory element of sc3ml
+    :param instrumentation_register: register of instrumentation metadata
     :param net_element: network element to be read
     :param _ns: namespace
     """
@@ -168,7 +216,7 @@ def _read_network(inventory_root, net_element, _ns):
     # Collect the stations
     stations = []
     for sta_element in net_element.findall(_ns("station")):
-        stations.append(_read_station(inventory_root, sta_element, _ns))
+        stations.append(_read_station(instrumentation_register, sta_element, _ns))
     network.stations = stations
 
     return network
@@ -189,12 +237,12 @@ def _get_restricted_status(element, _ns):
         return 'closed'
 
 
-def _read_station(inventory_root, sta_element, _ns):
+def _read_station(instrumentation_register, sta_element, _ns):
 
     """
     Reads the station structure
 
-    :param inventory_root: base inventory element of sc3ml
+    :param instrumentation_register: register of instrumentation metadata
     :param sta_element: station element to be read
     :param _ns: name space
     """
@@ -231,7 +279,7 @@ def _read_station(inventory_root, sta_element, _ns):
     channels = []
     for sen_loc_element in sta_element.findall(_ns("sensorLocation")):
         for channel in sen_loc_element.findall(_ns("stream")):
-            channels.append(_read_channel(inventory_root, channel, _ns))
+            channels.append(_read_channel(instrumentation_register, channel, _ns))
 
     station.channels = channels
 
@@ -314,12 +362,13 @@ def _read_sensor(equip_element, _ns):
         removal_date=None, calibration_dates=None)
 
 
-def _read_channel(inventory_root, cha_element, _ns):
+def _read_channel(instrumentation_register, cha_element, _ns):
 
     """
     reads channel element from sc3ml format
 
-    :param sta_element: channel element
+    :param instrumentation_register: register of instrumentation metadata
+    :param cha_element: channel element
     :param _ns: namespace
     """
 
@@ -364,19 +413,21 @@ def _read_channel(inventory_root, cha_element, _ns):
     # obtain the sensorID and link to particular publicID <sensor> element
     # in the inventory base node
     sensor_id = cha_element.get("sensor")
-    sensor_element = inventory_root.find(_ns("sensor[@publicID='" + sensor_id +
-                                             "']"))
+    sensor_element = instrumentation_register["sensors"].get(sensor_id)
+
     # obtain the poles and zeros responseID and link to particular
     # <responsePAZ> publicID element in the inventory base node
     if (sensor_element is not None and
-       sensor_element.get("response") is not None):
+        sensor_element.get("response") is not None):
 
         response_id = sensor_element.get("response")
         response_elements = []
 
-        for resp_type in ['responsePAZ', 'responsePolynomial']:
-            search = "{}[@publicID='{}']".format(resp_type, response_id)
-            response_elements += inventory_root.findall(_ns(search))
+        for resp_type in instrumentation_register["responses"].keys():
+            found_response = instrumentation_register["responses"][resp_type].get(response_id)
+            if found_response:
+                response_elements += found_response
+
         if len(response_elements) == 0:
             msg = ("Could not find response tag with public ID "
                    "'{}'.".format(response_id))
@@ -392,8 +443,7 @@ def _read_channel(inventory_root, cha_element, _ns):
     # obtain the dataloggerID and link to particular <responsePAZ> publicID
     # element in the inventory base node
     datalogger_id = cha_element.get("datalogger")
-    search = "datalogger[@publicID='" + datalogger_id + "']"
-    data_log_element = inventory_root.find(_ns(search))
+    data_log_element = instrumentation_register["dataloggers"].get(datalogger_id)
 
     channel.restricted_status = _get_restricted_status(cha_element, _ns)
 
@@ -459,7 +509,7 @@ def _read_channel(inventory_root, cha_element, _ns):
         if digital_filter_chain is not None:
             response_fir_id = digital_filter_chain.split(" ")
 
-    channel.response = _read_response(inventory_root, sensor_element,
+    channel.response = _read_response(instrumentation_register, sensor_element,
                                       response_element, cha_element,
                                       data_log_element, _ns,
                                       channel.sample_rate,
@@ -494,12 +544,12 @@ def _read_instrument_sensitivity(sen_element, cha_element, _ns):
     return sensitivity
 
 
-def _read_response(root, sen_element, resp_element, cha_element,
+def _read_response(instrumentation_register, sen_element, resp_element, cha_element,
                    data_log_element, _ns, samp_rate, fir, analogue):
     """
     reads response from sc3ml format
 
-    :param
+    :param instrumentation_register: register of instrumentation metadata
     :param _ns: namespace
     """
     response = obspy.core.inventory.response.Response()
@@ -533,8 +583,7 @@ def _read_response(root, sen_element, resp_element, cha_element,
         for fir_id in fir:
             # get the particular fir stage decimation factor
             # multiply the decimated sample rate by this factor
-            search = "responseFIR[@publicID='" + fir_id + "']"
-            fir_element = root.find(_ns(search))
+            fir_element = instrumentation_register["responses"]["responseFIR"].get(fir_id)
             if fir_element is None:
                 continue
             dec_fac = _tag2obj(fir_element, _ns("decimationFactor"), int)
@@ -573,8 +622,7 @@ def _read_response(root, sen_element, resp_element, cha_element,
     # Output unit: V
     if len(analogue):
         for analogue_id in analogue:
-            search = "responsePAZ[@publicID='" + analogue_id + "']"
-            analogue_element = root.find(_ns(search))
+            analogue_element = instrumentation_register["responses"]["responsePAZ"].get(analogue_id)
             if analogue_element is None:
                 msg = ('Analogue responsePAZ not in inventory:'
                        '%s, stopping before stage %i') % (analogue_id, stage)
@@ -602,8 +650,7 @@ def _read_response(root, sen_element, resp_element, cha_element,
     # Input unit: COUNTS
     # Output unit: COUNTS
     for fir_id, rate in zip(fir, fir_stage_rates):
-        search = "responseFIR[@publicID='" + fir_id + "']"
-        stage_element = root.find(_ns(search))
+        stage_element = instrumentation_register["responses"]["responseFIR"].get(fir_id)
         if stage_element is None:
             msg = ("fir response not in inventory: %s, stopping correction"
                    "before stage %i") % (fir_id, stage)

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -143,7 +143,8 @@ def _read_sc3ml(path_or_file_object):
     responses = {
         "responsePAZ": {},
         "responsePolynomial": {},
-        "responseFIR": {}
+        "responseFIR": {},
+        "responseIIR": {}
     }
     for response_type in responses.keys():
         for response_element in inv_element.findall(_ns(response_type)):

--- a/obspy/io/seiscomp/tests/data/EB_response_sc3ml
+++ b/obspy/io/seiscomp/tests/data/EB_response_sc3ml
@@ -1,2 +1,189 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7" version="0.7"><Inventory><sensor publicID="Sensor#20121207153142.207937.15385" name="EBR.2002.091.HE" response="ResponsePAZ#20121207153142.208772.15386"><description>STS-2</description><model>STS-2</model><unit>M/S</unit><type>STS-2</type><remark/></sensor><sensor publicID="Sensor#20121207153142.216173.15390" name="EBR.2002.091.HN" response="ResponsePAZ#20121207153142.21653.15391"><description>STS-2</description><model>STS-2</model><type>STS-2</type><unit>M/S</unit><remark/></sensor><sensor publicID="Sensor#20121207153142.223721.15395" name="EBR.2002.091.HZ" response="ResponsePAZ#20121207153142.224077.15396"><description>STS-2</description><model>STS-2</model><type>STS-2</type><unit>M/S</unit><remark/></sensor><datalogger publicID="Datalogger#20121207153142.199696.15381" name="EBR.2002.091.H"><description>EBR.2002.091.H</description><gain>422552</gain><maxClockDrift>0</maxClockDrift><remark/><decimation sampleRateNumerator="40" sampleRateDenominator="1"><analogueFilterChain/><digitalFilterChain>ResponseFIR#20121207153142.218657.15392 ResponseFIR#20121207153142.220807.15393 ResponseFIR#20121207153142.222609.15394</digitalFilterChain></decimation></datalogger><responsePAZ publicID="ResponsePAZ#20121207153142.208772.15386" name="EBR.2002.091.HE"><type>A</type><gain>1500</gain><gainFrequency>1</gainFrequency><normalizationFactor>2.3524e+17</normalizationFactor><normalizationFrequency>1</normalizationFrequency><numberOfZeros>9</numberOfZeros><numberOfPoles>14</numberOfPoles><zeros>(-5907,-3411)  (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros><poles>(-0.037,0.037)  (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles><remark/></responsePAZ><responsePAZ publicID="ResponsePAZ#20121207153142.21653.15391" name="EBR.2002.091.HN"><type>A</type><gain>1500</gain><gainFrequency>1</gainFrequency><normalizationFactor>2.3524e+17</normalizationFactor><normalizationFrequency>1</normalizationFrequency><numberOfZeros>9</numberOfZeros><numberOfPoles>14</numberOfPoles><zeros>(-5907,-3411) (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros><poles>(-0.037,0.037) (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles><remark/></responsePAZ><responsePAZ publicID="ResponsePAZ#20121207153142.224077.15396" name="EBR.2002.091.HZ"><type>A</type><gain>1500</gain><gainFrequency>1</gainFrequency><normalizationFactor>2.3524e+17</normalizationFactor><normalizationFrequency>1</normalizationFrequency><numberOfZeros>9</numberOfZeros><numberOfPoles>14</numberOfPoles><zeros>(-5907,-3411) (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros><poles>(-0.037,0.037) (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles><remark/></responsePAZ><responseFIR publicID="ResponseFIR#20121207153142.218657.15392" name="EBR..BHZ.2002.091.stage_3"><gain>1</gain><decimationFactor>5</decimationFactor><delay>0</delay><correction>0</correction><numberOfCoefficients>160</numberOfCoefficients><symmetry>A</symmetry><coefficients>0.000122702 0.000487772 0.00137444 0.00317439 0.0064039 0.0116563 0.0195096 0.0303968 0.0444432 0.0613064 0.0800596 0.099153 0.116493 0.129658 0.136239 0.134259 0.122607 0.101396 0.0721513 0.0377665 0.00218767 -0.030141 -0.0549948 -0.0691204 -0.0708734 -0.0605967 -0.0406432 -0.0150078 0.0113818 0.0335861 0.0476023 0.0511449 0.0440846 0.0284415 0.00792673 -0.0128754 -0.0295073 -0.0385979 -0.0385691 -0.0299301 -0.0150931 0.00223832 0.0179618 0.0285378 0.0317906 0.0273641 0.0167307 0.00276538 -0.0110038 -0.0212739 -0.0257575 -0.0236935 -0.0159616 -0.00478775 0.00687099 0.0160974 0.0207398 0.0199111 0.014146 0.00519124 -0.00450192 -0.012438 -0.0167151 -0.0164772 -0.012073 -0.00489628 0.00303413 0.00963288 0.013291 0.0132627 0.00980445 0.00404402 -0.00236986 -0.00773217 -0.0107308 -0.0107631 -0.00804452 -0.00349412 0.00155739 0.00574836 0.00804754 0.00800144 0.00581021 0.0022247 -0.00169532 -0.00488659 -0.00656448 -0.00640827 -0.00460787 -0.00177043 0.00127653 0.00372379 0.00499322 0.00486975 0.00352424 0.00143131 -0.000786368 -0.0025386 -0.00342105 -0.00330322 -0.00233405 -0.000871405 0.00063734 0.0017854 0.00231135 0.00215261 0.00143861 0.0004328 -0.000555537 -0.00126165 -0.00153162 -0.00135015 -0.000827507 -0.000152813 0.000468642 0.000874068 0.000982688 0.000806979 0.000436045 4.7845e-07 -0.000369898 -0.000582565 -0.000602332 -0.00045285 -0.000201922 6.47544e-05 0.000270714 0.000368176 0.000347351 0.000233553 7.41256e-05 -7.82947e-05 -0.000182015 -0.00021673 -0.000184688 -0.000106498 -1.31074e-05 6.60491e-05 0.000111544 0.000116734 8.79112e-05 4.01788e-05 -9.15771e-06 -4.52785e-05 -6.04436e-05 -5.52841e-05 -3.53122e-05 -9.37856e-06 1.27137e-05 2.57777e-05 2.85097e-05 2.18128e-05 1.04925e-05 -5.30604e-07 -8.71451e-06 -1.1724e-05 -1.05914e-05 -7.13148e-06 -3.92333e-06 1.33538e-05</coefficients><remark/></responseFIR><responseFIR publicID="ResponseFIR#20121207153142.220807.15393" name="EBR..BHZ.2002.091.stage_4"><gain>1</gain><decimationFactor>2</decimationFactor><delay>0</delay><correction>0</correction><numberOfCoefficients>96</numberOfCoefficients><symmetry>A</symmetry><coefficients>0.00158748 0.0125059 0.0499939 0.131099 0.245179 0.332017 0.307634 0.143493 -0.0721612 -0.182592 -0.108383 0.0573389 0.134413 0.0507088 -0.0787399 -0.0953076 0.00798777 0.0875963 0.0437628 -0.0524285 -0.0668836 0.0113016 0.0650235 0.0222038 -0.0470865 -0.0420307 0.0224986 0.0476652 0.0011739 -0.0419493 -0.0191002 0.0292177 0.0291722 -0.0139009 -0.0314879 -0.000359995 0.0276296 0.0111628 -0.0199142 -0.0174256 0.0107445 0.0192093 -0.00213721 -0.0173854 -0.00454401 0.0132485 0.00866123 -0.00817185 -0.0102821 0.00313511 0.00949588 0.000388783 -0.00804331 -0.0032968 0.00537866 0.00452224 -0.00275848 -0.00448416 0.000726857 0.00373429 0.000587488 -0.0027126 -0.00126149 0.00170907 0.00145636 -0.000881505 -0.00134665 0.000287937 0.0010829 7.88575e-05 -0.00077594 -0.000261277 0.000494951 0.000314315 -0.000274088 -0.000289878 0.000121231 0.000229791 -2.90765e-05 -0.000162258 -1.70402e-05 0.000103105 3.31562e-05 -5.89496e-05 -3.25909e-05 2.9931e-05 2.50748e-05 -1.31724e-05 -1.64432e-05 4.85992e-06 9.38671e-06 -1.23377e-06 -5.63954e-06 2.18465e-06 5.27728e-07 3.76714e-09</coefficients><remark/></responseFIR><responseFIR publicID="ResponseFIR#20121207153142.222609.15394" name="EBR..BHZ.2002.091.stage_5"><gain>1</gain><decimationFactor>5</decimationFactor><delay>0</delay><correction>0</correction><numberOfCoefficients>80</numberOfCoefficients><symmetry>C</symmetry><coefficients>4.03246e-05 7.45328e-05 0.000123455 0.000170189 0.000197311 0.000185489 0.000119346 -5.7231e-06 -0.000177923 -0.000367326 -0.00052951 -0.000615008 -0.000583235 -0.000417284 -0.000134952 0.000208333 0.000527709 0.00072819 0.000731259 0.00050192 6.78318e-05 -0.000477149 -0.000989158 -0.00130892 -0.00130736 -0.000930017 -0.000226254 0.000648348 0.00146171 0.00196322 0.00195662 0.00136772 0.000285463 -0.00104039 -0.00225068 -0.00296907 -0.00291274 -0.00199058 -0.000357354 0.00159884 0.00334097 0.00432376 0.00415564 0.002736 0.000323431 -0.00249475 -0.00493494 -0.0062252 -0.00583614 -0.00366897 -0.000139409 0.00388023 0.00726123 0.00891936 0.00814025 0.00483705 -0.000343478 -0.00611567 -0.0108478 -0.0129927 -0.0115499 -0.00643038 0.0013912 0.0100057 0.0169806 0.0199734 0.0174066 0.00902946 -0.00379497 -0.018183 -0.0302229 -0.0357833 -0.031469 -0.0155044 0.0116724 0.0472683 0.0865082 0.123467 0.152194 0.167894</coefficients><remark/></responseFIR><network publicID="Network/EB" code="EB"><start>1980-01-01T00:00:00.0000Z</start><description>SINGLE STATION</description><type>BB</type><netClass>p</netClass><archive>ODC</archive><restricted>false</restricted><shared>true</shared><remark/><station publicID="Station/EB/EBR/2002-04-01T00:00:00.0000Z" code="EBR"><start>2002-04-01T00:00:00.0000Z</start><description>EBRO ROQUETAS, SPAIN</description><latitude>40.820599</latitude><longitude>0.4933</longitude><elevation>40</elevation><place>EBRO ROQUETAS</place><country>SPAIN</country><affiliation>SINGLE STATION</affiliation><archive>ODC</archive><restricted>false</restricted><shared>true</shared><remark/><sensorLocation publicID="SensorLocation#20121207100904.25482.3625" code=""><start>2002-04-01T00:00:00.0000Z</start><latitude>40.820599</latitude><longitude>0.4933</longitude><elevation>40</elevation><stream code="BHE" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.207937.15385"><start>2002-04-01T00:00:00.0000Z</start><dataloggerSerialNumber>xxxx</dataloggerSerialNumber><dataloggerChannel>2</dataloggerChannel><sensorSerialNumber>yyyy</sensorSerialNumber><sensorChannel>2</sensorChannel><sampleRateNumerator>40</sampleRateNumerator><sampleRateDenominator>1</sampleRateDenominator><depth>0</depth><azimuth>90</azimuth><dip>0</dip><gain>620691000</gain><gainFrequency>1</gainFrequency><gainUnit>M/S</gainUnit><format>Steim2</format><flags>G</flags><restricted>false</restricted><shared>true</shared></stream><stream code="BHN" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.216173.15390"><start>2002-04-01T00:00:00.0000Z</start><dataloggerSerialNumber>xxxx</dataloggerSerialNumber><dataloggerChannel>1</dataloggerChannel><sensorSerialNumber>yyyy</sensorSerialNumber><sensorChannel>1</sensorChannel><sampleRateNumerator>40</sampleRateNumerator><sampleRateDenominator>1</sampleRateDenominator><depth>0</depth><azimuth>0</azimuth><dip>0</dip><gain>592855000</gain><gainFrequency>1</gainFrequency><gainUnit>M/S</gainUnit><format>Steim2</format><flags>G</flags><restricted>false</restricted><shared>true</shared></stream><stream code="BHZ" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.223721.15395"><start>2002-04-01T00:00:00.0000Z</start><dataloggerSerialNumber>xxxx</dataloggerSerialNumber><dataloggerChannel>0</dataloggerChannel><sensorSerialNumber>yyyy</sensorSerialNumber><sensorChannel>0</sensorChannel><sampleRateNumerator>40</sampleRateNumerator><sampleRateDenominator>1</sampleRateDenominator><depth>0</depth><azimuth>0</azimuth><dip>-90</dip><gain>633828000</gain><gainFrequency>1</gainFrequency><gainUnit>M/S</gainUnit><format>Steim2</format><flags>G</flags><restricted>false</restricted><shared>true</shared></stream></sensorLocation></station></network></Inventory></seiscomp>
+<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7" version="0.7">
+    <Inventory>
+        <sensor publicID="Sensor#20121207153142.207937.15385" name="EBR.2002.091.HE" response="ResponsePAZ#20121207153142.208772.15386">
+            <description>STS-2</description>
+            <model>STS-2</model>
+            <unit>M/S</unit>
+            <type>STS-2</type>
+            <remark/>
+        </sensor>
+        <sensor publicID="Sensor#20121207153142.216173.15390" name="EBR.2002.091.HN" response="ResponsePAZ#20121207153142.21653.15391">
+            <description>STS-2</description>
+            <model>STS-2</model>
+            <type>STS-2</type>
+            <unit>M/S</unit>
+            <remark/>
+        </sensor>
+        <sensor publicID="Sensor#20121207153142.223721.15395" name="EBR.2002.091.HZ" response="ResponsePAZ#20121207153142.224077.15396">
+            <description>STS-2</description>
+            <model>STS-2</model>
+            <type>STS-2</type>
+            <unit>M/S</unit>
+            <remark/>
+        </sensor>
+        <datalogger publicID="Datalogger#20121207153142.199696.15381" name="EBR.2002.091.H">
+            <description>EBR.2002.091.H</description>
+            <gain>422552</gain>
+            <maxClockDrift>0</maxClockDrift>
+            <remark/>
+            <decimation sampleRateNumerator="40" sampleRateDenominator="1">
+                <analogueFilterChain/>
+                <digitalFilterChain>ResponseFIR#20121207153142.218657.15392 ResponseFIR#20121207153142.220807.15393 ResponseFIR#20121207153142.222609.15394</digitalFilterChain>
+            </decimation>
+        </datalogger>
+        <responsePAZ publicID="ResponsePAZ#20121207153142.208772.15386" name="EBR.2002.091.HE">
+            <type>A</type>
+            <gain>1500</gain>
+            <gainFrequency>1</gainFrequency>
+            <normalizationFactor>2.3524e+17</normalizationFactor>
+            <normalizationFrequency>1</normalizationFrequency>
+            <numberOfZeros>9</numberOfZeros>
+            <numberOfPoles>14</numberOfPoles>
+            <zeros>(-5907,-3411)  (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros>
+            <poles>(-0.037,0.037)  (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles>
+            <remark/>
+        </responsePAZ>
+        <responsePAZ publicID="ResponsePAZ#20121207153142.21653.15391" name="EBR.2002.091.HN">
+            <type>A</type>
+            <gain>1500</gain>
+            <gainFrequency>1</gainFrequency>
+            <normalizationFactor>2.3524e+17</normalizationFactor>
+            <normalizationFrequency>1</normalizationFrequency>
+            <numberOfZeros>9</numberOfZeros>
+            <numberOfPoles>14</numberOfPoles>
+            <zeros>(-5907,-3411) (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros>
+            <poles>(-0.037,0.037) (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles>
+            <remark/>
+        </responsePAZ>
+        <responsePAZ publicID="ResponsePAZ#20121207153142.224077.15396" name="EBR.2002.091.HZ">
+            <type>A</type>
+            <gain>1500</gain>
+            <gainFrequency>1</gainFrequency>
+            <normalizationFactor>2.3524e+17</normalizationFactor>
+            <normalizationFrequency>1</normalizationFrequency>
+            <numberOfZeros>9</numberOfZeros>
+            <numberOfPoles>14</numberOfPoles>
+            <zeros>(-5907,-3411) (-5907,3411) (-683.9,-175.5) (-683.9,175.5) (-555.1,0) (-294.6,0) (-10.75,0) (0,0) (0,0)</zeros>
+            <poles>(-0.037,0.037) (-0.037,-0.037) (-6909,9208) (-6909,-9208) (-6227,0) (-4936,4713) (-4936,-4713) (-1391,0) (-556.8,-60.05) (-556.8,60.05) (-98.44,-442.8) (-98.44,442.8) (-10.95,0) (-255.1,0)</poles>
+            <remark/>
+        </responsePAZ>
+        <responseFIR publicID="ResponseFIR#20121207153142.218657.15392" name="EBR..BHZ.2002.091.stage_3">
+            <gain>1</gain>
+            <decimationFactor>5</decimationFactor>
+            <delay>0</delay>
+            <correction>0</correction>
+            <numberOfCoefficients>160</numberOfCoefficients>
+            <symmetry>A</symmetry>
+            <coefficients>0.000122702 0.000487772 0.00137444 0.00317439 0.0064039 0.0116563 0.0195096 0.0303968 0.0444432 0.0613064 0.0800596 0.099153 0.116493 0.129658 0.136239 0.134259 0.122607 0.101396 0.0721513 0.0377665 0.00218767 -0.030141 -0.0549948 -0.0691204 -0.0708734 -0.0605967 -0.0406432 -0.0150078 0.0113818 0.0335861 0.0476023 0.0511449 0.0440846 0.0284415 0.00792673 -0.0128754 -0.0295073 -0.0385979 -0.0385691 -0.0299301 -0.0150931 0.00223832 0.0179618 0.0285378 0.0317906 0.0273641 0.0167307 0.00276538 -0.0110038 -0.0212739 -0.0257575 -0.0236935 -0.0159616 -0.00478775 0.00687099 0.0160974 0.0207398 0.0199111 0.014146 0.00519124 -0.00450192 -0.012438 -0.0167151 -0.0164772 -0.012073 -0.00489628 0.00303413 0.00963288 0.013291 0.0132627 0.00980445 0.00404402 -0.00236986 -0.00773217 -0.0107308 -0.0107631 -0.00804452 -0.00349412 0.00155739 0.00574836 0.00804754 0.00800144 0.00581021 0.0022247 -0.00169532 -0.00488659 -0.00656448 -0.00640827 -0.00460787 -0.00177043 0.00127653 0.00372379 0.00499322 0.00486975 0.00352424 0.00143131 -0.000786368 -0.0025386 -0.00342105 -0.00330322 -0.00233405 -0.000871405 0.00063734 0.0017854 0.00231135 0.00215261 0.00143861 0.0004328 -0.000555537 -0.00126165 -0.00153162 -0.00135015 -0.000827507 -0.000152813 0.000468642 0.000874068 0.000982688 0.000806979 0.000436045 4.7845e-07 -0.000369898 -0.000582565 -0.000602332 -0.00045285 -0.000201922 6.47544e-05 0.000270714 0.000368176 0.000347351 0.000233553 7.41256e-05 -7.82947e-05 -0.000182015 -0.00021673 -0.000184688 -0.000106498 -1.31074e-05 6.60491e-05 0.000111544 0.000116734 8.79112e-05 4.01788e-05 -9.15771e-06 -4.52785e-05 -6.04436e-05 -5.52841e-05 -3.53122e-05 -9.37856e-06 1.27137e-05 2.57777e-05 2.85097e-05 2.18128e-05 1.04925e-05 -5.30604e-07 -8.71451e-06 -1.1724e-05 -1.05914e-05 -7.13148e-06 -3.92333e-06 1.33538e-05</coefficients>
+            <remark/>
+        </responseFIR>
+        <responseFIR publicID="ResponseFIR#20121207153142.220807.15393" name="EBR..BHZ.2002.091.stage_4">
+            <gain>1</gain>
+            <decimationFactor>2</decimationFactor>
+            <delay>0</delay>
+            <correction>0</correction>
+            <numberOfCoefficients>96</numberOfCoefficients>
+            <symmetry>A</symmetry>
+            <coefficients>0.00158748 0.0125059 0.0499939 0.131099 0.245179 0.332017 0.307634 0.143493 -0.0721612 -0.182592 -0.108383 0.0573389 0.134413 0.0507088 -0.0787399 -0.0953076 0.00798777 0.0875963 0.0437628 -0.0524285 -0.0668836 0.0113016 0.0650235 0.0222038 -0.0470865 -0.0420307 0.0224986 0.0476652 0.0011739 -0.0419493 -0.0191002 0.0292177 0.0291722 -0.0139009 -0.0314879 -0.000359995 0.0276296 0.0111628 -0.0199142 -0.0174256 0.0107445 0.0192093 -0.00213721 -0.0173854 -0.00454401 0.0132485 0.00866123 -0.00817185 -0.0102821 0.00313511 0.00949588 0.000388783 -0.00804331 -0.0032968 0.00537866 0.00452224 -0.00275848 -0.00448416 0.000726857 0.00373429 0.000587488 -0.0027126 -0.00126149 0.00170907 0.00145636 -0.000881505 -0.00134665 0.000287937 0.0010829 7.88575e-05 -0.00077594 -0.000261277 0.000494951 0.000314315 -0.000274088 -0.000289878 0.000121231 0.000229791 -2.90765e-05 -0.000162258 -1.70402e-05 0.000103105 3.31562e-05 -5.89496e-05 -3.25909e-05 2.9931e-05 2.50748e-05 -1.31724e-05 -1.64432e-05 4.85992e-06 9.38671e-06 -1.23377e-06 -5.63954e-06 2.18465e-06 5.27728e-07 3.76714e-09</coefficients>
+            <remark/>
+        </responseFIR>
+        <responseFIR publicID="ResponseFIR#20121207153142.222609.15394" name="EBR..BHZ.2002.091.stage_5">
+            <gain>1</gain>
+            <decimationFactor>5</decimationFactor>
+            <delay>0</delay>
+            <correction>0</correction>
+            <numberOfCoefficients>80</numberOfCoefficients>
+            <symmetry>C</symmetry>
+            <coefficients>4.03246e-05 7.45328e-05 0.000123455 0.000170189 0.000197311 0.000185489 0.000119346 -5.7231e-06 -0.000177923 -0.000367326 -0.00052951 -0.000615008 -0.000583235 -0.000417284 -0.000134952 0.000208333 0.000527709 0.00072819 0.000731259 0.00050192 6.78318e-05 -0.000477149 -0.000989158 -0.00130892 -0.00130736 -0.000930017 -0.000226254 0.000648348 0.00146171 0.00196322 0.00195662 0.00136772 0.000285463 -0.00104039 -0.00225068 -0.00296907 -0.00291274 -0.00199058 -0.000357354 0.00159884 0.00334097 0.00432376 0.00415564 0.002736 0.000323431 -0.00249475 -0.00493494 -0.0062252 -0.00583614 -0.00366897 -0.000139409 0.00388023 0.00726123 0.00891936 0.00814025 0.00483705 -0.000343478 -0.00611567 -0.0108478 -0.0129927 -0.0115499 -0.00643038 0.0013912 0.0100057 0.0169806 0.0199734 0.0174066 0.00902946 -0.00379497 -0.018183 -0.0302229 -0.0357833 -0.031469 -0.0155044 0.0116724 0.0472683 0.0865082 0.123467 0.152194 0.167894</coefficients>
+            <remark/>
+        </responseFIR>
+        <network publicID="Network/EB" code="EB">
+            <start>1980-01-01T00:00:00.0000Z</start>
+            <description>SINGLE STATION</description>
+            <type>BB</type>
+            <netClass>p</netClass>
+            <archive>ODC</archive>
+            <restricted>false</restricted>
+            <shared>true</shared>
+            <remark/>
+            <station publicID="Station/EB/EBR/2002-04-01T00:00:00.0000Z" code="EBR">
+                <start>2002-04-01T00:00:00.0000Z</start>
+                <description>EBRO ROQUETAS, SPAIN</description>
+                <latitude>40.820599</latitude>
+                <longitude>0.4933</longitude>
+                <elevation>40</elevation>
+                <place>EBRO ROQUETAS</place>
+                <country>SPAIN</country>
+                <affiliation>SINGLE STATION</affiliation>
+                <archive>ODC</archive>
+                <restricted>false</restricted>
+                <shared>true</shared>
+                <remark/>
+                <sensorLocation publicID="SensorLocation#20121207100904.25482.3625" code="">
+                    <start>2002-04-01T00:00:00.0000Z</start>
+                    <latitude>40.820599</latitude>
+                    <longitude>0.4933</longitude>
+                    <elevation>40</elevation>
+                    <stream code="BHE" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.207937.15385">
+                        <start>2002-04-01T00:00:00.0000Z</start>
+                        <dataloggerSerialNumber>xxxx</dataloggerSerialNumber>
+                        <dataloggerChannel>2</dataloggerChannel>
+                        <sensorSerialNumber>yyyy</sensorSerialNumber>
+                        <sensorChannel>2</sensorChannel>
+                        <sampleRateNumerator>40</sampleRateNumerator>
+                        <sampleRateDenominator>1</sampleRateDenominator>
+                        <depth>0</depth>
+                        <azimuth>90</azimuth>
+                        <dip>0</dip>
+                        <gain>620691000</gain>
+                        <gainFrequency>1</gainFrequency>
+                        <gainUnit>M/S</gainUnit>
+                        <format>Steim2</format>
+                        <flags>G</flags>
+                        <restricted>false</restricted>
+                        <shared>true</shared>
+                    </stream>
+                    <stream code="BHN" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.216173.15390">
+                        <start>2002-04-01T00:00:00.0000Z</start>
+                        <dataloggerSerialNumber>xxxx</dataloggerSerialNumber>
+                        <dataloggerChannel>1</dataloggerChannel>
+                        <sensorSerialNumber>yyyy</sensorSerialNumber>
+                        <sensorChannel>1</sensorChannel>
+                        <sampleRateNumerator>40</sampleRateNumerator>
+                        <sampleRateDenominator>1</sampleRateDenominator>
+                        <depth>0</depth>
+                        <azimuth>0</azimuth>
+                        <dip>0</dip>
+                        <gain>592855000</gain>
+                        <gainFrequency>1</gainFrequency>
+                        <gainUnit>M/S</gainUnit>
+                        <format>Steim2</format>
+                        <flags>G</flags>
+                        <restricted>false</restricted>
+                        <shared>true</shared>
+                    </stream>
+                    <stream code="BHZ" datalogger="Datalogger#20121207153142.199696.15381" sensor="Sensor#20121207153142.223721.15395">
+                        <start>2002-04-01T00:00:00.0000Z</start>
+                        <dataloggerSerialNumber>xxxx</dataloggerSerialNumber>
+                        <dataloggerChannel>0</dataloggerChannel>
+                        <sensorSerialNumber>yyyy</sensorSerialNumber>
+                        <sensorChannel>0</sensorChannel>
+                        <sampleRateNumerator>40</sampleRateNumerator>
+                        <sampleRateDenominator>1</sampleRateDenominator>
+                        <depth>0</depth>
+                        <azimuth>0</azimuth>
+                        <dip>-90</dip>
+                        <gain>633828000</gain>
+                        <gainFrequency>1</gainFrequency>
+                        <gainUnit>M/S</gainUnit>
+                        <format>Steim2</format>
+                        <flags>G</flags>
+                        <restricted>false</restricted>
+                        <shared>true</shared>
+                    </stream>
+                </sensorLocation>
+            </station>
+        </network>
+    </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -117,8 +117,10 @@ class SC3MLTestCase(unittest.TestCase):
         Assert depth, latitude, longitude, elevation set to 0.0 if left empty
         """
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("default")
             read_inventory(os.path.join(self.data_dir,
                                         "sc3ml_empty_depth_and_id.sc3ml"))
+            self.assertEqual(len(w), 4)
             self.assertEqual(str(w[0].message), "Sensor is missing "
                                                 "longitude information, "
                                                 "using 0.0")


### PR DESCRIPTION
**EDIT: This post was made by** @medlin01GA

Obspy version: 1.1.0
Python version: 2.7, 3.x (all platforms)
Platform: all

When loading sc3ml format station inventory using function `obspy.read_inventory` with channel data, file read time grows as O(N*M) where N is the total number of channels and M is the total number sensors, dataloggers, and responses.  Typically M ~ N, so load time is ~O(N^2), but it should be more like O(N).

Reading a large inventory (~500 MB) of global seismic networks in performance profiling tests on high performance workstation type platform takes in the order of 10 hours. The root cause is the fact that sc3ml has an unordered, flat list of instrument data for sensors, dataloggers and responses, and when reading sc3ml format the obspy implementation does a brute force search of such lists for each sensor, datalogger or response in each channel.

Code experimentation in medlin01GA fork shows that by pre-indexing the instrumentation nodes from sc3ml, the complete inventory file read time for ~500 MB file can be brought down to about 4 minutes.

Note: The self-contained example I have requires seiscomp3 to be installed on the test platform. Such an example could be provided on request, but I do not attach the test data file directly since problem is one of scaling to big data, and the file is large.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .