### PR TITLE
Backport for #2611 (EIDA Routing mass download bug)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,14 @@ maintenance_1.2.x
 =================
 
 Changes:
+ - obspy.core:
+   * Fix wrong values in Stats object after deepcopy or pickle of Stats object
+     for edge cases (see #2601)
+ - obspy.clients.fdsn:
+   * EIDA routing client: fix an issue that leaded to a request of *all* EIDA
+     data when requesting an invalid, out-of-epochs time window for a valid
+     station (see #2611)
+   * update RASPISHAKE URL mapping to use https
  - obspy.clients.neic:
    * Make client socket blocking (see #2617)
  - obspy.io.nordic:

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1880,6 +1880,10 @@ def parse_simple_xml(xml_string):
 
 
 def get_bulk_string(bulk, arguments):
+    if not bulk:
+        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
+               "of all available data")
+        raise FDSNException(msg)
     # If its an iterable, we build up the query string from it
     # StringIO objects also have __iter__ so check for 'read' as well
     if isinstance(bulk, collections_abc.Iterable) \

--- a/obspy/clients/fdsn/routing/eidaws_routing_client.py
+++ b/obspy/clients/fdsn/routing/eidaws_routing_client.py
@@ -16,6 +16,7 @@ from future.builtins import *  # NOQA
 import collections
 
 from ..client import get_bulk_string
+from ..header import FDSNNoDataException
 from .routing_client import (
     BaseRoutingClient, _assert_attach_response_not_in_kwargs,
     _assert_filename_not_in_kwargs)
@@ -105,6 +106,12 @@ class EIDAWSRoutingClient(BaseRoutingClient):
             for c in sorted(set(inv.get_contents()["channels"])):
                 new_bulk.append(c.split("."))
                 new_bulk[-1].extend(t)
+
+        # no available data, show appropriate error message and raise
+        if not new_bulk:
+            msg = ('No data available for request (requested time window '
+                   'might be out of bounds of valid station epochs).')
+            raise FDSNNoDataException(msg)
 
         # Finally get the waveforms by getting the routes and downloading
         # everytyhing. Don't directly pass in the initializer as the order

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -35,7 +35,8 @@ from obspy import UTCDateTime, read, read_inventory, Stream, Trace
 from obspy.core.compatibility import mock, RegExTestCase
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.clients.fdsn import Client, RoutingClient
-from obspy.clients.fdsn.client import build_url, parse_simple_xml
+from obspy.clients.fdsn.client import (build_url, parse_simple_xml,
+                                       get_bulk_string)
 from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
                                        FDSNException, FDSNRedirectException,
                                        FDSNNoDataException, DEFAULT_SERVICES)
@@ -106,6 +107,18 @@ class ClientTestCase(RegExTestCase):
         cls.client_auth = \
             Client(base_url="IRIS", user_agent=USER_AGENT,
                    user="nobody@iris.edu", password="anonymous")
+
+    def test_empty_bulk_string(self):
+        """
+        Makes sure an exception is raised if an empty bulk string would be
+        produced (e.g. empty list as input for `get_bulk_string()`)
+        """
+        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
+               "of all available data")
+        for bad_input in [[], '', None]:
+            with self.assertRaises(FDSNException) as e:
+                get_bulk_string(bulk=bad_input, arguments={})
+            self.assertEqual(e.exception.args[0], msg)
 
     def test_validate_base_url(self):
         """

--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -362,6 +362,23 @@ AA B2 -- DD 2017-01-01T00:00:00 2017-01-02T00:10:00
         # But the get_contents() method should be safe enough.
         self.assertEqual(inv.get_contents(), inv2.get_contents())
 
+    def test_proper_no_data_exception_on_out_of_epoch_dates(self):
+        """
+        Test for #2611 (EIDA/userfeedback#56) which was leading to bulk request
+        of *all* EIDA data when querying a legit station but an out-of-epoch
+        time window for which no data exists.
+        """
+        # this time window is before the requested station was installed
+        t1 = obspy.UTCDateTime('2012-01-01')
+        t2 = t1 + 2
+        msg = ('No data available for request (requested time window '
+               'might be out of bounds of valid station epochs).')
+        with self.assertRaises(FDSNNoDataException) as e:
+            self.client.get_waveforms(
+                network='OE', station='UNNA', channel='HHZ', location='*',
+                starttime=t1, endtime=t2)
+        self.assertEqual(e.exception.args[0], msg)
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(EIDAWSRoutingClientTestCase, 'test')


### PR DESCRIPTION
#2611 should maybe be backported for `maintenance_1.2.x`
+TESTS:clients.fdsn