### PR TITLE
fix changes in read_inventory that triggers error for SC3ML & Arclink (#2759)

### DIFF
--- a/obspy/io/arclink/inventory.py
+++ b/obspy/io/arclink/inventory.py
@@ -123,7 +123,7 @@ def _ns(tagname):
     return "{%s}%s" % (SCHEMA_NAMESPACE, tagname)
 
 
-def _read_inventory_xml(path_or_file_object):
+def _read_inventory_xml(path_or_file_object, **kwargs):
     """
     Function for reading an Arclink inventory file.
 

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -81,7 +81,7 @@ def _parse_list_of_complex_string(complex_string):
     return numbers
 
 
-def _read_sc3ml(path_or_file_object):
+def _read_sc3ml(path_or_file_object, **kwargs):
     """
     Function for reading a stationXML file.
 


### PR DESCRIPTION
### What does this PR do?

missing `level`/ `kwargs` for SC3ML and Arclink formats (linked to #2759)

