### PR TITLE
Removes quotation marks from .coveragerc omit section

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
-omit = "*/data/*","*/docs/*"
+omit = 
+       */data/*
+       */docs/*
 source = obspy/*
 
 [report]


### PR DESCRIPTION
Yesterday I was configuring coverage in my project and I noticed that `omit` section of the config did not work when paths were given within quotation marks. Removal of them makes them work.

I have no idea if it makes any difference for obspy but since we have it, better we have it right. 

https://coverage.readthedocs.io/en/latest/source.html#source