### PR TITLE
Make deep and shallow copies in Inventory add consistent

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+maintenance_1.2.x
+=================
+
+Changes:
+ - obspy.core:
+   * Inventory addition now consistently uses shallow copies (#2675, #2694)
+
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================
 

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -304,11 +304,11 @@ class Inventory(ComparingObject):
 
     def extend(self, network_list):
         """
-        Extends the current Catalog object with a list of Network objects.
+        Extends the current Inventory object with another Inventory or a list of Network objects.
         """
         if isinstance(network_list, list):
             for _i in network_list:
-                # Make sure each item in the list is a event.
+                # Make sure each item in the list is a Network.
                 if not isinstance(_i, Network):
                     msg = 'Extend only accepts a list of Network objects.'
                     raise TypeError(msg)

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -315,6 +315,7 @@ class Inventory(ComparingObject):
             self.networks.extend(network_list)
         elif isinstance(network_list, Inventory):
             self.networks.extend(network_list.networks)
+            self.__copy_inventory_metadata(network_list)
         else:
             msg = 'Extend only supports a list of Network objects as argument.'
             raise TypeError(msg)

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -178,10 +178,12 @@ class Inventory(ComparingObject):
 
     def __iadd__(self, other):
         if isinstance(other, Inventory):
+            other = copy.deepcopy(other)
             self.networks.extend(other.networks)
             # This is a straight inventory merge.
             self.__copy_inventory_metadata(other)
         elif isinstance(other, Network):
+            other = copy.deepcopy(other)
             self.networks.append(other)
         else:
             msg = ("Only Inventory and Network objects can be added to "

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -172,18 +172,16 @@ class Inventory(ComparingObject):
         return not self.__eq__(other)
 
     def __add__(self, other):
-        new = copy.deepcopy(self)
+        new = copy.copy(self)
         new += other
         return new
 
     def __iadd__(self, other):
         if isinstance(other, Inventory):
-            other = copy.deepcopy(other)
             self.networks.extend(other.networks)
             # This is a straight inventory merge.
             self.__copy_inventory_metadata(other)
         elif isinstance(other, Network):
-            other = copy.deepcopy(other)
             self.networks.append(other)
         else:
             msg = ("Only Inventory and Network objects can be added to "
@@ -304,7 +302,8 @@ class Inventory(ComparingObject):
 
     def extend(self, network_list):
         """
-        Extends the current Inventory object with another Inventory or a list of Network objects.
+        Extends the current Inventory object with another Inventory or a list
+        of Network objects.
         """
         if isinstance(network_list, list):
             for _i in network_list:

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -663,40 +663,34 @@ class InventoryTestCase(unittest.TestCase):
 
     def test_add(self):
         """
-        Test deep and shallow copies for inventory addition
+        Test shallow copies for inventory addition
         """
         inv1 = read_inventory()
         inv2 = read_inventory()
 
-        # __add__ creates two deep copies
+        # __add__ creates two shallow copies
         inv_sum = inv1 + inv2
-        self.assertEqual(len({id(net) for net in inv_sum} &
-                             {id(net) for net in inv1}), 0)
-        self.assertEqual(len({id(net) for net in inv_sum} &
-                             {id(net) for net in inv2}), 0)
+        self.assertEqual({id(net) for net in inv_sum},
+                         {id(net) for net in inv1} | {id(net) for net in inv2})
 
-        # __iadd__ creates a deep copy of other but keeps self
+        # __iadd__ creates a shallow copy of other and keeps self
         ids1 = {id(net) for net in inv1}
         inv1 += inv2
-        self.assertEqual(len({id(net) for net in inv1} &
-                             {id(net) for net in inv2}), 0)
-        self.assertEqual({id(net) for net in inv1} &
-                         ids1, ids1)
+        self.assertEqual({id(net) for net in inv1},
+                         ids1 | {id(net) for net in inv2})
 
-        # __add__ with a network creates two deep copies
+        # __add__ with a network appends the network to a shallow copy of
+        # the inventory
         net1 = Network('N1')
         inv_sum = inv1 + net1
-        self.assertEqual(len({id(net) for net in inv_sum} &
-                             {id(net) for net in inv1}), 0)
-        self.assertEqual(len({id(net) for net in inv_sum} &
-                             {id(net1)}), 0)
+        self.assertEqual({id(net) for net in inv_sum},
+                         {id(net) for net in inv1} | {id(net1)})
 
-        # __iadd__ with a network creates a deep copy of other but keeps self
+        # __iadd__ with a network appends the network to the inventory
         net1 = Network('N1')
         ids1 = {id(net) for net in inv1}
         inv1 += net1
-        self.assertEqual(len({id(net) for net in inv1} & {id(net1)}), 0)
-        self.assertEqual({id(net) for net in inv1} & ids1, ids1)
+        self.assertEqual({id(net) for net in inv1}, ids1 | {id(net1)})
 
     def test_extend_metadata(self):
         """

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -670,20 +670,26 @@ class InventoryTestCase(unittest.TestCase):
 
         # __add__ creates two deep copies
         inv_sum = inv1 + inv2
-        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv1}), 0)
-        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv2}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} &
+                             {id(net) for net in inv1}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} &
+                             {id(net) for net in inv2}), 0)
 
         # __iadd__ creates a deep copy of other but keeps self
         ids1 = {id(net) for net in inv1}
         inv1 += inv2
-        self.assertEqual(len({id(net) for net in inv1} & {id(net) for net in inv2}), 0)
-        self.assertEqual({id(net) for net in inv1} & ids1, ids1)
+        self.assertEqual(len({id(net) for net in inv1} &
+                             {id(net) for net in inv2}), 0)
+        self.assertEqual({id(net) for net in inv1} &
+                         ids1, ids1)
 
         # __add__ with a network creates two deep copies
         net1 = Network('N1')
         inv_sum = inv1 + net1
-        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv1}), 0)
-        self.assertEqual(len({id(net) for net in inv_sum} & {id(net1)}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} &
+                             {id(net) for net in inv1}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} &
+                             {id(net1)}), 0)
 
         # __iadd__ with a network creates a deep copy of other but keeps self
         net1 = Network('N1')

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -692,6 +692,18 @@ class InventoryTestCase(unittest.TestCase):
         self.assertEqual(len({id(net) for net in inv1} & {id(net1)}), 0)
         self.assertEqual({id(net) for net in inv1} & ids1, ids1)
 
+    def test_extend_metadata(self):
+        """
+        Test that extend merges the metadata of the Inventories
+        """
+        inv1 = Inventory([], source='S1', sender='T1')
+        inv2 = Inventory([], source='S2', sender='T2')
+
+        inv1.extend(inv2)
+
+        self.assertEqual(inv1.source, 'S1,S2')
+        self.assertEqual(inv1.sender, 'T1,T2')
+
     def test_read_inventory_with_wildcard(self):
         """
         Tests the read_inventory() function with a filename wild card.

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -661,6 +661,37 @@ class InventoryTestCase(unittest.TestCase):
         self.assertEqual(inv2[0][0][0].latitude, original_latitude + 1)
         self.assertNotEqual(inv[0][0][0].latitude, inv2[0][0][0].latitude)
 
+    def test_add(self):
+        """
+        Test deep and shallow copies for inventory addition
+        """
+        inv1 = read_inventory()
+        inv2 = read_inventory()
+
+        # __add__ creates two deep copies
+        inv_sum = inv1 + inv2
+        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv1}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv2}), 0)
+
+        # __iadd__ creates a deep copy of other but keeps self
+        ids1 = {id(net) for net in inv1}
+        inv1 += inv2
+        self.assertEqual(len({id(net) for net in inv1} & {id(net) for net in inv2}), 0)
+        self.assertEqual({id(net) for net in inv1} & ids1, ids1)
+
+        # __add__ with a network creates two deep copies
+        net1 = Network('N1')
+        inv_sum = inv1 + net1
+        self.assertEqual(len({id(net) for net in inv_sum} & {id(net) for net in inv1}), 0)
+        self.assertEqual(len({id(net) for net in inv_sum} & {id(net1)}), 0)
+
+        # __iadd__ with a network creates a deep copy of other but keeps self
+        net1 = Network('N1')
+        ids1 = {id(net) for net in inv1}
+        inv1 += net1
+        self.assertEqual(len({id(net) for net in inv1} & {id(net1)}), 0)
+        self.assertEqual({id(net) for net in inv1} & ids1, ids1)
+
     def test_read_inventory_with_wildcard(self):
         """
         Tests the read_inventory() function with a filename wild card.


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Makes use of deep and shallow copies for inventory addition consistent, by consequently using shallow copies. In addition, `Inventory.extend` now copies Inventory metadata when given an Inventory as argument. Makes minor fixes to documentation.

### Why was it initiated?  Any relevant Issues?

Fixes #2675, including the suggestions from @trichter.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
