### PR TITLE
fix flatline in section plot with single trace

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,8 @@ Changes:
    * update RESIF URL mapping to use https
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
+ - obspy.imaging:
+   * fix section plot in case of a single trace only (see #2764)
  - obspy.clients.filesystem.tsindex:
    * improvements to leap second file setup and other small fixes (see #2776)
  - obspy.clients.seedlink:

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1186,15 +1186,22 @@ class WaveformPlotting(object):
                     'coordinates and ev_coord. See documentation.'
                 raise ValueError(msg)
         # Define minimum and maximum offsets
-        if self.sect_offset_min is None:
-            self._offset_min = self._tr_offsets.min()
+        if (self.sect_offset_min is None and self.sect_offset_max is None
+                and len(self._tr_offsets) == 1):
+            # avoid flatline in case of a single trace and no custom offsets
+            # specified
+            self._offset_min = self._tr_offsets[0] * 0.8
+            self._offset_max = self._tr_offsets[0] * 1.2
         else:
-            self._offset_min = self.sect_offset_min
+            if self.sect_offset_min is None:
+                self._offset_min = self._tr_offsets.min()
+            else:
+                self._offset_min = self.sect_offset_min
+            if self.sect_offset_max is None:
+                self._offset_max = self._tr_offsets.max()
+            else:
+                self._offset_max = self.sect_offset_max
 
-        if self.sect_offset_max is None:
-            self._offset_max = self._tr_offsets.max()
-        else:
-            self._offset_max = self.sect_offset_max
         # Reduce data to indexes within offset_min/max
         mask = ((self._tr_offsets >= self._offset_min) &
                 (self._tr_offsets <= self._offset_max))


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix section plot in case of a single trace only and no custom offset min/max specified, which leaded to a flat line as automatic min/max offsets are set to the same value, messing up the scaling based on their difference.

### Why was it initiated?  Any relevant Issues?

https://discourse.obspy.org/t/trace-data-normalization-scaling-and-resampling-in-waveform-section-plots/1131

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
