### PR TITLE
SDS: Continue get_all_stations() when invalid channel codes are encountered

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@ Changes:
      station (see #2611)
    * update RASPISHAKE URL mapping to use https
    * fix a bug of not handling HTTPException in mass_downloader (see #2606)
+ - obspy.clients.filesystem:
+   * sds: continue get_all_stations() even if encountering an invalid channel
+     code (see #2636)
  - obspy.clients.neic:
    * Make client socket blocking (see #2617)
  - obspy.io.nordic:

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -573,7 +573,9 @@ class Client(object):
             try:
                 network = dict_["network"]
                 station = dict_["station"]
-            except (TypeError,KeyError) as e:
+            except (TypeError, KeyError) as e:
+                if isinstance(e, TypeError) and dict_ is not None:
+                    raise
                 msg = (
                     "Failed to extract key from pattern '{}' in path "
                     "'{}': {}").format(pattern_, file_, e)

--- a/obspy/clients/filesystem/sds.py
+++ b/obspy/clients/filesystem/sds.py
@@ -573,7 +573,7 @@ class Client(object):
             try:
                 network = dict_["network"]
                 station = dict_["station"]
-            except KeyError as e:
+            except (TypeError,KeyError) as e:
                 msg = (
                     "Failed to extract key from pattern '{}' in path "
                     "'{}': {}").format(pattern_, file_, e)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Adding `TypeError` in `get_all_stations` allows to have weird channels name in filenames like `1967/XX/WEIRD/D-6.D` without crashing ...

### Why was it initiated?  Any relevant Issues?

Because I have a channel code called `D-6` and it crashes `obspy-sds-report`.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
