### PR TITLE
Fix UTCDateTime Regex for ordinal day 360

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ maintenance_1.2.x
 Changes:
  - obspy.core:
    * Inventory addition now consistently uses shallow copies (#2675, #2694)
+   * Fix iso8601 regex for issue #2868 to cope with day 360 properly.
  - obspy.clients.fdsn:
    * add URL mapping for IRISPH5 (see #2739)
  - obspy.clients.seedlink:

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -195,6 +195,9 @@ class UTCDateTimeTestCase(unittest.TestCase):
         # enforce ISO8601 - no chance to detect that format
         dt = UTCDateTime("2009001", iso8601=True)
         self.assertEqual(dt, UTCDateTime(2009, 1, 1))
+        # Compact day 360 - see issues #2868
+        dt = UTCDateTime("2012360T")
+        self.assertEqual(dt, UTCDateTime(2012, 12, 25)) # Note leapyear
         # w/ trailing Z
         dt = UTCDateTime("2009-365T12:23:34.5Z")
         self.assertEqual(dt, UTCDateTime(2009, 12, 31, 12, 23, 34, 500000))

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -38,7 +38,7 @@ _ISO8601_REGEX = re.compile(r"""
      ((0[1-9]|1[0-2])
       (\3([12]\d|0[1-9]|3[01]))?
       |W([0-4]\d|5[0-3])(-?[1-7])?
-      |(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6]))
+      |(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[0-6]))
      )
      ([T\s]
       ((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?
@@ -159,6 +159,9 @@ class UTCDateTime(object):
 
             >>> UTCDateTime("2009001", iso8601=True)       # enforce ISO8601
             UTCDateTime(2009, 1, 1, 0, 0)
+
+            >>> UTCDateTime("2009360T")                    # compact no time
+            UTCDateTime(2009, 12, 26, 0, 0)
 
         * Week date representation.
 


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Adapts the `_ISO8601_REGEX` to catch ordinal day 360.

### Why was it initiated?  Any relevant Issues?

This patch copes with issue #2868 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~~
