### PR TITLE
Fix wrong import of DistutilsSetupError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,9 @@ import os
 import sys
 import platform
 from distutils.util import change_root
+from distutils.errors import DistutilsSetupError
 
-from numpy.distutils.core import DistutilsSetupError, setup
+from numpy.distutils.core import setup
 from numpy.distutils.ccompiler import get_default_compiler
 from numpy.distutils.command.build import build
 from numpy.distutils.command.install import install


### PR DESCRIPTION
Numpy released new version, 1.19, which broke the setup.
The problem is that we are importing  `DistutilsSetupError` through numpy and it just stopped working.

It was working only due to the fact that <1.19 in `numpy.core` they were doing `from distutils.core import *`. In 1.19 they changed it to `from distutils.core import Distribution` in https://github.com/numpy/numpy/pull/15465 

So instead of going around, I just import `DistutilsSetupError` directly from `distutils`. 

Fixes #2640