### PR TITLE
xseed: properly read elevation 0 value

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@ Changes:
  - obspy.io.gse2:
    * When reading GSE2 bulletins, station magnitudes now include waveform IDs
      and have associated station magnitude contributions (see #2718)
+ - obspy.io.xseed:
+   * Properly read a given value of 0.0 in station elevation and not replace it
+     with bogus value (see #2763)
 
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================

--- a/obspy/io/xseed/core.py
+++ b/obspy/io/xseed/core.py
@@ -234,6 +234,10 @@ def _parse_to_inventory_object(p, skip_invalid_responses=True):
         elevation = last_or_none("elevation")
         site_name = last_or_none("site_name")
 
+        # handle None in mandatory elevation field with obvious bogus value
+        if elevation is None:
+            elevation = 123456.0
+
         # Take the first start-date and the last end-date.
         start_effective_date = station_info["start_effective_date"][0] \
             if "start_effective_date" in station_info else None
@@ -258,9 +262,10 @@ def _parse_to_inventory_object(p, skip_invalid_responses=True):
         s = obspy.core.inventory.Station(
             code=station_call_letters,
             # Set to bogus values if not set.
+            # elevation bogus is handled above
             latitude=latitude or 0.0,
             longitude=longitude or 0.0,
-            elevation=elevation or 123456.0,
+            elevation=elevation,
             channels=None,
 
             site=obspy.core.inventory.Site(name=site_name),


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Properly read a value of `0.0` in station elevation in Full SEED and not replace it with bogus value used for "not set".

### Why was it initiated?  Any relevant Issues?
Fixes #2762 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
