### PR TITLE
Add "level" option to read_inventory / _read_stationxml

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -38,7 +38,8 @@ def _create_example_inventory():
 
 
 @map_example_filename("path_or_file_object")
-def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
+def read_inventory(path_or_file_object=None, format=None, level='response',
+                   *args, **kwargs):
     """
     Function to read inventory files.
 
@@ -51,6 +52,10 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
     :type format: str
     :param format: Format of the file to read (e.g. ``"STATIONXML"``). See the
         `Supported Formats`_ section below for a list of supported formats.
+    :type level: str
+    :param level: Level of detail to read from file. One of ``'response'``,
+        ``'channel'``, ``'station'`` or ``'network'``. Lower level of detail
+        can result in much shorter reading times for some file formats.
     :rtype: :class:`~obspy.core.inventory.inventory.Inventory`
     :return: An ObsPy :class:`~obspy.core.inventory.inventory.Inventory`
         object.
@@ -76,6 +81,9 @@ def read_inventory(path_or_file_object=None, format=None, *args, **kwargs):
         StationXML standard and how to output it to StationXML
         see the :ref:`ObsPy Tutorial <stationxml-extra>`.
     """
+    # add default parameters to kwargs so sub-modules may handle them
+    kwargs['level'] = level
+
     if path_or_file_object is None:
         # if no pathname or URL specified, return example catalog
         return _create_example_inventory()

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -139,11 +139,14 @@ def validate_stationxml(path_or_object):
     return (True, ())
 
 
-def _read_stationxml(path_or_file_object):
+def _read_stationxml(path_or_file_object, level='response'):
     """
     Function reading a StationXML file.
 
     :param path_or_file_object: File name or file like object.
+    :type level: str
+    :param level: Level of detail to read from file. One of ``'response'``,
+        ``'channel'``, ``'station'`` or ``'network'``.
     """
     root = etree.parse(path_or_file_object).getroot()
 
@@ -173,7 +176,7 @@ def _read_stationxml(path_or_file_object):
                 'Setting Numerator/Denominator with a unit is deprecated.',
                 ObsPyDeprecationWarning)
         for network in root.findall(_ns("Network")):
-            networks.append(_read_network(network, _ns))
+            networks.append(_read_network(network, _ns, level))
 
     inv = obspy.core.inventory.Inventory(networks=networks, source=source,
                                          sender=sender, created=created,
@@ -223,7 +226,7 @@ def _read_base_node(element, object_to_write_to, _ns):
     _read_extra(element, object_to_write_to)
 
 
-def _read_network(net_element, _ns):
+def _read_network(net_element, _ns, level):
     network = obspy.core.inventory.Network(net_element.get("code"))
     _read_base_node(net_element, network, _ns)
     for operator in net_element.findall(_ns("Operator")):
@@ -233,13 +236,14 @@ def _read_network(net_element, _ns):
     network.selected_number_of_stations = \
         _tag2obj(net_element, _ns("SelectedNumberStations"), int)
     stations = []
-    for station in net_element.findall(_ns("Station")):
-        stations.append(_read_station(station, _ns))
+    if level in ('station', 'channel', 'response'):
+        for station in net_element.findall(_ns("Station")):
+            stations.append(_read_station(station, _ns, level))
     network.stations = stations
     return network
 
 
-def _read_station(sta_element, _ns):
+def _read_station(sta_element, _ns, level):
     longitude = _read_floattype(sta_element, _ns("Longitude"), Longitude,
                                 datum=True)
     latitude = _read_floattype(sta_element, _ns("Latitude"), Latitude,
@@ -273,23 +277,24 @@ def _read_station(sta_element, _ns):
     for ref in sta_element.findall(_ns("ExternalReference")):
         station.external_references.append(_read_external_reference(ref, _ns))
     channels = []
-    for channel in sta_element.findall(_ns("Channel")):
-        # Skip empty channels.
-        if not channel.items() and not channel.attrib:
-            continue
-        cha = _read_channel(channel, _ns)
-        # Might be None in case the channel could not be parsed.
-        if cha is None:
-            # This is None if, and only if, one of the coordinates could not
-            # be set.
-            msg = ("Channel %s.%s of station %s does not have a complete set "
-                   "of coordinates and thus it cannot be read. It will not be "
-                   "part of the final inventory object." % (
-                       channel.get("locationCode"), channel.get("code"),
-                       sta_element.get("code")))
-            warnings.warn(msg, UserWarning)
-        else:
-            channels.append(cha)
+    if level in ('channel', 'response'):
+        for channel in sta_element.findall(_ns("Channel")):
+            # Skip empty channels.
+            if not channel.items() and not channel.attrib:
+                continue
+            cha = _read_channel(channel, _ns, level=level)
+            # Might be None in case the channel could not be parsed.
+            if cha is None:
+                # This is None if, and only if, one of the coordinates could
+                # not be set.
+                msg = ("Channel %s.%s of station %s does not have a complete "
+                       "set of coordinates and thus it cannot be read. It "
+                       "will not be part of the final inventory object." % (
+                           channel.get("locationCode"), channel.get("code"),
+                           sta_element.get("code")))
+                warnings.warn(msg, UserWarning)
+            else:
+                channels.append(cha)
     station.channels = channels
     return station
 
@@ -354,7 +359,7 @@ def _read_floattype_list(parent, tag, cls, unit=False, datum=False,
     return objs
 
 
-def _read_channel(cha_element, _ns):
+def _read_channel(cha_element, _ns, level):
     """
     Returns either a :class:`~obspy.core.inventory.channel.Channel` object or
     ``None``.
@@ -433,10 +438,11 @@ def _read_channel(cha_element, _ns):
     for equipment in cha_element.findall(_ns("Equipment")):
         channel.equipments.append(_read_equipment(equipment, _ns))
     # Finally parse the response.
-    response = cha_element.find(_ns("Response"))
-    if response is not None:
-        channel.response = _read_response(response, _ns)
-        channel.response._attempt_to_fix_units()
+    if level == 'response':
+        response = cha_element.find(_ns("Response"))
+        if response is not None:
+            channel.response = _read_response(response, _ns)
+            channel.response._attempt_to_fix_units()
     return channel
 
 


### PR DESCRIPTION


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Make it possible to read reduced level of detail from StationXML files.

### Why was it initiated?  Any relevant Issues?

Reading response is by far the most time (and potentially memory) consuming part and in many cases it is not needed, e.g. when only station coordinates or available channels are of interest.

Example speedups with a 20 MB StationXML file with 1000 channels with responses: not parsing responses reduces read time by 80%. Only reading station level cuts time down by 90%.
```
$ python -m timeit -n 3 -r 5 -s 'from obspy import read_inventory' 'read_inventory("inventory_jane.xml", "STATIONXML", level="response")'
3 loops, best of 5: 3.71 sec per loop

$ python -m timeit -n 3 -r 5 -s 'from obspy import read_inventory' 'read_inventory("inventory_jane.xml", "STATIONXML", level="channel")'
3 loops, best of 5: 745 msec per loop

$ python -m timeit -n 3 -r 5 -s 'from obspy import read_inventory' 'read_inventory("inventory_jane.xml", "STATIONXML", level="station")'
3 loops, best of 5: 335 msec per loop

$ python -m timeit -n 3 -r 5 -s 'from obspy import read_inventory' 'read_inventory("inventory_jane.xml", "STATIONXML", level="network")'
3 loops, best of 5: 244 msec per loop
```

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
