### PR TITLE
initial commit on waveform timemarks featuring

### DIFF
--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial.rst
@@ -114,13 +114,25 @@ by setting parameter ``type`` to ``'section'``:
 
     >>> stream.plot(type='section')
 
-To plot a record section the ObsPy header ``trace.stats.distance`` (Offset) must be 
-defined in meters. Or a geographical location ``trace.stats.coordinates.latitude`` & 
-``trace.stats.coordinates.longitude`` must be defined if the section is plotted in 
-great circle distances (``dist_degree=True``) along with parameter ``ev_coord``. 
+To plot a record section the ObsPy header ``trace.stats.distance`` (Offset) must be
+defined in meters. Or a geographical location ``trace.stats.coordinates.latitude`` &
+``trace.stats.coordinates.longitude`` must be defined if the section is plotted in
+great circle distances (``dist_degree=True``) along with parameter ``ev_coord``.
 For further information please see :meth:`~obspy.core.stream.Stream.plot`
 
 .. plot:: tutorial/code_snippets/waveform_plotting_tutorial_6.py
+
+----------------------------------------------------
+Plotting a Stream or a Record Section with TimeMarks
+----------------------------------------------------
+
+A :class:`~obspy.core.stream.Stream` object plot with type equal to section,
+normal or relative can be shown with time-marks information by adding the option
+``plot_time_marks=True``. Of course, th other necessary parameters (depending
+on type) must be provided as well.
+For further information please see :meth:`~obspy.core.stream.Stream.plot`
+
+.. plot:: tutorial/code_snippets/waveform_plotting_tutorial_8.py
 
 --------------------
 Plot & Color Options

--- a/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_8.py
+++ b/misc/docs/source/tutorial/code_snippets/waveform_plotting_tutorial_8.py
@@ -1,0 +1,85 @@
+from obspy import UTCDateTime
+import matplotlib.pyplot as plt
+from matplotlib.transforms import blended_transform_factory
+from obspy import read, Stream
+from obspy.geodetics import gps2dist_azimuth
+
+
+host = 'https://examples.obspy.org/'
+# Files (fmt: SAC)
+files = ['TOK.2011.328.21.10.54.OKR01.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR02.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR03.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR04.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR05.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR06.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR07.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR08.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR09.HHN.inv',
+         'TOK.2011.328.21.10.54.OKR10.HHN.inv']
+# Earthquakes' epicenter
+eq_lat = 35.565
+eq_lon = -96.792
+
+# Reading the waveforms
+st = Stream()
+for waveform in files:
+    st += read(host + waveform)
+
+# Calculating distance from SAC headers lat/lon and add custom TimeMarks
+# (trace.stats.sac.stla and trace.stats.sac.stlo)
+for tr in st:
+    tr.stats.distance = gps2dist_azimuth(tr.stats.sac.stla, tr.stats.sac.stlo,
+                                         eq_lat, eq_lon)[0]
+    # Setting Network name for plot title
+    tr.stats.network = 'TOK'
+
+    # Time Marks creation:
+    tr.stats.timemarks = [
+               (UTCDateTime("2011-11-24T21:11:07.0"),
+                {'color': 'sandybrown', 'markeredgewidth': 3}),
+       ]
+
+    if tr.stats.station == "OKR01":
+        tr.stats.timemarks.append(
+            (UTCDateTime("2011-11-24T21:11:09.39"),
+             {'markeredgewidth': 2, 'markersize': 40}))
+    elif tr.stats.station == "OKR02":
+        tr.stats.timemarks.append(
+            (UTCDateTime("2011-11-24T21:11:10.48"),
+             {'markeredgewidth': 2, 'markersize': 40}))
+    elif tr.stats.station == "OKR03":
+        tr.stats.timemarks.append(
+            (UTCDateTime("2011-11-24T21:11:12.5"),
+             {'markeredgewidth': 2, 'markersize': 40}))
+#
+st.filter('bandpass', freqmin=0.1, freqmax=10)
+
+
+# ========================= Section
+# Do the section plot..
+# If no customization is done after the section plot command, figure
+# initialization can be left out and also option ".., show=False, fig=fig)" can
+# be omitted, and figure is shown automatically
+
+fig1 = plt.figure()
+st.plot(type='section', plot_dx=20e3, recordlength=100, offset_max=60000,
+        time_down=True, linewidth=.25, grid_linewidth=.25, fig=fig1,
+        plot_time_marks=True)
+
+# Plot customization: Add station labels to offset axis
+ax = fig1.axes[0]
+transform = blended_transform_factory(ax.transData, ax.transAxes)
+for tr in st:
+    ax.text(tr.stats.distance / 1e3, 1.0, tr.stats.station, rotation=270,
+            va="bottom", ha="center", transform=transform, zorder=10)
+
+# ========================= Standard (normal/relative)
+fig2 = plt.figure()
+st[0:3].plot(type='normal', show=False, plot_time_marks=True, fig=fig2)
+
+fig3 = plt.figure()
+st[0:3].plot(type='relative', show=False, plot_time_marks=True, fig=fig3,
+             reftime=UTCDateTime("2011-11-24T21:11:9.39")-5.0)
+
+plt.show()

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -962,6 +962,38 @@ class Stream(object):
             Defaults to ``0.5``.
         :param grid_linestyle: Grid line style.
             Defaults to ``':'``
