### PR TITLE
Fix plot_response method to fail gracefully

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Allgeyer, Sebastien
 Ammon, Charles J.
 Antunes, Emanuel
 Arnarsson, Ólafur St.
+Bates, Garrett
 Bagagli, Matteo
 Bank, Markus
 Barsch, Robert

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -1117,7 +1117,8 @@ class Inventory(ComparingObject):
                                starttime=starttime, endtime=endtime)
 
         if not matching.networks:
-            raise ObsPyException("No channel match in inventory for the given filters.")
+                msg = "No matching channels for the given filters"
+                warnings.warn(msg, UserWarning)
 
         for net in matching.networks:
             for sta in net.stations:
@@ -1138,7 +1139,7 @@ class Inventory(ComparingObject):
                         msg = "Skipping plot of channel (%s):\n%s"
                         warnings.warn(msg % (str(e), str(cha)), UserWarning)
         # final adjustments to plot if we created the figure in here
-        if axes is None:
+        if axes is None and matching.networks:
             from obspy.core.inventory.response import _adjust_bode_plot_figure
             _adjust_bode_plot_figure(fig, plot_degrees, show=False)
         if outfile:

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -1116,6 +1116,9 @@ class Inventory(ComparingObject):
                                location=location, channel=channel, time=time,
                                starttime=starttime, endtime=endtime)
 
+        if not matching.networks:
+            raise ObsPyException("No channel match in inventory for the given filters.")
+
         for net in matching.networks:
             for sta in net.stations:
                 for cha in sta.channels:

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -723,7 +723,8 @@ class Network(BaseNode):
                                starttime=starttime, endtime=endtime)
 
         if not matching.stations:
-            raise ObsPyException("No channel match in inventory for the given filters.")
+                msg = "No matching channels for the given filters"
+                warnings.warn(msg, UserWarning)
 
         for sta in matching.stations:
             for cha in sta.channels:
@@ -742,7 +743,7 @@ class Network(BaseNode):
                     warnings.warn(msg % (str(e), str(cha)), UserWarning)
 
         # final adjustments to plot if we created the figure in here
-        if not axes:
+        if not axes and matching.stations:
             from obspy.core.inventory.response import _adjust_bode_plot_figure
             _adjust_bode_plot_figure(fig, show=False)
 

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -722,6 +722,9 @@ class Network(BaseNode):
                                channel=channel, time=time,
                                starttime=starttime, endtime=endtime)
 
+        if not matching.stations:
+            raise ObsPyException("No channel match in inventory for the given filters.")
+
         for sta in matching.stations:
             for cha in sta.channels:
                 label = _response_plot_label(

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -545,6 +545,10 @@ class Station(BaseNode):
         matching = self.select(location=location, channel=channel, time=time,
                                starttime=starttime, endtime=endtime)
 
+        if not matching.channels:
+                msg = "No matching channels for the given filters"
+                warnings.warn(msg, UserWarning)
+
         for cha in matching.channels:
             try:
                 cha.plot(min_freq=min_freq, output=output, axes=(ax1, ax2),
@@ -561,7 +565,7 @@ class Station(BaseNode):
                 warnings.warn(msg % (str(e), str(cha)), UserWarning)
 
         # final adjustments to plot if we created the figure in here
-        if not axes:
+        if not axes and matching.channels:
             from obspy.core.inventory.response import _adjust_bode_plot_figure
             _adjust_bode_plot_figure(fig, plot_degrees=plot_degrees,
                                      show=False)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

The `plot_response` methods of the `Inventory` and `Network` classes, as well as the `plot` method of the `Station` class all cause `_adjust_bode_plot_figure()` to raise a `ValueError` exception when no matching channels are found. This pull request fixes that problem by checking whether or not the `select` method was able to return a non-empty list, and instead emits a warning to the user while displaying an empty plot.

### Why was it initiated?  Any relevant Issues?

This pull request was initiated to fix a bug reported by [Issue #2685](https://github.com/obspy/obspy/issues/2685), to mitigate an undesirable exception without properly notifying the user of what actually occurred.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
