### PR TITLE
Adds dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We are using more and more actions. The whole GH action consists of a lot of parts that are very often quite non transparent for users, updated without any visible notification. Dependabot, that is built in the Github, will check weekly if our dependencies within GH Actions are up to date. In case of anything being out of date, it will create PR.

After merging this PR, it should start working immediately. Results are on on my fork:
https://github.com/heavelock/obspy/pulls/app%2Fdependabot