+        :param plot_time_marks: Boolean value. If True the plot method will
+            search for a ``trace.stats.timemarks`` attribute. The attribute
+            must be an iterable-container of lists/tuples. Each single element
+            must cotain 2 element: an UTCDateTime object and a dictionary
+            containing matplotlib attributes for individual customizations.
+            The defaults change based on plot type selected (currently this
+            option is not supported by ``dayplot`` type only)
+            Example::
+
+
+                tr.stats.timemarks=[
+                    ( UTCDateTime(...), {marker:"|", color:"r" ...}),
+                    ( UTCDateTime(...), {marker:"o", markersize:10, ...})
+                    ...
+                    ]
+
+
+            The defaults plotting attribute are called when the dictionary is
+            set to either ``None`` or ``{}``.
+            Example::
+
+
+                tr.stats.timemarks=[
+                    ( UTCDateTime(...), {}),
+                    ]
+
+
+            It set to True but no timemarks attributes are found, This option
+            is simply ignored and will not raise any error.
+            Defaults to ``False``
+
+
 
         **Dayplot Parameters**
 

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -213,6 +213,7 @@ class WaveformPlotting(object):
         self.title = kwargs.get('title', self.stream[0].id)
         self.fillcolor_pos, self.fillcolor_neg = \
             kwargs.get('fillcolors', (None, None))
