### PR TITLE
Clarify xcorr_max() docstring

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -45,6 +45,7 @@ Inza, Adolfo
 Isken, Marius
 Kearns, Aaron
 Ketchum, David
+Khan, Lewis
 Koymans, Mathijs
 Kremers, Simon
 Kress, Victor

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -387,7 +387,9 @@ def xcorr_max(fct, abs_max=True):
 
     :type fct: :class:`~numpy.ndarray`
     :param fct: Cross-correlation function e.g. returned by correlate.
-    :param bool abs_max: Determines if the absolute maximum should be used.
+    :param bool abs_max: Determines if the absolute maximum (positive or
+        negative) should be used. If `False`, maximum positive
+        cross-correlation used.
     :return: **shift, value** - Shift and value of maximum of
         cross-correlation.
 

--- a/obspy/signal/cross_correlation.py
+++ b/obspy/signal/cross_correlation.py
@@ -387,9 +387,10 @@ def xcorr_max(fct, abs_max=True):
 
     :type fct: :class:`~numpy.ndarray`
     :param fct: Cross-correlation function e.g. returned by correlate.
-    :param bool abs_max: Determines if the absolute maximum (positive or
-        negative) should be used. If `False`, maximum positive
-        cross-correlation used.
+    :param bool abs_max: Determines if the largest value of the correlation
+        function is returned, independent of it being positive (correlation) or
+        negative (anti-correlation). Defaults to `True`. If `False` the maximum
+        returned is positive only.
     :return: **shift, value** - Shift and value of maximum of
         cross-correlation.
 


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Clarifies the ambiguity in the meaning of the Boolean abs_max in 
xcorr_max() by editing docstring.

### Why was it initiated?  Any relevant Issues?

Resolves #2820.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
