### PR TITLE
inv plotting: fix "if axes:" check for arrays

### DIFF
--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -716,7 +716,7 @@ class Network(BaseNode):
         """
         import matplotlib.pyplot as plt
 
-        if axes:
+        if axes is not None:
             ax1, ax2 = axes
             fig = ax1.figure
         else:

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1811,7 +1811,7 @@ class Response(ComparingObject):
             t_samp=t_samp, nfft=nfft, output=output, start_stage=start_stage,
             end_stage=end_stage)
 
-        if axes:
+        if axes is not None:
             ax1, ax2 = axes
             fig = ax1.figure
         else:

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -540,7 +540,7 @@ class Station(BaseNode):
         """
         import matplotlib.pyplot as plt
 
-        if axes:
+        if axes is not None:
             ax1, ax2 = axes
             fig = ax1.figure
         else:


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes a minor bug in plotting inventories' response. When providing existing `axes` for amplitude/phase response as arrays (e.g. grabbing axes from after `fig, axes = plt.subplots(ncols=2, nrows=2)`), an exception is raised by numpy because `bool()` is not defined on arrays.

```
  File ".../lib/python3.7/site-packages/obspy/core/inventory/response.py", line 1795, in plot
    if axes:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

It's easy to avoid for users by using `my_axes.tolist()` if its an array, but it should still be fixed in next release.

*still needs changelog and maybe some other stuff, this is mostly a quick reminder*

### Why was it initiated?  Any relevant Issues?

*Please fill in*

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