+        self.plottimemarks = kwargs.get('plot_time_marks', False)
 
     def __del__(self):
         """
@@ -323,6 +324,67 @@ class WaveformPlotting(object):
                     # Also return the figure to make it work the jupyter
                     # notebooks.
                     return self.fig
+
+    def __init_time_marks(self):
+        """
+        Extract TimeMarks attributes from Trace objects
+
+        TimeMarks must be a container of tuples/lists.
+        Each tuple must contain an UTCDateTime object and a matplotlib
+        plotting dictionary.
+        """
+        self._tr_timemarks = [None] * len(self.stream)
+        # Define TimeMarks with station-level allocation.
+        for _i, tr in enumerate(self.stream):
+            try:
+                # TimeMark -> tuple(UTCDateTime, {matplotlib dict})
+                self._tr_timemarks[_i] = tr.stats.timemarks
+            except AttributeError:
+                self._tr_timemarks[_i] = (None, None)
+        if len(self._tr_timemarks) == 1:
+            self._tr_timemarks = (self._tr_timemarks,)
+
+    def __draw_time_marks_normal(self,
+                                 trace_idx,
+                                 ax,
+                                 trace,
+                                 timemarks,
+                                 mode):
+        """
+        Draw on given axis the Trace time-marks.
+        The ax must belong to a 'normal' type plot.
+        """
+        if len(np.shape(timemarks)) == 1:
+            msg = ("The timemarks attribute must be a container of tuples! " +
+                   "Maybe try the syntax ((),) or [(),] to produce a tuple " +
+                   "of tuples or a list of tuples")
+            raise ValueError(msg)
+        # "_" hline , "|" vline
+
+        for (_xx, (tm, tmpl)) in enumerate(timemarks):
+            if mode == "relative":
+                # Relative UTCDateTime obj.
+                tmsec = tm + (trace.stats.starttime - self.reftime)
+                # Final relative seconds
+                tmsec = tmsec - trace.stats.starttime
+            else:
+                tmsec = (
+                    ((tm - trace.stats.starttime) / SECONDS_PER_DAY) +
+                    date2num(trace.stats.starttime.datetime))
+            # Actual plot
+            try:
+                pltdict = {'marker': '|',
+                           'color': 'teal',
+                           'markeredgewidth': 2,
+                           'markersize': 40}
+                if tmpl:
+                    pltdict.update(tmpl)
+                ax.plot(tmsec, 0.0, **pltdict)
+
+            except Exception:
+                msg = ("Something wrong with the TimeMark %d on Trace %d" %
+                       (_xx + 1, trace_idx + 1))
+                raise ValueError(msg)
 
     def plot(self, *args, **kwargs):
         """
@@ -670,7 +732,7 @@ class WaveformPlotting(object):
         # trace argument seems to actually be a list of traces..
         st = Stream(trace)
         self._draw_overlap_axvspans(st, ax)
-        for trace in st:
+        for _ii, trace in enumerate(st):
             # Check if it is a preview file and adjust accordingly.
             # XXX: Will look weird if the preview file is too small.
             if trace.stats.get('preview'):
@@ -700,6 +762,13 @@ class WaveformPlotting(object):
                             date2num(trace.stats.starttime.datetime))
             ax.plot(x_values, trace.data, color=self.color,
                     linewidth=self.linewidth, linestyle=self.linestyle)
+            #
+            if self.plottimemarks:
+                self.__draw_time_marks_normal(_ii,
+                                              ax,
+                                              trace,
+                                              trace.stats.timemarks,
+                                              self.type)
         # Write to self.ids
         trace = st[0]
         if trace.stats.get('preview'):
@@ -774,6 +843,15 @@ class WaveformPlotting(object):
             x_values = np.repeat(x_values, 2)
             y_values = extreme_values.flatten()
             ax.plot(x_values, y_values, color=self.color)
+            #
+            if self.plottimemarks:
+                # hack because trace is actually a Stream in this method
+                self.__draw_time_marks_normal(_i,
+                                              ax,
+                                              trace[0],
+                                              trace.stats.timemarks,
+                                              self.type)
+
         # remember xlim state and add callback to warn when zooming in
         self._initial_xrange = (self._time_to_xvalue(self.endtime) -
                                 self._time_to_xvalue(self.starttime))
