### PR TITLE
CI: fix flake8 on master

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,5 +19,8 @@ hang-closing = True
 # E704: multiple statements on one line (def)
 # W503: line break before binary operator
 # W504: line break after binary operator
-ignore = E121, E123, E126, E133, E24, E226, E402, E704, W503, W504, 
+# E741: ambiguous variable name 'l'
+#   we mostly use it in some for loops and most people working with code use
+#   truetype fonts anyway
+ignore = E121, E123, E126, E133, E24, E226, E402, E704, W503, W504, E741
 exclude = __init__.py

--- a/.flake8
+++ b/.flake8
@@ -21,6 +21,6 @@ hang-closing = True
 # W504: line break after binary operator
 # E741: ambiguous variable name 'l'
 #   we mostly use it in some for loops and most people working with code use
-#   truetype fonts anyway
+#   monospace fonts anyway
 ignore = E121, E123, E126, E133, E24, E226, E402, E704, W503, W504, E741
 exclude = __init__.py

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -463,7 +463,7 @@ def _write_radiation_pattern_vtk(
         vtk_file.write('VECTORS s_radiation float\n')
         for x, y, z in np.transpose(disps):
             vtk_file.write('{:.3e} {:.3e} {:.3e}\n'.format(x, y, z))
-        vtk_file.write('VECTORS p_radiation float\n'.format(npoints))
+        vtk_file.write('VECTORS p_radiation float\n')
         for x, y, z in np.transpose(dispp):
             vtk_file.write('{:.3e} {:.3e} {:.3e}\n'.format(x, y, z))
 


### PR DESCRIPTION
Can somebody have a look at these two, these look fishy, not sure if the first or last `%` operator should be replaced.. i'd have to look it up (maybe @krischer or @barsch?)

```
obspy/io/xseed/blockette/blockette048.py:57:21: F507 '...' % ... has 4 placeholder(s) but 3 substitution(s)
obspy/io/xseed/blockette/blockette058.py:90:21: F507 '...' % ... has 4 placeholder(s) but 3 substitution(s)
```

```python
 55             for _i in range(self.number_of_history_values):
 56                 string += \ 
 57                     'B048F08-09   %2s %13s %13s %s\n' \ 
 58                     % (format_resp(self.sensitivity_for_calibration[_i], 6),
 59                        format_resp(
 60                            self.frequency_of_calibration_sensitivity[_i], 6),
 61                        self.time_of_above_calibration[_i].format_seed())
 62         elif self.number_of_history_values == 1:
~/git/obspy/obspy/io/xseed/blockette/blockette048.py
```