### PR TITLE
Fixed bug in nordic _str_conv and set default phase weight to ' '

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@ Changes:
  - obspy.io.gse2:
    * When reading GSE2 bulletins, station magnitudes now include waveform IDs
      and have associated station magnitude contributions (see #2718)
+ - obspy.io.nordic:
+   * fixed a bug where the number 0 was converted to string ' ' instead of '0'
+   * Made default pick weight ' ' (unspecified) instead of '0' (best)
 
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -1393,7 +1393,7 @@ def nordpick(event, high_accuracy=True):
             if arrival.time_weight is None:
                 weight = ' '
             else:
-                weight = _str_conv(int(arrival.time_weight or 0))
+                weight = _str_conv(int(arrival.time_weight))
             # Extract azimuth residual
             if arrival.backazimuth_residual is not None:
                 azimuthres = _str_conv(int(arrival.backazimuth_residual))

--- a/obspy/io/nordic/core.py
+++ b/obspy/io/nordic/core.py
@@ -1390,7 +1390,10 @@ def nordpick(event, high_accuracy=True):
                 warnings.warn("Multiple arrivals for pick - only writing one")
             arrival = arrival[0]
             # Extract weight - should be stored as 0-4, or 9 for seisan.
-            weight = _str_conv(int(arrival.time_weight or 0))
+            if arrival.time_weight is None:
+                weight = ' '
+            else:
+                weight = _str_conv(int(arrival.time_weight or 0))
             # Extract azimuth residual
             if arrival.backazimuth_residual is not None:
                 azimuthres = _str_conv(int(arrival.backazimuth_residual))
@@ -1425,7 +1428,7 @@ def nordpick(event, high_accuracy=True):
                 caz = ' '
         else:
             caz, distance, timeres, azimuthres, azimuth, weight, ain = (
-                ' ', ' ', ' ', ' ', ' ', 0, ' ')
+                ' ', ' ', ' ', ' ', ' ', ' ', ' ')
         phase_hint = pick.phase_hint or ' '
         # Extract amplitude: note there can be multiple amplitudes, but they
         # should be associated with different picks.

--- a/obspy/io/nordic/utils.py
+++ b/obspy/io/nordic/utils.py
@@ -75,12 +75,14 @@ def _str_conv(number, rounded=False):
     12.3
     >>> print(_str_conv(12.34546, rounded=1))
     12.3
+    >>> print(_str_conv(0))
+    0
     >>> print(_str_conv(None))
     <BLANKLINE>
     >>> print(_str_conv(1123040))
     11.2e5
     """
-    if not number:
+    if number is None:
         return str(' ')
     if not rounded and isinstance(number, (float, int)):
         if number < 100000:


### PR DESCRIPTION
Change "if not number" to "if number is None"



### What does this PR do?

Fixes a bug in the function _str_conv(), which converts floats or ints to a string.  The original version
returned ' ' instead of '0' if the input value was 0.

### Why was it initiated?  Any relevant Issues?

Nordic files created from catalogs were having weighting set to "0" (best quality) if the catalog had
no weighting information.  The bug could affect other translations as well.

Example original output file:
```
 2019  519  6 9 45.3 L                           12 0.0                        1
 Action:ARG 20-11-16 12:55 OP:OBSP STATUS:               ID:20190519060945     I
 2019-05-19-0609-17M.MAYOB_051                                                 6
 STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
 MOFA E3  Pg  3A   6 949.001                                                    
 MOFA E2  Sg  2A   6 951.153                                                    
 IF5A E2  Pg   A   6 950.929                                                    
 MONA E3  Pg  1A   6 948.834                                                    
 MONA E2  Sg  3A   6 951.522                                                    
 MOSA E3  Pg  3A   6 948.846                                                    
 MOSA E2  Sg  3A   6 951.438                                                    
 MOFA E2  IAML A   6 953.057       367.4 0.10                                   
 IF5A E2  IAML A   6 953.057       496.3 0.10                                   
 MONA E2  IAML A   6 953.050       367.4 0.10                                   
 MOSA E2  IAML A   6 953.054       367.4 0.10                                   
```

Output file with all corrections, good pick at station IF5A has correct weight=0
```
 2019  519  6 9 45.3 L                           12 0.0                        1
 Action:ARG 20-11-16 13:01 OP:OBSP STATUS:               ID:20190519060945     I
 2019-05-19-0609-17M.MAYOB_051                                                 6
 STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
 MOFA E3  Pg  3A   6 949.001                                                    
 MOFA E2  Sg  2A   6 951.153                                                    
 IF5A E2  Pg  0A   6 950.929                                                    
 MONA E3  Pg  1A   6 948.834                                                    
 MONA E2  Sg  3A   6 951.522                                                    
 MOSA E3  Pg  3A   6 948.846                                                    
 MOSA E2  Sg  3A   6 951.438                                                    
 MOFA E2  IAML A   6 953.057       367.4 0.10                                   
 IF5A E2  IAML A   6 953.057       496.3 0.10                                   
 MONA E2  IAML A   6 953.050       367.4 0.10                                   
 MOSA E2  IAML A   6 953.054       367.4 0.10                                   
```                                                                           

                                                                                

Example output file with only _str_conv() bugfix applied: amplitude picks are improperly assigned weight=0
```
 2019  519  6 9 45.3 L                           12 0.0                        1
 Action:ARG 20-11-16 13:04 OP:OBSP STATUS:               ID:20190519060945     I
 2019-05-19-0609-17M.MAYOB_051                                                 6
 STAT SP IPHASW D HRMM SECON CODA AMPLIT PERI AZIMU VELO AIN AR TRES W  DIS CAZ7
 MOFA E3  Pg  3A   6 949.001                                                    
 MOFA E2  Sg  2A   6 951.153                                                    
 IF5A E2  Pg  0A   6 950.929                                                    
 MONA E3  Pg  1A   6 948.834                                                    
 MONA E2  Sg  3A   6 951.522                                                    
 MOSA E3  Pg  3A   6 948.846                                                    
 MOSA E2  Sg  3A   6 951.438                                                    
 MOFA E2  IAML0A   6 953.057       367.4 0.10                                   
 IF5A E2  IAML0A   6 953.057       496.3 0.10                                   
 MONA E2  IAML0A   6 953.050       367.4 0.10                                   
 MOSA E2  IAML0A   6 953.054       367.4 0.10                                   
```                                                                                


### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