@@ -1281,6 +1359,47 @@ class WaveformPlotting(object):
         """
         return fraction * self._tr_offsets.max()
 
+    def __draw_time_marks_section(self,
+                                  trace_idx,
+                                  ax,
+                                  off,
+                                  plotmode,
+                                  timemarks):
+        """
+        Draw on given axis the Trace time-marks.
+        The ax must belong to a 'section' type plot.
+        """
+        reftime = self.sect_reftime or min(self._tr_starttimes)
+        if len(np.shape(timemarks)) == 1:
+            msg = ("The timemarks attribute must be a container of tuples! " +
+                   "Maybe try the syntax ((),) or [(),] to produce a tuple " +
+                   "of tuples or a list of tuples")
+            raise ValueError(msg)
+        # "_" hline , "|" vline
+        for (_xx, (tm, tmpl)) in enumerate(timemarks):
+            # Actual plot
+            try:
+                if plotmode == "vertical":
+                    pltdict = {'marker': '_',
+                               'color': 'teal',
+                               'markeredgewidth': 1.5,
+                               'markersize': 20}
+                    if tmpl:
+                        pltdict.update(tmpl)
+                    ax.plot(off, tm-reftime, **pltdict)
+                elif plotmode == "horizontal":
+                    pltdict = {'marker': '|',
+                               'color': 'teal',
+                               'markeredgewidth': 1.5,
+                               'markersize': 20}
+                    if tmpl:
+                        pltdict.update(tmpl)
+                    ax.plot(tm-reftime, off,  **pltdict)
+            except Exception:
+                msg = ("Something wrong with the TimeMark %d on Trace %d" %
+                       (_xx + 1, trace_idx + 1))
+                raise ValueError(msg)
+
     def __sect_init_plot(self):
         """
         Function initialises plot all the illustration is done by
@@ -1301,6 +1420,9 @@ class WaveformPlotting(object):
         self.__sect_normalize_traces()
         # Calculate scaling factor
         self.__sect_scale_traces()
+        # Extract TimeMarks scaling factor
+        if self.plottimemarks:
+            self.__init_time_marks()
         lines = []
         # ax.plot() preferred over containers
         for _tr in range(self._tr_num):
@@ -1311,8 +1433,22 @@ class WaveformPlotting(object):
             time = self._tr_times[_tr]
             if self.sect_orientation == 'vertical':
                 lines += ax.plot(data, time)
+                if self.plottimemarks and self._tr_timemarks[_tr][0]:
+                    self.__draw_time_marks_section(_tr,
+                                                   ax,
+                                                   self._tr_offsets[_tr],
+                                                   'vertical',
+                                                   self._tr_timemarks[_tr])
+
             elif self.sect_orientation == 'horizontal':
                 lines += ax.plot(time, data)
+                if self.plottimemarks and self._tr_timemarks[_tr][0]:
+                    self.__draw_time_marks_section(_tr,
+                                                   ax,
+                                                   self._tr_offsets[_tr],
+                                                   'horizontal',
+                                                   self._tr_timemarks[_tr])
+
             else:
                 raise NotImplementedError("sect_orientiation '%s' is not "
                                           "valid." % self.sect_orientation)


### PR DESCRIPTION
### What does this PR do?

Yet another feature on `Stream.plot()` method. This PR introduces a new boolean parameter called `plot_time_marks`. This parameter  will allow the user to plot `timemarks` on plto types `normal`, `reference` and `section`. This PR introduce a new parameter for StThese time marks are customizable like any other matplotlib line object. 

These timemarks are defined in an additional attribute in `Trace.stats` object. The attribute is a container of tuples/lists of 2 elements each: a time, and a matplotlib dictionary plot.

```
tr.stats.timemarks=[
            (UTCDateTime("2011-11-24T21:11:07.0"),
            {'color': 'b', 'markeredgewidth': 3, 'markersize': 10 ...}),
            ...
]
```

### Why was it initiated?  Any relevant Issues?

It started due to a personal need to fast-plot custom TimeMarks over Stream section's plot. 
Then I thought the community could also benefit from it, and I've implemented also on `normal` and `relative` type-plot as well. 
We all know that users must create their own custom scripts for ad-hoc figures, but this additional parameter could give a quick vision of different time-features (ie. picks, swarns etc..). 
No relevant issues. At the moment it is not implemented in the `dayplot` type but I could of course add it if we prefer so.


### PR Checklist
- [ x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ x] This PR is not directly related to an existing issue (which has no PR yet).
- [ x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
