### PR TITLE
mseed: fix bug leading to endless loop when reading a fullseed file without data records as MSEED

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -99,6 +99,8 @@ master:
  - obspy.io.gcf:
    * Fixes Python 3.8 compatibility of GCF reader. (see #2505)
  - obspy.io.mseed:
+   * Fix a bug resulting in an infinite loop when trying to read a FullSEED
+     file without any data records (see #2534 and #2535)
    * Add ability to write int64 data to mseed if it can safely be downcast
      to int32 data, otherwise raises ObsPyMSEEDError. (see #2356)
    * The recordanalyzer can now detect calibration blockettes 300, 310,

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -1324,6 +1324,21 @@ class MSEEDUtilTestCase(unittest.TestCase):
             'number_of_records': 1,
             'excess_bytes': 0})
 
+    def test_read_fullseed_no_data_record(self):
+        # see 2534
+        filename = os.path.join(self.path, 'data',
+                                'RJOB.BW.EHZ.D.300806.0000.fullseed')
+        # file contains two records, the second being the miniseed record.
+        # make a bytes buffer without the data record
+        with open(filename, 'rb') as fh:
+            data = fh.read()
+        buf = io.BytesIO(data[:512])  # only first record
+        buf.seek(0)
+        with self.assertRaises(ValueError) as e:
+            _read_mseed(buf)
+        self.assertEqual(
+            str(e.exception), "No MiniSEED data record found in file.")
+
 
 def suite():
     return unittest.makeSuite(MSEEDUtilTestCase, 'test')

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -643,7 +643,15 @@ def _get_record_information(file_object, offset=0, endian=None):
         # reset file pointer
         file_object.seek(record_start, 0)
         # cycle through file using record length until first data record found
-        while file_object.read(7)[6:7] not in [b'D', b'R', b'Q', b'M']:
+        while True:
+            data = file_object.read(7)[6:7]
+            if data in [b'D', b'R', b'Q', b'M']:
+                break
+            # stop looking when hitting end of file
+            # the second check should be enough.. but play it safe
+            if not data or record_start > info['filesize']:
+                msg = "No MiniSEED data record found in file."
+                raise ValueError(msg)
             record_start += rec_len
             file_object.seek(record_start, 0)
 


### PR DESCRIPTION

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Removes a bug resulting in an infinite loop when trying to read a full SEED file without any data records.

### Why was it initiated?  Any relevant Issues?

Fixes #2534 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
