### PR TITLE
adding apply_calib=False by default for Kinemetrics' EVT format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,12 +34,18 @@ Changes:
  - obspy.io.hypodd
    * add PHA write support (see #2687)
    * add read support for horizontal and vertical origin uncertainty (see #2687)
+ - obspy.io.kinemetrics:
+   * adds the ``apply_calib`` argument to the ``read_evt`` method to allow
+     obtaining the raw data bits stored in the evt file (see #2582), note this
+     changes the default (wrong!) behaviour, by default the data returned will
+     be the NOT corrected ones. When passing ``apply_calib=True``, the
+     calibration factor will be used.
  - obspy.io.nordic:
    * add read and write support for New Nordic format (see #2814)
    * fix bug where negative magnitudes were not read properly
    * fix bug where empty hours / minutes / seconds were not read as zero
    * fix bug where lat/lon-errors were read as lon/lat
-   * fix bug where origin-error was written with RMS rather than time_error 
+   * fix bug where origin-error was written with RMS rather than time_error
    * for reading picks in Old Nordic format, set network code to None
      (was 'NA' previously)
    * stop writing waveform-file link to a DUMMY-file by default

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -82,6 +82,7 @@ Rapagnani, Giovanni
 Parker, Tom
 Pestourie, Romain
 Pourpoint, Maeva
+Rapagnani, Giovanni
 Reyes, Celso
 Ringler, Adam
 Rothenhäusler, Nicolas

--- a/obspy/io/kinemetrics/__init__.py
+++ b/obspy/io/kinemetrics/__init__.py
@@ -21,7 +21,7 @@ Reading
 Similar to reading any other waveform data format using obspy.core:
 
     >>> from obspy import read
-    >>> st = read("/path/to/BI008_MEMA-04823.evt")
+    >>> st = read("/path/to/BI008_MEMA-04823.evt", apply_calib=True)
     >>> st  # doctest: +ELLIPSIS
     <obspy.core.stream.Stream object at 0x...>
     >>> print (st)  # doctest: +NORMALIZE_WHITESPACE
@@ -53,7 +53,7 @@ a ``kinemetrics_evt`` dictionary with specific attributes.
        sampling_rate: 250.0
                delta: 0.004
                 npts: 5750
-               calib: 1.0
+               calib: 1.1694431304931641e-06
              _format: KINEMETRICS_EVT
     >>> for k, v in sorted(stats_evt.items()):
     ...     print(k, v)

--- a/obspy/io/kinemetrics/core.py
+++ b/obspy/io/kinemetrics/core.py
@@ -66,5 +66,5 @@ def read_evt(filename_or_object, **kwargs):
     :return: Stream object containing header and data
     """
     evt_obj = evt.Evt()
-    stream = evt_obj.read_file(filename_or_object)
+    stream = evt_obj.read_file(filename_or_object, **kwargs)
     return stream

--- a/obspy/io/kinemetrics/evt.py
+++ b/obspy/io/kinemetrics/evt.py
@@ -9,11 +9,13 @@ Evt (Kinemetrics) format support for ObsPy.
     (https://www.gnu.org/copyleft/lesser.html)
 """
 from struct import unpack
+import warnings
 
 import numpy as np
 
 from obspy import Stream, Trace
 from obspy.core.compatibility import from_buffer
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from .evt_base import (EvtBadDataError, EvtBadHeaderError, EvtEOFError,
                        EvtVirtual)
 
@@ -53,9 +55,9 @@ class Evt(object):
         self.e_data = EvtData()
         self.samplingrate = 0
 
-    def calibration(self):
+    def get_calibs(self):
         """
-        Apply calibrations on data matrix
+        Gets calibration values for each traces
 
         Note about calibration:
             fullscale of instrument = +/- 2.5V & +/-20V
@@ -66,26 +68,47 @@ class Evt(object):
             calibration in MKS units = (data_in_volts / sensitivity) * g
 
         """
+        calibs = []
         for i in range(self.e_header.nchannels):
             calib_volts = 8388608.0 / self.e_header.chan_fullscale[i]
             # 8388608 = 2**23
             calib_mks = (calib_volts *
                          self.e_header.chan_sensitivity[i]) / (9.81)
             # 9.81 = mean value of g on earth
-            self.data[i] /= calib_mks
+            calibs.append(calib_mks)
+        return calibs
 
-    def read_file(self, filename_or_object, raw=False):
+    def calibration(self):
+        """
+        Apply calibrations on data matrix
+        """
+        calibs = self.get_calibs()
+        for i in range(self.e_header.nchannels):
+            self.data[i] /= calibs[i]
+
+    def read_file(self, filename_or_object, apply_calib=False, **kwargs):
         """
         Reads an Evt file to the internal data structure
 
         :type filename_or_object: str or file-like object
         :param filename_or_object: Evt file to be read
-        :type raw : bool
-        :param raw : True if raw data (no corrections, int32)
-                     False if data in m/s2 (default)
+        :type apply_calib: bool
+        :param apply_calib: If False, the raw data will be returned (no
+            corrections, int32, default), if True, the data will be in m/s2.
         :rtype: obspy.core.stream.Stream
         :return: Obspy Stream with data
         """
+
+        # Need to deprecate "raw" until version 2.1
+        if "raw" in kwargs:
+            apply_calib = not kwargs["raw"]
+            warnings.warn(
+                'The "raw" keyword argument is deprecated, please use '
+                '"apply_calib" instead. Note the behaviour is flipped, so '
+                '"raw=True" becomes "apply_calib=False, which is default now. '
+                'Setting "apply_calib=%s" and continuing...' % apply_calib,
+                ObsPyDeprecationWarning)
+
         # Support reading from filenames of file-like objects.
         if hasattr(filename_or_object, "seek") and \
                 hasattr(filename_or_object, "tell") and \
@@ -126,7 +149,8 @@ class Evt(object):
         if self.e_frame.count() != self.e_header.duration:
             raise EvtBadDataError("Bad number of blocks")
 
-        if not raw:
+        calibs = self.get_calibs()
+        if apply_calib:
             self.calibration()
 
         traces = []
@@ -137,6 +161,8 @@ class Evt(object):
             cur_trace.stats.sampling_rate = float(self.samplingrate)
             cur_trace.stats.starttime = self.e_header.starttime
             cur_trace.stats.kinemetrics_evt = self.e_header.make_obspy_dict(i)
+            if not apply_calib:
+                cur_trace.stats.calib = 1./calibs[i]
             traces.append(cur_trace)
 
         return Stream(traces=traces)

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -75,7 +75,7 @@ class CoreTestCase(unittest.TestCase):
         """
         filename = os.path.join(self.path, 'BI008_MEMA-04823.evt')
         # 1
-        st = read(filename)
+        st = read(filename, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 3)
         self.assertEqual(st[0].stats.starttime,
@@ -95,7 +95,7 @@ class CoreTestCase(unittest.TestCase):
 
         # 2
         filename = os.path.join(self.path, 'BX456_MOLA-02351.evt')
-        st = read(filename)
+        st = read(filename, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 6)
         self.assertEqual(st[0].stats.starttime,
@@ -124,7 +124,7 @@ class CoreTestCase(unittest.TestCase):
         with open(filename, "rb") as fh:
             buf = io.BytesIO(fh.read())
         buf.seek(0, 0)
-        st = read(buf)
+        st = read(buf, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 3)
         self.assertEqual(st[0].stats.starttime,
@@ -147,7 +147,7 @@ class CoreTestCase(unittest.TestCase):
         with open(filename, "rb") as fh:
             buf = io.BytesIO(fh.read())
         buf.seek(0, 0)
-        st = read(buf)
+        st = read(buf, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 6)
         self.assertEqual(st[0].stats.starttime,
@@ -173,7 +173,7 @@ class CoreTestCase(unittest.TestCase):
         """
         filename = os.path.join(self.path, 'BI008_MEMA-04823.evt')
         # 1
-        st = read_evt(filename)
+        st = read_evt(filename, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 3)
         self.assertEqual(st[0].stats.starttime,
@@ -193,7 +193,7 @@ class CoreTestCase(unittest.TestCase):
 
         # 2
         filename = os.path.join(self.path, 'BX456_MOLA-02351.evt')
-        st = read_evt(filename)
+        st = read_evt(filename, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 6)
         self.assertEqual(st[0].stats.starttime,
@@ -223,7 +223,7 @@ class CoreTestCase(unittest.TestCase):
         with open(filename, "rb") as fh:
             buf = io.BytesIO(fh.read())
         buf.seek(0, 0)
-        st = read_evt(buf)
+        st = read_evt(buf, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 3)
         self.assertEqual(st[0].stats.starttime,
@@ -246,7 +246,7 @@ class CoreTestCase(unittest.TestCase):
         with open(filename, "rb") as fh:
             buf = io.BytesIO(fh.read())
         buf.seek(0, 0)
-        st = read_evt(buf)
+        st = read_evt(buf, apply_calib=True)
         st.verify()
         self.assertEqual(len(st), 6)
         self.assertEqual(st[0].stats.starttime,
@@ -314,6 +314,66 @@ class CoreTestCase(unittest.TestCase):
         valuesend = np.array([-4.4538296759e-002, -4.4549994171e-002,
                               -4.4493857771e-002, -4.4451754540e-002,
                               -4.4409647584e-002])
+
+        # Data values from Tsoft Program
+        # length is 5750
+
+        self.assertEqual(len(data), 5750)
+        self.assertTrue(np.allclose(valuesdeb, data[:len(valuesdeb)]))
+        self.assertTrue(np.allclose(valuesend, data[-len(valuesend):]))
+
+    def test_read_via_module_raw(self):
+        """
+        Read files via obspy.io.kinemetrics.core.read_evt function.
+        """
+        filename = os.path.join(self.path, 'BI008_MEMA-04823.evt')
+        # 1
+        st = read_evt(filename, apply_calib=False)
+        st.verify()
+        self.assertEqual(len(st), 3)
+        self.assertEqual(st[0].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(st[1].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(st[2].stats.starttime,
+                         UTCDateTime('2013-08-15T09:20:28.000000Z'))
+        self.assertEqual(len(st[0]), 230 * 25)
+        self.assertAlmostEqual(st[0].stats.sampling_rate, 250.0)
+        self.assertEqual(st[0].stats.channel, '0')
+        self.assertEqual(st[0].stats.station, 'MEMA')
+
+        self.verify_stats_evt(st[0].stats.kinemetrics_evt)
+        self.verify_data_evt0_raw(st[0].data)
+        self.verify_data_evt2_raw(st[2].data)
+
+    def verify_data_evt0_raw(self, data):
+        valuesdeb = np.array([-20920., -20980., -20922., -20960.,
+                             -20932., -20936., -20894., -20954.,
+                             -20974., -20912., -20958., -20932.,
+                             -20986., -20948., -20906., -20952.,
+                             -20882., -20912., -20990., -20958.])
+        valuesend = np.array([-21070., -20962., -20930., -20918.,
+                              -20964., -20910., -20934., -21026.,
+                              -20968., -20956., -20976., -20954.,
+                              -20954., -21000., -20966., -20940.,
+                              -20976., -20972., -20956., -20886.])
+        # Data values from Tsoft Program
+
+        self.assertEqual(len(data), 5750)
+        self.assertTrue(np.allclose(valuesdeb, data[:len(valuesdeb)]))
+        self.assertTrue(np.allclose(valuesend, data[-len(valuesend):]))
+
+    def verify_data_evt2_raw(self, data):
+        valuesdeb = np.array([-37922., -38032., -38004., -37936.,
+                              -37966., -37952., -37930., -37998.,
+                              -37974., -37960., -37982., -37992.,
+                              -38000., -37984., -37988., -37980.,
+                              -37954., -37930., -37928., -37932.])
+        valuesend = np.array([-37996., -38010., -38024., -38048.,
+                              -37960., -37878., -37842., -37864.,
+                              -37902., -37908., -38038., -38070.,
+                              -38126., -38170., -38070., -38082.,
+                              -38092., -38044., -38008., -37972.])
 
         # Data values from Tsoft Program
         # length is 5750


### PR DESCRIPTION
this is a replacement for https://github.com/obspy/obspy/pull/2585 ; I didn't manage to clean/rebase properly, so here we are.

still have to add warning that the default behaviour is now to return the RAW data and no longer the corrected ones