### PR TITLE
Fix io sh write with append option

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,8 @@ Changes:
      (see #2678)
    * properly take into account native system byteorder, should fix reading
      rt130 data on big endian systems (see #2678)
+ - obspy.io.sh:
+   * fix appending traces to existing Q file (see #2870)
  - obspy.io.xseed:
    * fix a bug reading SEED blockettes 48 and 58 which was likely never
      encountered (see #2668)

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -91,6 +91,7 @@ Satriano, Claudio
 Saul, Joachim
 Scarabello, Luca
 Scheingraber, Chris
+Schneider, Felix M.
 Schneider, Simon
 Sippl, Christian
 Snoke, Arthur

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -512,12 +512,14 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
             trcs = _read_q(filename_header, headonly=True)
             mode = 'ab'
             count_offset = len(trcs)
+            cur_npts_offset = sum([trcs[i].stats.npts for i in range(len(trcs))])
         except Exception:
             raise Exception("Target filename '%s' not readable!" % filename)
     else:
         append = False
         mode = 'wb'
         count_offset = 0
+        cur_npts_offset = 0
 
     fh = open(filename_header, mode)
     fh_data = open(filename_data + '.QBN', mode)
@@ -525,7 +527,7 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
     # build up header strings
     headers = []
     minnol = 4
-    cur_npts = 0
+    cur_npts = 0 + cur_npts_offset
     for trace in stream:
         temp = "L000:%d~ " % cur_npts
         cur_npts += trace.stats.npts

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -512,7 +512,8 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
             trcs = _read_q(filename_header, headonly=True)
             mode = 'ab'
             count_offset = len(trcs)
-            cur_npts_offset = sum([trcs[i].stats.npts for i in range(len(trcs))])
+            cur_npts_offset = sum(
+                [trcs[i].stats.npts for i in range(len(trcs))])
         except Exception:
             raise Exception("Target filename '%s' not readable!" % filename)
     else:

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -510,12 +510,11 @@ def _write_q(stream, filename, data_directory=None, byteorder='=',
     if Path(filename_header).exists() and append:
         try:
             trcs = _read_q(filename_header, headonly=True)
-            mode = 'ab'
-            count_offset = len(trcs)
-            cur_npts_offset = sum(
-                [trcs[i].stats.npts for i in range(len(trcs))])
         except Exception:
             raise Exception("Target filename '%s' not readable!" % filename)
+        mode = 'ab'
+        count_offset = len(trcs)
+        cur_npts_offset = sum([trcs[i].stats.npts for i in range(len(trcs))])
     else:
         append = False
         mode = 'wb'

--- a/obspy/io/sh/tests/test_core.py
+++ b/obspy/io/sh/tests/test_core.py
@@ -297,6 +297,28 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(len(tr.stats.sh.COMMENT), len(tr2.stats.sh.COMMENT))
         self.assertEqual(tr.stats.sh.COMMENT, tr2.stats.sh.COMMENT)
 
+    def test_append_traces(self):
+        """
+        Test for issue #2870
+        """
+        stream = read()
+        with NamedTemporaryFile(suffix='.QHD') as tf:
+            tempfile = tf.name
+            stream.write(tempfile, format="Q")
+            with open(tempfile) as f:
+                header1 = f.read()
+            # remove binary file too (dynamically created)
+            os.remove(os.path.splitext(tempfile)[0] + '.QBN')
+        with NamedTemporaryFile(suffix='.QHD') as tf:
+            tempfile = tf.name
+            stream[:1].write(tempfile, format="Q")
+            stream[1:].write(tempfile, format="Q", append=True)
+            with open(tempfile) as f:
+                header2 = f.read()
+            # remove binary file too (dynamically created)
+            os.remove(os.path.splitext(tempfile)[0] + '.QBN')
+        self.assertEqual(header2, header1)
+
 
 def suite():
     return unittest.makeSuite(CoreTestCase, 'test')


### PR DESCRIPTION

This PR is a bug fix, which corrects a bug in the obspy/io/sh/_write_q function  

When appending traces to existing .QHD/QBN files (with the option append=True) the resulting Q-file was not read correctly with seismic handler. Reason: The L000 header value was set to falsely to zero for appended traces. 

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [ X] Any new features or fixed regressions are be covered via new tests.
- [ X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .

