### PR TITLE
FDSN: set timeout according to default or user setting in service discovery

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changes:
      station (see #2611)
    * update RASPISHAKE URL mapping to use https
    * fix a bug of not handling HTTPException in mass_downloader (see #2606)
+   * use the client's set timeout in service discovery, too (see #2656)
  - obspy.clients.filesystem:
    * sds: continue get_all_stations() even if encountering an invalid channel
      code (see #2636)

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1453,7 +1453,7 @@ class Client(object):
                     try:
                         code, data = download_url(
                             url, opener=opener, headers=headers,
-                            debug=debug)
+                            debug=debug, timeout=self.timeout)
                         if code == 200:
                             wadl_queue.put((url, data))
                         # Pass on the redirect exception.

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1453,7 +1453,7 @@ class Client(object):
                     try:
                         code, data = download_url(
                             url, opener=opener, headers=headers,
-                            debug=debug, timeout=self.timeout)
+                            debug=debug, timeout=self._timeout)
                         if code == 200:
                             wadl_queue.put((url, data))
                         # Pass on the redirect exception.
@@ -1471,7 +1471,9 @@ class Client(object):
                         wadl_queue.put((url, "timeout"))
                     except socket_timeout:
                         wadl_queue.put((url, "timeout"))
-            return ThreadURL()
+            threadurl = ThreadURL()
+            threadurl._timeout = self.timeout
+            return threadurl
 
         threads = list(map(get_download_thread, urls))
         for thread in threads:


### PR DESCRIPTION
### What does this PR do?

Uses the FDSNWS Clients' timeout value for service discovery too.

### Why was it initiated?  Any relevant Issues?

Service discovery was on a different timeout than every other http request issued by the client. Discovering services is vital and should not be on a short timeout. 10s is relatively bad response time for a server, but nevertheless we should allow higher timeout here.
I stumbled over this while trying to debug some flakiness in service discovery and some other requests in EIDA routing client use.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .

CC @krischer 
