### PR TITLE
Fix for Feature class removal from setuptools v46

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -565,7 +565,7 @@ def export_symbols(*path):
 
 # adds --with-system-libs command-line option if possible
 def add_features():
-    if 'setuptools' not in sys.modules:
+    if 'setuptools' not in sys.modules or not hasattr(setuptools, 'Feature'):
         return {}
 
     class ExternalLibFeature(setuptools.Feature):


### PR DESCRIPTION
The setuptools.Feature class was removed from setuptools v46.0.0.  For now, detect that case and disable the --with-system-libs option. A better solution would find an alternative to setuptools.Feature.

Sorry, I haven't followed the PR checklist. This is just a quick fix you may want to use or not.

EDIT: I see there is already an issue: https://github.com/obspy/obspy/issues/2564