### PR TITLE
implement get_waveforms_bulk for SDS client

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ master
 ======
 
 Changes:
+ - obspy.clients.filesystem:
+   * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
 
 maintenance_1.2.x
 =================

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -56,6 +56,7 @@ Leeman, John
 Legovini, Paride
 Lesage, Philippe
 Li, Yulin
+Lindeman, Matthew C.
 Lomax, Anthony
 Lopes, Rui L.
 MacCarthy, Jonathan

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -196,9 +196,11 @@ class Client(object):
 
     def get_waveforms_bulk(self, bulk):
         """
-        Reads bulk data from a local SeisComP Data Structure (SDS) directory tree.
+        Reads bulk data from a local SeisComP Data Structure (SDS) directory
+        tree.
 
-        Returns a stream object with with the data requested from the local directory.
+        Returns a stream object with with the data requested from the local
+        directory.
 
         :type bulk: list of tuples
         :param bulk: Information about the requested data.

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -194,6 +194,20 @@ class Client(object):
             st.merge(merge)
         return st
 
+    def get_waveforms_bulk(self, bulk):
+        """
+        Reads bulk data from a local SeisComP Data Structure (SDS) directory tree.
+
+        Returns a stream object with with the data requested from the local directory.
+
+        :type bulk: list of tuples
+        :param bulk: Information about the requested data.
+        """
+        st = Stream()
+        for bulk_string in bulk:
+            st += self.get_waveforms(*bulk_string)
+        return st
+
     def _get_filenames(self, network, station, location, channel, starttime,
                        endtime, sds_type=None):
         """

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -42,7 +42,7 @@ import warnings
 from datetime import timedelta
 
 import numpy as np
-# This is a test comment
+
 from obspy import Stream, read, UTCDateTime
 from obspy.core.stream import _headonly_warning_msg
 from obspy.core.util.misc import BAND_CODE

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -42,7 +42,7 @@ import warnings
 from datetime import timedelta
 
 import numpy as np
-
+# This is a test comment
 from obspy import Stream, read, UTCDateTime
 from obspy.core.stream import _headonly_warning_msg
 from obspy.core.util.misc import BAND_CODE

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -222,6 +222,39 @@ class SDSTestCase(unittest.TestCase):
             if failed:
                 raise Exception
 
