### PR TITLE
Fix bug in nordic file read with non-positive definite covariance matrix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ maintenance_1.2.x
 Changes:
  - obspy.clients.neic:
    * Make client socket blocking (see #2617)
+ - obspy.io.nordic:
+   * Fixed a bug raising an exception when reading a nordic file with a non
+     positive-definite covariance matrix (see #2593)
 
 1.2.1 (doi: 10.5281/zenodo.3706479)
 ===================================

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -1294,7 +1294,29 @@ def _write_hyp_error_line(origin):
         errors = origin.origin_uncertainty[
             'confidence_ellipsoid'].confidence_ellipsoid_to_xyz()
     except AttributeError:
-        return ''.join(error_line)
+        try:
+            cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).to_cov()
+            errors['x_err'] = np.sqrt(cov(0,0)) / 1000.0
+            errors['y_err'] = np.sqrt(cov(1,1)) / 1000.0
+            errors['xy_cov'] = cov(0,1) / 1.e06
+            errors['z_err'] = origin.depth_errors / 1000.0
+            error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
+            error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
+            error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(6)
+            error_line[43:55] = ("%.4e" % (errors['xy_cov'])).rjust(12)
+        except AttributeError:
+            try:
+                errors['x_err'] = origin.longitude_errors.uncertainty / 
+                                  _km_to_deg_lon(1.0, origin.latitude))
+                errors['y_err'] = origin.latitude_errors.uncertainty / 
+                                  _km_to_deg_lat(1.0)
+                errors['z_err'] = origin.depth_errors.uncertainty / 1000.0
+                error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
+                error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
+                error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(6)
+            except AttributeError: 
+                return ''.join(error_line)
+            
     error_line[24:30] = (_str_conv(errors['y_err'] / 1000.0, 1)).rjust(6)
     error_line[32:38] = (_str_conv(errors['x_err'] / 1000.0, 1)).rjust(6)
     error_line[38:43] = (_str_conv(errors['z_err'] / 1000.0, 1)).rjust(5)

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -1292,40 +1292,41 @@ def _write_hyp_error_line(origin):
     error_line[5:8] = str(int(origin.quality['azimuthal_gap'])).ljust(3)
     error_line[14:20] = (_str_conv(
         origin.quality['standard_error'], 2)).rjust(6)
-    try:
-        errors = origin.origin_uncertainty[
-            'confidence_ellipsoid'].confidence_ellipsoid_to_xyz()
-    except AttributeError:
+    # try:
+    errors = dict()
+    if hasattr(origin, 'origin_uncertainty'):
+        # Following will work once Ellipsoid class added
+        # if hasattr(origin.origin_uncertainty, 'confidence_ellipsoid'):
+        #     cov = Ellipsoid.from_confidence_ellipsoid(
+        #         origin.origin_uncertainty['confidence_ellipsoid']).to_cov()
+        #     errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
+        #     errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
+        #     errors['z_err'] = m.sqrt(cov(2, 2)) / 1000.0
+        #     # xy_, xz_, then yz_cov fields
+        #     error_line[43:55] = ("%.4e" % (cov(0, 1) / 1.e06)).rjust(12)
+        #     error_line[55:67] = ("%.4e" % (cov(0, 2) / 1.e06)).rjust(12)
+        #     error_line[67:79] = ("%.4e" % (cov(1, 2) / 1.e06)).rjust(12)
+        # else:
+        cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).\
+              to_cov()
+        errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
+        errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
+        errors['z_err'] = origin.depth_errors / 1000.0
+        # xy covariance field
+        error_line[43:55] = ("%.4e" % (cov(0, 1) / 1.e06)).rjust(12)
+    else:
         try:
