### PR TITLE
Docsbuilding docker image & GH Action

### DIFF
--- a/.github/workflows/image_building.yml
+++ b/.github/workflows/image_building.yml
@@ -1,0 +1,34 @@
+name: image_building
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./misc/docker/docsbuilder/Dockerfile
+          push: true
+          tags: obspy/docsbuilding:latest

--- a/.github/workflows/image_building.yml
+++ b/.github/workflows/image_building.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+  pull_request: # to be deleted before merging to master
 
 jobs:
   docker:

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.8-slim-buster
+
+LABEL name="obspy-docbuilder"
+LABEL description="Image for building docs for obspy"
+LABEL maintainer="Damian Kula, dkula@unistra.fr"
+LABEL version="1.0.0"
+LABEL date="2021.02.10"
+LABEL schema-version="1.0.0"
+
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        build-essential \
+        gcc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade --no-cache-dir pip && \
+    python -m pip install --upgrade --no-cache-dir setuptools wheel && \
+    python -m pip install --no-cache-dir \
+        'numpy>=1.15.0' \
+        'scipy>=1.0.0' \
+        'matplotlib>=3.2.0' \
+        'lxml' \
+        'setuptools' \
+        'sqlalchemy' \
+        'decorator' \
+        'requests' \
+        'flake8>=2' \
+        'pyimgur' \
+        'pyproj' \
+        'pep8-naming' \
+        'cryptography' \
+        'pyshp' \
+        'sphinx>=3.1.1' \
+        'm2r2>=0.2.7' \
+        'pybtex>=0.22.2' \
+        'sphinx_rtd_theme' \
+        'matplotlib' \
+        'obspy'

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -10,7 +10,11 @@ LABEL schema-version="1.0.0"
 RUN apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         build-essential \
-        gcc && \
+        gcc \
+        libproj-dev \
+        proj-data \
+        libgeos-dev \
+        proj-bin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -35,5 +39,15 @@ RUN python -m pip install --upgrade --no-cache-dir pip && \
         'm2r2>=0.2.7' \
         'pybtex>=0.22.2' \
         'sphinx_rtd_theme' \
-        'matplotlib' \
-        'obspy'
+        'matplotlib' && \
+    python -m pip install --no-cache-dir 'cartopy>=0.18.0' && \
+    mkdir /obspy
+
+COPY . /obspy
+
+RUN python -m pip install /obspy
+
+WORKDIR /obspy/misc/docs
+
+ENTRYPOINT ["make"]
+CMD ["html"]

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
 
 LABEL name="obspy-docbuilder"
-LABEL description="Image for building docs for obspy"
-LABEL maintainer="Damian Kula, dkula@unistra.fr"
-LABEL version="1.0.0"
-LABEL date="2021.02.10"
+LABEL description="Image with all dependencies to build documentation for obspy"
+LABEL maintainer="Damian Kula, heavelock@gmail.com"
+LABEL version="1.1.0"
+LABEL date="2021.11.05"
 LABEL schema-version="1.0.0"
 
 RUN apt-get update -yqq && \
@@ -18,34 +18,12 @@ RUN apt-get update -yqq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade --no-cache-dir pip && \
-    python -m pip install --upgrade --no-cache-dir setuptools wheel && \
-    python -m pip install --no-cache-dir \
-        'numpy>=1.15.0' \
-        'scipy>=1.0.0' \
-        'matplotlib>=3.2.0' \
-        'lxml' \
-        'setuptools' \
-        'sqlalchemy' \
-        'decorator' \
-        'requests' \
-        'flake8>=2' \
-        'pyimgur' \
-        'pyproj' \
-        'pep8-naming' \
-        'cryptography' \
-        'pyshp' \
-        'sphinx>=3.5.1' \
-        'm2r2>=0.2.7' \
-        'pybtex>=0.22.2' \
-        'sphinx_rtd_theme' \
-        'matplotlib' && \
-    python -m pip install --no-cache-dir 'cartopy>=0.18.0' && \
-    mkdir /obspy
-
 COPY . /obspy
 
-RUN python -m pip install -e /obspy
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir --upgrade setuptools wheel && \
+    python -m pip install --no-cache-dir -e /obspy  && \
+    python -m pip install --no-cache-dir -r /obspy/misc/docs/requirements.txt
 
 WORKDIR /obspy/misc/docs
 

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -28,4 +28,4 @@ RUN python -m pip install --no-cache-dir --upgrade pip && \
 WORKDIR /obspy/misc/docs
 
 ENTRYPOINT ["make"]
-CMD ["html"]
+CMD ["html-docker"]

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -45,7 +45,7 @@ RUN python -m pip install --upgrade --no-cache-dir pip && \
 
 COPY . /obspy
 
-RUN python -m pip install /obspy
+RUN python -m pip install -e /obspy
 
 WORKDIR /obspy/misc/docs
 

--- a/misc/docker/docsbuilder/Dockerfile
+++ b/misc/docker/docsbuilder/Dockerfile
@@ -31,7 +31,7 @@ RUN python -m pip install --upgrade --no-cache-dir pip && \
         'pep8-naming' \
         'cryptography' \
         'pyshp' \
-        'sphinx>=3.1.1' \
+        'sphinx>=3.5.1' \
         'm2r2>=0.2.7' \
         'pybtex>=0.22.2' \
         'sphinx_rtd_theme' \

--- a/misc/docs/requirements.txt
+++ b/misc/docs/requirements.txt
@@ -1,0 +1,13 @@
+sphinx>=4.2.0
+m2r2>=0.2.7 # m2r is not maintained anymore, this fork is
+pybtex>=0.24.0
+sphinx_rtd_theme
+matplotlib
+numpy # required by cartopy
+cython # required by cartopy
+cartopy >= 0.20
+obspy
+
+# deps used in tutorial but not working anymore
+# basemap
+# mlpy

--- a/misc/docs/requirements.txt
+++ b/misc/docs/requirements.txt
@@ -5,7 +5,7 @@ sphinx_rtd_theme
 matplotlib
 numpy # required by cartopy
 cython # required by cartopy
-cartopy >= 0.20
+cartopy <= 0.20 # It requires Proj 8 which is not available even on bullseye
 obspy
 
 # deps used in tutorial but not working anymore


### PR DESCRIPTION
Hey,
This is a one more part of docs revival saga.

This PR:
- Adds a base image for building docs. Small image based on debian with dependencies for building obspy and documentation installed.
- Adds a workflow running on pushes to Master that build said image. It is also pushing it to Dockerhub.

This PR makes it quite trivial to build documentation of obspy by anyone interested. I will add an instruction to sphinx3 branch.

Questions:
- Is `obspy/docsbuilding:latest` apropriate tag ?
- Do we have in repository's secrets token to Dockerhub? Are the variables I used here okay?
- What do you think about execution strategy of the workflow? I think the push to master is quite reasonable but it could be as executed as well on tags/releases or on cron schedule.

Since this workflow is already set to be executed on pushes to master only, it will not be triggered. I had it triggered on my fork though:
https://github.com/heavelock/obspy/runs/1997973335?check_suite_focus=true

Also, I pushed the resulting image to my account on DockerHub:
https://hub.docker.com/r/heavelock/obspy-testing/tags?page=1&ordering=last_updated
with a tag `heavelock/obspy-testing:docsbuilding`
