### PR TITLE
clients.filesystem.tsindex updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@ Changes:
    * add URL mapping for IRISPH5 (see #2739)
  - obspy.clients.seedlink:
    * Fix a bug in basic client when printing debug output (see #2734)
+ - obspy.clients.filesystem.tsindex:
+   * improvements to leap second file setup and other small fixes (see #2776)
  - obspy.io.gse2:
    * When reading GSE2 bulletins, station magnitudes now include waveform IDs
      and have associated station magnitude contributions (see #2718)

--- a/obspy/clients/filesystem/tests/test_tsindex.py
+++ b/obspy/clients/filesystem/tests/test_tsindex.py
@@ -17,7 +17,7 @@ import uuid
 
 from obspy.core.compatibility import mock, RegExTestCase
 from obspy.clients.filesystem.tsindex import Client, Indexer, \
-    TSIndexDatabaseHandler, _sqlalchemy_version_insufficient
+    TSIndexDatabaseHandler
 from obspy import read
 from obspy import UTCDateTime
 
@@ -39,8 +39,6 @@ def get_test_client():
     return client
 
 
-@unittest.skipIf(_sqlalchemy_version_insufficient,
-                 'TSIndex needs sqlalchemy 1.0.0 or higher')
 class ClientTestCase(RegExTestCase):
 
     def test_bad_sqlitdb_filepath(self):
@@ -600,8 +598,6 @@ def purge(dir, pattern):
             os.remove(os.path.join(dir, f))
 
 
-@unittest.skipIf(_sqlalchemy_version_insufficient,
-                 'TSIndex needs sqlalchemy 1.0.0 or higher')
 class IndexerTestCase(RegExTestCase):
 
     def test_bad_rootpath(self):
@@ -897,8 +893,6 @@ class IndexerTestCase(RegExTestCase):
             purge(filepath, '^{}.*$'.format(fname))
 
 
-@unittest.skipIf(_sqlalchemy_version_insufficient,
-                 'TSIndex needs sqlalchemy 1.0.0 or higher')
 class TSIndexDatabaseHandlerTestCase(RegExTestCase):
 
     def test_bad_sqlitdb_filepath(self):

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1017,7 +1017,12 @@ class Indexer(object):
                     "mseedindex at https://github.com/iris-edu/mseedindex/."
                     .format(self.index_cmd))
         self.request_handler._set_sqlite_pragma()
-        file_paths = self.build_file_list(relative_paths, reindex)
+
+        try:
+            file_paths = self.build_file_list(relative_paths, reindex)
+        except OSError as error:
+            print(error)
+            return
 
         # always keep the original file paths as specified. absolute and
         # relative paths are determined in the build_file_list method

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1382,7 +1382,7 @@ class TSIndexDatabaseHandler(object):
             otherwise it will be created by querying the tsindex table.
         """
         session = self.session()
-        tsindex_summary_cte_name = "tsindex_summary"
+        tsindex_summary_cte_name = "tsindex_summary_cte"
         if self.has_tsindex_summary():
             # get tsindex summary cte by querying tsindex_summary table
             tsindex_summary_cte = \

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -121,6 +121,10 @@ The :class:`~Indexer` provides a high level
 API for indexing a directory tree of miniSEED files using the IRIS
 `mseedindex <https://github.com/iris-edu/mseedindex/>`_ software.
 
+An important feature of this module is the ability to index data files
+in parallel, making it convenient for indexing large data sets of many
+files.
+
 Initialize an indexer object by supplying the root path to data to be indexed.
 
 >>> from obspy.clients.filesystem.tsindex import Indexer

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1196,8 +1196,7 @@ class Indexer(object):
             else:
                 raise OSError("No leap seconds file exists at `{}`. "
                               .format(leap_seconds_file))
-            os.environ["LIBMSEED_LEAPSECOND_FILE"] = os.path.abspath(
-                                                        leap_seconds_file)
+            os.environ["LIBMSEED_LEAPSECOND_FILE"] = leap_seconds_file
         else:
             # warn user and don't use a leap seconds file
             logger.warning("No leap second file specified. This is highly "

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1302,8 +1302,8 @@ class TSIndexDatabaseHandler(object):
                     raise OSError("Database path '{}' does not exist."
                                   .format(db_dirpath))
                 elif not os.path.isfile(self.database):
-                    logger.warning("No sqlite3 database file exists at `{}`."
-                                   .format(self.database))
+                    logger.info("No sqlite3 database file exists at `{}`."
+                                .format(self.database))
             else:
                 raise ValueError("database must be a string.")
             db_path = "sqlite:///{}".format(self.database)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This PR cleans up minor issues with the clients.filesystem.tsindex module and improving the documented a bit.
Some additions reduce the dependency of the module on providing a path to an SQLite database file, but for
now usage with a custom database handler is not supported and a warning has been added to that effect.

- Allow leap second file to be `DOWNLOAD`, to allow downloading if needed during initialization of an Indexer.
- Avoid errors when leap-second.list file is explicitly unused
- Avoid SQLAlchemy circular reference
- Avoid running SQLite-specific initialization unless SQLite is being used

### Why was it initiated?  Any relevant Issues?

Rough edges requiring manual setup of leap second file, now significantly reduced.
#2761 is partially related, but not fully addressed.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