-            cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).\
-                  to_cov()
-            errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
-            errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
-            errors['xy_cov'] = cov(0, 1) / 1.e06
-            errors['z_err'] = origin.depth_errors / 1000.0
-            error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
-            error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
-            error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(6)
-            error_line[43:55] = ("%.4e" % (errors['xy_cov'])).rjust(12)
+            errors['x_err'] = origin.longitude_errors.uncertainty / \
+                              _km_to_deg_lon(1.0, origin.latitude)
+            errors['y_err'] = origin.latitude_errors.uncertainty / \
+                _km_to_deg_lat(1.0)
+            errors['z_err'] = origin.depth_errors.uncertainty / 1000.0
         except AttributeError:
-            try:
-                errors['x_err'] = origin.longitude_errors.uncertainty / \
-                                  _km_to_deg_lon(1.0, origin.latitude)
-                errors['y_err'] = origin.latitude_errors.uncertainty / \
-                    _km_to_deg_lat(1.0)
-                errors['z_err'] = origin.depth_errors.uncertainty / 1000.0
-                error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
-                error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
-                error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(6)
-            except AttributeError:
-                return ''.join(error_line)
+            return ''.join(error_line)
 
-    error_line[24:30] = (_str_conv(errors['y_err'] / 1000.0, 1)).rjust(6)
-    error_line[32:38] = (_str_conv(errors['x_err'] / 1000.0, 1)).rjust(6)
-    error_line[38:43] = (_str_conv(errors['z_err'] / 1000.0, 1)).rjust(5)
-    error_line[43:55] = ("%.4e" % (errors['xy_cov'] / 1E06)).rjust(12)
-    error_line[55:67] = ("%.4e" % (errors['xz_cov'] / 1E06)).rjust(12)
-    error_line[67:79] = ("%.4e" % (errors['yz_cov'] / 1E06)).rjust(12)
+    error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
+    error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
+    error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(5)
     return ''.join(error_line)
 
 

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -472,16 +472,17 @@ def _read_uncertainty(tagged_lines, event):
         e = Ellipse.from_uncerts(errors['x_err'],
                                  errors['y_err'],
                                  errors['xy_cov'])
-        orig.origin_uncertainty = OriginUncertainty(
-            max_horizontal_uncertainty=e.a * 1000.,
-            min_horizontal_uncertainty=e.b * 1000.,
-            azimuth_max_horizontal_uncertainty=e.theta,
-            preferred_description="uncertainty ellipse")
-        orig.latitude_errors = QuantityError(
-            _km_to_deg_lat(errors['y_err']))
-        orig.longitude_errors = QuantityError(
-            _km_to_deg_lon(errors['x_err'], orig.latitude))
-        orig.depth_errors = QuantityError(errors['z_err'] * 1000.)
+        if e:
+            orig.origin_uncertainty = OriginUncertainty(
+                max_horizontal_uncertainty=e.a * 1000.,
+                min_horizontal_uncertainty=e.b * 1000.,
+                azimuth_max_horizontal_uncertainty=e.theta,
+                preferred_description="uncertainty ellipse")
+            orig.latitude_errors = QuantityError(
+                _km_to_deg_lat(errors['y_err']))
+            orig.longitude_errors = QuantityError(
+                _km_to_deg_lon(errors['x_err'], orig.latitude))
+            orig.depth_errors = QuantityError(errors['z_err'] * 1000.)
     try:
         gap = int(line[5:8])
     except ValueError:

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -29,7 +29,7 @@ import warnings
 import datetime
 import os
 import io
-import math as m
+from math import sqrt
 
 from obspy import UTCDateTime, read
 from obspy.geodetics import kilometers2degrees, degrees2kilometers
@@ -1299,9 +1299,9 @@ def _write_hyp_error_line(origin):
         # if hasattr(origin.origin_uncertainty, 'confidence_ellipsoid'):
         #     cov = Ellipsoid.from_confidence_ellipsoid(
         #         origin.origin_uncertainty['confidence_ellipsoid']).to_cov()
