### PR TITLE
Refactor _robust_resize in TauBranch

### DIFF
--- a/obspy/clients/arclink/tests/test_client.py
+++ b/obspy/clients/arclink/tests/test_client.py
@@ -393,7 +393,7 @@ class ClientTestCase(unittest.TestCase):
         start = UTCDateTime(2008, 1, 1)
         end = start + 1
         result = client.get_networks(start, end)
-        self.assertIn('BW', result.keys())
+        self.assertIn('BW', list(result.keys()))
         self.assertEqual(result['BW']['code'], 'BW')
         self.assertEqual(result['BW']['description'], 'BayernNetz')
 

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -489,9 +489,9 @@ class TauBranch(object):
         try:
             arr.resize(new_size)
         except ValueError:
-            # msg = ('Resizing a TauP array inplace failed due to the existence'
-            #        ' of other references to the array, creating a new array. '
-            #        'See Obspy #2280.')
+            # msg = ('Resizing a TauP array inplace failed due to the '
+            #        'existence of other references to the array, creating '
+            #        'a new array. See Obspy #2280.')
             # warnings.warn(msg)
             arr = np.resize(arr, new_size)
         return arr

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -8,6 +8,8 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
+import warnings
+
 import numpy as np
 
 from .c_wrappers import clibtau
@@ -153,15 +155,15 @@ class TauBranch(object):
     def shift_branch(self, index):
         new_size = len(self.dist) + 1
 
-        self.time = self._robust_resize(self.time, new_size)
+        self._robust_resize('time', new_size)
         self.time[index + 1:] = self.time[index:-1]
         self.time[index] = 0
 
-        self.dist = self._robust_resize(self.dist, new_size)
+        self._robust_resize('dist', new_size)
         self.dist[index + 1:] = self.dist[index:-1]
         self.dist[index] = 0
 
-        self.tau = self._robust_resize(self.tau, new_size)
+        self._robust_resize('tau', new_size)
         self.tau[index + 1:] = self.tau[index:-1]
         self.tau[index] = 0
 
@@ -478,18 +480,16 @@ class TauBranch(object):
             setattr(branch, key, arr_)
         return branch
 
-    @staticmethod
-    def _robust_resize(arr, new_size):
+    def _robust_resize(self, attr, new_size):
         """
         Try to resize an array inplace. If an error is raised use numpy
         resize function to create a new array. Return the array.
         """
         try:
-            arr.resize(new_size)
+            getattr(self, attr).resize(new_size)
         except ValueError:
-            # msg = ('Resizing a TauP array inplace failed due to the '
-            #        'existence of other references to the array, creating '
-            #        'a new array. See Obspy #2280.')
-            # warnings.warn(msg)
-            arr = np.resize(arr, new_size)
-        return arr
+            msg = ('Resizing a TauP array inplace failed due to the '
+                   'existence of other references to the array, creating '
+                   'a new array. See Obspy #2280.')
+            warnings.warn(msg)
+            setattr(self, attr, np.resize(getattr(self, attr), new_size))

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, print_function,
 from future.builtins import *  # NOQA
 from future.utils import native_str
 
-import warnings
-
 import numpy as np
 
 from .c_wrappers import clibtau

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -483,7 +483,8 @@ class TauBranch(object):
     def _robust_resize(self, attr, new_size):
         """
         Try to resize an array inplace. If an error is raised use numpy
-        resize function to create a new array. Return the array.
+        resize function to create a new array. Assign the array to self as
+        attribute listed in attr.
         """
         try:
             getattr(self, attr).resize(new_size)

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -489,9 +489,9 @@ class TauBranch(object):
         try:
             arr.resize(new_size)
         except ValueError:
-            msg = ('Resizing a TauP array inplace failed due to the existence'
-                   ' of other references to the array, creating a new array. '
-                   'See Obspy #2280.')
-            warnings.warn(msg)
+            # msg = ('Resizing a TauP array inplace failed due to the existence'
+            #        ' of other references to the array, creating a new array. '
+            #        'See Obspy #2280.')
+            # warnings.warn(msg)
             arr = np.resize(arr, new_size)
         return arr


### PR DESCRIPTION
`_robust_resize` was previously introduced (#2280) because of some numpy resize fails (#2541 for fails).

A warning was introduced, but because of this new addition the resizing now failed in all cases and the warning was therefore seen very often. This PR leaves the warning as is, but rewrites the _resize_robust method, that it only shows the warning and falls back to numpy.resize when it is really necessary.

This PR is branched from #2540 and includes its changes.