### PR TITLE
Fix Seedlink basic_client get_info failing when location and channel not in Seedlink reply

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -68,6 +68,7 @@ Meschede, Matthias
 Michelini, Alberto
 Miller, Nathaniel C.
 Morgenstern, Bernhard
+Moushall, Brenainn
 Murray-Bergquist, Louisa
 Nesbitt, Ian M.
 Nof, Ran Novitsky

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -308,7 +308,7 @@ class Client(object):
                 # seems the seedlink server replies with no subtags for the
                 # channels
                 if not subtags:
-                    station_cache.add(item + (None, None))
+                    station_cache.add(item + ('', ''))
             else:
                 station_cache.add(item)
         # change results to an Inventory object


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

In `seedlink.basic_client.get_info`, sets `loc` and `cha` as empty strings if they are not included in the Seedlink reply.

### Why was it initiated?  Any relevant Issues?

Current behaviour is to set `loc` and `cha` in `station_cache` as `None` if they aren't in the Seedlink reply. This causes the function to fail, as `station_cache` is then searched using `fname`, with `loc` and `cha` provided as `name` argument. A value of `None` for `name` will cause `fname` to raise, as it calls `os.path.normpath(name)`, which expects a string. Empty strings get around this issue. This does mean missing codes will be returned as '' and it's up to the user to understand this means Seedlink didn't reply with the code, and that the stream may not be available.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.seedlink"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
