### PR TITLE
Fix the docstring formatting of obspy_to_sac_header

### DIFF
--- a/obspy/io/sac/util.py
+++ b/obspy/io/sac/util.py
@@ -285,6 +285,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
     :param keep_sac_header: If keep_sac_header is True, old stats.sac
         header values are kept, and a minimal set of values are updated from
         the stats dictionary according to these guidelines:
+
         * npts, delta always come from stats
         * If a valid old reftime is found, the new b and e will be made
           and properly referenced to it. All other old SAC headers are simply
@@ -301,6 +302,7 @@ def obspy_to_sac_header(stats, keep_sac_header=True):
         * If 'kstnm', 'knetwk', 'kcmpnm', or 'khole' are not set or differ
           from Stats values 'station', 'network', 'channel', or 'location',
           they are taken from the Stats values.
+
         If keep_sac_header is False, a new SAC header is constructed from only
         information found in the Stats dictionary, with some other default
         values introduced.  It will be an iztype 9 ("ib") file, with small


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

The [documentation of `obspy_to_sac_header`](https://docs.obspy.org/master/packages/autogen/obspy.io.sac.util.obspy_to_sac_header.html#obspy.io.sac.util.obspy_to_sac_header) is incorrectly formatted. This PR fixes the issue.

Screenshot:

![image](https://user-images.githubusercontent.com/3974108/103175253-8dd65580-4836-11eb-9677-21035d2a769d.png)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
