### PR TITLE
Adds build backend to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,4 @@ requires = [
     'numpy>=1.6.1',
     'setuptools'
     ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This line introduces `build backend` to pyproject.toml in order to fulfil the requirements of PEP517. Should fix building on Travis.

Ref to: #2640 