### PR TITLE
Adds pyproject.toml (PEP518) to make pip install more robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = [
+    'numpy>=1.15.0',
+    'scipy>=1.0.0',
+    'matplotlib>=3.2.0',
+    'lxml',
+    'setuptools',
+    'sqlalchemy',
+    'decorator',
+    'requests']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    'numpy>=1.15.0',
-    'scipy>=1.0.0',
-    'matplotlib>=3.2.0',
-    'lxml',
-    'setuptools',
-    'sqlalchemy',
-    'decorator',
-    'requests']
+    'numpy>=1.6.1',
+    'setuptools'
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
+# see PEP518: https://www.python.org/dev/peps/pep-0518/
 requires = [
     'numpy>=1.6.1',
     'setuptools'


### PR DESCRIPTION
This little file is a containing a list of required packages to be installed before obspy. Current version of pip (probably since v19) are able to resolve the order and install multiple packages at once.

Currently, if you are in a fresh environment and want to install numpy and obspy, you have to run pip twice. `python -m pip install numpy && python -m pip install obspy` 
It's because: 
```
$ python -m pip install numpy obspy

...

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-pk9jzee2/setup.py", line 37, in <module>
        raise ImportError(msg)
    ImportError: No module named numpy. Please install numpy first, it is needed before installing ObsPy.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

``` 

With this file included, pip will first install first numpy and only then will try to build wheels for obspy.

You can try it yourself:

```
$ pip install numpy git+git://github.com/heavelock/obspy@41bb2ae
```

I'm merging it into master but it could be also backported to 1.2.x branch with changed versions.

https://github.com/pypa/pip/issues/5761