### PR TITLE
docs: fix api documentation for number_of_ticks

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -917,8 +917,6 @@ class Stream(object):
         :param transparent: Make all backgrounds transparent (True/False). This
             will override the ``bgcolor`` and ``face_color`` arguments.
             Defaults to ``False``.
-        :param number_of_ticks: The number of ticks on the x-axis.
-            Defaults to ``4``.
         :param tick_format: The way the time axis is formatted.
             Defaults to ``'%H:%M:%S'`` or ``'%.2f'`` if ``type='relative'``.
         :param tick_rotation: Tick rotation in degrees.
@@ -1006,6 +1004,8 @@ class Stream(object):
             backslashes, or use r-prefixed strings, e.g.,
             ``r"$\\\\frac{m}{s}$"``.
             Defaults to ``None``, meaning no scale is drawn.
+        :param number_of_ticks: The number of ticks on the x-axis.
+            Defaults to ``4``.
         :param events: An optional list of events can be drawn on the plot if
             given.  They will be displayed as yellow stars with optional
             annotations.  They are given as a list of dictionaries. Each


### PR DESCRIPTION
### What does this PR do?
### Why was it initiated?  Any relevant Issues?

According to #2727, number_of_ticks is only ever used in dayplot mode.