### PR TITLE
fix taup bug with floating point precision on IBM machines

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -255,6 +255,7 @@ Changes:
      functions to detect events based on template matching (see #2315)
  - obspy.taup:
    * fix cycling through colors in ray path plots (see #2470, #2478)
+   * fix a floating point issue on IBM machines (see #2559, #2560)
 
 1.1.1: (doi: 10.5281/zenodo.1040770)
  - General:

--- a/obspy/taup/src/inner_tau_loops.c
+++ b/obspy/taup/src/inner_tau_loops.c
@@ -177,14 +177,17 @@ void bullen_radial_slowness_inner_loop(
 
     for (i=0; i<max_i; i++) {
         double dumb_var = (LAYER(i, SL_BOT_DEPTH) - LAYER(i, SL_TOP_DEPTH));
-        if ((dumb_var < 0.0000000001) || isnan(dumb_var)) {continue;}
+        if ((dumb_var < 0.0000000001) || dumb_var != dumb_var) {continue;}
 
         B = log(LAYER(i, SL_TOP_P) / LAYER(i, SL_BOT_P)) /
             log((radius - LAYER(i, SL_TOP_DEPTH)) /
                 (radius - LAYER(i, SL_BOT_DEPTH)));
-
-        sqrt_top = sqrt(fmax(0.,pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2)));
-        sqrt_bot = sqrt(fmax(0.,pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2)));
+        double arg_top = pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2);
+        double arg_bot = pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2);
+        if (arg_top < 0.) {arg_top = 0.;}
+        if (arg_bot < 0.) {arg_bot = 0.;}
+        sqrt_top = sqrt(arg_top);
+        sqrt_bot = sqrt(arg_bot);
 
         dist[i] = (atan2(p[i], sqrt_bot) - atan2(p[i], sqrt_top)) / B;
         time[i] = (sqrt_top - sqrt_bot) / B;

--- a/obspy/taup/src/inner_tau_loops.c
+++ b/obspy/taup/src/inner_tau_loops.c
@@ -174,16 +174,17 @@ void bullen_radial_slowness_inner_loop(
         int max_i) {
     int i;
     double B, sqrt_top, sqrt_bot;
+    double arg_top, arg_bot, dumb_var;
 
     for (i=0; i<max_i; i++) {
-        double dumb_var = (LAYER(i, SL_BOT_DEPTH) - LAYER(i, SL_TOP_DEPTH));
-        if ((dumb_var < 0.0000000001) || dumb_var != dumb_var) {continue;}
+        dumb_var = (LAYER(i, SL_BOT_DEPTH) - LAYER(i, SL_TOP_DEPTH));
+        if ((dumb_var < 0.0000000001) || (dumb_var != dumb_var)) {continue;}
 
         B = log(LAYER(i, SL_TOP_P) / LAYER(i, SL_BOT_P)) /
             log((radius - LAYER(i, SL_TOP_DEPTH)) /
                 (radius - LAYER(i, SL_BOT_DEPTH)));
-        double arg_top = pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2);
-        double arg_bot = pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2);
+        arg_top = pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2);
+        arg_bot = pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2);
         if (arg_top < 0.) {arg_top = 0.;}
         if (arg_bot < 0.) {arg_bot = 0.;}
         sqrt_top = sqrt(arg_top);

--- a/obspy/taup/src/inner_tau_loops.c
+++ b/obspy/taup/src/inner_tau_loops.c
@@ -176,16 +176,15 @@ void bullen_radial_slowness_inner_loop(
     double B, sqrt_top, sqrt_bot;
 
     for (i=0; i<max_i; i++) {
-        if ((LAYER(i, SL_BOT_DEPTH) - LAYER(i, SL_TOP_DEPTH)) < 0.0000000001) {
-            continue;
-        }
+        double dumb_var = (LAYER(i, SL_BOT_DEPTH) - LAYER(i, SL_TOP_DEPTH));
+        if ((dumb_var < 0.0000000001) || isnan(dumb_var)) {continue;}
 
         B = log(LAYER(i, SL_TOP_P) / LAYER(i, SL_BOT_P)) /
             log((radius - LAYER(i, SL_TOP_DEPTH)) /
                 (radius - LAYER(i, SL_BOT_DEPTH)));
 
-        sqrt_top = sqrt(pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2));
-        sqrt_bot = sqrt(pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2));
+        sqrt_top = sqrt(fmax(0.,pow(LAYER(i, SL_TOP_P), 2) - pow(p[i], 2)));
+        sqrt_bot = sqrt(fmax(0.,pow(LAYER(i, SL_BOT_P), 2) - pow(p[i], 2)));
 
         dist[i] = (atan2(p[i], sqrt_bot) - atan2(p[i], sqrt_top)) / B;
         time[i] = (sqrt_top - sqrt_bot) / B;


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

fix taup bug described in #2559 

### Why was it initiated?  Any relevant Issues?

Closes #2559 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