-        #     errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
-        #     errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
-        #     errors['z_err'] = m.sqrt(cov(2, 2)) / 1000.0
+        #     errors['x_err'] = sqrt(cov(0, 0)) / 1000.0
+        #     errors['y_err'] = sqrt(cov(1, 1)) / 1000.0
+        #     errors['z_err'] = sqrt(cov(2, 2)) / 1000.0
         #     # xy_, xz_, then yz_cov fields
         #     error_line[43:55] = ("%.4e" % (cov(0, 1) / 1.e06)).rjust(12)
         #     error_line[55:67] = ("%.4e" % (cov(0, 2) / 1.e06)).rjust(12)
@@ -1309,8 +1309,8 @@ def _write_hyp_error_line(origin):
         # else:
         cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).\
               to_cov()
-        errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
-        errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
+        errors['x_err'] = sqrt(cov(0, 0)) / 1000.0
+        errors['y_err'] = sqrt(cov(1, 1)) / 1000.0
         errors['z_err'] = origin.depth_errors / 1000.0
         # xy covariance field
         error_line[43:55] = ("%.4e" % (cov(0, 1) / 1.e06)).rjust(12)

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -29,6 +29,7 @@ import warnings
 import datetime
 import os
 import io
+import math as m
 
 from obspy import UTCDateTime, read
 from obspy.geodetics import kilometers2degrees, degrees2kilometers
@@ -1295,10 +1296,11 @@ def _write_hyp_error_line(origin):
             'confidence_ellipsoid'].confidence_ellipsoid_to_xyz()
     except AttributeError:
         try:
-            cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).to_cov()
-            errors['x_err'] = np.sqrt(cov(0,0)) / 1000.0
-            errors['y_err'] = np.sqrt(cov(1,1)) / 1000.0
-            errors['xy_cov'] = cov(0,1) / 1.e06
+            cov = Ellipse.from_origin_uncertainty(origin.origin_uncertainty).\
+                  to_cov()
+            errors['x_err'] = m.sqrt(cov(0, 0)) / 1000.0
+            errors['y_err'] = m.sqrt(cov(1, 1)) / 1000.0
+            errors['xy_cov'] = cov(0, 1) / 1.e06
             errors['z_err'] = origin.depth_errors / 1000.0
             error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
             error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
@@ -1306,17 +1308,17 @@ def _write_hyp_error_line(origin):
             error_line[43:55] = ("%.4e" % (errors['xy_cov'])).rjust(12)
         except AttributeError:
             try:
-                errors['x_err'] = origin.longitude_errors.uncertainty / 
-                                  _km_to_deg_lon(1.0, origin.latitude))
-                errors['y_err'] = origin.latitude_errors.uncertainty / 
-                                  _km_to_deg_lat(1.0)
+                errors['x_err'] = origin.longitude_errors.uncertainty / \
+                                  _km_to_deg_lon(1.0, origin.latitude)
+                errors['y_err'] = origin.latitude_errors.uncertainty / \
+                    _km_to_deg_lat(1.0)
                 errors['z_err'] = origin.depth_errors.uncertainty / 1000.0
                 error_line[24:30] = (_str_conv(errors['y_err'], 1)).rjust(6)
                 error_line[32:38] = (_str_conv(errors['x_err'], 1)).rjust(6)
                 error_line[38:43] = (_str_conv(errors['z_err'], 1)).rjust(6)
-            except AttributeError: 
+            except AttributeError:
                 return ''.join(error_line)
