### PR TITLE
Fix deprecated link to IPGP webservices in tests

### DIFF
--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -327,7 +327,7 @@ class ClientTestCase(unittest.TestCase):
         """
         c = Client(
             service_mappings={'dataselect':
-                              'http://eida.ipgp.fr/fdsnws/dataselect/1'})
+                              'http://ws.ipgp.fr/fdsnws/dataselect/1'})
         starttime = UTCDateTime('2016-11-01T00:00:00')
         endtime = UTCDateTime('2016-11-01T00:00:10')
         stream = c.get_waveforms('G', 'PEL', '*', 'LHZ', starttime, endtime)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes a deprecated link to IPGP webservices

### Why was it initiated?  Any relevant Issues?

The deprecated link will soon be removed

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS: clients.fdsn"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
