### PR TITLE
FDSN: add short URL mapping for IRISPH5

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ maintenance_1.2.x
 Changes:
  - obspy.core:
    * Inventory addition now consistently uses shallow copies (#2675, #2694)
+ - obspy.clients.fdsn:
+   * add URL mapping for IRISPH5 (see #2739)
  - obspy.clients.seedlink:
    * Fix a bug in basic client when printing debug output (see #2734)
  - obspy.io.gse2:

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -43,6 +43,7 @@ ICGC        http://ws.icgc.cat
 INGV        http://webservices.ingv.it
 IPGP        http://ws.ipgp.fr
 IRIS        http://service.iris.edu
+IRISPH5     http://service.iris.edu
 ISC         http://isc-mirror.iris.washington.edu
 KNMI        http://rdsa.knmi.nl
 KOERI       http://eida.koeri.boun.edu.tr

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -48,6 +48,7 @@ URL_MAPPINGS = {
     "INGV": "http://webservices.ingv.it",
     "IPGP": "http://ws.ipgp.fr",
     "IRIS": "http://service.iris.edu",
+    "IRISPH5": "http://service.iris.edu",
     "ISC": "http://isc-mirror.iris.washington.edu",
     "KNMI": "http://rdsa.knmi.nl",
     "KOERI": "http://eida.koeri.boun.edu.tr",
@@ -64,6 +65,10 @@ URL_MAPPINGS = {
     "UIB-NORSAR": "http://eida.geo.uib.no",
     "USGS": "http://earthquake.usgs.gov",
     "USP": "http://sismo.iag.usp.br"}
+URL_MAPPING_SUBPATHS = {
+    "IRISPH5": "/ph5ws",
+    }
+URL_DEFAULT_SUBPATH = '/fdsnws'
 
 FDSNWS = ("dataselect", "event", "station")
 

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -55,11 +55,13 @@ class MassDownloader(object):
     implementations.
 
     :param providers: List of FDSN client names or service URLS. Will use
-        all FDSN implementations known to ObsPy except RASPISHAKE if set to
-        None. The order in the list also determines their priority, if data
-        is available at more then one provider it will always be downloaded
-        from the provider that comes first in the list. To include RASPISHAKE,
-        you must set this parameter to
+        all FDSN implementations known to ObsPy except RASPISHAKE (generally
+        worse quality data) and IRISPH5 (active source / nodal experiments that
+        might match a very large amount of data occasionally) if set to None.
+        The order in the list also determines their priority, if data is
+        available at more then one provider it will always be downloaded from
+        the provider that comes first in the list. To include RASPISHAKE and
+        IRISPH5, you must set this parameter to
         `obspy.clients.fdsn.header.URL_MAPPINGS` explicitly.
     :param debug: Debug flag passed to the underlying FDSN web service clients.
     :type providers: list of str or :class:`~obspy.clients.fdsn.client.Client`
@@ -95,6 +97,11 @@ class MassDownloader(object):
                 del providers["ORFEUS"]
             else:
                 has_orfeus = False
+
+            # leave out IRISPH5 which is for nodal experiments and might match
+            # insanely large datasets, depending on restrictions
+            if "IRISPH5" in providers:
+                del providers["IRISPH5"]
 
             _p = sorted(providers)
             if has_orfeus:

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -493,6 +493,18 @@ class ClientTestCase(RegExTestCase):
             # does not only check the preferred magnitude..
             self.assertTrue(any(m.mag >= 3.999 for m in event.magnitudes))
 
+    def test_irisph5_event(self):
+        """
+        Tests the IRISPH5 URL mapping, which is special due to its custom
+        subpath.
+        """
+        client = Client('IRISPH5')
+
+        # Event id query.
+        cat = client.get_events(catalog='8A')
+        self.assertEqual(len(cat), 19)
+        self.assertEqual(cat[0].event_type, 'controlled explosion')
+
     def test_iris_example_queries_station(self):
         """
         Tests the (sometimes modified) example queries given on IRIS webpage.


### PR DESCRIPTION
### What does this PR do?

Adds support for IRISPH5 short URL mapping in FDSNWS Client. To make it work it would need some changes to internals unfortunately, since this FDSNWS is not following the FDSN specifications in that it does not have a `/fdsnws` subpath in between the base URL and the service endpoints.

Two possibilities to alleviate it:
 - change internals as done in this PR. implies that users should be able to navigate service versions using `major_versions` on Client init.
 - other option: set the full service URLS in `headers.py` and leave internals as is. less changes in code, but then users would not be able to use the `"IRISPH5"` URL mapping and use an (eventual) higher service major version. (not done in this PR)

This isn't really beautiful, so I'd like to hear some opinions on this.

Tests pass locally: http://tests.obspy.org/112201/

+TESTS:clients.fdsn

### Why was it initiated?  Any relevant Issues?

closes #2737 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
