### PR TITLE
clients.neic: Make NEIC client socket blocking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
+maintenance_1.2.x
+=================
+
+Changes:
  - obspy.clients.neic:
-   * Remove neic client socket setblocking(0) call
+   * Make client socket blocking (see #2617)
 
 1.2.1 (doi: 10.5281/zenodo.3706479)
 ===================================

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+ - obspy.clients.neic:
+   * Remove neic client socket setblocking(0) call
+
 1.2.1 (doi: 10.5281/zenodo.3706479)
 ===================================
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We love pull requests! Here's a quick guide:
 First, if the pull request (PR) is directly related to an already existing issue (which is no PR yet), drop us a note in that issue before opening the PR. We can convert existing issues into a PR, which avoids duplicated tickets. Otherwise, please follow the ObsPy [branching model](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model). If it is unclear what base branch is appropriate for your code changes, please contact us on gitter, the users mailing list or by opening an issue to discuss the PR first.
 
  1. Fork the repo.
- 2. Make a new branch. For feature additions/changes base your new branch at `master`, for pure bugfixes base your new branch at e.g. `maintenance_1.0.x` .
+ 2. Make a new branch. For feature additions/changes base your new branch at `master`, for pure bugfixes base your new branch at e.g. `maintenance_1.2.x` .
  3. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test!
  4. Make the test pass (call `obspy-runtests` or run individual tests using e.g. [pytest](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests))
  5. Push to your fork and submit a pull request.

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -194,7 +194,6 @@ class Client(object):
                     s.connect((self.host, self.port))
 
                 with io.BytesIO() as tf:
-                    s.setblocking(0)
                     s.send(line.encode('ascii', 'strict'))
                     if self.debug:
                         print(ascdate(), asctime(), "Connected - start reads")


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This removes the call `socket.setblocking(0)` in the NEIC client.

### Why was it initiated?  Any relevant Issues?

Excessive CPU usage has been observed on systems using this client.

A `setblocking(0)` call is commented out in the seedlink client, but is otherwise not referenced within obspy for any other socket handling.  Using a blocking socket waits for data to be available instead of endlessly looping.

The python documentation states:
> You have (of course) a number of choices. You can check return code and error codes and generally drive yourself crazy. If you don’t believe me, try it sometime. Your app will grow large, buggy and **suck CPU**.
> https://docs.python.org/2/howto/sockets.html#non-blocking-sockets


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.neic"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .

