### PR TITLE
Fix deepcopy edge cases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+2.0.0 (master)
+==============
+
+Changes:
+ - obspy.core:
+   * Fix wrong values in Stats object after deepcopy or pickle of Stats object
+     for edge cases (see #2601)
+
 1.2.1 (doi: 10.5281/zenodo.3706479)
 ===================================
 

--- a/obspy/core/event/event.py
+++ b/obspy/core/event/event.py
@@ -291,7 +291,7 @@ class Event(__Event):
         return result
 
     def __setstate__(self, state_dict):
-        super(Event, self).__setstate__(state_dict)
+        self.__dict__.update(state_dict)
         self.scope_resource_ids()
 
     def write(self, filename, format, **kwargs):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2795,6 +2795,16 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(np.sum(np.abs(st4[0].data[same_sign]) <=
                                 np.abs(st2[0].data[same_sign])), npts)
 
+    def test_deepcopy_issue2600(self):
+        """
+        Tests correct deepcopy of Stream, Trace and Stats objects, issue 2600
+        """
+        tr = Trace(data=np.ones(100000), header={'sampling_rate': 1e5})
+        sr1 = tr.stats.sampling_rate
+        sr2 = tr.copy().stats.sampling_rate
+        self.assertEqual(sr1, 1e5)
+        self.assertEqual(sr2, sr1)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2795,16 +2795,6 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(np.sum(np.abs(st4[0].data[same_sign]) <=
                                 np.abs(st2[0].data[same_sign])), npts)
 
-    def test_deepcopy_issue2600(self):
-        """
-        Tests correct deepcopy of Stream, Trace and Stats objects, issue 2600
-        """
-        tr = Trace(data=np.ones(100000), header={'sampling_rate': 1e5})
-        sr1 = tr.stats.sampling_rate
-        sr2 = tr.copy().stats.sampling_rate
-        self.assertEqual(sr1, 1e5)
-        self.assertEqual(sr2, sr1)
-
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2744,6 +2744,16 @@ class TraceTestCase(unittest.TestCase):
         tr_pickled = pickle.loads(pickle.dumps(tr_orig, protocol=2))
         self.assertEqual(tr_orig, tr_pickled)
 
+    def test_deepcopy_issue2600(self):
+        """
+        Tests correct deepcopy of Trace and Stats objects, issue 2600
+        """
+        tr = Trace(data=np.ones(2), header={'sampling_rate': 1e5})
+        sr1 = tr.stats.sampling_rate
+        sr2 = tr.copy().stats.sampling_rate
+        self.assertEqual(sr1, 1e5)
+        self.assertEqual(sr2, sr1)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2754,6 +2754,17 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(sr1, 1e5)
         self.assertEqual(sr2, sr1)
 
+    def test_pickle_issue2600(self):
+        """
+        Tests correct pickle of Trace and Stats objects, issue 2600
+        """
+        tr = Trace(data=np.ones(2), header={'sampling_rate': 1e5})
+        sr1 = tr.stats.sampling_rate
+        tr_pickled = pickle.loads(pickle.dumps(tr, protocol=2))
+        sr2 = tr_pickled.stats.sampling_rate
+        self.assertEqual(sr1, 1e5)
+        self.assertEqual(sr2, sr1)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_util_attribdict.py
+++ b/obspy/core/tests/test_util_attribdict.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
+import pickle
 import unittest
 import warnings
 
 from obspy.core import AttribDict
+
+
+class DefaultTestAttribDict(AttribDict):
+    defaults = {'test': 1}
 
 
 class AttribDictTestCase(unittest.TestCase):
@@ -247,18 +252,20 @@ class AttribDictTestCase(unittest.TestCase):
         self.assertEqual(ad.test, 1)
         self.assertRaises(AttributeError, ad.__setitem__, 'test', 1)
 
-    def test_deepcopy(self):
+    def test_deepcopy_and_pickle(self):
         """
-        Tests deepcopy of AttribDict.
+        Tests deepcopy and pickle of AttribDict.
         """
-        class MyAttribDict(AttribDict):
-            defaults = {'test': 1}
-
-        ad = MyAttribDict()
+        ad = DefaultTestAttribDict()
         ad.muh = 2
         ad2 = ad.copy()
         self.assertEqual(ad2.test, 1)
         self.assertEqual(ad2.muh, 2)
+        self.assertEqual(ad2, ad)
+        ad3 = pickle.loads(pickle.dumps(ad, protocol=2))
+        self.assertEqual(ad3.test, 1)
+        self.assertEqual(ad3.muh, 2)
+        self.assertEqual(ad3, ad)
 
     def test_compare_with_dict(self):
         """

--- a/obspy/core/tests/test_util_attribdict.py
+++ b/obspy/core/tests/test_util_attribdict.py
@@ -249,14 +249,14 @@ class AttribDictTestCase(unittest.TestCase):
 
     def test_deepcopy(self):
         """
-        Tests __deepcopy__ method of AttribDict.
+        Tests deepcopy of AttribDict.
         """
         class MyAttribDict(AttribDict):
             defaults = {'test': 1}
 
         ad = MyAttribDict()
         ad.muh = 2
-        ad2 = ad.__deepcopy__()
+        ad2 = ad.copy()
         self.assertEqual(ad2.test, 1)
         self.assertEqual(ad2.muh, 2)
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -242,18 +242,14 @@ class Stats(AttribDict):
         p.text(str(self))
 
     def __getstate__(self):
-        # Copy the object's state from self.__dict__ which contains
-        # all our instance attributes. Always use the dict.copy()
-        # method to avoid modifying the original state.
         state = self.__dict__.copy()
-        # Remove the unneeded entries.
+        # Remove the unneeded entries
         del state['delta']
         del state['endtime']
         return state
 
     def __setstate__(self, state):
-        # Restore instance attributes
-        self.__dict__.update(state)
+        super(Stats, self).__setstate__(state)
         # trigger refreshing
         self.__setitem__('sampling_rate', state['sampling_rate'])
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -253,6 +253,7 @@ class Stats(AttribDict):
         # trigger refreshing
         self.__setitem__('sampling_rate', state['sampling_rate'])
 
+
 @decorator
 def _add_processing_info(func, *args, **kwargs):
     """

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -249,7 +249,7 @@ class Stats(AttribDict):
         return state
 
     def __setstate__(self, state):
-        super(Stats, self).__setstate__(state)
+        self.__dict__.update(state)
         # trigger refreshing
         self.__setitem__('sampling_rate', state['sampling_rate'])
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -253,7 +253,6 @@ class Stats(AttribDict):
         # trigger refreshing
         self.__setitem__('sampling_rate', state['sampling_rate'])
 
-
 @decorator
 def _add_processing_info(func, *args, **kwargs):
     """

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -244,8 +244,8 @@ class Stats(AttribDict):
     def __getstate__(self):
         state = self.__dict__.copy()
         # Remove the unneeded entries
-        del state['delta']
-        del state['endtime']
+        state.pop('delta', None)
+        state.pop('endtime', None)
         return state
 
     def __setstate__(self, state):

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -241,6 +241,22 @@ class Stats(AttribDict):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
 
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        # Remove the unneeded entries.
+        del state['delta']
+        del state['endtime']
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes
+        self.__dict__.update(state)
+        # trigger refreshing
+        self.__setitem__('sampling_rate', state['sampling_rate'])
+
 
 @decorator
 def _add_processing_info(func, *args, **kwargs):

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -106,15 +106,6 @@ class AttribDict(compatibility.collections_abc.MutableMapping):
     def __delitem__(self, name):
         del self.__dict__[name]
 
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, adict):
-        # set default values
-        self.__dict__.update(self.defaults)
-        # update with pickle dictionary
-        self.update(adict)
-
     def __getattr__(self, name, default=None):
         """
         Py3k hasattr() expects an AttributeError no KeyError to be

--- a/obspy/core/util/attribdict.py
+++ b/obspy/core/util/attribdict.py
@@ -131,11 +131,6 @@ class AttribDict(compatibility.collections_abc.MutableMapping):
     def copy(self):
         return copy.deepcopy(self)
 
-    def __deepcopy__(self, *args, **kwargs):  # @UnusedVariable
-        ad = self.__class__()
-        ad.update(copy.deepcopy(self.__dict__))
-        return ad
-
     def update(self, adict={}):
         for (key, value) in adict.items():
             if key in self.readonly:


### PR DESCRIPTION
Fixes #2600 and the same issue for pickled objects

deepcopy uses the `__deepcopy__` method or if not present `__getstate__`, `__setstate__` methods.
I added custom `__getstate__/__setstate__` methods in Stats and removed the `__deepcopy__` method in Attribdict. 

Update: I also remove `__getstate__/__setstate__ ` in AttribDict. I think they are not necessary.
