### PR TITLE
unify logging configuration

### DIFF
--- a/.github/workflows/master_default_tests.yml
+++ b/.github/workflows/master_default_tests.yml
@@ -52,9 +52,9 @@ jobs:
           export MODULELISTSPACES=`obshub get-module-list --group default --sep ' '`
           export MODULES=${MODULELISTSPACES//obspy.}
           if [ "$RUNNER_OS" == "macOS" ]; then
-              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" $MODULES
+              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" $MODULES
           else
-              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" $MODULES
+              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" $MODULES
               coverage xml -o coverage.xml
           fi
 

--- a/.github/workflows/master_network_tests.yml
+++ b/.github/workflows/master_network_tests.yml
@@ -43,9 +43,9 @@ jobs:
           export MODULELISTSPACES=`obshub get-module-list --group default --sep ' '`
           export MODULES=${MODULELISTSPACES//obspy.}
           if [ "$RUNNER_OS" == "macOS" ]; then
-              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" $MODULES
+              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" $MODULES
           else
-              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" $MODULES
+              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" $MODULES
               coverage xml -o coverage.xml
           fi
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -122,9 +122,9 @@ jobs:
           export MODULELIST=`obshub read-config-value module_list --path=${CONFIG_PATH}`
           export MODULELISTSPACES=`obshub read-config-value module_list_spaces --path=${CONFIG_PATH}`
           if [ "$RUNNER_OS" == "macOS" ]; then
-              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
           else
-              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r -v --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
               coverage xml -o coverage.xml
           fi
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,11 +8,11 @@ Changes:
      to solve test issues (#2900)
    * added python 3.9 tests for all platforms, required to disable image
      comparisons for 3.9 (#2925)
- - obspy.clients.seishub:
-   * added deprecation message
- - obspy.db:
-   * added deprecation message
-   * removed from default test suite
+   * removed individual logging configurations in Obspy, logging can be
+     configured by the user, see documentation of Pythons logging module,
+     only the FDSN mass downloader automatically configures logging as before,
+     but this behavior can be turned off now. The loglevel keywords are
+     therefore deprecated and have no effect anymore (see #2720)
  - obspy.core:
    * read_inventory(): add "level" option to read files faster when less level
      of detail is needed. currently only implemented for StationXML reading
@@ -35,6 +35,11 @@ Changes:
      FDSN server URLs (#2878)
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
+ - obspy.clients.seishub:
+   * added deprecation message
+ - obspy.db:
+   * added deprecation message
+   * removed from default test suite
  - obspy.io
    * add support to resolve the SEED id of picks for nlloc hyp files and
      nordic files, refactor the same functionality for SeismicHandler evt
@@ -80,6 +85,10 @@ Changes:
  - obspy.io.xseed:
    * fix a bug reading SEED blockettes 48 and 58 which was likely never
      encountered (see #2668)
+ - obspy.scripts
+   * obspy-runtests can take one or two -v flags for a more smooth verbosity
+     control (see #2720)
+   * fix broken "--raise-all-warnings" flag in obspy-runtests (see #2720)
  - obspy.signal.array_analysis
    * fixed an issue in array_processing function returning wrong times
      for matplotlib versions >= 3.3 due to the epoch change in matplotlib

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -69,8 +69,8 @@ if requests.__version__ in ('2.12.0', '2.12.1', '2.12.2'):
 if int(sys.version[0]) < 3:
     raise ImportError("""You are running ObsPy >= 2.0 on Python 2
 
-ObsPy version 2.0 and above is not compatible with Python 2, and you still 
-ended up with this version installed. This should not have happened. 
+ObsPy version 2.0 and above is not compatible with Python 2, and you still
+ended up with this version installed. This should not have happened.
 Make sure you have pip >= 9.0 and setuptools >= 24.2:
 
  $ pip install pip setuptools --upgrade

--- a/obspy/__init__.py
+++ b/obspy/__init__.py
@@ -67,9 +67,9 @@ if requests.__version__ in ('2.12.0', '2.12.1', '2.12.2'):
     warnings.warn(msg)
 
 if int(sys.version[0]) < 3:
-    raise ImportError("""You are running ObsPy >= 2.0 on Python 2
+    raise ImportError("""You are running ObsPy >= 1.3 on Python 2
 
-ObsPy version 2.0 and above is not compatible with Python 2, and you still
+ObsPy version 1.3 and above is not compatible with Python 2, and you still
 ended up with this version installed. This should not have happened.
 Make sure you have pip >= 9.0 and setuptools >= 24.2:
 
@@ -81,7 +81,7 @@ Your choices:
 
 - Install an older version of ObsPy:
 
- $ pip install 'obspy<2.0'
+ $ pip install 'obspy<1.3'
 """)
 
 

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -22,19 +22,7 @@ from . import utils
 from .download_helpers import ClientDownloadHelper, STATUS
 
 
-# Setup the logger.
 logger = logging.getLogger("obspy.clients.fdsn.mass_downloader")
-logger.setLevel(logging.DEBUG)
-# Prevent propagating to higher loggers.
-logger.propagate = 0
-# Console log handler.
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
-# Add formatter
-FORMAT = "[%(asctime)s] - %(name)s - %(levelname)s: %(message)s"
-formatter = logging.Formatter(FORMAT)
-ch.setFormatter(formatter)
-logger.addHandler(ch)
 
 
 class FDSNMassDownloaderException(FDSNException):
@@ -62,7 +50,19 @@ class MassDownloader(object):
     :type providers: list of str or :class:`~obspy.clients.fdsn.client.Client`
         instances
     """
-    def __init__(self, providers=None, debug=False):
+    def __init__(self, providers=None, debug=False, configure_logging=True):
+        if configure_logging:
+            logger.setLevel(logging.DEBUG)
+            # Prevent propagating to higher loggers.
+            logger.propagate = 0
+            # Console log handler.
+            ch = logging.StreamHandler()
+            ch.setLevel(logging.INFO)
+            # Add formatter
+            formatter = logging.Formatter(
+                    "[%(asctime)s] - %(name)s - %(levelname)s: %(message)s")
+            ch.setFormatter(formatter)
+            logger.addHandler(ch)
         self.debug = debug
         # If not given, use all providers ObsPy knows. They will be sorted
         # alphabetically except that ORFEUS is second to last and IRIS last.

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -73,12 +73,12 @@ def failmsg(got, expected, ignore_lines=[]):
     excluded from the comparison.
     """
     if isinstance(got, str) and isinstance(expected, str):
-        got = [l for l in got.splitlines(True)
-               if all([x not in l for x in ignore_lines])]
-        expected = [l for l in expected.splitlines(True)
-                    if all([x not in l for x in ignore_lines])]
+        got = [line for line in got.splitlines(True)
+               if all([x not in line for x in ignore_lines])]
+        expected = [line for line in expected.splitlines(True)
+                    if all([x not in line for x in ignore_lines])]
         diff = Differ().compare(got, expected)
-        diff = "".join([l for l in diff if l[0] in "-+?"])
+        diff = "".join([line for line in diff if line[0] in "-+?"])
         if diff:
             return "\nDiff:\n%s" % diff
         else:
@@ -96,7 +96,7 @@ def normalize_version_number(string):
     """
     match = r'v[0-9]+\.[0-9]+\.[0-9]+'
     repl = re.sub(match, "vX.X.X", string).replace(",", "")
-    return [l.strip() for l in repl.splitlines()]
+    return [line.strip() for line in repl.splitlines()]
 
 
 class ClientTestCase(unittest.TestCase):

--- a/obspy/clients/filesystem/miniseed.py
+++ b/obspy/clients/filesystem/miniseed.py
@@ -13,6 +13,7 @@ from io import BytesIO
 
 from obspy import read, Stream, UTCDateTime
 from obspy.clients.filesystem.msriterator import _MSRIterator
+from obspy.core.util.decorator import deprecated_keywords
 
 
 logger = logging.getLogger('obspy.clients.filesystem.miniseed')
@@ -61,8 +62,9 @@ class _MSRIDataSegment(_ExtractedDataSegment):
     """
     Segment of data from a _MSRIterator
     """
+    @deprecated_keywords({"loglevel": None})
     def __init__(self, msri, sample_rate, start_time, end_time, src_name,
-                 loglevel="WARNING"):
+                 loglevel=None):
         """
         :param msri: A `_MSRIterator`
         :param sample_rate: Sample rate of the data
@@ -70,15 +72,7 @@ class _MSRIDataSegment(_ExtractedDataSegment):
                            requested data
         :param end_time: A `UTCDateTime` giving the end of the requested data
         :param src_name: Name of the data source for logging
-        :type loglevel: str
-        :param loglevel: logging verbosity
         """
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
-
         self.msri = msri
         self.sample_rate = sample_rate
         self.start_time = start_time
@@ -163,23 +157,15 @@ class _MiniseedDataExtractor(object):
     """
     Component for extracting, trimming, and validating data.
     """
-    def __init__(self, dp_replace=None, request_limit=0, loglevel="WARNING"):
+    @deprecated_keywords({"loglevel": None})
+    def __init__(self, dp_replace=None, request_limit=0, loglevel=None):
         """
         :param dp_replace: optional tuple of (regex, replacement) indicating
           the location of data files. If regex is omitted, then the replacement
           string is appended to the beginning of the file name.
         :param request_limit: optional limit (in bytes) on how much data can
           be extracted at once
-        :type loglevel: str
-        :param loglevel: logging verbosity
         """
-        self.loglevel = loglevel
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
-
         if dp_replace:
             self.dp_replace_re = re.compile(dp_replace[0])
             self.dp_replace_sub = dp_replace[1]
@@ -306,8 +292,7 @@ class _MiniseedDataExtractor(object):
                                            nrow.samplerate,
                                            nrow.starttime,
                                            nrow.endtime,
-                                           nrow.srcname,
-                                           loglevel=self.loglevel)
+                                           nrow.srcname)
 
                     # Check for passing end offset
                     if (offset + msri.msr.contents.reclen) >= \

--- a/obspy/clients/filesystem/tests/test_tsindex.py
+++ b/obspy/clients/filesystem/tests/test_tsindex.py
@@ -32,8 +32,7 @@ def get_test_client():
 
     client = Client(db_path,
                     datapath_replace=("^",
-                                      filepath),
-                    loglevel="ERROR")
+                                      filepath))
     return client
 
 
@@ -47,8 +46,7 @@ class ClientTestCase(TestCase):
         self.assertRaisesRegex(OSError,
                                "^Database path.*does not exist.$",
                                Client,
-                               "/some/bad/path/timeseries.sqlite",
-                               loglevel="ERROR")
+                               "/some/bad/path/timeseries.sqlite")
 
     def test_get_waveforms(self):
         filepath = get_test_data_filepath()
@@ -614,8 +612,7 @@ class IndexerTestCase(TestCase):
                                "/some/bad/path",
                                database=database,
                                filename_pattern="*.mseed",
-                               parallel=2,
-                               loglevel="ERROR")
+                               parallel=2)
 
     def test_bad_sqlitdb_filepath(self):
         """
@@ -628,8 +625,7 @@ class IndexerTestCase(TestCase):
                                Indexer,
                                filepath,
                                database='/some/bad/path/',
-                               filename_pattern="*.mseed",
-                               loglevel="ERROR")
+                               filename_pattern="*.mseed")
 
     def test_bad_database(self):
         """
@@ -644,15 +640,13 @@ class IndexerTestCase(TestCase):
                                Indexer,
                                filepath,
                                database=None,
-                               filename_pattern="*.mseed",
-                               loglevel="ERROR")
+                               filename_pattern="*.mseed")
 
     def test_download_leap_seconds_file(self):
         filepath = get_test_data_filepath()
         database = os.path.join(filepath, 'timeseries.sqlite')
         indexer = Indexer(filepath,
-                          database=database,
-                          loglevel="ERROR")
+                          database=database)
         # mock actually downloading the file since this requires a internet
         # connection
         indexer._download = mock.MagicMock(return_value=requests.Response())
@@ -670,8 +664,7 @@ class IndexerTestCase(TestCase):
         filepath = get_test_data_filepath()
         database = os.path.join(filepath, 'timeseries.sqlite')
         indexer = Indexer(filepath,
-                          database=database,
-                          loglevel="ERROR")
+                          database=database)
         # mock actually downloading the file since this requires a internet
         # connection
         indexer._download = mock.MagicMock(return_value=requests.Response())
@@ -691,8 +684,7 @@ class IndexerTestCase(TestCase):
         filepath = get_test_data_filepath()
         database = os.path.join(filepath, 'timeseries.sqlite')
         indexer = Indexer(filepath,
-                          database=database,
-                          loglevel="ERROR")
+                          database=database)
 
         # test that a bad leap second file path raises an error
         self.assertRaisesRegex(OSError,
@@ -700,8 +692,7 @@ class IndexerTestCase(TestCase):
                                Indexer,
                                filepath,
                                database=database,
-                               leap_seconds_file="/some/bad/path/",
-                               loglevel="ERROR")
+                               leap_seconds_file="/some/bad/path/")
         self.assertRaisesRegex(OSError,
                                "^No leap seconds file exists at.*$",
                                indexer._get_leap_seconds_file,
@@ -721,8 +712,7 @@ class IndexerTestCase(TestCase):
         database = os.path.join(filepath, 'timeseries.sqlite')
         indexer = Indexer(filepath,
                           database=database,
-                          filename_pattern="*.mseed",
-                          loglevel="ERROR")
+                          filename_pattern="*.mseed")
 
         # test for relative paths
         file_list = indexer.build_file_list(relative_paths=True,
@@ -743,8 +733,7 @@ class IndexerTestCase(TestCase):
         # data path, to assert that already indexed files are still skipped
         indexer = Indexer(tempfile.mkdtemp(),
                           database=TSIndexDatabaseHandler(database=database),
-                          filename_pattern="*.mseed",
-                          loglevel="ERROR")
+                          filename_pattern="*.mseed")
         self.assertRaisesRegex(OSError,
                                "^No files matching filename.*$",
                                indexer.build_file_list,
@@ -755,8 +744,7 @@ class IndexerTestCase(TestCase):
         indexer = Indexer(filepath,
                           database=TSIndexDatabaseHandler(database=database),
                           filename_pattern="*.mseed",
-                          leap_seconds_file=None,
-                          loglevel="ERROR")
+                          leap_seconds_file=None)
         file_list = indexer.build_file_list(reindex=True)
         file_list.sort()
         self.assertEqual(len(file_list), 3)
@@ -816,8 +804,7 @@ class IndexerTestCase(TestCase):
         filepath = get_test_data_filepath()
         indexer = Indexer(filepath,
                           filename_pattern="*.mseed",
-                          index_cmd="some_bad_command",
-                          loglevel="ERROR"
+                          index_cmd="some_bad_command"
                           )
 
         self.assertRaisesRegex(OSError,
@@ -833,8 +820,7 @@ class IndexerTestCase(TestCase):
             indexer = Indexer(filepath,
                               database=database,
                               filename_pattern="*.mseed",
-                              parallel=2,
-                              loglevel="ERROR")
+                              parallel=2)
             if indexer._is_index_cmd_installed():
                 indexer.run(relative_paths=True)
                 keys = ['network', 'station', 'location', 'channel',
@@ -905,16 +891,14 @@ class TSIndexDatabaseHandlerTestCase(TestCase):
                                filepath,
                                database='/some/bad/path/',
                                filename_pattern="*.mseed",
-                               parallel=2,
-                               loglevel="ERROR")
+                               parallel=2)
 
     def test__fetch_summary_rows(self):
         # test with actual sqlite3 database that is missing a summary table
         # a temporary summary table gets created at runtime
         filepath = get_test_data_filepath()
         db_path = os.path.join(filepath, 'timeseries.sqlite')
-        request_handler = TSIndexDatabaseHandler(db_path,
-                                                 loglevel="ERROR")
+        request_handler = TSIndexDatabaseHandler(db_path)
 
         keys = ['network', 'station', 'location', 'channel',
                 'earliest', 'latest']
@@ -962,8 +946,7 @@ class TSIndexDatabaseHandlerTestCase(TestCase):
         # supply an existing session
         engine = sa.create_engine("sqlite:///{}".format(db_path))
         session = sessionmaker(bind=engine)
-        request_handler = TSIndexDatabaseHandler(session=session,
-                                                 loglevel="ERROR")
+        request_handler = TSIndexDatabaseHandler(session=session)
 
         ts_summary_cte = request_handler.get_tsindex_summary_cte()
 

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -172,6 +172,7 @@ from obspy.clients.filesystem.miniseed import _MiniseedDataExtractor, \
 from obspy.clients.filesystem.db import _get_tsindex_table, \
     _get_tsindex_summary_table
 from obspy.core.stream import Stream
+from obspy.core.util.decorator import deprecated_keywords
 
 logger = logging.getLogger('obspy.clients.filesystem.tsindex')
 
@@ -193,8 +194,8 @@ class Client(object):
     """
     Time series extraction client for IRIS tsindex database schema.
     """
-
-    def __init__(self, database, datapath_replace=None, loglevel="WARNING"):
+    @deprecated_keywords({"loglevel": None})
+    def __init__(self, database, datapath_replace=None, loglevel=None):
         """
         Initializes the client.
 
@@ -206,20 +207,11 @@ class Client(object):
         :param datapath_replace: A ``tuple(str, str)``, where any
             occurrence of the first value will be replaced with the second
             value in filename paths from the index.
-        :type loglevel: str
-        :param loglevel: logging verbosity
         """
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
-
         # setup handler for database
         if isinstance(database, str):
             self.request_handler = TSIndexDatabaseHandler(
-                os.path.normpath(database),
-                loglevel=loglevel)
+                os.path.normpath(database))
         elif isinstance(database, TSIndexDatabaseHandler):
             self.request_handler = database
         else:
@@ -228,8 +220,7 @@ class Client(object):
 
         # Create and configure the data extraction
         self.data_extractor = _MiniseedDataExtractor(
-            dp_replace=datapath_replace,
-            loglevel=loglevel)
+            dp_replace=datapath_replace)
 
     def get_waveforms(self, network, station, location,
                       channel, starttime, endtime, merge=-1):
@@ -904,11 +895,11 @@ class Indexer(object):
     is not already in the index. After all new files are indexed a summary
     table is generated with the extents of each timeseries.
     """
-
+    @deprecated_keywords({"loglevel": None})
     def __init__(self, root_path, database="timeseries.sqlite",
                  leap_seconds_file="SEARCH", index_cmd='mseedindex',
                  bulk_params=None, filename_pattern='*', parallel=5,
-                 loglevel="WARNING"):
+                 loglevel=None):
         """
         Initializes the Indexer.
 
@@ -943,15 +934,7 @@ class Indexer(object):
         :type parallel: int
         :param parallel: Max number of ``index_cmd`` instances to run in
             parallel. By default a max of 5 parallel process are run.
-        :type loglevel: str
-        :param loglevel: logging verbosity
         """
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
-
         self.index_cmd = index_cmd
         if bulk_params is None:
             bulk_params = {}
@@ -961,8 +944,7 @@ class Indexer(object):
 
         # setup handler for database
         if isinstance(database, str):
-            self.request_handler = TSIndexDatabaseHandler(database,
-                                                          loglevel=loglevel)
+            self.request_handler = TSIndexDatabaseHandler(database)
         elif isinstance(database, TSIndexDatabaseHandler):
             self.request_handler = database
         else:
@@ -1348,9 +1330,10 @@ class TSIndexDatabaseHandler(object):
 
     """
 
+    @deprecated_keywords({"loglevel": None})
     def __init__(self, database=None, tsindex_table="tsindex",
                  tsindex_summary_table="tsindex_summary",
-                 session=None, loglevel="WARNING"):
+                 session=None, loglevel=None):
         """
         Main query interface to timeseries index database.
 
@@ -1362,15 +1345,7 @@ class TSIndexDatabaseHandler(object):
         :param tsindex_summary_table: Name of timeseries index summary table
         :type session: :class:`sqlalchemy.orm.session.Session`
         :param session: An existing database session object.
-        :type loglevel: str
-        :param loglevel: logging verbosity
         """
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
-
         self.database = None
         self.tsindex_table = tsindex_table
         self.tsindex_summary_table = tsindex_summary_table

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -45,7 +45,6 @@ class Client(object):
         """
         self.timeout = timeout
         self.debug = debug
-        self.loglevel = debug and "DEBUG" or "CRITICAL"
         self._server_url = "%s:%i" % (server, port)
         self._station_cache = None
         self._station_cache_level = None
@@ -57,7 +56,7 @@ class Client(object):
         Should be done before any request to server, since SLClient keeps
         things like multiselect etc for subsequent requests
         """
-        self._slclient = SLClient(loglevel=self.loglevel, timeout=self.timeout)
+        self._slclient = SLClient(timeout=self.timeout)
 
     def _connect(self):
         """

--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -27,11 +27,6 @@ from ..slpacket import SLPacket
 # default logger
 logger = logging.getLogger('obspy.clients.seedlink')
 
-# set to True for debugging to stdout
-if False:
-    import sys
-    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-
 
 class SeedLinkConnection(object):
     """

--- a/obspy/clients/seedlink/slclient.py
+++ b/obspy/clients/seedlink/slclient.py
@@ -16,10 +16,9 @@ JSeedLink of Anthony Lomax
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-import logging
 import sys
-import traceback
 
+from obspy.core.util.decorator import deprecated_keywords
 from .client.seedlinkconnection import SeedLinkConnection
 from .seedlinkexception import SeedLinkException
 from .slpacket import SLPacket
@@ -55,10 +54,6 @@ USAGE = """
 <[host]:port>  Address of the SeedLink server in host:port format
                if host is omitted (i.e. ':18000'), localhost is assumed
 """
-
-
-# default logger
-logger = logging.getLogger('obspy.clients.seedlink')
 
 
 class SLClient(object):
@@ -103,16 +98,11 @@ class SLClient(object):
     PROGRAM_NAME = "SLClient v" + VERSION
     VERSION_INFO = PROGRAM_NAME + " (" + VERSION_DATE + ")"
 
-    def __init__(self, loglevel='DEBUG', timeout=None):
+    @deprecated_keywords({"loglevel": None})
+    def __init__(self, loglevel=None, timeout=None):
         """
         Creates a new instance of SLClient with the specified logging object
         """
-#        numeric_level = getattr(logging, loglevel.upper(), None)
-#        if not isinstance(numeric_level, int):
-#            raise ValueError('Invalid log level: %s' % loglevel)
-#        logging.basicConfig(level=numeric_level)
-#        logger.setLevel(numeric_level)
-
         self.verbose = 0
         self.ppackets = False
         self.streamfile = None
@@ -341,16 +331,12 @@ class SLClient(object):
         Main method - creates and runs an SLClient using the specified
         command line arguments
         """
-        try:
-            sl_client = SLClient()
-            rval = sl_client.parse_cmd_line_args(args)
-            if (rval != 0):
-                sys.exit(rval)
-            sl_client.initialize()
-            sl_client.run()
-        except Exception as e:
-            logger.critical(e)
-            traceback.print_exc()
+        sl_client = SLClient()
+        rval = sl_client.parse_cmd_line_args(args)
+        if (rval != 0):
+            sys.exit(rval)
+        sl_client.initialize()
+        sl_client.run()
 
 
 if __name__ == '__main__':

--- a/obspy/clients/seedlink/slclient.py
+++ b/obspy/clients/seedlink/slclient.py
@@ -107,11 +107,11 @@ class SLClient(object):
         """
         Creates a new instance of SLClient with the specified logging object
         """
-        numeric_level = getattr(logging, loglevel.upper(), None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % loglevel)
-        logging.basicConfig(level=numeric_level)
-        logger.setLevel(numeric_level)
+#        numeric_level = getattr(logging, loglevel.upper(), None)
+#        if not isinstance(numeric_level, int):
+#            raise ValueError('Invalid log level: %s' % loglevel)
+#        logging.basicConfig(level=numeric_level)
+#        logger.setLevel(numeric_level)
 
         self.verbose = 0
         self.ppackets = False

--- a/obspy/clients/seedlink/tests/example_SL_RTTrace.py
+++ b/obspy/clients/seedlink/tests/example_SL_RTTrace.py
@@ -1,19 +1,10 @@
 # -*- coding: utf-8 -*-
-import logging
-import sys
-import traceback
-
 import numpy as np
 
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.realtime.rttrace import RtTrace
-from obspy.clients.seedlink.seedlinkexception import SeedLinkException
 from obspy.clients.seedlink.slclient import SLClient
 from obspy.clients.seedlink.slpacket import SLPacket
-
-
-# default logger
-logger = logging.getLogger('obspy.clients.seedlink')
 
 
 class MySLClient(SLClient):
@@ -114,36 +105,27 @@ def main():
           "them to an RTTrace object.")
 
     # create SeedLink client
-    try:
-        sl_client = MySLClient(rt_trace=rttrace)
-        #
-        sl_client.slconn.set_sl_address("geofon.gfz-potsdam.de:18000")
-        sl_client.multiselect = ("GE_STU:BHZ")
-        #
-        # slClient.slconn.set_sl_address("discovery.rm.ingv.it:39962")
-        # slClient.multiselect = ("IV_MGAB:BHZ")
-        #
-        # slClient.slconn.set_sl_address("rtserve.iris.washington.edu:18000")
-        # slClient.multiselect = ("AT_TTA:BHZ")
-        #
-        # set a time window from 2 min in the past to 5 sec in the future
-        dt = UTCDateTime()
-        sl_client.begin_time = (dt - 120.0).format_seedlink()
-        sl_client.end_time = (dt + 5.0).format_seedlink()
-        print("SeedLink date-time range:", sl_client.begin_time, " -> ",
-              end=' ')
-        print(sl_client.end_time)
-        sl_client.verbose = 3
-        sl_client.initialize()
-        sl_client.run()
-    except SeedLinkException as sle:
-        logger.critical(sle)
-        traceback.print_exc()
-        raise sle
-    except Exception as e:
-        sys.stderr.write("Error:" + str(e))
-        traceback.print_exc()
-        raise e
+    sl_client = MySLClient(rt_trace=rttrace)
+    #
+    sl_client.slconn.set_sl_address("geofon.gfz-potsdam.de:18000")
+    sl_client.multiselect = ("GE_STU:BHZ")
+    #
+    # slClient.slconn.set_sl_address("discovery.rm.ingv.it:39962")
+    # slClient.multiselect = ("IV_MGAB:BHZ")
+    #
+    # slClient.slconn.set_sl_address("rtserve.iris.washington.edu:18000")
+    # slClient.multiselect = ("AT_TTA:BHZ")
+    #
+    # set a time window from 2 min in the past to 5 sec in the future
+    dt = UTCDateTime()
+    sl_client.begin_time = (dt - 120.0).format_seedlink()
+    sl_client.end_time = (dt + 5.0).format_seedlink()
+    print("SeedLink date-time range:", sl_client.begin_time, " -> ",
+          end=' ')
+    print(sl_client.end_time)
+    sl_client.verbose = 3
+    sl_client.initialize()
+    sl_client.run()
 
 
 if __name__ == '__main__':

--- a/obspy/clients/seedlink/tests/test_slclient.py
+++ b/obspy/clients/seedlink/tests/test_slclient.py
@@ -12,7 +12,7 @@ class SLClientTestCase(unittest.TestCase):
 
     @unittest.skipIf(__name__ != '__main__', 'test must be started manually')
     def test_info(self):
-        sl_client = SLClient(loglevel='DEBUG')
+        sl_client = SLClient()
         sl_client.slconn.set_sl_address("geofon.gfz-potsdam.de:18000")
         sl_client.infolevel = "ID"
         sl_client.verbose = 2

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -89,7 +89,7 @@ def deprecated_keywords(keywords):
                          if new_key == key_])
                     raise Exception(msg3 % (conflicting_keys, fname, new_key))
             # map deprecated keywords to new keywords
-            for kw in kwargs.keys():
+            for kw in list(kwargs):
                 if kw in keywords:
                     nkw = keywords[kw]
                     if nkw is None:
@@ -101,7 +101,7 @@ def deprecated_keywords(keywords):
                                       category=ObsPyDeprecationWarning,
                                       stacklevel=3)
                         kwargs[nkw] = kwargs[kw]
-                    del(kwargs[kw])
+                    del kwargs[kw]
             return func(*args, **kwargs)
         return echo_func
 

--- a/obspy/db/scripts/indexer.py
+++ b/obspy/db/scripts/indexer.py
@@ -40,6 +40,9 @@ from obspy.db.indexer import WaveformFileCrawler, worker
 from obspy.db.util import parse_mapping_data
 
 
+logger = logging.getLogger('obspy.db.indexer')
+
+
 class MyHandler(http_server.BaseHTTPRequestHandler):
     def do_GET(self):  # noqa
         """
@@ -100,10 +103,10 @@ class WaveformIndexer(http_server.HTTPServer, WaveformFileCrawler):
 
 
 def _run_indexer(options):
-    logging.info("Starting indexer %s:%s ..." % (options.host, options.port))
+    logger.info("Starting indexer %s:%s ..." % (options.host, options.port))
     # initialize crawler
     service = WaveformIndexer((options.host, options.port), MyHandler)
-    service.log = logging
+    service.log = logger
     try:
         # prepare paths
         if ',' in options.data:
@@ -118,8 +121,8 @@ def _run_indexer(options):
             with open(options.mapping_file, 'r') as f:
                 data = f.readlines()
             mappings = parse_mapping_data(data)
-            logging.info("Parsed %d lines from mapping file %s" %
-                         (len(data), options.mapping_file))
+            logger.info("Parsed %d lines from mapping file %s" %
+                        (len(data), options.mapping_file))
         else:
             mappings = {}
         # create file queue and worker processes
@@ -158,7 +161,7 @@ def _run_indexer(options):
         service.serve_forever(options.poll_interval)
     except KeyboardInterrupt:
         quit()
-    logging.info("Indexer stopped.")
+    logger.info("Indexer stopped.")
 
 
 def main(argv=None):

--- a/obspy/geodetics/base.py
+++ b/obspy/geodetics/base.py
@@ -478,7 +478,7 @@ def inside_geobounds(obj, minlatitude=None, maxlatitude=None,
     if maxlongitude is not None:
         if olongitude is None or olongitude > maxlongitude:
             return False
-    if all([l is not None for l in
+    if all([coord is not None for coord in
            (latitude, longitude, olatitude, olongitude)]):
         distance = locations2degrees(latitude, longitude,
                                      olatitude, olongitude)

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -198,7 +198,7 @@ class LibGSE2TestCase(unittest.TestCase):
                                 'loc_RJOB20050831023349_first100_dos.z')
         fout = io.BytesIO()
         with open(filename, 'rb') as fin:
-            lines = (l for l in fin if not l.startswith(b'DAT2'))
+            lines = (line for line in fin if not line.startswith(b'DAT2'))
             fout.write(b"".join(lines))
         fout.seek(0)
         with SuppressOutput():

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -2111,7 +2111,7 @@ def nordpick(event, high_accuracy=True, nordic_format='OLD'):
             # Coda, backzimuth (add extra line), amplitude, or other phase pick
             add_amp_line = False
             is_amp_pick = False
-            add_BAZ_line = False
+            add_baz_line = False
             par1 = '       '
             par2 = '      '
             residual = '     '
@@ -2129,7 +2129,7 @@ def nordpick(event, high_accuracy=True, nordic_format='OLD'):
                 impulsivity = ''
             # Back Azimuth
             elif azimuth.strip() != '':  # back-azimuth
-                add_BAZ_line = True
+                add_baz_line = True
                 if len(phase_hint) <= 4:  # max total phase name length is 8
                     baz_phase_hint = 'BAZ-' + phase_hint
                 else:
@@ -2226,7 +2226,7 @@ def nordpick(event, high_accuracy=True, nordic_format='OLD'):
                     finalweight=amp_finalweight,
                     distance=distance.rjust(5)[0:5],
                     caz=_str_conv(caz).rjust(3)[0:3]))
-            if add_BAZ_line:
+            if add_baz_line:
                 pick_strings.append(pick_string_formatter.format(
                     station=pick.waveform_id.station_code,
                     channel=channel_code, network=network_code,

--- a/obspy/io/sac/tests/test_sacpz.py
+++ b/obspy/io/sac/tests/test_sacpz.py
@@ -40,8 +40,9 @@ class SACPZTestCase(unittest.TestCase):
         with open(self.file1) as fh:
             expected = fh.read()
         # remove CREATED line that changes
-        got = [l for l in got.split("\n") if "CREATED" not in l]
-        expected = [l for l in expected.split("\n") if "CREATED" not in l]
+        got = [line for line in got.split("\n") if "CREATED" not in line]
+        expected = [line for line in expected.split("\n")
+                    if "CREATED" not in line]
         self.assertEqual(got, expected)
 
     def test_write_sacpz_multiple_channels(self):
@@ -56,8 +57,9 @@ class SACPZTestCase(unittest.TestCase):
         with open(self.file2) as fh:
             expected = fh.read()
         # remove CREATED line that changes
-        got = [l for l in got.split("\n") if "CREATED" not in l]
-        expected = [l for l in expected.split("\n") if "CREATED" not in l]
+        got = [line for line in got.split("\n") if "CREATED" not in line]
+        expected = [line for line in expected.split("\n")
+                    if "CREATED" not in line]
         self.assertEqual(got, expected)
 
     def test_write_sacpz_soh(self):

--- a/obspy/scripts/runtests.py
+++ b/obspy/scripts/runtests.py
@@ -86,6 +86,8 @@ import copy
 import doctest
 import glob
 import importlib
+import logging
+import logging.config
 import operator
 import os
 import platform
@@ -658,11 +660,20 @@ def run(argv=None, interactive=True):
                              'diff images (but not images that passed the '
                              'corresponding test).')
     args = parser.parse_args(argv)
+
     # set correct verbosity level
     if args.verbose:
         verbosity = 2
         # raise all NumPy warnings
         np.seterr(all='warn')
+        conf = {'version': 1,
+                'formatters': {'test': {
+                        'format': '%(levelname)s:%(message)s'}},
+                'handlers': {'console': {'class': 'logging.StreamHandler',
+                                         'formatter': 'test'}},
+                'loggers': {'obspy': {'level': 'INFO',
+                                      'handlers': ['console']}}}
+        logging.config.dictConfig(conf)
     elif args.quiet:
         verbosity = 0
         # ignore user and deprecation warnings
@@ -670,12 +681,14 @@ def run(argv=None, interactive=True):
         warnings.simplefilter("ignore", UserWarning)
         # don't ask to send a report
         args.dontask = True
+        logging.basicConfig(handlers=[logging.NullHandler()])
     else:
         verbosity = 1
         # show all NumPy warnings
         np.seterr(all='print')
         # ignore user warnings
         warnings.simplefilter("ignore", UserWarning)
+        logging.basicConfig(handlers=[logging.NullHandler()])
     # whether to raise any warning that's appearing
     if args.raise_all_warnings:
         # raise all NumPy warnings

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -825,7 +825,7 @@ def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
         for j, sy in enumerate(np.arange(symin, symax + sstep / 10., sstep)):
             for k, f in enumerate(np.arange(fmin, fmax + fstep / 10., fstep)):
                 _sum = 0j
-                for l in np.arange(len(coords)):
+                for l in np.arange(len(coords)):  # NOQA
                     _sum += np.exp(
                         complex(0., (coords[l, 0] * sx + coords[l, 1] * sy) *
                                 2 * np.pi * f))

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -106,7 +106,7 @@ def rotate_zne_lqt(z, n, e, ba, inc):
     return l, q, t
 
 
-def rotate_lqt_zne(l, q, t, ba, inc):
+def rotate_lqt_zne(l, q, t, ba, inc):  # NOQA
     """
     Rotates all components of a seismogram.
 

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -24,6 +24,15 @@ from obspy.imaging.cm import obspy_sequential, obspy_divergent
 from obspy.signal import util
 
 
+def _pcolormesh_same_dim(ax, x, y, v, **kwargs):
+    # x, y, v must have the same dimension
+    try:
+        return ax.pcolormesh(x, y, v, shading='nearest', **kwargs)
+    except TypeError:
+        # matplotlib versions < 3.3
+        return ax.pcolormesh(x, y, v[:-1, :-1], **kwargs)
+
+
 def cwt(st, dt, w0, fmin, fmax, nf=100, wl='morlet'):
     """
     Continuous Wavelet Transformation in the Frequency Domain.
@@ -1015,8 +1024,7 @@ def plot_tf_misfits(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfem[itr].shape[0]))
-        img_tfem = ax_tfem.pcolormesh(x, y, _tfem[itr], cmap=cmap,
-                                      shading='auto')
+        img_tfem = _pcolormesh_same_dim(ax_tfem, x, y, _tfem[itr], cmap=cmap)
         img_tfem.set_rasterized(True)
         ax_tfem.set_yscale("log")
         ax_tfem.set_ylim(fmin, fmax)
@@ -1034,8 +1042,7 @@ def plot_tf_misfits(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         ax_tfpm = fig.add_axes([left + w_1, bottom + h_2, w_2, h_3])
 
         x, y = np.meshgrid(t, f)
-        img_tfpm = ax_tfpm.pcolormesh(x, y, _tfpm[itr], cmap=cmap,
-                                      shading='auto')
+        img_tfpm = _pcolormesh_same_dim(ax_tfpm, x, y, _tfpm[itr], cmap=cmap)
         img_tfpm.set_rasterized(True)
         ax_tfpm.set_yscale("log")
         ax_tfpm.set_ylim(f[0], f[-1])
@@ -1277,8 +1284,7 @@ def plot_tf_gofs(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfeg[itr].shape[0]))
-        img_tfeg = ax_tfeg.pcolormesh(x, y, _tfeg[itr], cmap=cmap,
-                                      shading='auto')
+        img_tfeg = _pcolormesh_same_dim(ax_tfeg, x, y, _tfeg[itr], cmap=cmap)
         img_tfeg.set_rasterized(True)
         ax_tfeg.set_yscale("log")
         ax_tfeg.set_ylim(fmin, fmax)
@@ -1296,8 +1302,7 @@ def plot_tf_gofs(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         ax_tfpg = fig.add_axes([left + w_1, bottom + h_2, w_2, h_3])
 
         x, y = np.meshgrid(t, f)
-        img_tfpg = ax_tfpg.pcolormesh(x, y, _tfpg[itr], cmap=cmap,
-                                      shading='auto')
+        img_tfpg = _pcolormesh_same_dim(ax_tfpg, x, y, _tfpg[itr], cmap=cmap)
         img_tfpg.set_rasterized(True)
         ax_tfpg.set_yscale("log")
         ax_tfpg.set_ylim(f[0], f[-1])
@@ -1498,8 +1503,7 @@ def plot_tfr(st, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6, left=0.1,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfr[itr].shape[0]))
-        img_tfr = ax_tfr.pcolormesh(x, y, _tfr[itr], cmap=cmap,
-                                    shading='auto')
+        img_tfr = _pcolormesh_same_dim(ax_tfr, x, y, _tfr[itr], cmap=cmap)
         img_tfr.set_rasterized(True)
         ax_tfr.set_yscale("log")
         ax_tfr.set_ylim(fmin, fmax)

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -1015,7 +1015,8 @@ def plot_tf_misfits(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfem[itr].shape[0]))
-        img_tfem = ax_tfem.pcolormesh(x, y, _tfem[itr], cmap=cmap)
+        img_tfem = ax_tfem.pcolormesh(x, y, _tfem[itr], cmap=cmap,
+                                      shading='auto')
         img_tfem.set_rasterized(True)
         ax_tfem.set_yscale("log")
         ax_tfem.set_ylim(fmin, fmax)
@@ -1033,7 +1034,8 @@ def plot_tf_misfits(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         ax_tfpm = fig.add_axes([left + w_1, bottom + h_2, w_2, h_3])
 
         x, y = np.meshgrid(t, f)
-        img_tfpm = ax_tfpm.pcolormesh(x, y, _tfpm[itr], cmap=cmap)
+        img_tfpm = ax_tfpm.pcolormesh(x, y, _tfpm[itr], cmap=cmap,
+                                      shading='auto')
         img_tfpm.set_rasterized(True)
         ax_tfpm.set_yscale("log")
         ax_tfpm.set_ylim(f[0], f[-1])
@@ -1275,7 +1277,8 @@ def plot_tf_gofs(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfeg[itr].shape[0]))
-        img_tfeg = ax_tfeg.pcolormesh(x, y, _tfeg[itr], cmap=cmap)
+        img_tfeg = ax_tfeg.pcolormesh(x, y, _tfeg[itr], cmap=cmap,
+                                      shading='auto')
         img_tfeg.set_rasterized(True)
         ax_tfeg.set_yscale("log")
         ax_tfeg.set_ylim(fmin, fmax)
@@ -1293,7 +1296,8 @@ def plot_tf_gofs(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         ax_tfpg = fig.add_axes([left + w_1, bottom + h_2, w_2, h_3])
 
         x, y = np.meshgrid(t, f)
-        img_tfpg = ax_tfpg.pcolormesh(x, y, _tfpg[itr], cmap=cmap)
+        img_tfpg = ax_tfpg.pcolormesh(x, y, _tfpg[itr], cmap=cmap,
+                                      shading='auto')
         img_tfpg.set_rasterized(True)
         ax_tfpg.set_yscale("log")
         ax_tfpg.set_ylim(f[0], f[-1])
@@ -1494,7 +1498,8 @@ def plot_tfr(st, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6, left=0.1,
         x, y = np.meshgrid(
             t, np.logspace(np.log10(fmin), np.log10(fmax),
                            _tfr[itr].shape[0]))
-        img_tfr = ax_tfr.pcolormesh(x, y, _tfr[itr], cmap=cmap)
+        img_tfr = ax_tfr.pcolormesh(x, y, _tfr[itr], cmap=cmap,
+                                    shading='auto')
         img_tfr.set_rasterized(True)
         ax_tfr.set_yscale("log")
         ax_tfr.set_ylim(fmin, fmax)

--- a/obspy/taup/slowness_model.py
+++ b/obspy/taup/slowness_model.py
@@ -105,7 +105,7 @@ class SlownessModel(object):
             desc += str(fl.top_depth) + "," + str(fl.bot_depth) + " "
         desc += "\n"
         desc += "\n**** P Layers ****************\n"
-        for l in self.p_layers:
+        for l in self.p_layers:  # NOQA
             desc += str(l) + "\n"
         return desc
 


### PR DESCRIPTION
This PR tries to unify the logging configuration.
All calls to `logging.basicConfig` inside the library are deleted and some `loglevel` keywords are removed. Logging should be configured in the user's code. A simple `logging.basicConfig()` is often good enough. ~~I added the NullHandler to the obspy's root logger `'obspy'` so that by default no logging is emmited.~~ Logging is only ~~configured~~ displayed for `obspy-runtests -v`.

~~WIP: If this PR is endorsed I would further refine it.~~

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
