### PR TITLE
remove_response with ResponseList type response

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,10 @@ Changes:
  - obspy.core:
    * Fix wrong values in Stats object after deepcopy or pickle of Stats object
      for edge cases (see #2601)
+   * when calling evalresp with a ResponseList type response that does not
+     cover the full frequency range, show a meaningful warning instead of
+     raising an exception and continue nevertheless with extrapolated values
+     (see #2614)
  - obspy.clients.fdsn:
    * EIDA routing client: fix an issue that leaded to a request of *all* EIDA
      data when requesting an invalid, out-of-epochs time window for a valid

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1374,12 +1374,15 @@ class Response(ComparingObject):
 
                 if min_f < min_f_avail or max_f > max_f_avail:
                     msg = (
-                        "Cannot calculate the response as it contains a "
+                        "The response contains a "
                         "response list stage with frequencies only from "
                         "%.4f - %.4f Hz. You are requesting a response from "
-                        "%.4f - %.4f Hz.")
-                    raise ValueError(msg % (min_f_avail, max_f_avail, min_f,
-                                            max_f))
+                        "%.4f - %.4f Hz. A spline will be used for inter- "
+                        "and extrapolation. Make sure to use appropriate "
+                        "means to stabilize the deconvolution (e.g. "
+                        "'pre_filt' to above frequency range.)")
+                    warnings.warn(
+                        msg % (min_f_avail, max_f_avail, min_f, max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
                     f, amp, k=3)(frequencies)


### PR DESCRIPTION
In some cases when working with industry, a Frequency-Amplitude-Phase table is the only information on Response for a given sensor/datalogger combination.
These calibration sheets usually only cover a relatively narrow set of frequencies, e.g. ~20 discrete frequencies, in this case from 0.5 to 80 Hertz.

Currently, ObsPy will error out in basically all scenarios when trying to `remove_response()` with such a `ResponseList` only instrument response, due to this piece of code: https://github.com/obspy/obspy/blob/1440229af113d30933ca808a7a2b1daaa1eb6af6/obspy/core/inventory/response.py#L1375-L1382

When commenting out that check, evalresp actually computes an output and it seems sensible, when using appropriate means to stabilize the deconvolution (in this case: `pre_filt=0.2, 0.5, 50, 80`).

I would propose to convert that Exception into a warning, but would like to hear comments / other opinions, especially from people that are more familiar with evalresp internals.

@krischer, maybe @aringler-usgs ?