-            
+
     error_line[24:30] = (_str_conv(errors['y_err'] / 1000.0, 1)).rjust(6)
     error_line[32:38] = (_str_conv(errors['x_err'] / 1000.0, 1)).rjust(6)
     error_line[38:43] = (_str_conv(errors['z_err'] / 1000.0, 1)).rjust(5)

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -47,14 +47,10 @@ class Ellipse:
         :return: ellipse
         :rtype: :class: `~obspy.io.nordic.ellipse.Ellipse`
         """
-        if a==None or b==None:
-            self.a=None
-            self.b=None
-        else:
-            if a < b:
-                warnings.warn('Semi-major smaller than semi-minor! Switching...')
-            self.a = max(a, b)
-            self.b = min(a, b)
+        if a < b:
+            warnings.warn('Semi-major smaller than semi-minor! Switching...')
+        self.a = max(a, b)
+        self.b = min(a, b)
         self.theta = theta
         self.x = center[0]
         self.y = center[1]
@@ -97,7 +93,6 @@ class Ellipse:
             cov = _fix_cov(cov)
         evals, evecs = np.linalg.eig(cov)
         if np.any(evals < 0):
-            np.set_printoptions(precision=3)
             cov_factor=cov[0][1]
             cov_base=cov/cov_factor
             warnings.warn("Can't make data ellipse because cov matrix not pos "

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -92,8 +92,9 @@ class Ellipse:
         if np.any(evals < 0):
             cov_factor = cov[0][1]
             cov_base = cov/cov_factor
-            warnings.warn("Can't make data ellipse because cov matrix not pos "
-                          "definite: {:g}x[{:.2f} {:g}][{:g} {:.2f}]. ".format(
+            warnings.warn("Can't make data ellipse because covariance matrix "
+                          "is not positive definite: "
+                          "{:g}x[{:.2f} {:g}][{:g} {:.2f}]. ".format(
                             cov_factor, cov_base[0][0], cov_base[0][1],
                             cov_base[1][0], cov_base[1][1]))
             # return cls(None, None, None, center)
@@ -173,13 +174,13 @@ class Ellipse:
     def __eq__(self, other):
         """
         Returns true if two Ellipses are equal
-        
+
         :param other: second Ellipse
         :type other:  :class: `~ellipsoid.Ellipse`
         :return: equal
         :rtype: bool
         """
-        eps=1e-5
+        eps = 1e-5
         if not abs((self.a - other.a) / self.a) < eps:
             return False
         if not abs((self.b - other.b) / self.b) < eps:

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -47,10 +47,14 @@ class Ellipse:
         :return: ellipse
         :rtype: :class: `~obspy.io.nordic.ellipse.Ellipse`
         """
-        if a < b:
-            warnings.warn('Semi-major smaller than semi-minor! Switching...')
-        self.a = max(a, b)
-        self.b = min(a, b)
+        if a==None or b==None:
+            self.a=None
+            self.b=None
+        else:
+            if a < b:
+                warnings.warn('Semi-major smaller than semi-minor! Switching...')
+            self.a = max(a, b)
+            self.b = min(a, b)
         self.theta = theta
         self.x = center[0]
         self.y = center[1]
@@ -88,12 +92,19 @@ class Ellipse:
         :return: ellipse
         :rtype: :class: `~obspy.io.nordic.ellipse.Ellipse`
         """
+        cov = np.array(cov)
         if _almost_good_cov(cov):
             cov = _fix_cov(cov)
         evals, evecs = np.linalg.eig(cov)
         if np.any(evals < 0):
-            warnings.warn('Bad covariance matrix, no ellipse calculated')
-            return cls(None, None, None, center)
+            np.set_printoptions(precision=3)
+            cov_factor=cov[0][1]
+            cov_base=cov/cov_factor
+            warnings.warn("Can't make data ellipse because cov matrix not pos "
+                          "definite: {:g}x[{:.2f} {:g}][{:g} {:.2f}]. ".format(
+                cov_factor,cov_base[0][0],cov_base[0][1], cov_base[1][0],cov_base[1][1]))
+            # return cls(None, None, None, center)
+            return None
         # Sort eigenvalues in decreasing order
         sort_indices = np.argsort(evals)[::-1]
         # Select semi-major and semi-minor axes

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -56,6 +56,22 @@ class Ellipse:
         self.y = center[1]
 
     @classmethod
+    def from_origin_uncertainty(cls, uncert, center=(0, 0)):
+        """Set Ellipse from obspy origin_uncertainty
+
+        :param uncert: obspy origin_uncertainty
+        :type uncert: :class: `~obspy.origin.origin_uncertainty`
+        :param center: center position (x,y)
+        :type center: 2-tuple of numeric
+        :return: ellipse
+        :rtype: :class: `~obspy.io.nordic.ellipse.Ellipse`
+        """
+        a = uncert.max_horizontal_uncertainty
+        b = uncert.min_horizontal_uncertainty
+        theta = uncert.azimuth_max_horizontal_uncertainty 
+        return cls(a, b, theta, center)
+
+    @classmethod
     def from_cov(cls, cov, center=(0, 0)):
         """Set error ellipse using covariance matrix
 

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -93,11 +93,12 @@ class Ellipse:
             cov = _fix_cov(cov)
         evals, evecs = np.linalg.eig(cov)
         if np.any(evals < 0):
