### PR TITLE
Use reviewdog to post flake8 violations to PRs.

### DIFF
--- a/.github/workflows/master_default_tests.yml
+++ b/.github/workflows/master_default_tests.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup conda
         uses: goanpeca/setup-miniconda@v1

--- a/.github/workflows/master_network_tests.yml
+++ b/.github/workflows/master_network_tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup conda
         uses: goanpeca/setup-miniconda@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,11 +51,27 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: flake8
+      - name: Install flake8
         run: |
           pip install wheel
           pip install flake8
-          python -m flake8 obspy
+
+      - name: Set up reviewdog
+        run: |
+          mkdir -p $HOME/bin
+          curl -sfL \
+            https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
+              sh -s -- -b $HOME/bin
+          echo ::add-path::$HOME/bin
+
+      - name: flake8
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          python -m flake8 obspy | \
+            reviewdog -f=pep8 -name=flake8 \
+              -tee -reporter=github-check -filter-mode nofilter
 
   # Runs the tests on combinations of the supported python/os matrix.
   test_code:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v1
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v1
         with:
@@ -83,7 +83,7 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup conda
         uses: goanpeca/setup-miniconda@v1

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup conda
         uses: goanpeca/setup-miniconda@v1


### PR DESCRIPTION
### What does this PR do?

Like matplotlib/matplotlib#17143, this posts flake8 violations as Checks directly to PRs. They appear on the diffs instead of having to look at the build log.

### Why was it initiated?  Any relevant Issues?

See https://github.com/obspy/obspy/pull/2706#issuecomment-683385658

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .