### PR TITLE
Cope with missing pick-info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -117,7 +117,8 @@ master:
    * Include AIN as takeoff-angle when reading and writing nordic files
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
-   * BUG-FIX: cope with missing pick evaluation information (see #2520)
+   * Fix the incorrect handling of events missing pick evaluation information
+     (see #2520)
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -117,6 +117,7 @@ master:
    * Include AIN as takeoff-angle when reading and writing nordic files
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
+   * BUG-FIX: cope with missing pick evaluation information (see #XXXX)
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -117,7 +117,7 @@ master:
    * Include AIN as takeoff-angle when reading and writing nordic files
      (see #2404).
    * Add error ellipses and read high-accuracy hypocenter lines (see #2451)
-   * BUG-FIX: cope with missing pick evaluation information (see #XXXX)
+   * BUG-FIX: cope with missing pick evaluation information (see #2520)
  - obspy.io.reftek:
    * Implement reading reftek encodings '16' and '32' (uncompressed data,
      16/32bit integers, see #2058 and #2059)

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -671,6 +671,8 @@ def _read_picks(tagged_lines, new_event):
         weight = line[14]
         if weight not in ' 012349_':  # Long phase name
             weight = line[8]
+            if weight == ' ':
+                weight = 0
             phase = line[10:17].strip()
             polarity = ''
         elif weight == '_':
@@ -682,7 +684,8 @@ def _read_picks(tagged_lines, new_event):
             polarity = line[16]
             if weight == ' ':
                 weight = 0
-        polarity = POLARITY_MAPPING.get(polarity, "undecidable")
+        polarity = POLARITY_MAPPING.get(polarity, None)  # Empty could be None
+        # or undecidable.
         # It is valid nordic for the origin to be hour 23 and picks to be hour
         # 00 or 24: this signifies a pick over a day boundary.
         pick_hour = int(line[18:20])
@@ -1445,6 +1448,7 @@ def nordpick(event, high_accuracy=True):
         if eval_mode is None:
             warnings.warn("Evaluation mode {0} is not mappable".format(
                 pick.evaluation_mode))
+            eval_mode = " "
         # Generate a print string and attach it to the list
         channel_code = pick.waveform_id.channel_code or '   '
         pick_hour = pick.time.hour

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -1182,13 +1182,14 @@ def _test_similarity(event_1, event_2):
                 if not amp_1[key] == amp_2[key]:
                     return ("{0} is not the same as {1} for key "
                             "{2}\n{3}\n{4}".format(
-                        amp_1[key], amp_2[key], key, amp_1, amp_2))
+                                amp_1[key], amp_2[key], key, amp_1, amp_2))
             elif key == "waveform_id":
                 if pick_1[key].station_code != pick_2[key].station_code:
                     return 'Station codes do not match'
                 if pick_1[key].channel_code[0] != pick_2[key].channel_code[0]:
                     return 'Channel codes do not match'
-                if pick_1[key].channel_code[-1] != pick_2[key].channel_code[-1]:
+                if pick_1[key].channel_code[-1] !=\
+                        pick_2[key].channel_code[-1]:
                     return 'Channel codes do not match'
             elif key in ["magnitude_hint", "type"]:
                 # Reading back in will define both, but input event might have

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -58,9 +58,13 @@ class TestNordicMethods(unittest.TestCase):
         test_cat += test_event
         # Check the read-write s-file functionality
         with TemporaryWorkingDirectory():
-            sfile = _write_nordic(test_cat[0], filename=None, userid='TEST',
-                                  evtype='L', outdir='.', wavefiles='test',
-                                  explosion=True, overwrite=True)
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                sfile = _write_nordic(
+                    test_cat[0], filename=None, userid='TEST', evtype='L',
+                    outdir='.', wavefiles='test', explosion=True,
+                    overwrite=True)
             self.assertEqual(readwavename(sfile), ['test'])
             read_cat = Catalog()
             # raises "UserWarning: AIN in header, currently unsupported"
@@ -165,52 +169,66 @@ class TestNordicMethods(unittest.TestCase):
         test_cat.append(full_test_event())
         with self.assertRaises(NordicParsingError):
             # Raises error due to multiple events in catalog
-            _write_nordic(test_cat, filename=None, userid='TEST',
-                          evtype='L', outdir='.',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(test_cat, filename=None, userid='TEST',
+                              evtype='L', outdir='.',
+                              wavefiles='test', explosion=True,
+                              overwrite=True)
         with self.assertRaises(NordicParsingError):
             # Raises error due to too long userid
-            _write_nordic(test_ev, filename=None, userid='TESTICLE',
-                          evtype='L', outdir='.',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(test_ev, filename=None, userid='TESTICLE',
+                              evtype='L', outdir='.',
+                              wavefiles='test', explosion=True,
+                              overwrite=True)
         with self.assertRaises(NordicParsingError):
             # Raises error due to unrecognised event type
-            _write_nordic(test_ev, filename=None, userid='TEST',
-                          evtype='U', outdir='.',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(test_ev, filename=None, userid='TEST',
+                              evtype='U', outdir='.',
+                              wavefiles='test', explosion=True,
+                              overwrite=True)
         with self.assertRaises(NordicParsingError):
             # Raises error due to no output directory
-            _write_nordic(test_ev, filename=None, userid='TEST',
-                          evtype='L', outdir='albatross',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(test_ev, filename=None, userid='TEST',
+                              evtype='L', outdir='albatross',
+                              wavefiles='test', explosion=True,
+                              overwrite=True)
         invalid_origin = test_ev.copy()
 
         invalid_origin.origins = []
         with self.assertRaises(NordicParsingError):
-            _write_nordic(invalid_origin, filename=None, userid='TEST',
-                          evtype='L', outdir='.',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(invalid_origin, filename=None, userid='TEST',
+                              evtype='L', outdir='.', wavefiles='test',
+                              explosion=True, overwrite=True)
         invalid_origin = test_ev.copy()
         invalid_origin.origins[0].time = None
         with self.assertRaises(NordicParsingError):
-            _write_nordic(invalid_origin, filename=None, userid='TEST',
-                          evtype='L', outdir='.',
-                          wavefiles='test', explosion=True,
-                          overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(invalid_origin, filename=None, userid='TEST',
+                              evtype='L', outdir='.', wavefiles='test',
+                              explosion=True, overwrite=True)
         # Write a near empty origin
         valid_origin = test_ev.copy()
         valid_origin.origins[0].latitude = None
         valid_origin.origins[0].longitude = None
         valid_origin.origins[0].depth = None
         with NamedTemporaryFile() as tf:
-            _write_nordic(valid_origin, filename=tf.name, userid='TEST',
-                          evtype='L', outdir='.', wavefiles='test',
-                          explosion=True, overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                _write_nordic(
+                    valid_origin, filename=tf.name, userid='TEST',
+                    evtype='L', outdir='.', wavefiles='test',
+                    explosion=True, overwrite=True)
             self.assertTrue(os.path.isfile(tf.name))
 
     def test_blanksfile(self):
@@ -373,10 +391,15 @@ class TestNordicMethods(unittest.TestCase):
         sfiles = []
         with TemporaryWorkingDirectory():
             for _i in range(59):
-                sfiles.append(_write_nordic(event=event, filename=None,
-                                            overwrite=False))
+                with warnings.catch_warnings():
+                    # Evaluation mode mapping warning
+                    warnings.simplefilter('ignore', UserWarning)
+                    sfiles.append(_write_nordic(event=event, filename=None,
+                                                overwrite=False))
             with self.assertRaises(NordicParsingError):
-                _write_nordic(event=event, filename=None, overwrite=False)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', UserWarning)
+                    _write_nordic(event=event, filename=None, overwrite=False)
 
     def test_mag_conv(self):
         """
@@ -414,17 +437,22 @@ class TestNordicMethods(unittest.TestCase):
         test_cat += test_event
         # Check the read-write s-file functionality
         with TemporaryWorkingDirectory():
-            sfile = _write_nordic(
-                test_cat[0], filename=None, userid='TEST', evtype='L',
-                outdir='.', wavefiles=['walrus/test'], explosion=True,
-                overwrite=True)
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                sfile = _write_nordic(
+                    test_cat[0], filename=None, userid='TEST', evtype='L',
+                    outdir='.', wavefiles=['walrus/test'], explosion=True,
+                    overwrite=True)
             self.assertEqual(readwavename(sfile), ['test'])
         # Check that multiple wavefiles are read properly
         with TemporaryWorkingDirectory():
-            sfile = _write_nordic(
-                test_cat[0], filename=None, userid='TEST', evtype='L',
-                outdir='.', wavefiles=['walrus/test', 'albert'],
-                explosion=True, overwrite=True)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                sfile = _write_nordic(
+                    test_cat[0], filename=None, userid='TEST', evtype='L',
+                    outdir='.', wavefiles=['walrus/test', 'albert'],
+                    explosion=True, overwrite=True)
             self.assertEqual(readwavename(sfile), ['test', 'albert'])
 
     def test_read_event(self):
@@ -640,7 +668,10 @@ class TestNordicMethods(unittest.TestCase):
         event = full_test_event()
         event.origins[0].longitude = -120
         with NamedTemporaryFile(suffix=".out") as tf:
-            event.write(tf.name, format="NORDIC")
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                event.write(tf.name, format="NORDIC")
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', UserWarning)
                 event_back = read_events(tf.name)
@@ -654,7 +685,10 @@ class TestNordicMethods(unittest.TestCase):
         event.origins.append(preferred_origin)
         event.preferred_origin_id = preferred_origin.resource_id
         with NamedTemporaryFile(suffix=".out") as tf:
-            event.write(tf.name, format="NORDIC")
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                event.write(tf.name, format="NORDIC")
             with warnings.catch_warnings():
                 # Type I warning
                 warnings.simplefilter('ignore', UserWarning)
@@ -768,7 +802,10 @@ class TestNordicMethods(unittest.TestCase):
         self.assertGreater(
             event.picks[0].time.date, event.origins[0].time.date)
         with NamedTemporaryFile(suffix=".out") as tf:
-            write_select(Catalog([event]), filename=tf.name)
+            with warnings.catch_warnings():
+                # Evaluation mode mapping warning
+                warnings.simplefilter('ignore', UserWarning)
+                write_select(Catalog([event]), filename=tf.name)
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', UserWarning)
                 event_back = read_events(tf.name)[0]
@@ -1054,15 +1091,16 @@ class TestNordicMethods(unittest.TestCase):
         self.assertAlmostEqual(azi_max, 167.9407699)
 
 
-def _assert_similarity(event_1, event_2, verbose=True):
+def _assert_similarity(event_1, event_2):
     """
     Raise AssertionError if testing similarity fails
     """
-    if not _test_similarity(event_1, event_2, verbose=verbose):
-        raise AssertionError('Events failed similarity check')
+    similarity_output = _test_similarity(event_1, event_2)
+    if similarity_output:
+        raise AssertionError(similarity_output)
 
 
-def _test_similarity(event_1, event_2, verbose=False):
+def _test_similarity(event_1, event_2):
     """
     Check the similarity of the components of obspy events, discounting
     resource IDs, which are not maintained in nordic files.
@@ -1089,37 +1127,28 @@ def _test_similarity(event_1, event_2, verbose=False):
                            "quality", "creation_info", "evaluation_mode",
                            "depth_errors", "time_errors"]:
                 if ori_1[key] != ori_2[key]:
-                    if verbose:
-                        print('%s is not the same as %s for key %s' %
-                              (ori_1[key], ori_2[key], key))
-                    return False
+                    return ('%s is not the same as %s for key %s' %
+                            (ori_1[key], ori_2[key], key))
             elif key == "arrivals":
                 if len(ori_1[key]) != len(ori_2[key]):
-                    print('%i is not the same as %i for key %s' %
-                          (len(ori_1[key]), len(ori_2[key]), key))
-                    return False
+                    return ('%i is not the same as %i for key %s' %
+                            (len(ori_1[key]), len(ori_2[key]), key))
                 for arr_1, arr_2 in zip(ori_1[key], ori_2[key]):
                     for arr_key in arr_1.keys():
                         if arr_key not in ["resource_id", "pick_id",
                                            "distance"]:
                             if arr_1[arr_key] != arr_2[arr_key]:
-                                if verbose:
-                                    print('%s does not match %s for key %s' %
-                                          (arr_1[arr_key], arr_2[arr_key],
-                                           arr_key))
-                                return False
+                                return ('%s does not match %s for key %s' %
+                                        (arr_1[arr_key], arr_2[arr_key],
+                                         arr_key))
                     if arr_1["distance"] and round(
                             arr_1["distance"]) != round(arr_2["distance"]):
-                        if verbose:
-                            print('%s does not match %s for key %s' %
-                                  (arr_1[arr_key], arr_2[arr_key],
-                                   arr_key))
-                        return False
+                        return ('%s does not match %s for key %s' %
+                                (arr_1[arr_key], arr_2[arr_key],
+                                 arr_key))
     # Check picks
     if len(event_1.picks) != len(event_2.picks):
-        if verbose:
-            print('Number of picks is not equal')
-        return False
+        return 'Number of picks is not equal'
     for pick_1, pick_2 in zip(event_1.picks, event_2.picks):
         # Assuming same ordering of picks...
         for key in pick_1.keys():
@@ -1132,65 +1161,43 @@ def _test_similarity(event_1, event_2, verbose=False):
                     elif pick_2[key] is None:
                         if pick_1[key] == default:
                             continue
-                    if verbose:
-                        print('%s is not the same as %s for key %s' %
-                              (pick_1[key], pick_2[key], key))
-                    return False
+                    return ('%s is not the same as %s for key %s' %
+                            (pick_1[key], pick_2[key], key))
             elif key == "waveform_id":
                 if pick_1[key].station_code != pick_2[key].station_code:
-                    if verbose:
-                        print('Station codes do not match')
-                    return False
+                    return 'Station codes do not match'
                 if pick_1[key].channel_code[0] != pick_2[key].channel_code[0]:
-                    if verbose:
-                        print('Channel codes do not match')
-                    return False
+                    return 'Channel codes do not match'
                 if pick_1[key].channel_code[-1] !=\
                    pick_2[key].channel_code[-1]:
-                    if verbose:
-                        print('Channel codes do not match')
-                    return False
+                    return 'Channel codes do not match'
     # Check amplitudes
     if not len(event_1.amplitudes) == len(event_2.amplitudes):
-        if verbose:
-            print('Not the same number of amplitudes')
-        return False
+        return 'Not the same number of amplitudes'
     for amp_1, amp_2 in zip(event_1.amplitudes, event_2.amplitudes):
         # Assuming same ordering of amplitudes
         for key in amp_1.keys():
             if key not in ["resource_id", "pick_id", "waveform_id", "snr",
                            "magnitude_hint", 'type']:
                 if not amp_1[key] == amp_2[key]:
-                    if verbose:
-                        print('%s is not the same as %s for key %s' %
-                              (amp_1[key], amp_2[key], key))
-                        print(amp_1)
-                        print(amp_2)
-                    return False
+                    return ("{0} is not the same as {1} for key "
+                            "{2}\n{3}\n{4}".format(
+                        amp_1[key], amp_2[key], key, amp_1, amp_2))
             elif key == "waveform_id":
                 if pick_1[key].station_code != pick_2[key].station_code:
-                    if verbose:
-                        print('Station codes do not match')
-                    return False
+                    return 'Station codes do not match'
                 if pick_1[key].channel_code[0] != pick_2[key].channel_code[0]:
-                    if verbose:
-                        print('Channel codes do not match')
-                    return False
-                if pick_1[key].channel_code[-1] !=\
-                   pick_2[key].channel_code[-1]:
-                    if verbose:
-                        print('Channel codes do not match')
-                    return False
+                    return 'Channel codes do not match'
+                if pick_1[key].channel_code[-1] != pick_2[key].channel_code[-1]:
+                    return 'Channel codes do not match'
             elif key in ["magnitude_hint", "type"]:
                 # Reading back in will define both, but input event might have
                 # None
                 if amp_1[key] is not None:
                     if not amp_1[key] == amp_2[key]:
-                        if verbose:
-                            print('%s is not the same as %s for key %s' %
-                                  (amp_1[key], amp_2[key], key))
-                        return False
-    return True
+                        return ('%s is not the same as %s for key %s' %
+                                (amp_1[key], amp_2[key], key))
+    return None
 
 
 def full_test_event():


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Cope with missing pick.evaluation_mode as highlighted on the message-list. This is a bug in the current version of Obspy, and lots of nordic-type things have gone into master, so this ends up needing to go there.

### Why was it initiated?  Any relevant Issues?

Not all catalogues have `pick.evaluation_mode`, and shouldn't have to. The example below errors in the current version:
```python
from obspy.clients.fdsn import Client 
 
client=Client("ISC") 
cat = client.get_events(eventid=867982, includearrivals=True)  
cat.write("select.out", format="NORDIC")
```

This PR fixes this, and patches an issue with missing weights (with long-phase names) and polarities.  It also changes mapping of an empty polarity field from `undecidable` to `None` when reading nordic files.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
~~- [ ] If the PR is making changes to documentation, docs pages can be built automatically.~~
~~      Just remove the space in the following string after the + sign: "+ DOCS"~~
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
~~- [ ] Any new or changed features have are fully documented.~~
- [x] Significant changes have been added to `CHANGELOG.txt` .
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~~
