### PR TITLE
stationxml: work around empty string tags getting converted to a string value "None"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,8 @@ master:
    * fixed UTCDateTime(..., julday=366) for non-leap years. This was returning
      January 1st of the next year in case of non-leap years being used. Now it
      properly raises an out-of-bounds ValueError (see #2369)
+   * When reading StationXML/SC3ML, make sure to properly read empty string
+     fields as empty strings instead of "None" (see #2519 and #2527)
    * better ISO8601 detection for UTCDateTime objects and UTCDateTime(...,
      iso8601=False) now completely disables ISO8601 handling (see #2447)
    * Added replace method to UTCDateTime class (see #2077).
@@ -138,6 +140,11 @@ master:
    * Very large performance improvement reading large sc3ml inventory files by
      pre-indexing sensors, dataloggers and responses and reducing lxml calls
      (see #2296).
+   * When reading StationXML/SC3ML, make sure to properly read empty string
+     fields as empty strings instead of "None" (see #2519 and #2527)
+ - obspy.io.stationxml:
+   * When reading StationXML/SC3ML, make sure to properly read empty string
+     fields as empty strings instead of "None" (see #2519 and #2527)
  - obspy.io.quakeml:
    * Allow writing invalid ids but raise a warning
      (see #2104, #2090, #2093, #1872).

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ Falco, Nicholas
 Fee, Jeremy
 Grellier, Clément
 Grunberg, Marc
+Hagerty, Mike
 Hammer, Conny
 Heimann, Sebastian
 Heiniger, Lukas

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -536,7 +536,7 @@ def _read_instrument_sensitivity(sen_element, cha_element, _ns):
     frequency = _tag2obj(cha_element, _ns("gainFrequency"), float)
 
     input_units_name = _tag2obj(sen_element, _ns("unit"), str)
-    output_units_name = str(None)
+    output_units_name = ''
 
     sensitivity = obspy.core.inventory.response.InstrumentSensitivity(
         value=gain, frequency=frequency,

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -1445,18 +1445,37 @@ def _write_extra(parent, obj):
             _write_element(parent, element, tagname)
 
 
-def _tag2obj(element, tag, convert):
-    # we use future.builtins.str and are sure we have unicode here
+def _convert(text, convert):
+    if convert is str:
+        return _convert_str(text)
     try:
-        return convert(element.find(tag).text)
+        return convert(text)
     except Exception:
         None
+
+
+def _convert_str(text):
+    # we use future.builtins.str and are sure we have unicode here
+    # lxml gives ``None`` for tags with empty text, best way to handle this is
+    # probably to give back an empty string
+    if not text:
+        # Returning an empty string
+        return ''
+    return text
+
+
+def _tag2obj(element, tag, convert):
+    try:
+        text = element.find(tag).text
+    except Exception:
+        return None
+    return _convert(text, convert)
 
 
 def _tags2obj(element, tag, convert):
     values = []
     for elem in element.findall(tag):
-        values.append(convert(elem.text))
+        values.append(_convert(elem.text, convert))
     return values
 
 


### PR DESCRIPTION


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Tries to fix empty string tags getting converted to a string `"None"` since lxml returns `None` instead of `''` which is what we kind of expected inherently it seems.

### Why was it initiated?  Any relevant Issues?

Fixes #2519 
CC @mikehagerty

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
