### PR TITLE
try to fix loading cdll on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,27 +22,13 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    # - PYTHON: "C:\\Miniconda"
-    #   PYTHON_VERSION: "2.7"
-    #   PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "32"
-      SKIP_NOTAG: "true"
-
     - PYTHON: "C:\\Miniconda3-x64"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
-      SKIP_NOTAG: "true"
-
-    - PYTHON: "C:\\Miniconda35"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
       SKIP_NOTAG: "true"
 
     - PYTHON: "C:\\Miniconda35-x64"
@@ -50,17 +36,9 @@ environment:
       PYTHON_ARCH: "64"
       SKIP_NOTAG: "true"
 
-    - PYTHON: "C:\\Miniconda36"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Miniconda37"
-      PYTHON_VERSION: "3.7"
-      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,11 +85,11 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python -c \"import sys; print(sys.version)\""
 
-  # Install the build and runtime dependencies of the project.
-  - "conda update -q --yes conda"
   - "conda config --add channels conda-forge"
   # add channel twice to move it to the top of the channel priority list
   - "conda config --add channels conda-forge"
+  # Install the build and runtime dependencies of the project.
+  - "conda update -q --yes conda"
   # Create a conda environment using the required ObsPy packages.
   - "conda create -q --yes -n test python=%PYTHON_VERSION%"
   - "activate test"

--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -90,6 +90,8 @@ def _load_cdll(name):
     libdir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
                           'lib')
     libpath = os.path.join(libdir, libname)
+    # resolve parent directory '../' for windows
+    libpath = os.path.normpath(libpath)
     try:
         cdll = ctypes.CDLL(str(libpath))
     except Exception as e:

--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -92,6 +92,7 @@ def _load_cdll(name):
     libpath = os.path.join(libdir, libname)
     # resolve parent directory '../' for windows
     libpath = os.path.normpath(libpath)
+    libpath = os.path.abspath(libpath)
     libpath = str(libpath)
     try:
         cdll = ctypes.CDLL(libpath)

--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -92,11 +92,22 @@ def _load_cdll(name):
     libpath = os.path.join(libdir, libname)
     # resolve parent directory '../' for windows
     libpath = os.path.normpath(libpath)
+    libpath = str(libpath)
     try:
-        cdll = ctypes.CDLL(str(libpath))
+        cdll = ctypes.CDLL(libpath)
     except Exception as e:
-        msg = 'Could not load shared library "%s" ("%s").\n\n %s' % (
-            libname, str(libpath), str(e))
+        import textwrap
+        dirlisting = textwrap.wrap(
+            ', '.join(sorted(os.path.dirname(libpath))))
+        msg = ['Could not load shared library "%s"' % libname,
+               'Path: %s' % libpath,
+               'Current directory: %s' % os.path.abspath(os.curdir),
+               'ctypes error message: %s' % str(e),
+               'Directory listing of lib directory:',
+               '  ',
+               ]
+        msg = '\n  '.join(msg)
+        msg = msg + '\n    '.join(dirlisting)
         raise ImportError(msg)
     return cdll
 


### PR DESCRIPTION

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Seems on Windows we suddenly have issues with '../' in the path?

see e.g. https://ci.appveyor.com/project/obspy/obspy/builds/30964871/job/rkt1cfbwk09uuejh#L3481
```
[00:06:52]   File "obspy\clients\filesystem\miniseed.py", line 20, in <module>
[00:06:52]     from obspy.clients.filesystem.msriterator import _MSRIterator
[00:06:52]   File "obspy\clients\filesystem\msriterator.py", line 14, in <module>
[00:06:52]     from obspy.io.mseed.headers import (HPTMODULUS, MS_NOERROR, MS_ENDOFFILE,
[00:06:52]   File "obspy\io\mseed\headers.py", line 22, in <module>
[00:06:52]     __clibmseed = _load_cdll("mseed")
[00:06:52]   File "obspy\core\util\libnames.py", line 98, in _load_cdll
[00:06:52]     raise ImportError(msg)
[00:06:52] 
[00:06:52] ImportError: Could not load shared library "libmseed_Windows_64bit_py27.pyd" ("obspy\core\util\..\..\lib\libmseed_Windows_64bit_py27.pyd").
[00:06:52] 
[00:06:52]  [Error 126] The specified module could not be found
[00:06:52] 
[00:06:52] >>> Cannot import test suite for module obspy.core due to:
```

Not sure why this never was a problem before.. maybe it's some other issue, we'll see after CI..


### Why was it initiated?  Any relevant Issues?

*Please fill in*

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
