### PR TITLE
Fix azimuth read type in nlloc read

### DIFF
--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -319,7 +319,7 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks):
         phase = str(line[4])
         arrival.phase = phase
         arrival.distance = kilometer2degrees(float(line[21]))
-        arrival.azimuth = float(line[23])
+        arrival.azimuth = float(line[22])
         arrival.takeoff_angle = float(line[24])
         arrival.time_residual = float(line[16])
         arrival.time_weight = float(line[17])


### PR DESCRIPTION
ObsPy V1.2.0, OSX

When reading in a NonLinLoc .hyp event file, the value assigned to `arrival.azimuth` is the "RAz" parameter (Col. 23), which is according to the NLL manual:

> Ray take-off azimuth at maximum likelihood hypocenter or expectation in degrees CW from North

not the epicentral distance "SDist" :

> Maximum likelihood or expectation hypocenter to station epicentral azimuth in degrees CW from North

which is in the preceding column (Col. 22) of the hyp file.
When using the `arrival.azimuth` object to plot traces against azimuth, I was getting very different results from those obtained with `gps2dist_azimuth`

So I have made this PR to read the epicentral azimuth, "SDist" instead.