### PR TITLE
should fix flake8 issues for io.xseed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ master
 Changes:
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
+ - obspy.io.xseed:
+   * fix a bug reading SEED blockettes 48 and 58 which was likely never
+     encountered (see #2668)
 
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -256,7 +256,6 @@ class SDSTestCase(unittest.TestCase):
             self.assertEqual(st[4].stats.channel, "BHN")
             self.assertEqual(st[5].stats.channel, "BHE")
 
-
     def test_get_all_stations_and_nslc(self):
         """
         Test `get_all_stations` and `get_all_nslc` methods

--- a/obspy/io/xseed/blockette/blockette048.py
+++ b/obspy/io/xseed/blockette/blockette048.py
@@ -52,13 +52,13 @@ class Blockette048(Blockette):
             string += \
                 '#\t\tCalibrations:\n' + \
                 '#\t\t i, sensitivity, frequency, time of calibration\n'
-            for _i in range(self.number_of_history_values):
-                string += \
-                    'B048F08-09   %2s %13s %13s %s\n' \
-                    % (format_resp(self.sensitivity_for_calibration[_i], 6),
-                       format_resp(
-                           self.frequency_of_calibration_sensitivity[_i], 6),
-                       self.time_of_above_calibration[_i].format_seed())
+            for i in range(self.number_of_history_values):
+                string += 'B048F08-09   %2s %13s %13s %s\n' % (
+                    i,
+                    format_resp(self.sensitivity_for_calibration[i], 6),
+                    format_resp(
+                        self.frequency_of_calibration_sensitivity[i], 6),
+                    self.time_of_above_calibration[i].format_seed())
         elif self.number_of_history_values == 1:
             string += \
                 '#\t\tCalibrations:\n' + \

--- a/obspy/io/xseed/blockette/blockette058.py
+++ b/obspy/io/xseed/blockette/blockette058.py
@@ -85,13 +85,13 @@ class Blockette058(Blockette):
             string += \
                 '#\t\tCalibrations:\n' + \
                 '#\t\t i, sensitivity, frequency, time of calibration\n'
-            for _i in range(self.number_of_history_values):
-                string += \
-                    'B058F07-08   %2s %13s %13s %s\n' \
-                    % (format_resp(self.sensitivity_for_calibration[_i], 6),
-                       format_resp(
-                           self.frequency_of_calibration_sensitivity[_i], 6),
-                       self.time_of_above_calibration[_i].format_seed())
+            for i in range(self.number_of_history_values):
+                string += 'B058F07-08   %2s %13s %13s %s\n' % (
+                    i,
+                    format_resp(self.sensitivity_for_calibration[i], 6),
+                    format_resp(
+                        self.frequency_of_calibration_sensitivity[i], 6),
+                    self.time_of_above_calibration[i].format_seed())
         elif self.number_of_history_values == 1:
             string += \
                 '#\t\tCalibrations:\n' + \


### PR DESCRIPTION
unfortunatly I can't find a single RESP example containing blockette 48 or 59 **with** any calibration data - therefore no test case atm ...

see https://github.com/obspy/obspy/pull/2665#issuecomment-652869882 and https://github.com/obspy/obspy/pull/2631#issue-432383084
