### PR TITLE
io/nordic/core: fix to let read_nordic properly return waveform file name

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -31,6 +31,7 @@ Fee, Jeremy
 Grellier, Clément
 Grunberg, Marc
 Hagerty, Mike
+Halpaap, Felix
 Hammer, Conny
 Heimann, Sebastian
 Heiniger, Lukas

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -812,7 +812,7 @@ def _readwavename(tagged_lines):
     Internal wave-name reader.
 
     :type tagged_lines: list
-    :param tagged_lines: 
+    :param tagged_lines:
         List of tuples of (strings, line-number) of the waveform lines.
 
     :return: list of wave-file names

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -429,14 +429,13 @@ def _extract_event(event_str, catalog, wav_names, return_wavnames=False):
     for event_line in event_str:
         tmp_sfile.write(event_line)
     tagged_lines = _get_line_tags(f=tmp_sfile)
-    tmp_sfile.seek(0)
     new_event = _readheader(head_lines=tagged_lines['1'])
     new_event = _read_uncertainty(tagged_lines, new_event)
     new_event = _read_highaccuracy(tagged_lines, new_event)
     new_event = _read_focal_mechanisms(tagged_lines, new_event)
     new_event = _read_moment_tensors(tagged_lines, new_event)
     if return_wavnames:
-        wav_names.append(_readwavename(f=tmp_sfile))
+        wav_names.append(_readwavename(tagged_lines=tagged_lines['6']))
     new_event = _read_picks(tagged_lines=tagged_lines, new_event=new_event)
     catalog += new_event
     return catalog, wav_names
@@ -800,23 +799,27 @@ def readwavename(sfile, encoding='latin-1'):
     :rtype: list
     """
     with open(sfile, 'r', encoding=encoding) as f:
-        wavenames = _readwavename(f=f)
+        tagged_lines = _get_line_tags(f=f)
+        if len(tagged_lines['6']) == 0:
+            msg = ('No waveform files in sfile %s' % sfile)
+            warnings.warn(msg)
+        wavenames = _readwavename(tagged_lines=tagged_lines['6'])
     return wavenames
 
 
-def _readwavename(f):
+def _readwavename(tagged_lines):
     """
     Internal wave-name reader.
 
-    :type f: file
-    :param f: File open in read-mode
+    :type tagged_lines: list
+    :param tagged_lines: 
+        List of tuples of (strings, line-number) of the waveform lines.
 
     :return: list of wave-file names
     """
     wavename = []
-    for line in f:
-        if len(line) == 81 and line[79] == '6':
-            wavename.append(line[1:79].strip())
+    for line in tagged_lines:
+        wavename.append(line[0][1:79].strip())
     return wavename
 
 

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -429,6 +429,7 @@ def _extract_event(event_str, catalog, wav_names, return_wavnames=False):
     for event_line in event_str:
         tmp_sfile.write(event_line)
     tagged_lines = _get_line_tags(f=tmp_sfile)
+    tmp_sfile.seek(0)
     new_event = _readheader(head_lines=tagged_lines['1'])
     new_event = _read_uncertainty(tagged_lines, new_event)
     new_event = _read_highaccuracy(tagged_lines, new_event)

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -430,6 +430,9 @@ class TestNordicMethods(unittest.TestCase):
         testing_path = os.path.join(self.testing_path, '01-0411-15L.S201309')
         wavefiles = readwavename(testing_path)
         self.assertEqual(len(wavefiles), 1)
+        #  Check that the read_nordic reads wavname with return_wavnames=True 
+        cat, wavefiles = read_nordic(testing_path, return_wavnames=True)
+        self.assertEqual(len(wavefiles[0]), 1)
         # Test that full paths are handled
         test_event = full_test_event()
         # Add the event to a catalogue which can be used for QuakeML testing

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -432,7 +432,7 @@ class TestNordicMethods(unittest.TestCase):
         self.assertEqual(len(wavefiles), 1)
         # Check that read_nordic reads wavname when return_wavnames=True
         cat, wavefiles = read_nordic(testing_path, return_wavnames=True)
-        self.assertEqual(len(wavefiles[0]), 1)
+        self.assertEqual(wavefiles, [['2013-09-01-0410-35.DFDPC_024_00']])
         # Test that full paths are handled
         test_event = full_test_event()
         # Add the event to a catalogue which can be used for QuakeML testing

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -430,7 +430,7 @@ class TestNordicMethods(unittest.TestCase):
         testing_path = os.path.join(self.testing_path, '01-0411-15L.S201309')
         wavefiles = readwavename(testing_path)
         self.assertEqual(len(wavefiles), 1)
-        #  Check that the read_nordic reads wavname with return_wavnames=True 
+        # Check that read_nordic reads wavname when return_wavnames=True
         cat, wavefiles = read_nordic(testing_path, return_wavnames=True)
         self.assertEqual(len(wavefiles[0]), 1)
         # Test that full paths are handled


### PR DESCRIPTION
### What does this PR do?
It fixes an issue with the `read_nordic`-function which did not correctly return the waveform filenames when specifying the option `return_wavnames=True`.

### Why was it initiated?  Any relevant Issues?
The following code should, besides a catalog, return the waveform files for each event:
`from obspy.io.nordic.core import read_nordic
sfile = '/obspy/io/nordic/tests/data/01-0411-15L.S201309'
cat, wavname = read_nordic(sfile, return_wavnames=True)`
The option `return_wavnames=True` correctly worked in obspy 1.1.0. Refactoring of the functions in io/nordic led to a small bug: A loop over a StringIO object that contains the nordic file's contents was supposed to read the file line by line to find the waveform file name. But for the loop to work, the StringIO object needs to be at position 0 (`.seek(0)`).
The issue arose because the tests only checked the `readwavname(..)`-function, but not the `cat, wavnames = read_nordic(sfile, return_wavnames=True`-option.

### PR Checklist
- [] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes (I understand that there's not `maintenance_1.2.x` yet, therefore submitting to master)
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
~- [ ] Any new or changed features have are fully documented.~
~- [ ] Significant changes have been added to `CHANGELOG.txt` .~
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