-            cov_factor=cov[0][1]
-            cov_base=cov/cov_factor
+            cov_factor = cov[0][1]
+            cov_base = cov/cov_factor
             warnings.warn("Can't make data ellipse because cov matrix not pos "
                           "definite: {:g}x[{:.2f} {:g}][{:g} {:.2f}]. ".format(
-                cov_factor,cov_base[0][0],cov_base[0][1], cov_base[1][0],cov_base[1][1]))
+                            cov_factor, cov_base[0][0], cov_base[0][1],
+                            cov_base[1][0], cov_base[1][1]))
             # return cls(None, None, None, center)
             return None
         # Sort eigenvalues in decreasing order

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -12,9 +12,6 @@ Routines for error ellipses in seismological coordinates (N=0, W=90)
 - See if a point is inside or on an ellipse
 - Calculate the angle subtended by an ellipse (for back-azimuth uncertainty)
 - Plot an ellipse
-
-.. note:
- TODO: ellipsoids (3D ellipses)
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -172,6 +169,29 @@ class Ellipse:
             s += ', ({:.3g},{:.3g})'.format(self.x, self.y)
         s += ')'
         return s
+
+    def __eq__(self, other):
+        """
+        Returns true if two Ellipses are equal
+        
+        :param other: second Ellipse
+        :type other:  :class: `~ellipsoid.Ellipse`
+        :return: equal
+        :rtype: bool
+        """
+        eps=1e-5
+        if not abs((self.a - other.a) / self.a) < eps:
+            return False
+        if not abs((self.b - other.b) / self.b) < eps:
+            return False
+        if not self.x == other.x:
+            return False
+        if not self.y == other.y:
+            return False
+        theta_diff = (self.theta - other.theta) % 180
+        if not (abs(theta_diff) < eps or abs(theta_diff-180) < eps):
+            return False
+        return True
 
     def to_cov(self):
         """Convert to covariance matrix notation

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -93,8 +93,8 @@ class Ellipse:
         if np.any(evals < 0):
             cov_factor = cov[0][1]
             cov_base = cov/cov_factor
-            warnings.warn("Can't make data ellipse because covariance matrix "
-                          "is not positive definite: "
+            warnings.warn("Can not make data ellipse because covariance "
+                          "matrix is not positive definite: "
                           "{:g}x[{:.2f} {:g}][{:g} {:.2f}]. ".format(
                             cov_factor, cov_base[0][0], cov_base[0][1],
                             cov_base[1][0], cov_base[1][1]))

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -68,7 +68,7 @@ class Ellipse:
         """
         a = uncert.max_horizontal_uncertainty
         b = uncert.min_horizontal_uncertainty
-        theta = uncert.azimuth_max_horizontal_uncertainty 
+        theta = uncert.azimuth_max_horizontal_uncertainty
         return cls(a, b, theta, center)
 
     @classmethod

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -51,6 +51,7 @@ class Ellipse:
         self.theta = theta
         self.x = center[0]
         self.y = center[1]
+        self.rtol = 1e-5    # tolerance for __eq__ method
 
     @classmethod
     def from_origin_uncertainty(cls, uncert, center=(0, 0)):
