### PR TITLE
PPSD: Need to adjust to `set_clim` API change in matplotlib 3.1-3.3

### DIFF
--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -2093,7 +2093,7 @@ class PPSD(object):
 
         if "colorbar" not in fig.ppsd:
             cb = plt.colorbar(ppsd, ax=ax)
-            cb.set_clim(*fig.ppsd.color_limits)
+            cb.mappable.set_clim(*fig.ppsd.color_limits)
             cb.set_label(fig.ppsd.label)
             fig.ppsd.colorbar = cb
 


### PR DESCRIPTION
We need to adjust some PPSD plotting internals to a matplotlib API change:

```
[...]\obspy\signal\spectral_estimation.py:2096: MatplotlibDeprecationWarning: 
The set_clim function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use ScalarMappable.set_clim instead.
  cb.set_clim(*fig.ppsd.color_limits)
```

@millipedes this is something pretty simple and confined, if you wanna give it a shot? It might need an if/else depending on matplotlib version, but actually my guess is that the mentioned `ScalarMappable.set_clim` should be in all old matplotlibs as well, but needs to be checked. This should be worked on branching off of `maintenance_1.2.x`