### PR TITLE
add raw trace support to Kinemetrics' EVT format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 master
 ======
 
+Work on this release was in parts and among others supported by the following
+institutions/companies and grants (in alphabetical order):
+ - The Royal Observatory of Belgium
+
 Changes:
  - obspy.core:
    * Fix wrong values in Stats object after deepcopy or pickle of Stats object
@@ -10,6 +14,9 @@ Changes:
      data when requesting an invalid, out-of-epochs time window for a valid
      station (see #2611)
    * update RASPISHAKE URL mapping to use https
+ - obspy.io.kinemetrics:
+   * adds the ``raw`` argument to the ``read_evt`` method to allow obtaining 
+     the raw data bits stored in the evt file (see #2582)
 
 1.2.1 (doi: 10.5281/zenodo.3706479)
 ===================================

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -72,9 +72,9 @@ Murray-Bergquist, Louisa
 Nesbitt, Ian M.
 Nof, Ran Novitsky
 Panning, Mark P.
-Rapagnani, Giovanni
 Parker, Tom
 Pestourie, Romain
+Rapagnani, Giovanni
 Reyes, Celso
 Ringler, Adam
 Rothenhäusler, Nicolas

--- a/obspy/io/kinemetrics/core.py
+++ b/obspy/io/kinemetrics/core.py
@@ -52,7 +52,7 @@ def is_evt(filename_or_object):
                 return False
 
 
-def read_evt(filename_or_object, **kwargs):
+def read_evt(filename_or_object, raw=False, **kwargs):
     """
     Reads a Evt file and returns a Stream object.
 
@@ -62,9 +62,12 @@ def read_evt(filename_or_object, **kwargs):
 
     :type filename_or_object: str or file-like object
     :param filename_or_object: Evt file to be read
+    :type raw: bool
+    :param raw: if True, returns the raw data as saved in the Evt file, if
+        False (by default) returns the data converted to m/s**2.
     :rtype: :class:`~obspy.core.stream.Stream`
     :return: Stream object containing header and data
     """
     evt_obj = evt.Evt()
-    stream = evt_obj.read_file(filename_or_object)
+    stream = evt_obj.read_file(filename_or_object, raw=raw)
     return stream

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -266,6 +266,30 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(st[0].stats.channel, '0')
         self.assertEqual(st[0].stats.station, 'MOLA')
 
+    def test_read_via_module_raw(self):
+        """
+        Read files via obspy.io.kinemetrics.core.read_evt function.
+        """
+        filename = os.path.join(self.path, 'BI008_MEMA-04823.evt')
+        # 1
+        st = read_evt(filename, raw=True)
+        st.verify()
+        self.assertEqual(len(st), 3)
+        self.assertEqual(st[0].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(st[1].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(st[2].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(len(st[0]), 230 * 25)
+        self.assertAlmostEqual(st[0].stats.sampling_rate, 250.0)
+        self.assertEqual(st[0].stats.channel, '0')
+        self.assertEqual(st[0].stats.station, 'MEMA')
+
+        self.verify_stats_evt(st[0].stats.kinemetrics_evt)
+        self.verify_data_evt0_raw(st[0].data)
+        self.verify_data_evt2_raw(st[2].data)
+
     def verify_stats_evt(self, evt_stats):
         dico = {'chan_fullscale': 2.5, 'chan_sensorgain': 1,
                 'chan_calcoil': 0.0500, 'chan_damping': 0.7070,
@@ -314,6 +338,42 @@ class CoreTestCase(unittest.TestCase):
         valuesend = np.array([-4.4538296759e-002, -4.4549994171e-002,
                               -4.4493857771e-002, -4.4451754540e-002,
                               -4.4409647584e-002])
+
+        # Data values from Tsoft Program
+        # length is 5750
+
+        self.assertEqual(len(data), 5750)
+        self.assertTrue(np.allclose(valuesdeb, data[:len(valuesdeb)]))
+        self.assertTrue(np.allclose(valuesend, data[-len(valuesend):]))
+
+    def verify_data_evt0_raw(self, data):
+        valuesdeb = np.array([-20920., -20980., -20922., -20960.,
+                             -20932., -20936., -20894., -20954.,
+                             -20974., -20912., -20958., -20932.,
+                             -20986., -20948., -20906., -20952.,
+                             -20882., -20912., -20990., -20958.])
+        valuesend = np.array([-21070., -20962., -20930., -20918.,
+                              -20964., -20910., -20934., -21026.,
+                              -20968., -20956., -20976., -20954.,
+                              -20954., -21000., -20966., -20940.,
+                              -20976., -20972., -20956., -20886.])
+        # Data values from Tsoft Program
+
+        self.assertEqual(len(data), 5750)
+        self.assertTrue(np.allclose(valuesdeb, data[:len(valuesdeb)]))
+        self.assertTrue(np.allclose(valuesend, data[-len(valuesend):]))
+
+    def verify_data_evt2_raw(self, data):
+        valuesdeb = np.array([-37922., -38032., -38004., -37936.,
+                              -37966., -37952., -37930., -37998.,
+                              -37974., -37960., -37982., -37992.,
+                              -38000., -37984., -37988., -37980.,
+                              -37954., -37930., -37928., -37932.])
+        valuesend = np.array([-37996., -38010., -38024., -38048.,
+                              -37960., -37878., -37842., -37864.,
+                              -37902., -37908., -38038., -38070.,
+                              -38126., -38170., -38070., -38082.,
+                              -38092., -38044., -38008., -37972.])
 
         # Data values from Tsoft Program
         # length is 5750


### PR DESCRIPTION
### What does this PR do?

ref to #2582 - add arg to get the raw bits from the evt files, not only (remains default) the data converted to m/s**2

### Why was it initiated?  Any relevant Issues?

everything was ready, the kw was just lacking in the call.
closes #2585 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
