### PR TITLE
Brings back consistency in ignored errors in .flake8 and test-suite internal config

### DIFF
--- a/obspy/core/tests/test_code_formatting.py
+++ b/obspy/core/tests/test_code_formatting.py
@@ -36,6 +36,7 @@ FLAKE8_IGNORE_CODES = [
     'E704',
     'W503',
     'W504',
+    'E741',
 ]
 FLAKE8_EXCLUDE_FILES = [
     "*/__init__.py",


### PR DESCRIPTION
So we have two places where we keep config of flake8. One is `.flake8`, second is `obspy/core/tests/test_code_formatting.py` with list of  `FLAKE8_IGNORE_CODES`. 

The .flake8 was recently modified, without modifying the second place. 

flake8 still did not get new API that would allow for using a config file with the api calls. https://flake8.pycqa.org/en/latest/user/python-api.html 