### PR TITLE
Removal of matplotlib<3 compatibility checks

### DIFF
--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -41,13 +41,10 @@ class ChannelTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         cha = read_inventory()[0][0][0]
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
-            with ImageComparison(self.image_dir, "channel_response.png",
-                                 reltol=reltol) as ic:
+            with ImageComparison(self.image_dir, "channel_response.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 cha.plot(0.005, outfile=ic.name)
 

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -17,7 +17,6 @@ import warnings
 import numpy as np
 from matplotlib import rcParams
 
-from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.testing import ImageComparison
 from obspy import read_inventory
 from obspy.core.inventory import Channel, Equipment

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -42,11 +42,7 @@ class ChannelTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         cha = read_inventory()[0][0][0]
         with warnings.catch_warnings(record=True):

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -179,11 +179,7 @@ class InventoryTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         inv = read_inventory()
         t = UTCDateTime(2008, 7, 1)

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -179,14 +179,12 @@ class InventoryTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         inv = read_inventory()
         t = UTCDateTime(2008, 7, 1)
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
-            with ImageComparison(self.image_dir, "inventory_response.png",
-                                 reltol=reltol) as ic:
+            with ImageComparison(self.image_dir,
+                                 "inventory_response.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 inv.plot_response(0.01, output="ACC", channel="*N",
                                   station="[WR]*", time=t, outfile=ic.name)

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -126,11 +126,7 @@ class NetworkTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         net = read_inventory()[0]
         t = UTCDateTime(2008, 7, 1)

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -126,14 +126,11 @@ class NetworkTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         net = read_inventory()[0]
         t = UTCDateTime(2008, 7, 1)
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
-            with ImageComparison(self.image_dir, "network_response.png",
-                                 reltol=reltol) as ic:
+            with ImageComparison(self.image_dir, "network_response.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 net.plot_response(0.002, output="DISP", channel="B*E",
                                   time=t, outfile=ic.name)

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -126,11 +126,7 @@ class ResponseTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         resp = read_inventory()[0][0][0].response
         with warnings.catch_warnings(record=True):
@@ -145,11 +141,7 @@ class ResponseTestCase(unittest.TestCase):
         """
         Tests the response plot in degrees.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         resp = read_inventory()[0][0][0].response
         with warnings.catch_warnings(record=True):

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -125,13 +125,11 @@ class ResponseTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         resp = read_inventory()[0][0][0].response
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
-            with ImageComparison(self.image_dir, "response_response.png",
-                                 reltol=reltol) as ic:
+            with ImageComparison(self.image_dir,
+                                 "response_response.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 resp.plot(0.001, output="VEL", start_stage=1, end_stage=3,
                           outfile=ic.name)
@@ -140,14 +138,11 @@ class ResponseTestCase(unittest.TestCase):
         """
         Tests the response plot in degrees.
         """
-        reltol = 1.0
-
         resp = read_inventory()[0][0][0].response
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
             with ImageComparison(self.image_dir,
-                                 "response_response_degrees.png",
-                                 reltol=reltol) as ic:
+                                 "response_response_degrees.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 resp.plot(0.001, output="VEL", start_stage=1, end_stage=3,
                           plot_degrees=True, outfile=ic.name)

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -22,7 +22,6 @@ from matplotlib import rcParams
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
     _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, Response)
-from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
 from obspy.core.util.testing import ImageComparison

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -17,7 +17,6 @@ import numpy as np
 from matplotlib import rcParams
 
 from obspy import read_inventory, UTCDateTime
-from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.testing import ImageComparison
 
 

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -37,11 +37,7 @@ class StationTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         sta = read_inventory()[0][0]
         with warnings.catch_warnings(record=True):
@@ -55,11 +51,7 @@ class StationTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        # Bug in matplotlib 1.4.0 - 1.4.x:
-        # See https://github.com/matplotlib/matplotlib/issues/4012
         reltol = 1.0
-        if [1, 4, 0] <= MATPLOTLIB_VERSION <= [1, 5, 0]:
-            reltol = 2.0
 
         sta = read_inventory()[0][0]
         with warnings.catch_warnings(record=True):

--- a/obspy/core/tests/test_station.py
+++ b/obspy/core/tests/test_station.py
@@ -36,13 +36,10 @@ class StationTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         sta = read_inventory()[0][0]
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
-            with ImageComparison(self.image_dir, "station_response.png",
-                                 reltol=reltol) as ic:
+            with ImageComparison(self.image_dir, "station_response.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 sta.plot(0.05, channel="*[NE]", outfile=ic.name)
 
@@ -50,14 +47,11 @@ class StationTestCase(unittest.TestCase):
         """
         Tests the response plot.
         """
-        reltol = 1.0
-
         sta = read_inventory()[0][0]
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
             with ImageComparison(self.image_dir,
-                                 "station_response_degrees.png",
-                                 reltol=reltol) as ic:
+                                 "station_response_degrees.png") as ic:
                 rcParams['savefig.dpi'] = 72
                 sta.plot(0.05, channel="*[NE]", plot_degrees=True,
                          outfile=ic.name)

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -331,10 +331,9 @@ class ImageComparison(NamedTemporaryFile):
         # which is after https://github.com/matplotlib/matplotlib/issues/7905
         # has been fixed.
         #
-        # Thus test images should accurate for matplotlib >= 2.0.1 anf
+        # Thus test images should accurate for matplotlib >= 2.0.1.
         if adjust_tolerance:
-
-            # One last pass depending on the freetype version.
+            # Adjusts tolerance depending on the freetype version.
             # XXX: Should eventually be handled differently!
             try:
                 from matplotlib import ft2font

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -321,13 +321,8 @@ class ImageComparison(NamedTemporaryFile):
         self.plt_close_all_exit = plt_close_all_exit
         self.no_uploads = no_uploads
 
-        if (MATPLOTLIB_VERSION < [1, 4, 0] or
-                (MATPLOTLIB_VERSION[:2] == [1, 4] and style is None)):
-            # No good style support.
-            self.style = None
-        else:
-            import matplotlib.style as mstyle
-            self.style = mstyle.context(style or 'classic')
+        import matplotlib.style as mstyle
+        self.style = mstyle.context(style or 'classic')
 
         # Adjust the tolerance based on the matplotlib version. This works
         # well enough and otherwise testing is just a pain.
@@ -337,30 +332,7 @@ class ImageComparison(NamedTemporaryFile):
         # has been fixed.
         #
         # Thus test images should accurate for matplotlib >= 2.0.1 anf
-        # fairly accurate for matplotlib 1.5.x.
         if adjust_tolerance:
-            # Really old versions.
-            if MATPLOTLIB_VERSION < [1, 3, 0]:
-                self.tol *= 30
-            # 1.3 + 1.4 have slightly different text positioning mostly.
-            elif [1, 3, 0] <= MATPLOTLIB_VERSION < [1, 5, 0]:
-                self.tol *= 15
-            # A few plots with mpl 1.5 have ticks and axis slightl shifted.
-            # This is especially true for ticks with exponential numbers.
-            # Thus the tolerance also has to be a bit higher here.
-            elif [1, 5, 0] <= MATPLOTLIB_VERSION < [2, 0, 0]:
-                self.tol *= 5.0
-            # Matplotlib 2.0.0 has a bug with the tick placement. This is
-            # fixed in 2.0.1 but the tolerance for 2.0.0 has to be much
-            # higher. 12 is an empiric value. The tick placement potentially
-            # influences the axis locations and then the misfit is really
-            # quite high.
-            elif [2, 0, 0] <= MATPLOTLIB_VERSION < [2, 0, 1]:
-                self.tol *= 12
-            # Some section waveform plots made on 2.2.2 have offset ticks on
-            # 2.0.2, so up tolerance a bit (see #2493)
-            elif MATPLOTLIB_VERSION < [2, 1]:
-                self.tol *= 5
 
             # One last pass depending on the freetype version.
             # XXX: Should eventually be handled differently!
@@ -398,10 +370,7 @@ class ImageComparison(NamedTemporaryFile):
         rcdefaults()
         if self.style is not None:
             self.style.__enter__()
-        if MATPLOTLIB_VERSION >= [2, 0, 0]:
-            default_font = 'DejaVu Sans'
-        else:
-            default_font = 'Bitstream Vera Sans'
+        default_font = 'DejaVu Sans'
         rcParams['font.family'] = default_font
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', 'findfont:.*')

--- a/obspy/core/util/testing.py
+++ b/obspy/core/util/testing.py
@@ -23,7 +23,7 @@ from distutils.version import LooseVersion
 import numpy as np
 from lxml import etree
 
-from obspy.core.util.base import NamedTemporaryFile, MATPLOTLIB_VERSION
+from obspy.core.util.base import NamedTemporaryFile
 from obspy.core.util.misc import MatplotlibBackend
 
 # this dictionary contains the locations of checker routines that determine

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -423,10 +423,7 @@ def _plot_basemap_into_axes(
             raise ValueError(msg)
 
         # draw coast lines, country boundaries, fill continents.
-        if MATPLOTLIB_VERSION >= [2, 0, 0]:
-            ax.set_facecolor(water_fill_color)
-        else:
-            ax.set_axis_bgcolor(water_fill_color)
+        ax.set_facecolor(water_fill_color)
         # newer matplotlib errors out if called with empty coastline data (no
         # coast on map)
         if np.size(getattr(bmap, 'coastsegs', [])):
@@ -701,10 +698,7 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
         _CARTOPY_FEATURES[resolution] = (borders, land, ocean)
 
     # Draw coast lines, country boundaries, fill continents.
-    if MATPLOTLIB_VERSION >= [2, 0, 0]:
-        map_ax.set_facecolor(water_fill_color)
-    else:
-        map_ax.set_axis_bgcolor(water_fill_color)
+    map_ax.set_facecolor(water_fill_color)
     map_ax.add_feature(ocean, facecolor=water_fill_color)
     map_ax.add_feature(land, facecolor=continent_fill_color)
     map_ax.add_feature(borders, edgecolor='0.75')

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -2368,12 +2368,7 @@ class BeachBall:
         size = min(width, height)
 
         fig = plt.figure(34, figsize=(size, size))
-        # TODO remove once minimum required matplotlib version reaches 2.0
-        # see matplotlib/matplotlib#5501
-        if MATPLOTLIB_VERSION < [2, 0]:
-            axis_facecolor_kwargs = dict(axisbg='#d5de9c')
-        else:
-            axis_facecolor_kwargs = dict(facecolor='#d5de9c')
+        axis_facecolor_kwargs = dict(facecolor='#d5de9c')
         ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], polar=True,
                           **axis_facecolor_kwargs)
 

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -268,9 +268,6 @@ def _plot_radiation_pattern_quiver(ax3d, ned_mt, type):
     :param type: 'P' or 'S' (P or S wave).
     """
     import matplotlib.pyplot as plt
-    if MATPLOTLIB_VERSION < [1, 4]:
-        msg = ("Matplotlib 3D quiver plot needs matplotlib version >= 1.4.")
-        raise ImportError(msg)
 
     type = type.upper()
     if type not in ("P", "S"):

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -16,7 +16,6 @@ Functions to compute and plot radiation patterns
 import numpy as np
 from matplotlib.cm import get_cmap
 
-from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.event.source import farfield
 from obspy.imaging.scripts.mopad import MomentTensor, BeachBall
 from obspy.imaging.mopad_wrapper import beach

--- a/obspy/imaging/tests/test_ppsd.py
+++ b/obspy/imaging/tests/test_ppsd.py
@@ -28,6 +28,9 @@ class PPSDTestCase(unittest.TestCase):
         # Catch underflow warnings due to plotting on log-scale.
         with np.errstate(all='ignore'):
             with ImageComparison(self.path, 'ppsd.png', reltol=1.5) as ic:
+                # mpl < 2.2 has slightly offset ticks/ticklabels, so it needs
+                # a higher `reltol` tolerance
+                # (see e.g. http://tests.obspy.org/102260)
                 self.ppsd.plot(
                     show=False, show_coverage=True, show_histogram=True,
                     show_percentiles=True, percentiles=[75, 90],

--- a/obspy/imaging/tests/test_ppsd.py
+++ b/obspy/imaging/tests/test_ppsd.py
@@ -8,7 +8,7 @@ import unittest
 import matplotlib.pyplot as plt
 import numpy as np
 
-from obspy.core.util.testing import ImageComparison, MATPLOTLIB_VERSION
+from obspy.core.util.testing import ImageComparison
 from obspy.signal.tests.test_spectral_estimation import _get_ppsd
 
 

--- a/obspy/imaging/tests/test_ppsd.py
+++ b/obspy/imaging/tests/test_ppsd.py
@@ -43,11 +43,7 @@ class PPSDTestCase(unittest.TestCase):
         """
         Test plot of ppsd example data, normal (non-cumulative) style.
         """
-        # mpl < 2.2 has slightly offset ticks/ticklabels, so needs a higher
-        # tolerance (see e.g. http://tests.obspy.org/102260)
         reltol = 2
-        if MATPLOTLIB_VERSION < [2, 2]:
-            reltol = 4
         # Catch underflow warnings due to plotting on log-scale.
         with np.errstate(all='ignore'):
             with ImageComparison(self.path, 'ppsd_freq.png',

--- a/obspy/imaging/tests/test_source.py
+++ b/obspy/imaging/tests/test_source.py
@@ -6,7 +6,6 @@ import os
 import unittest
 
 from obspy.imaging.source import plot_radiation_pattern
-from obspy.core.util.base import MATPLOTLIB_VERSION
 
 
 class RadPatternTestCase(unittest.TestCase):

--- a/obspy/imaging/tests/test_source.py
+++ b/obspy/imaging/tests/test_source.py
@@ -19,8 +19,6 @@ class RadPatternTestCase(unittest.TestCase):
         self.path = path
         self.image_dir = os.path.join(os.path.dirname(__file__), 'images')
 
-    @unittest.skipIf(MATPLOTLIB_VERSION < [1, 4],
-                     'matplotlib >= 1.4 needed for 3D quiver plot.')
     def test_farfield_with_quiver(self):
         """
         Tests to plot P/S wave farfield radiation pattern

--- a/obspy/imaging/util.py
+++ b/obspy/imaging/util.py
@@ -16,7 +16,6 @@ from matplotlib.dates import (
 from matplotlib.ticker import FuncFormatter
 
 from obspy import UTCDateTime
-from obspy.core.util import MATPLOTLIB_VERSION
 
 
 def _seconds_to_days(sec):

--- a/obspy/imaging/util.py
+++ b/obspy/imaging/util.py
@@ -97,10 +97,7 @@ class ObsPyAutoDateFormatter(AutoDateFormatter):
     def __init__(self, *args, **kwargs):
         # the root class of AutoDateFormatter (TickHelper) is an old style
         # class prior to matplotlib version 1.2
-        if MATPLOTLIB_VERSION < [1, 2, 0]:
-            AutoDateFormatter.__init__(self, *args, **kwargs)
-        else:
-            super(ObsPyAutoDateFormatter, self).__init__(*args, **kwargs)
+        super(ObsPyAutoDateFormatter, self).__init__(*args, **kwargs)
         # Reset the scale to make it reproducible across matplotlib versions.
         self.scaled = {}
         self.scaled[1.0] = '%b %d %Y'

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -32,7 +32,7 @@ from matplotlib.ticker import MaxNLocator, ScalarFormatter
 import scipy.signal as signal
 
 from obspy import Stream, Trace, UTCDateTime
-from obspy.core.util import create_empty_data_chunk, MATPLOTLIB_VERSION
+from obspy.core.util import create_empty_data_chunk
 from obspy.geodetics import FlinnEngdahl, kilometer2degrees, locations2degrees
 from obspy.imaging.util import (_set_xaxis_obspy_dates, _id_key, _timestring)
 

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1291,13 +1291,6 @@ class WaveformPlotting(object):
         # Should be integrated by version 2.1
         # (see https://github.com/matplotlib/matplotlib/pull/6560)
         fill_kwargs = {"lw": 0}
-        # There's a strange problem with matplotlib 1.4.1 and 1.4.2.
-        # It seems to not render the filled PolyCollection
-        # objects if linewidth is set to 0 (see http://tests.obspy.org/48219/,
-        # #1502). To circumvent this, use a line color with alpha 0 (and a very
-        # small linewidth).
-        if [1, 4, 1] <= MATPLOTLIB_VERSION < [1, 4, 3]:
-            fill_kwargs = {"edgecolor": (0, 0, 0, 0), "lw": 0.01}
 
         if self.sect_orientation == 'vertical':
             self.fillfun = functools.partial(ax.fill_betweenx, **fill_kwargs)

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -374,12 +374,7 @@ class WaveformPlotting(object):
                 sharex = None
             else:
                 sharex = self.axis[0]
-            # TODO remove once minimum required matplotlib version reaches 2.0
-            # see matplotlib/matplotlib#5501
-            if MATPLOTLIB_VERSION < [2, 0]:
-                axis_facecolor_kwargs = dict(axisbg=self.background_color)
-            else:
-                axis_facecolor_kwargs = dict(facecolor=self.background_color)
+            axis_facecolor_kwargs = dict(facecolor=self.background_color)
             ax = self.fig.add_subplot(len(stream_new), 1, _i + 1,
                                       sharex=sharex, **axis_facecolor_kwargs)
             self.axis.append(ax)
@@ -441,12 +436,7 @@ class WaveformPlotting(object):
                 self.repeat = intervals
         # Create axis to plot on.
         if self.background_color:
-            # TODO remove once minimum required matplotlib version reaches 2.0
-            # see matplotlib/matplotlib#5501
-            if MATPLOTLIB_VERSION < [2, 0]:
-                axis_facecolor_kwargs = dict(axisbg=self.background_color)
-            else:
-                axis_facecolor_kwargs = dict(facecolor=self.background_color)
+            axis_facecolor_kwargs = dict(facecolor=self.background_color)
             ax = self.fig.add_subplot(1, 1, 1, **axis_facecolor_kwargs)
         else:
             ax = self.fig.add_subplot(1, 1, 1)

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -478,11 +478,7 @@ class PsdTestCase(unittest.TestCase):
             np.testing.assert_array_equal(selection_got, expected_selection)
 
         # test one particular selection as an image test
-        # mpl < 2.2 has slightly offset ticks/ticklabels, so needs a higher
-        # tolerance (see e.g. http://tests.obspy.org/102260)
         reltol = 1.5
-        if MATPLOTLIB_VERSION < [2, 2]:
-            reltol = 5
         plot_kwargs = dict(max_percentage=15, xaxis_frequency=True,
                            period_lim=(0.01, 50))
         ppsd.calculate_histogram(**stack_criteria_list[1])
@@ -526,8 +522,6 @@ class PsdTestCase(unittest.TestCase):
                                  plt_close_all_exit=False) as ic:
                 # rms of the valid comparison above is ~31,
                 # rms of the invalid comparison we test here is ~36
-                if MATPLOTLIB_VERSION == [1, 1, 1]:
-                    ic.tol = 33
                 ppsd._plot_histogram(fig=fig, draw=True)
                 with np.errstate(under='ignore'):
                     fig.savefig(ic.name)

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -477,6 +477,8 @@ class PsdTestCase(unittest.TestCase):
             np.testing.assert_array_equal(selection_got, expected_selection)
 
         # test one particular selection as an image test
+        # mpl < 2.2 has slightly offset ticks/ticklabels, so needs a higher
+        # `reltol` tolerance (see e.g. http://tests.obspy.org/102260)
         reltol = 1.5
         plot_kwargs = dict(max_percentage=15, xaxis_frequency=True,
                            period_lim=(0.01, 50))

--- a/obspy/signal/tests/test_spectral_estimation.py
+++ b/obspy/signal/tests/test_spectral_estimation.py
@@ -11,15 +11,14 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
-
 from obspy import Stream, Trace, UTCDateTime, read, read_inventory, Inventory
 from obspy.core import Stats
 from obspy.core.inventory import Response
 from obspy.core.util import NUMPY_VERSION
-from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.base import NamedTemporaryFile, MATPLOTLIB_VERSION
 from obspy.core.util.obspy_types import ObsPyException
 from obspy.core.util.testing import (
-    ImageComparison, ImageComparisonException, MATPLOTLIB_VERSION)
+    ImageComparison, ImageComparisonException)
 from obspy.io.xseed import Parser
 from obspy.signal.spectral_estimation import (PPSD, welch_taper, welch_window)
 from obspy.signal.spectral_estimation import earthquake_models


### PR DESCRIPTION
I noticed a few TODOs to remove some compatibility checks when minimum matplotlib version will be higher than 2.0.  Since we have minimum of 3.2 now, I went ahead and removed them. I also searched the codebase for all checks agains `MATPLOTLIB_VERSION` and I removed all that were checking for versions <3.0. There are left a few of them that are checking for `MATPLOTLIB_VERSION == [3, 0, 1]` but since we still support 3 as a major version, I didn't touch them.