### PR TITLE
enables hiding sensitivity mismatch warning in response.get_evalresp_response

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ master
 ======
 
 Changes:
+ - obspy.core:
+   * add option to suppress evalresp sensitivity mismatch warning when removing
+     instrument response (see #2677)
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
  - obspy.io.xseed:

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1627,11 +1627,11 @@ class Response(ComparingObject):
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """
+        hsmw = hide_sensitivity_mismatch_warning  # PEP8
         output, chan = self._call_eval_resp_for_frequencies(
             frequencies, output=output, start_stage=start_stage,
             end_stage=end_stage,
-            hide_sensitivity_mismatch_warning=
-            hide_sensitivity_mismatch_warning)
+            hide_sensitivity_mismatch_warning=hsmw)
         return output
 
     def get_evalresp_response(self, t_samp, nfft, output="VEL",
@@ -1676,10 +1676,10 @@ class Response(ComparingObject):
         except Exception:
             freqs = np.linspace(0, fy, int(nfft // 2) + 1).astype(np.float64)
 
+        hsmw = hide_sensitivity_mismatch_warning  # PEP8
         response = self.get_evalresp_response_for_frequencies(
             freqs, output=output, start_stage=start_stage, end_stage=end_stage,
-            hide_sensitivity_mismatch_warning=
-            hide_sensitivity_mismatch_warning)
+            hide_sensitivity_mismatch_warning=hsmw)
         return response, freqs
 
     def __str__(self):

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1598,7 +1598,8 @@ class Response(ComparingObject):
         return output, chan
 
     def get_evalresp_response_for_frequencies(
-            self, frequencies, output="VEL", start_stage=None, end_stage=None):
+            self, frequencies, output="VEL", start_stage=None, end_stage=None,
+            hide_sensitivity_mismatch_warning=False):
         """
         Returns frequency response for given frequencies using evalresp.
 
@@ -1620,16 +1621,22 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
+        :type hide_sensitivity_mismatch_warning: bool
+        :param hide_sensitivity_mismatch_warning: Hide the evalresp warning
+            that computed and reported sensitivities don't match.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """
         output, chan = self._call_eval_resp_for_frequencies(
             frequencies, output=output, start_stage=start_stage,
-            end_stage=end_stage)
+            end_stage=end_stage,
+            hide_sensitivity_mismatch_warning=
+            hide_sensitivity_mismatch_warning)
         return output
 
     def get_evalresp_response(self, t_samp, nfft, output="VEL",
-                              start_stage=None, end_stage=None):
+                              start_stage=None, end_stage=None,
+                              hide_sensitivity_mismatch_warning=False):
         """
         Returns frequency response and corresponding frequencies using
         evalresp.
@@ -1654,6 +1661,9 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
+        :type hide_sensitivity_mismatch_warning: bool
+        :param hide_sensitivity_mismatch_warning: Hide the evalresp warning
+            that computed and reported sensitivities don't match.
         :rtype: tuple of two arrays
         :returns: frequency response and corresponding frequencies
         """
@@ -1667,7 +1677,9 @@ class Response(ComparingObject):
             freqs = np.linspace(0, fy, int(nfft // 2) + 1).astype(np.float64)
 
         response = self.get_evalresp_response_for_frequencies(
-            freqs, output=output, start_stage=start_stage, end_stage=end_stage)
+            freqs, output=output, start_stage=start_stage, end_stage=end_stage,
+            hide_sensitivity_mismatch_warning=
+            hide_sensitivity_mismatch_warning)
         return response, freqs
 
     def __str__(self):

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1663,7 +1663,7 @@ class Response(ComparingObject):
             used (disregarding all later stages).
         :type hide_sensitivity_mismatch_warning: bool
         :param hide_sensitivity_mismatch_warning: Hide the evalresp warning
-            that computed and reported sensitivities don't match.
+            that computed and reported sensitivities do not match.
         :rtype: tuple of two arrays
         :returns: frequency response and corresponding frequencies
         """

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1623,7 +1623,7 @@ class Response(ComparingObject):
             used (disregarding all later stages).
         :type hide_sensitivity_mismatch_warning: bool
         :param hide_sensitivity_mismatch_warning: Hide the evalresp warning
-            that computed and reported sensitivities don't match.
+            that computed and reported sensitivities do not match.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2679,7 +2679,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             Any additional kwargs will be passed on to
             :meth:`obspy.core.inventory.response.Response.get_evalresp_response`,
             see documentation of that method for further customization (e.g.
-            start/stop stage).
+            start/stop stage and hiding overall sensitivity mismatch warning).
 
         .. note::
 


### PR DESCRIPTION

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This branch simply adds the possibility to hide  sensitivity mismatch warnings in response.get_evalresp_response, leaving the default of False for legacy code using the method

### Why was it initiated?  Any relevant Issues?

In the Response object public methods a user can not ignore sensitivity mismatch warning, printing to stderr and particularly tedious because the warnings seem to be issued from external C-libraries and thus they are hard (albeit not impossible) to capture from within Python. The fix is simple: the parameter hide_sensitivity_warnings is already implemented in the private class methods: This PR simply adds the optional parameter in response.get_evalresp_response, passing then the value to the nested private methods

Note: I did not implement any new test because it would involve testing external libraries which should not be ObsPy goal (on a terminal it works though)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
