### PR TITLE
Backport numpy distutils fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,9 @@ import os
 import sys
 import platform
 from distutils.util import change_root
+from distutils.errors import DistutilsSetupError
 
-from numpy.distutils.core import DistutilsSetupError, setup
+from numpy.distutils.core import setup
 from numpy.distutils.ccompiler import get_default_compiler
 from numpy.distutils.command.build import build
 from numpy.distutils.command.install import install


### PR DESCRIPTION
This is a backport of https://github.com/obspy/obspy/pull/2643 to the maintenance branch.

Installation of ObsPy with the latest numpy is currently not possible on platform without wheels. I think this warrants a new minor ObsPy release.