+    def test_get_waveforms_bulk(self):
+        """
+        Test get_waveforms_bulk method.
+        """
+        for year, doy in ((2015, 123), (2015, 1), (2012, 1)):
+            t = UTCDateTime("%d-%03dT00:00:00" % (year, doy))
+            with TemporarySDSDirectory(year=year, doy=doy) as temp_sds:
+                chunks = [
+                    ["BW", "ALTM", "", "EHE", t,
+                    t + 20, os.path.join(temp_sds.tempdir, "file_1.mseed")],
+                    ["BW", "ALTM", "", "EHE", t + 20,
+                    t + 40, os.path.join(temp_sds.tempdir, "file_2.mseed")],
+                    ["BW", "ALTM", "", "EHE", t + 40,
+                    t + 60, os.path.join(temp_sds.tempdir, "file_3.mseed")],
+                    ["BW", "ALTM", "", "EHE", t + 60,
+                    t + 80, os.path.join(temp_sds.tempdir, "file_4.mseed")],
+                    ["BW", "ALTM", "", "EHE", t + 80,
+                    t + 100, os.path.join(temp_sds.tempdir, "file_5.mseed")],
+                    ["BW", "ALTM", "", "EHE", t + 120,
+                    t + 140, os.path.join(temp_sds.tempdir, "file_6.mseed")]
+                ]
+                client = Client(temp_sds.tempdir)
+                ret_val = client.get_waveforms_bulk(chunks)
+                contents = [("file_1.mseed", "BW.ALTM..EHE"),
+                        ("file_2.mseed", "BW.ALTM..EHE"),
+                        ("file_3.mseed", "BW.ALTM..EHE"),
+                        ("file_4.mseed", "BW.ALTM..EHE"),
+                        ("file_5.mseed", "BW.ALTM..EHE"),
+                        ("file_6.mseed", "BW.ALTM..EHE")]
+                self.assertEqual(ret_val,
+                             sorted([os.path.join(temp_sds.tempdir, _i[0])
+                                     for _i in contents]))
+
     def test_get_all_stations_and_nslc(self):
         """
         Test `get_all_stations` and `get_all_nslc` methods

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -238,25 +238,25 @@ class SDSTestCase(unittest.TestCase):
                 ["CD", "ZZZ3", "00", "BHN", t + 80,t + 100],
                 ["CD", "ZZZ3", "00", "BHE", t + 120,t + 140]
             ]
-            st = Client(temp_sds.tempdir)
-            ret_val = st.get_waveforms_bulk(chunks)
+            client = Client(temp_sds.tempdir)
+            st = client.get_waveforms_bulk(chunks)
 
             for _i in range(6):
                 if _i <= 2 :
-                    self.assertEqual(ret_val[_i].stats.network, "AB")
-                    self.assertEqual(ret_val[_i].stats.station, "XYZ")
-                    self.assertEqual(ret_val[_i].stats.location, "")
+                    self.assertEqual(st[_i].stats.network, "AB")
+                    self.assertEqual(st[_i].stats.station, "XYZ")
+                    self.assertEqual(st[_i].stats.location, "")
                 elif _i >= 2 :
-                    self.assertEqual(ret_val[_i].stats.network, "CD")
-                    self.assertEqual(ret_val[_i].stats.station, "ZZZ3")
-                    self.assertEqual(ret_val[_i].stats.location, "00")
+                    self.assertEqual(st[_i].stats.network, "CD")
+                    self.assertEqual(st[_i].stats.station, "ZZZ3")
+                    self.assertEqual(st[_i].stats.location, "00")
 
-            self.assertEqual(ret_val[0].stats.channel, "HHZ")
-            self.assertEqual(ret_val[1].stats.channel, "HHN")
-            self.assertEqual(ret_val[2].stats.channel, "HHE")
-            self.assertEqual(ret_val[3].stats.channel, "BHZ")
-            self.assertEqual(ret_val[4].stats.channel, "BHN")
-            self.assertEqual(ret_val[5].stats.channel, "BHE")
+            self.assertEqual(st[0].stats.channel, "HHZ")
+            self.assertEqual(st[1].stats.channel, "HHN")
+            self.assertEqual(st[2].stats.channel, "HHE")
+            self.assertEqual(st[3].stats.channel, "BHZ")
+            self.assertEqual(st[4].stats.channel, "BHN")
+            self.assertEqual(st[5].stats.channel, "BHE")
 
 
     def test_get_all_stations_and_nslc(self):

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -226,42 +226,37 @@ class SDSTestCase(unittest.TestCase):
         """
         Test get_waveforms_bulk method.
         """
-        for year, doy in ((2015, 213), (2015, 1), (2012, 1)):
-            t = UTCDateTime("%d-%03dT00:00:00" % (year, doy))
-            with TemporarySDSDirectory(year=year, doy=doy) as temp_sds:
-                chunks = [
-                    ["AB", "XYZ", "", "HHZ", t,
-                    t + 20, os.path.join(temp_sds.tempdir, "file_1.mseed")],
-                    ["AB", "XYZ", "", "HHN", t + 20,
-                    t + 40, os.path.join(temp_sds.tempdir, "file_2.mseed")],
-                    ["AB", "XYZ", "", "HHE", t + 40,
-                    t + 60, os.path.join(temp_sds.tempdir, "file_3.mseed")],
-                    ["CD", "ZZZ3", "00", "BHZ", t + 60,
-                    t + 80, os.path.join(temp_sds.tempdir, "file_4.mseed")],
-                    ["CD", "ZZZ3", "00", "BHN", t + 80,
-                    t + 100, os.path.join(temp_sds.tempdir, "file_5.mseed")],
-                    ["CD", "ZZZ3", "00", "BHE", t + 120,
-                    t + 140, os.path.join(temp_sds.tempdir, "file_6.mseed")]
-                ]
-                client = Client(temp_sds.tempdir)
-                ret_val = client.get_waveforms_bulk(chunks)
+        year = 2015
+        doy = 247
+        t = UTCDateTime("%d-%03dT00:00:00" % (year, doy))
+        with TemporarySDSDirectory(year=year, doy=doy) as temp_sds:
+            chunks = [
+                ["AB", "XYZ", "", "HHZ", t, t + 20],
+                ["AB", "XYZ", "", "HHN", t + 20,t + 40],
+                ["AB", "XYZ", "", "HHE", t + 40,t + 60],
+                ["CD", "ZZZ3", "00", "BHZ", t + 60,t + 80],
+                ["CD", "ZZZ3", "00", "BHN", t + 80,t + 100],
+                ["CD", "ZZZ3", "00", "BHE", t + 120,t + 140]
+            ]
+            st = Client(temp_sds.tempdir)
+            ret_val = st.get_waveforms_bulk(chunks)
 
-                for _i in range(6):
-                    if _i <= 2 :
-                        self.assertEqual(ret_val[_i].stats.network, "AB")
-                        self.assertEqual(ret_val[_i].stats.station, "XYZ")
-                        self.assertEqual(ret_val[_i].stats.location, "")
-                    elif _i >= 2 :
-                        self.assertEqual(ret_val[_i].stats.network, "CD")
-                        self.assertEqual(ret_val[_i].stats.station, "ZZZ3")
-                        self.assertEqual(ret_val[_i].stats.location, "00")
+            for _i in range(6):
+                if _i <= 2 :
+                    self.assertEqual(ret_val[_i].stats.network, "AB")
+                    self.assertEqual(ret_val[_i].stats.station, "XYZ")
+                    self.assertEqual(ret_val[_i].stats.location, "")
+                elif _i >= 2 :
+                    self.assertEqual(ret_val[_i].stats.network, "CD")
+                    self.assertEqual(ret_val[_i].stats.station, "ZZZ3")
+                    self.assertEqual(ret_val[_i].stats.location, "00")
 
-                self.assertEqual(ret_val[0].stats.channel, "HHZ")
-                self.assertEqual(ret_val[1].stats.channel, "HHN")
-                self.assertEqual(ret_val[2].stats.channel, "HHE")
-                self.assertEqual(ret_val[3].stats.channel, "BHZ")
-                self.assertEqual(ret_val[4].stats.channel, "BHN")
-                self.assertEqual(ret_val[5].stats.channel, "BHE")
+            self.assertEqual(ret_val[0].stats.channel, "HHZ")
+            self.assertEqual(ret_val[1].stats.channel, "HHN")
+            self.assertEqual(ret_val[2].stats.channel, "HHE")
+            self.assertEqual(ret_val[3].stats.channel, "BHZ")
+            self.assertEqual(ret_val[4].stats.channel, "BHN")
+            self.assertEqual(ret_val[5].stats.channel, "BHE")
 
 
     def test_get_all_stations_and_nslc(self):

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -246,35 +246,23 @@ class SDSTestCase(unittest.TestCase):
                 client = Client(temp_sds.tempdir)
                 ret_val = client.get_waveforms_bulk(chunks)
 
-                self.assertEqual(ret_val[0].stats.network, "AB")
-                self.assertEqual(ret_val[0].stats.station, "XYZ")
-                self.assertEqual(ret_val[0].stats.location, "")
+                for _i in range(6):
+                    if _i <= 2 :
+                        self.assertEqual(ret_val[_i].stats.network, "AB")
+                        self.assertEqual(ret_val[_i].stats.station, "XYZ")
+                        self.assertEqual(ret_val[_i].stats.location, "")
+                    elif _i >= 2 :
+                        self.assertEqual(ret_val[_i].stats.network, "CD")
+                        self.assertEqual(ret_val[_i].stats.station, "ZZZ3")
+                        self.assertEqual(ret_val[_i].stats.location, "00")
+
                 self.assertEqual(ret_val[0].stats.channel, "HHZ")
-
-                self.assertEqual(ret_val[1].stats.network, "AB")
-                self.assertEqual(ret_val[1].stats.station, "XYZ")
-                self.assertEqual(ret_val[1].stats.location, "")
                 self.assertEqual(ret_val[1].stats.channel, "HHN")
-
-                self.assertEqual(ret_val[2].stats.network, "AB")
-                self.assertEqual(ret_val[2].stats.station, "XYZ")
-                self.assertEqual(ret_val[2].stats.location, "")
                 self.assertEqual(ret_val[2].stats.channel, "HHE")
-
-                self.assertEqual(ret_val[3].stats.network, "CD")
-                self.assertEqual(ret_val[3].stats.station, "ZZZ3")
-                self.assertEqual(ret_val[3].stats.location, "00")
                 self.assertEqual(ret_val[3].stats.channel, "BHZ")
-
-                self.assertEqual(ret_val[4].stats.network, "CD")
-                self.assertEqual(ret_val[4].stats.station, "ZZZ3")
-                self.assertEqual(ret_val[4].stats.location, "00")
                 self.assertEqual(ret_val[4].stats.channel, "BHN")
-
-                self.assertEqual(ret_val[5].stats.network, "CD")
-                self.assertEqual(ret_val[5].stats.station, "ZZZ3")
-                self.assertEqual(ret_val[5].stats.location, "00")
                 self.assertEqual(ret_val[5].stats.channel, "BHE")
+
 
     def test_get_all_stations_and_nslc(self):
         """

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -245,15 +245,36 @@ class SDSTestCase(unittest.TestCase):
                 ]
                 client = Client(temp_sds.tempdir)
                 ret_val = client.get_waveforms_bulk(chunks)
