### PR TITLE
gh-actions: slightly verbose output for flake8

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           pip install wheel
           pip install flake8
-          python -m flake8 obspy
+          python -m flake8 obspy -v
 
   # Runs the tests on combinations of the supported python/os matrix.
   test_code:


### PR DESCRIPTION


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Makes flake8 check print some slightly verbose information when linting code in CI / gh-actions.

### Why was it initiated?  Any relevant Issues?

Without that `-v` flag, the actual flake8 run shows no output at all if no linter doesn't find any problems, which can be confusing when looking at CI results because then "Successfully installed flake8" is the last thing that is shown in the CI log:

![Screenshot from 2020-08-28 11-08-31](https://user-images.githubusercontent.com/1842780/91543549-d7fa0980-e91e-11ea-9fc5-16c83f6f78f5.png)


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