@@ -180,17 +181,17 @@ class Ellipse:
         :return: equal
         :rtype: bool
         """
-        eps = 1e-5
-        if not abs((self.a - other.a) / self.a) < eps:
+        if not abs((self.a - other.a) / self.a) < self.rtol:
             return False
-        if not abs((self.b - other.b) / self.b) < eps:
+        if not abs((self.b - other.b) / self.b) < self.rtol:
             return False
         if not self.x == other.x:
             return False
         if not self.y == other.y:
             return False
         theta_diff = (self.theta - other.theta) % 180
-        if not (abs(theta_diff) < eps or abs(theta_diff-180) < eps):
+        if not ((abs(theta_diff) < self.rtol)
+                or (abs(theta_diff-180) < self.rtol)):
             return False
         return True
 

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -191,7 +191,7 @@ class Ellipse:
             return False
         theta_diff = (self.theta - other.theta) % 180
         if not ((abs(theta_diff) < self.rtol)
-                or (abs(theta_diff-180) < self.rtol)):
+                or (abs(theta_diff - 180) < self.rtol)):
             return False
         return True
 

--- a/obspy/io/nordic/tests/data/sfile_bad_covariance
+++ b/obspy/io/nordic/tests/data/sfile_bad_covariance
@@ -1,0 +1,20 @@
+ 2016  519 0433 29.0 L  37.275 -32.288  6.3  wcc  4 0.2 0.2Lwcc                1
+ GAP=226        0.47     999.9   999.9999.9  0.7587E+08 -0.1111E+09 -0.9411E+08E
+ ACTION:UPD 20-02-26 15:57 OP:sb   STATUS:               ID:20160519043329 L   I
+ 2016-05-19-0433-10M.VNRC__020                                                 6
+ STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
+ LSVWIS1  Sg  0A   433 31.34                             139   -0.0910 4.05 306 
+ LSVWIS1  IAML A   433 31.58       52.03 0.13                          4.05 306 
+ LSVWISZ IPg       433 27.23                                                    
+ LSVWISZ ISg       433 31.31                                                    
+ LSVNISZ  IAML A   433 30.90        54.0 0.10                          5.05   9 
+ LSVNISZ IPg       433 26.60                                                    
+ LSVNISZ ISg       433 30.48                                                    
+ LSVEISZ  IAML A   433 31.75        18.4 0.16                          4.04  80 
+ LSVEISZ IPg       433 26.69                                                    
+ LSVEISZ ISg       433 30.48                                                    
+ LSVCISZ  IAML A   433 30.99        67.6 0.10                          1.99  20 
+ LSVCISZ IPg       433 26.88                                                    
+ LSVCISZ ISg       433 30.72                                                    
+ LSVSISZ IPg       433 27.34                                                    
+ LSVSISZ ISg       433 31.84                                                    

--- a/obspy/io/nordic/tests/test_nordic.py
+++ b/obspy/io/nordic/tests/test_nordic.py
@@ -842,6 +842,16 @@ class TestNordicMethods(unittest.TestCase):
             self.assertEqual(len(pick), 1)
             self.assertEqual(pick[0].time, value)
 
+    def test_read_bad_covariance(self):
+        """
+        Verify graceful exit if covariance matrix is not positive-definite
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            cat = read_events(
+                os.path.join(self.testing_path, "sfile_bad_covariance"))
+        self.assertIs(cat[0].origins[0].origin_uncertainty, None)
+
     def test_read_high_accuracy(self):
         """
         Verify that high-accuracy locations are read, if present


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes a bug in reading nordic files with non positive-definite covariance matrices

### Why was it initiated?  Any relevant Issues?

Previously crashed  with the following message if a nordic file had a non positive-definite covariance matrix.:

```
warnings.warn('Bad covariance matrix, no ellipse calculated')

TypeError                                 Traceback (most recent call last)
<ipython-input-4-16fc7a31ac75> in <module>()
----> 1 cat = read_events('LSVI_ppol_CATALOG_0.0.nordic', 'NORDIC')

<decorator-gen-161> in read_events(pathname_or_url, format, **kwargs)

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/util/decorator.py in _map_example_filename(func, *args, **kwargs)
    298                         except IOError:
    299                             pass
--> 300         return func(*args, **kwargs)
    301     return _map_example_filename
    302 

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/event/catalog.py in read_events(pathname_or_url, format, **kwargs)
    810         return _create_example_catalog()
    811     else:
--> 812         return _generic_reader(pathname_or_url, _read, format=format, **kwargs)
    813 
    814 

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/util/base.py in _generic_reader(pathname_or_url, callback_func, **kwargs)
    699                 raise IOError(2, "No such file or directory", pathname)
    700 
--> 701         generic = callback_func(pathnames[0], **kwargs)
    702         if len(pathnames) > 1:
    703             for filename in pathnames[1:]:

<decorator-gen-162> in _read(filename, format, **kwargs)

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/util/decorator.py in uncompress_file(func, filename, *args, **kwargs)
    208     else:
    209         # no compressions
--> 210         result = func(filename, *args, **kwargs)
    211     return result
    212 

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/event/catalog.py in _read(filename, format, **kwargs)
    819     """
    820     catalog, format = _read_from_plugin('event', filename, format=format,
--> 821                                         **kwargs)
    822     for event in catalog:
    823         event._format = format

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/core/util/base.py in _read_from_plugin(plugin_type, filename, format, **kwargs)
    467         raise TypeError(msg % (format_ep.name, ', '.join(eps)))
    468     # read
