### PR TITLE
Create StationMagnitudeContributions when importing GSE2 bulletin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ maintenance_1.2.x
 Changes:
  - obspy.core:
    * Inventory addition now consistently uses shallow copies (#2675, #2694)
+ - obspy.io.gse2:
+   * When reading GSE2 bulletins, station magnitudes now include waveform IDs
+     and have associated station magnitude contributions (see #2718)
 
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Bes de Berc, Maxime
 Beyreuther, Moritz
 Boltz, Shawn
 Bonaimé, Sébastien
+Carapetis, Anthony
 Carothers, Lloyd
 Chamberlain, Calum
 Chambers, Derrick

--- a/obspy/io/gse2/bulletin.py
+++ b/obspy/io/gse2/bulletin.py
@@ -917,6 +917,7 @@ class Unpickler(object):
                     sta_mag.amplitude_id = amplitude.resource_id
                     sta_mag.station_magnitude_type = magnitude_types[i]
                     sta_mag.mag = magnitude_values[i]
+                    sta_mag.waveform_id = pick.waveform_id
                     public_id = "magnitude/station/%s/%s" % (line_id, i)
                     sta_mag.resource_id = self._get_res_id(public_id)
                     event.station_magnitudes.append(sta_mag)

--- a/obspy/io/gse2/tests/test_bulletin.py
+++ b/obspy/io/gse2/tests/test_bulletin.py
@@ -299,9 +299,16 @@ class BulletinTestCase(unittest.TestCase):
         self.assertEqual(sta_mag_1.station_magnitude_type, 'ML')
         self.assertEqual(sta_mag_1.amplitude_id, 'smi:local/amplitude/3586432')
         self.assertEqual(sta_mag_1.method_id, None)
-        self.assertEqual(sta_mag_1.waveform_id, None)
         self.assertNotEqual(sta_mag_1.creation_info, None)
         self.assertEqual(len(sta_mag_1.comments), 0)
+
+        waveform_1 = sta_mag_1.waveform_id
+        self.assertEqual(waveform_1.network_code, 'XX')
+        self.assertEqual(waveform_1.station_code, 'GERES')
+        self.assertEqual(waveform_1.channel_code, None)
+        self.assertEqual(waveform_1.location_code, None)
+        self.assertEqual(waveform_1.resource_uri, None)
+
         # Test second StationMagnitude
         sta_mag_2 = station_magnitudes[1]
         self.assertEqual(
@@ -311,9 +318,16 @@ class BulletinTestCase(unittest.TestCase):
         self.assertEqual(sta_mag_2.station_magnitude_type, 'mb')
         self.assertEqual(sta_mag_2.amplitude_id, 'smi:local/amplitude/3586555')
         self.assertEqual(sta_mag_2.method_id, None)
-        self.assertEqual(sta_mag_2.waveform_id, None)
         self.assertNotEqual(sta_mag_2.creation_info, None)
         self.assertEqual(len(sta_mag_2.comments), 0)
+
+        waveform_2 = sta_mag_2.waveform_id
+        self.assertEqual(waveform_2.network_code, 'XX')
+        self.assertEqual(waveform_2.station_code, 'FINES')
+        self.assertEqual(waveform_2.channel_code, None)
+        self.assertEqual(waveform_2.location_code, None)
+        self.assertEqual(waveform_2.resource_uri, None)
+
 
     def test_amplitude(self):
         """

--- a/obspy/io/gse2/tests/test_bulletin.py
+++ b/obspy/io/gse2/tests/test_bulletin.py
@@ -263,7 +263,7 @@ class BulletinTestCase(unittest.TestCase):
         self.assertEqual(mag_1.evaluation_status, None)
         self.assertNotEqual(mag_1.creation_info, None)
         self.assertEqual(len(mag_1.comments), 0)
-        self.assertEqual(len(mag_1.station_magnitude_contributions), 0)
+        self.assertEqual(len(mag_1.station_magnitude_contributions), 3)
         # Test second Magnitude
         mag_2 = magnitudes[1]
         self.assertEqual(
@@ -278,8 +278,8 @@ class BulletinTestCase(unittest.TestCase):
         self.assertEqual(mag_2.evaluation_mode, None)
         self.assertEqual(mag_2.evaluation_status, None)
         self.assertNotEqual(mag_2.creation_info, None)
-        self.assertEqual(len(mag_1.comments), 0)
-        self.assertEqual(len(mag_1.station_magnitude_contributions), 0)
+        self.assertEqual(len(mag_2.comments), 0)
+        self.assertEqual(len(mag_2.station_magnitude_contributions), 1)
 
     def test_station_magnitude(self):
         """

--- a/obspy/io/gse2/tests/test_bulletin.py
+++ b/obspy/io/gse2/tests/test_bulletin.py
@@ -328,7 +328,6 @@ class BulletinTestCase(unittest.TestCase):
         self.assertEqual(waveform_2.location_code, None)
         self.assertEqual(waveform_2.resource_uri, None)
 
-
     def test_amplitude(self):
         """
         Test Amplitude object.


### PR DESCRIPTION
### What does this PR do?

Modifies the `obspy.io.gse2` bulletin reader to link station magnitudes with network magnitudes. For each pick with a station magnitude, we check if the origin has any network magnitudes with the same magnitude type, and if so, we associate them together with a `StationMagnitudeContribution`.

Also ensures the `StationMagnitude.waveformID` attribute is populated (with the same value as `Amplitude.waveformID` and `Pick.waveformID`). (The [documentation](https://docs.obspy.org/packages/autogen/obspy.core.event.magnitude.StationMagnitude.html) suggests this is unnecessary when the stamag's linked amplitude/pick already includes the waveformID; but currently if you import GSE2, export to seiscomp XML and open the resulting magnitude in seiscomp, the station information is missing in the GUI; so at least from a seiscomp-centric perspective the data seems incomplete.)

I've updated the existing `test_bulletin.py`, replacing the previous assertions (which were that there were no associated stamagcontributions and no waveformID) with new ones - hopefully that's all that's required?

Based it on the maintenance branch since it feels like a bug fix to me, let me know if it needs to be rebased.

### Why was it initiated?  Any relevant Issues?

Fixes #2718 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
