### PR TITLE
Select traces in Stream based on an Inventory

### DIFF
--- a/obspy/core/data/BW_RJOB__EHZ.xml
+++ b/obspy/core/data/BW_RJOB__EHZ.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0">
+  <Source>Erdbebendienst Bayern</Source>
+  <Module>fdsn-stationxml-converter/1.0.0</Module>
+  <ModuleURI>http://www.iris.edu/fdsnstationconverter</ModuleURI>
+  <Created>2013-12-07T18:00:42.878000Z</Created>
+  <Network code="BW">
+    <Description>BayernNetz</Description>
+    <Station code="RJOB" startDate="2007-12-17T00:00:00.000000Z">
+      <Latitude unit="DEGREES">47.737167</Latitude>
+      <Longitude unit="DEGREES">12.795714</Longitude>
+      <Elevation>860.0</Elevation>
+      <Site>
+        <Name>Jochberg, Bavaria, BW-Net</Name>
+      </Site>
+      <CreationDate>2007-12-17T00:00:00.000000Z</CreationDate>
+      <Channel code="EHZ" startDate="2007-12-17T00:00:00.000000Z" locationCode="">
+        <Latitude unit="DEGREES">47.737167</Latitude>
+        <Longitude unit="DEGREES">12.795714</Longitude>
+        <Elevation>860.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>TRIGGERED</Type>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">200.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">1.0</ClockDrift>
+        <CalibrationUnits>
+          <Name>A</Name>
+          <Description>Amperes</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Type>Streckeisen STS-2/N seismometer</Type>
+        </Sensor>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1822,7 +1822,9 @@ class Stream(object):
         All other selection criteria that accept strings (network, station,
         location) may also contain Unix style wildcards (``*``, ``?``, ...).
         """
-        if inventory is not None:
+        if inventory is None:
+            traces = self.traces
+        else:
             trace_ids = []
             start_dates = []
             end_dates = []
@@ -1852,7 +1854,7 @@ class Stream(object):
                         traces.append(trace)
                     except ValueError:
                         break
-            return self.__class__(traces=traces)
+        traces_after_inventory_filter = traces
 
         # make given component letter uppercase (if e.g. "z" is given)
         if component is not None and channel is not None:
@@ -1864,7 +1866,7 @@ class Stream(object):
                       "mutually exclusive!"
                 raise ValueError(msg)
         traces = []
-        for trace in self:
+        for trace in traces_after_inventory_filter:
             # skip trace if any given criterion is not matched
             if id and not fnmatch.fnmatch(trace.id.upper(), id.upper()):
                 continue


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Select traces in `Stream` based on the content of an `Inventory` object:
trace will be selected if the inventory contains a matching channel
active at the trace start time.

### Why was it initiated?  Any relevant Issues?

This is a follow-up of #2515.
Sometimes datacenter provides preassembled datasets with data and metadata for all the stations in the network (ex.: http://cnt.rm.ingv.it/event/23558121 --> Download). 
Using #2515, inventory can be filtered based on geographic parameters.
With the present PR, data in stream can be selected based on the inventory content.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