--> 469     list_obj = read_format(filename, **kwargs)
    470     return list_obj, format_ep.name
    471 

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/core.py in read_nordic(select_file, return_wavnames, encoding)
    396             catalog, wav_names = _extract_event(
    397                 event_str=event_str, catalog=catalog, wav_names=wav_names,
--> 398                 return_wavnames=return_wavnames)
    399             event_str = []
    400     f.close()

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/core.py in _extract_event(event_str, catalog, wav_names, return_wavnames)
    431     tagged_lines = _get_line_tags(f=tmp_sfile)
    432     new_event = _readheader(head_lines=tagged_lines['1'])
--> 433     new_event = _read_uncertainty(tagged_lines, new_event)
    434     new_event = _read_highaccuracy(tagged_lines, new_event)
    435     new_event = _read_focal_mechanisms(tagged_lines, new_event)

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/core.py in _read_uncertainty(tagged_lines, event)
    471         e = Ellipse.from_uncerts(errors['x_err'],
    472                                  errors['y_err'],
--> 473                                  errors['xy_cov'])
    474         orig.origin_uncertainty = OriginUncertainty(
    475             max_horizontal_uncertainty=e.a * 1000.,

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/ellipse.py in from_uncerts(cls, x_err, y_err, c_xy, center)
    109         """
    110         cov = [[x_err**2, c_xy], [c_xy, y_err**2]]
--> 111         return cls.from_cov(cov, center)
    112 
    113     @classmethod

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/ellipse.py in from_cov(cls, cov, center)
     78         if np.any(evals < 0):
     79             warnings.warn('Bad covariance matrix, no ellipse calculated')
---> 80             return cls(None, None, None, center)
     81         # Sort eigenvalues in decreasing order
     82         sort_indices = np.argsort(evals)[::-1]

~/anaconda3/envs/obspy/lib/python3.6/site-packages/obspy/io/nordic/ellipse.py in __init__(self, a, b, theta, center)
     48         :rtype: :class: `~obspy.io.nordic.ellipse.Ellipse`
     49         """
---> 50         if a < b:
     51             warnings.warn('Semi-major smaller than semi-minor! Switching...')
     52         self.a = max(a, b)

TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

Now gives a warning and jumps out.

There are a few minor additions (but no new features) in the ellipse.py code that I had written in the meantime but not submitted.  When one of my students reported the crash I tested my updated code, which worked.  So I am submitting the full updated code.  I also added a unittest
case corresponding to the crash case.

No new features
No significant changes

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
