### PR TITLE
fix matplotlib_date tests for matploltib>=3.3, skip basemap tests upon ImportError (due to incompatible matplotlib - basemap version combinations)

### DIFF
--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -29,6 +29,7 @@ from obspy.core.util import (
 from obspy.core.util.testing import ImageComparison
 from obspy.core.inventory import (Channel, Inventory, Network, Response,
                                   Station)
+from obspy.imaging.maps import HAS_BASEMAP
 
 
 class NetworkTestCase(unittest.TestCase):
@@ -319,7 +320,7 @@ class NetworkTestCase(unittest.TestCase):
         self.assertEqual(inv, inv2)
 
 
-@unittest.skipIf(not BASEMAP_VERSION, 'basemap not installed')
+@unittest.skipIf(not HAS_BASEMAP, 'no or invalid basemap installation')
 @unittest.skipIf(
     BASEMAP_VERSION >= [1, 1, 0] and MATPLOTLIB_VERSION == [3, 0, 1],
     'matplotlib 3.0.1 is not compatible with basemap')

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1406,6 +1406,8 @@ class TraceTestCase(unittest.TestCase):
         Test if the correct times array is returned for normal traces and
         traces with gaps.
         """
+        from distutils.version import LooseVersion
+        from matplotlib import __version__
         tr = Trace(data=np.ones(100))
         tr.stats.sampling_rate = 20
         delta = tr.stats.delta
@@ -1442,9 +1444,13 @@ class TraceTestCase(unittest.TestCase):
         np.testing.assert_allclose(got[:5], expected, rtol=1e-17)
         got = tr.times("matplotlib")
         expected = np.array([
-            730120.00000000000000000000, 730120.00000057870056480169,
-            730120.00000115740112960339, 730120.00000173610169440508,
-            730120.00000231480225920677])
+                10957.000000000000, 10957.000000578704, 10957.000001157407,
+                10957.000001736111, 10957.000002314815])
+        if LooseVersion(__version__) < LooseVersion('3.3'):
+            expected = np.array([
+                730120.00000000000000000000, 730120.00000057870056480169,
+                730120.00000115740112960339, 730120.00000173610169440508,
+                730120.00000231480225920677])
         np.testing.assert_allclose(got[:5], expected, rtol=1e-17)
 
     def test_modulo_operation(self):

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1084,11 +1084,18 @@ class UTCDateTimeTestCase(unittest.TestCase):
         Test convenience method and property for conversion to matplotlib
         datetime float numbers.
         """
-        for t_, expected in zip(
+        from distutils.version import LooseVersion
+        from matplotlib import __version__
+
+        for t_, expected_old, expected in zip(
                 ("1986-05-02T13:44:12.567890Z", "2009-08-24T00:20:07.700000Z",
                  "2026-11-27T03:12:45.4"),
-                (725128.5723676839, 733643.0139780092, 739947.1338587963)):
+                (725128.5723676839, 733643.0139780092, 739947.1338587963),
+                (5965.57236768, 14480.013978, 20784.1338588),
+                ):
             t = UTCDateTime(t_)
+            if LooseVersion(__version__) < LooseVersion('3.3'):
+                expected = expected_old
             np.testing.assert_almost_equal(
                 t.matplotlib_date, expected, decimal=8)
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2526,9 +2526,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         array([  1.25107320e+09,   1.25107320e+09,   1.25107320e+09, ...,
                  1.25107323e+09,   1.25107323e+09,   1.25107323e+09])
 
-        >>> tr.times("matplotlib")
-        array([ 733643.01392361,  733643.01392373,  733643.01392384, ...,
-                733643.01427049,  733643.0142706 ,  733643.01427072])
+        >>> tr.times("matplotlib")  # doctest: +SKIP
+        array([ 14480.01392361,  14480.01392373,  14480.01392384, ...,
+                14480.01427049,  14480.0142706 ,  14480.01427072])
 
         :type type: str
         :param type: Determines type of returned time array, see above for

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -1712,8 +1712,8 @@ class UTCDateTime(object):
         :meth:`obspy.core.stream.Stream.plot()`.
 
         >>> t = UTCDateTime("2009-08-24T00:20:07.700000Z")
-        >>> t.matplotlib_date
-        733643.0139780092
+        >>> t.matplotlib_date  # doctest: +SKIP
+        14480.01397800926
 
         :rtype: float
         """

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -30,8 +30,13 @@ from obspy.geodetics.base import mean_longitude
 
 
 if BASEMAP_VERSION:
-    from mpl_toolkits.basemap import Basemap
-    HAS_BASEMAP = True
+    try:
+        from mpl_toolkits.basemap import Basemap
+    except ImportError as ex:
+        warnings.warn("Basemap installation not working: %s" % ex)
+        HAS_BASEMAP = False
+    else:
+        HAS_BASEMAP = True
     if BASEMAP_VERSION < [1, 0, 4]:
         warnings.warn("All basemap version < 1.0.4 contain a serious bug "
                       "when rendering countries and continents. ObsPy will "


### PR DESCRIPTION
### What does this PR do?

fixes #2690
by checking the matplotlib version.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] ~~All tests still pass.~~ All tests now pass on travis for python>=3.6.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
