### PR TITLE
Add support for `eventtype` in Client.get_events()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ Changes:
      read_events() functions (see #2743)
  - obspy.clients.fdsn:
    * introduce fine-grained FDSN client exceptions (see #2653)
+   * support for "eventtype" parameter in get_events(), as specified in version
+     1.2 of the FDSN event web service (see #2780)
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
  - obspy.io.css:

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -405,10 +405,11 @@ class Client(object):
                    latitude=None, longitude=None, minradius=None,
                    maxradius=None, mindepth=None, maxdepth=None,
                    minmagnitude=None, maxmagnitude=None, magnitudetype=None,
-                   includeallorigins=None, includeallmagnitudes=None,
-                   includearrivals=None, eventid=None, limit=None, offset=None,
-                   orderby=None, catalog=None, contributor=None,
-                   updatedafter=None, filename=None, **kwargs):
+                   eventtype=None, includeallorigins=None,
+                   includeallmagnitudes=None, includearrivals=None,
+                   eventid=None, limit=None, offset=None, orderby=None,
+                   catalog=None, contributor=None, updatedafter=None,
+                   filename=None, **kwargs):
         """
         Query the event service of the client.
 
@@ -475,6 +476,12 @@ class Client(object):
         :type magnitudetype: str, optional
         :param magnitudetype: Specify a magnitude type to use for testing the
             minimum and maximum limits.
+        :type eventtype: str, optional
+        :param eventtype: Limit to events with a specified event type.
+            Multiple types are comma-separated (e.g.,
+            ``"earthquake,quarry blast"``). Allowed values are from QuakeML.
+            See :const:`obspy.core.event.header.EventType` for a list of
+            allowed event types.
         :type includeallorigins: bool, optional
         :param includeallorigins: Specify if all origins for the event should
             be included, default is data center dependent but is suggested to

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -157,8 +157,9 @@ DEFAULT_EVENT_PARAMETERS = [
 
 OPTIONAL_EVENT_PARAMETERS = [
     "latitude", "longitude", "minradius", "maxradius", "magnitudetype",
-    "includeallorigins", "includeallmagnitudes", "includearrivals", "eventid",
-    "limit", "offset", "catalog", "contributor", "updatedafter"]
+    "eventtype", "includeallorigins", "includeallmagnitudes",
+    "includearrivals", "eventid", "limit", "offset", "catalog", "contributor",
+    "updatedafter"]
 
 DEFAULT_PARAMETERS = {
     "dataselect": DEFAULT_DATASELECT_PARAMETERS,
@@ -226,6 +227,7 @@ DEFAULT_TYPES = {
     "includearrivals": bool,
     "matchtimeseries": bool,
     "eventid": str,
+    "eventtype": str,
     "limit": int,
     "offset": int,
     "orderby": str,
@@ -269,6 +271,7 @@ DEFAULT_VALUES = {
     "includearrivals": False,
     "matchtimeseries": False,
     "eventid": None,
+    "eventtype": None,
     "limit": None,
     "offset": 1,
     "orderby": "time",


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

[Version 1.2 of the FDSN event web service](https://www.fdsn.org/webservices/fdsnws-event-1.2.pdf) (released on 2019-04-02) introduced the `eventtype` parameter.
This is already implicitly supported by ObsPy, given the way the FDSN client is written.
~~It only needs documentation, which is the scope of this PR.~~
It actually needs some editing of the list of allowed parameters (see the commits) and some testing (TODO).

### Why was it initiated?  Any relevant Issues?

Should fix #2778.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .

