### PR TITLE
EIDA Routing Client creating mass requests when asking for non-existing data

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,9 @@ Changes:
    * Fix wrong values in Stats object after deepcopy or pickle of Stats object
      for edge cases (see #2601)
  - obspy.clients.fdsn:
+   * EIDA routing client: fix an issue that leaded to a request of *all* EIDA
+     data when requesting an invalid, out-of-epochs time window for a valid
+     station (see #2611)
    * update RASPISHAKE URL mapping to use https
 
 1.2.1 (doi: 10.5281/zenodo.3706479)

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1869,6 +1869,10 @@ def parse_simple_xml(xml_string):
 
 
 def get_bulk_string(bulk, arguments):
+    if not bulk:
+        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
+               "of all available data")
+        raise FDSNException(msg)
     # If its an iterable, we build up the query string from it
     # StringIO objects also have __iter__ so check for 'read' as well
     if isinstance(bulk, collections_abc.Iterable) \

--- a/obspy/clients/fdsn/routing/eidaws_routing_client.py
+++ b/obspy/clients/fdsn/routing/eidaws_routing_client.py
@@ -12,6 +12,7 @@ Routing client for the EIDAWS routing service.
 import collections
 
 from ..client import get_bulk_string
+from ..header import FDSNNoDataException
 from .routing_client import (
     BaseRoutingClient, _assert_attach_response_not_in_kwargs,
     _assert_filename_not_in_kwargs)
@@ -101,6 +102,12 @@ class EIDAWSRoutingClient(BaseRoutingClient):
             for c in sorted(set(inv.get_contents()["channels"])):
                 new_bulk.append(c.split("."))
                 new_bulk[-1].extend(t)
+
+        # no available data, show appropriate error message and raise
+        if not new_bulk:
+            msg = ('No data available for request (requested time window '
+                   'might be out of bounds of valid station epochs).')
+            raise FDSNNoDataException(msg)
 
         # Finally get the waveforms by getting the routes and downloading
         # everytyhing. Don't directly pass in the initializer as the order

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -27,7 +27,8 @@ import requests
 from obspy import UTCDateTime, read, read_inventory, Stream, Trace
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn import Client, RoutingClient
-from obspy.clients.fdsn.client import build_url, parse_simple_xml
+from obspy.clients.fdsn.client import (build_url, parse_simple_xml,
+                                       get_bulk_string)
 from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
                                        FDSNException, FDSNRedirectException,
                                        FDSNNoDataException, DEFAULT_SERVICES)
@@ -98,6 +99,18 @@ class ClientTestCase(unittest.TestCase):
         cls.client_auth = \
             Client(base_url="IRIS", user_agent=USER_AGENT,
                    user="nobody@iris.edu", password="anonymous")
+
+    def test_empty_bulk_string(self):
+        """
+        Makes sure an exception is raised if an empty bulk string would be
+        produced (e.g. empty list as input for `get_bulk_string()`)
+        """
+        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
+               "of all available data")
+        for bad_input in [[], '', None]:
+            with self.assertRaises(FDSNException) as e:
+                get_bulk_string(bulk=bad_input, arguments={})
+            self.assertEqual(e.exception.args[0], msg)
 
     def test_validate_base_url(self):
         """


### PR DESCRIPTION
<!--

**GitHub should mainly be used for bug reports and code developments/discussions. For generic questions, please use either the [[obspy-users] mailing list](http://lists.swapbytes.de/mailman/listinfo/obspy-users) (for scientific questions to the general ObsPy community) or our [gitter chat](https://gitter.im/obspy/obspy) (for technical questions and direct contact to the developers).**

Before submitting an Issue, please review the [Issue Guidelines](https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-an-issue).

-->

Looks like we have a bug in EIDA Routing Client, see EIDA/userfeedback#56.


  -  ObsPy version 1.2.1
