### PR TITLE
Fix some issues with Response stage Numerator/Denominator handling in 1.2.0rc3

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -345,10 +345,10 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         The function tries to match inputs to one of three types if it can.
     :type numerator: list of
-        :class:`~obspy.core.util.obspy_types.FloatWithUncertaintiesAndUnit`
+        :class:`~obspy.core.util.obspy_types.CoefficientWithUncertainties`
     :param numerator: Numerator of the coefficient response stage.
     :type denominator: list of
-        :class:`~obspy.core.util.obspy_types.FloatWithUncertaintiesAndUnit`
+        :class:`~obspy.core.util.obspy_types.CoefficientWithUncertainties`
     :param denominator: Denominator of the coefficient response stage.
     """
     def __init__(self, stage_sequence_number, stage_gain,
@@ -406,12 +406,12 @@ class CoefficientsTypeResponseStage(ResponseStage):
             return
         value = list(value) if isinstance(
             value, compatibility.collections_abc.Iterable) else [value]
-        for _i, x in enumerate(value):
-            if not isinstance(x, FloatWithUncertaintiesAndUnit):
-                value[_i] = FloatWithUncertaintiesAndUnit(x)
-        if any(x.unit is not None for x in value):
+        if any(getattr(x, 'unit', None) is not None for x in value):
             msg = 'Setting Numerator/Denominator with a unit is deprecated.'
             warnings.warn(msg, ObsPyDeprecationWarning)
+        for _i, x in enumerate(value):
+            if not isinstance(x, CoefficientWithUncertainties):
+                value[_i] = CoefficientWithUncertainties(x)
         self._numerator = value
 
     @property
@@ -425,12 +425,12 @@ class CoefficientsTypeResponseStage(ResponseStage):
             return
         value = list(value) if isinstance(
             value, compatibility.collections_abc.Iterable) else [value]
-        for _i, x in enumerate(value):
-            if not isinstance(x, FloatWithUncertaintiesAndUnit):
-                value[_i] = FloatWithUncertaintiesAndUnit(x)
-        if any(x.unit is not None for x in value):
+        if any(getattr(x, 'unit', None) is not None for x in value):
             msg = 'Setting Numerator/Denominator with a unit is deprecated.'
             warnings.warn(msg, ObsPyDeprecationWarning)
+        for _i, x in enumerate(value):
+            if not isinstance(x, CoefficientWithUncertainties):
+                value[_i] = CoefficientWithUncertainties(x)
         self._denominator = value
 
     @property

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -616,11 +616,11 @@ def _read_response_stage(stage_elem, _ns):
             _tag2obj(elem, _ns("CfTransferFunctionType"), str)
         numerator = \
             _read_floattype_list(elem, _ns("Numerator"),
-                                 FloatWithUncertaintiesAndUnit, unit=True,
+                                 CoefficientWithUncertainties, unit=False,
                                  additional_mapping={"number": "number"})
         denominator = \
             _read_floattype_list(elem, _ns("Denominator"),
-                                 FloatWithUncertaintiesAndUnit, unit=True,
+                                 CoefficientWithUncertainties, unit=False,
                                  additional_mapping={"number": "number"})
         obj = obspy.core.inventory.CoefficientsTypeResponseStage(
             cf_transfer_function_type=cf_transfer_function_type,

--- a/obspy/io/stationxml/tests/data/full_random_stationxml.xml
+++ b/obspy/io/stationxml/tests/data/full_random_stationxml.xml
@@ -592,10 +592,10 @@
                                 <Description>gTe8KIKiU3RfrWAJOg.CTy8f7Cz</Description>
                             </OutputUnits>
                             <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
-                            <Numerator plusError="-1096718463.14" minusError="1126505295.72">643096860.28</Numerator>
-                            <Numerator plusError="1487660393.16" minusError="1518618020.33">-1135677195.92</Numerator>
-                            <Denominator plusError="-1418173713.21" minusError="-696602068.55">1504792438.09</Denominator>
-                            <Denominator plusError="587099516.91" minusError="618144513.11">1711947659.78</Denominator>
+                            <Numerator number="1" plusError="-1096718463.14" minusError="1126505295.72">643096860.28</Numerator>
+                            <Numerator number="2" plusError="1487660393.16" minusError="1518618020.33">-1135677195.92</Numerator>
+                            <Denominator number="3" plusError="-1418173713.21" minusError="-696602068.55">1504792438.09</Denominator>
+                            <Denominator number="4" plusError="587099516.91" minusError="618144513.11">1711947659.78</Denominator>
                         </Coefficients>
                         <Decimation>
                             <InputSampleRate unit="HERTZ" plusError="59663358.91" minusError="-1077596674.88">-2002635152.29</InputSampleRate>

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -297,6 +297,13 @@ class StationXMLTestCase(unittest.TestCase):
                 clear=['obspy.core.inventory.channel'],
                 expected=[(ObsPyDeprecationWarning, msg)]):
             self.assertEqual(cha.storage_format, None)
+        # check new number attributes on Numerator/Denominator
+        resp = cha.response
+        stage = resp.response_stages[1]
+        self.assertEqual(stage.numerator[0].number, 1)
+        self.assertEqual(stage.numerator[1].number, 2)
+        self.assertEqual(stage.denominator[0].number, 3)
+        self.assertEqual(stage.denominator[1].number, 4)
 
     def test_writing_module_tags(self):
         """


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes some oversights in #2510 not properly transitioning Numerator/Denominator over to StationXML1.1. Both of these behave same as `Coefficient` now.

### Why was it initiated?  Any relevant Issues?

Fixes #2548 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
