### PR TITLE
Getting rid of Sphinx warnings for pages "not in toctrees"

### DIFF
--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -78,7 +78,7 @@ assets:
 html: assets credits citations
 	if [ ! -d $(BUILDDIR) ]; then mkdir $(BUILDDIR); fi
 	if [ ! -d $(BUILDDIR)/html ]; then mkdir $(BUILDDIR)/html; fi
-	$(SPHINXBUILD) -w $(BUILDDIR)/html/sphinx-build_warnings.txt -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 1> $(BUILDDIR)/html/sphinx-build_stdout.txt 2> $(BUILDDIR)/html/sphinx-build_stderr.txt
+	SPHINX=true $(SPHINXBUILD) -w $(BUILDDIR)/html/sphinx-build_warnings.txt -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html 1> $(BUILDDIR)/html/sphinx-build_stdout.txt 2> $(BUILDDIR)/html/sphinx-build_stderr.txt
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/misc/docs/source/packages/obspy.core.event.header.rst
+++ b/misc/docs/source/packages/obspy.core.event.header.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. currentmodule:: obspy.core.event.header
 .. automodule:: obspy.core.event.header
     :members:

--- a/misc/docs/source/packages/obspy.core.event.rst
+++ b/misc/docs/source/packages/obspy.core.event.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. currentmodule:: obspy.core.event
 .. automodule:: obspy.core.event
 

--- a/misc/docs/source/packages/obspy.core.inventory.rst
+++ b/misc/docs/source/packages/obspy.core.inventory.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. currentmodule:: obspy.core.inventory
 .. automodule:: obspy.core.inventory
 

--- a/misc/docs/source/packages/obspy.core.util.rst
+++ b/misc/docs/source/packages/obspy.core.util.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. currentmodule:: obspy.core.util
 .. automodule:: obspy.core.util
 

--- a/misc/docs/source/packages/obspy.io.nied.rst
+++ b/misc/docs/source/packages/obspy.io.nied.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. currentmodule:: obspy.io.nied
 .. automodule:: obspy.io.nied
 

--- a/obspy/clients/arclink/__init__.py
+++ b/obspy/clients/arclink/__init__.py
@@ -161,6 +161,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
+import os
 import warnings
 
 from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
@@ -172,7 +173,9 @@ msg = (
     "the client contacting the routing service provided by EIDA: "
     "https://docs.obspy.org/packages/obspy.clients.fdsn.html#"
     "basic-routing-clients-usage")
-warnings.warn(msg, category=ObsPyDeprecationWarning)
+# suppress warning on docs build
+if os.environ.get('SPHINX') != 'true':
+    warnings.warn(msg, category=ObsPyDeprecationWarning)
 
 from .client import Client  # NOQA
 


### PR DESCRIPTION
### What does this PR do?

Removes warnings issued by sphinx for pages "not in toctrees", although they are properly referenced in different locations.

### Why was it initiated?  Any relevant Issues?

I'm annoyed that the great DocBuildBot systematically fails while all is OK.

+DOCS

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is linked to an existing issue (which has no PR yet). #2518 
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] All tests still pass.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