-                contents = [("file_1.mseed", "AB.XYZ..HHZ"),
-                        ("file_2.mseed", "AB.XYZ..HHN"),
-                        ("file_3.mseed", "AB.XYZ..HHE"),
-                        ("file_4.mseed", "CD.ZZZ3.00.BHZ"),
-                        ("file_5.mseed", "CD.ZZZ3.00.BHN"),
-                        ("file_6.mseed", "CD.ZZZ3.00.BHE")]
-                self.assertEqual(ret_val,
-                             sorted([os.path.join(temp_sds.tempdir, _i[0])
-                                     for _i in contents]))
+
+                self.assertEqual(ret_val[0].stats.network, "AB")
+                self.assertEqual(ret_val[0].stats.station, "XYZ")
+                self.assertEqual(ret_val[0].stats.location, "")
+                self.assertEqual(ret_val[0].stats.channel, "HHZ")
+
+                self.assertEqual(ret_val[1].stats.network, "AB")
+                self.assertEqual(ret_val[1].stats.station, "XYZ")
+                self.assertEqual(ret_val[1].stats.location, "")
+                self.assertEqual(ret_val[1].stats.channel, "HHN")
+
+                self.assertEqual(ret_val[2].stats.network, "AB")
+                self.assertEqual(ret_val[2].stats.station, "XYZ")
+                self.assertEqual(ret_val[2].stats.location, "")
+                self.assertEqual(ret_val[2].stats.channel, "HHE")
+
+                self.assertEqual(ret_val[3].stats.network, "CD")
+                self.assertEqual(ret_val[3].stats.station, "ZZZ3")
+                self.assertEqual(ret_val[3].stats.location, "00")
+                self.assertEqual(ret_val[3].stats.channel, "BHZ")
+
+                self.assertEqual(ret_val[4].stats.network, "CD")
+                self.assertEqual(ret_val[4].stats.station, "ZZZ3")
+                self.assertEqual(ret_val[4].stats.location, "00")
+                self.assertEqual(ret_val[4].stats.channel, "BHN")
+
+                self.assertEqual(ret_val[5].stats.network, "CD")
+                self.assertEqual(ret_val[5].stats.station, "ZZZ3")
+                self.assertEqual(ret_val[5].stats.location, "00")
+                self.assertEqual(ret_val[5].stats.channel, "BHE")
 
     def test_get_all_stations_and_nslc(self):
         """

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -226,31 +226,31 @@ class SDSTestCase(unittest.TestCase):
         """
         Test get_waveforms_bulk method.
         """
-        for year, doy in ((2015, 123), (2015, 1), (2012, 1)):
+        for year, doy in ((2015, 213), (2015, 1), (2012, 1)):
             t = UTCDateTime("%d-%03dT00:00:00" % (year, doy))
             with TemporarySDSDirectory(year=year, doy=doy) as temp_sds:
                 chunks = [
-                    ["BW", "ALTM", "", "EHE", t,
+                    ["AB", "XYZ", "", "HHZ", t,
                     t + 20, os.path.join(temp_sds.tempdir, "file_1.mseed")],
-                    ["BW", "ALTM", "", "EHE", t + 20,
+                    ["AB", "XYZ", "", "HHN", t + 20,
                     t + 40, os.path.join(temp_sds.tempdir, "file_2.mseed")],
-                    ["BW", "ALTM", "", "EHE", t + 40,
+                    ["AB", "XYZ", "", "HHE", t + 40,
                     t + 60, os.path.join(temp_sds.tempdir, "file_3.mseed")],
-                    ["BW", "ALTM", "", "EHE", t + 60,
+                    ["CD", "ZZZ3", "00", "BHZ", t + 60,
                     t + 80, os.path.join(temp_sds.tempdir, "file_4.mseed")],
-                    ["BW", "ALTM", "", "EHE", t + 80,
+                    ["CD", "ZZZ3", "00", "BHN", t + 80,
                     t + 100, os.path.join(temp_sds.tempdir, "file_5.mseed")],
-                    ["BW", "ALTM", "", "EHE", t + 120,
+                    ["CD", "ZZZ3", "00", "BHE", t + 120,
                     t + 140, os.path.join(temp_sds.tempdir, "file_6.mseed")]
                 ]
                 client = Client(temp_sds.tempdir)
                 ret_val = client.get_waveforms_bulk(chunks)
-                contents = [("file_1.mseed", "BW.ALTM..EHE"),
-                        ("file_2.mseed", "BW.ALTM..EHE"),
-                        ("file_3.mseed", "BW.ALTM..EHE"),
-                        ("file_4.mseed", "BW.ALTM..EHE"),
-                        ("file_5.mseed", "BW.ALTM..EHE"),
-                        ("file_6.mseed", "BW.ALTM..EHE")]
+                contents = [("file_1.mseed", "AB.XYZ..HHZ"),
+                        ("file_2.mseed", "AB.XYZ..HHN"),
+                        ("file_3.mseed", "AB.XYZ..HHE"),
+                        ("file_4.mseed", "CD.ZZZ3.00.BHZ"),
+                        ("file_5.mseed", "CD.ZZZ3.00.BHN"),
+                        ("file_6.mseed", "CD.ZZZ3.00.BHE")]
                 self.assertEqual(ret_val,
                              sorted([os.path.join(temp_sds.tempdir, _i[0])
                                      for _i in contents]))

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -232,25 +232,23 @@ class SDSTestCase(unittest.TestCase):
         with TemporarySDSDirectory(year=year, doy=doy) as temp_sds:
             chunks = [
                 ["AB", "XYZ", "", "HHZ", t, t + 20],
-                ["AB", "XYZ", "", "HHN", t + 20,t + 40],
-                ["AB", "XYZ", "", "HHE", t + 40,t + 60],
-                ["CD", "ZZZ3", "00", "BHZ", t + 60,t + 80],
-                ["CD", "ZZZ3", "00", "BHN", t + 80,t + 100],
-                ["CD", "ZZZ3", "00", "BHE", t + 120,t + 140]
+                ["AB", "XYZ", "", "HHN", t + 20, t + 40],
+                ["AB", "XYZ", "", "HHE", t + 40, t + 60],
+                ["CD", "ZZZ3", "00", "BHZ", t + 60, t + 80],
+                ["CD", "ZZZ3", "00", "BHN", t + 80, t + 100],
+                ["CD", "ZZZ3", "00", "BHE", t + 120, t + 140]
             ]
             client = Client(temp_sds.tempdir)
             st = client.get_waveforms_bulk(chunks)
-
             for _i in range(6):
-                if _i <= 2 :
+                if _i <= 2:
                     self.assertEqual(st[_i].stats.network, "AB")
                     self.assertEqual(st[_i].stats.station, "XYZ")
                     self.assertEqual(st[_i].stats.location, "")
-                elif _i >= 2 :
+                elif _i >= 2:
                     self.assertEqual(st[_i].stats.network, "CD")
                     self.assertEqual(st[_i].stats.station, "ZZZ3")
                     self.assertEqual(st[_i].stats.location, "00")
-
             self.assertEqual(st[0].stats.channel, "HHZ")
             self.assertEqual(st[1].stats.channel, "HHN")
             self.assertEqual(st[2].stats.channel, "HHE")


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This PR has implemented the `get_waveforms_bulk` method in obspy/clients/filesystem/sds.py.

### Why was it initiated?  Any relevant Issues?

This PR was initiated due to issue #2616 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
