### PR TITLE
Use https in RESIF webservice url

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changes:
    * Inventory addition now consistently uses shallow copies (#2675, #2694)
  - obspy.clients.fdsn:
    * add URL mapping for IRISPH5 (see #2739)
+   * update RESIF URL mapping to use https
  - obspy.clients.seedlink:
    * Fix a bug in basic client when printing debug output (see #2734)
  - obspy.io.gse2:

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -25,7 +25,7 @@ Danecek, Peter
 van Driel, Martin
 Egdorf, Sven
 Ely, Geoffrey
-Engels, Fabian
+Engels, Fabien
 Ermert, Laura
 Eulenfeld, Tom
 Fabbri, Tommaso

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -55,7 +55,7 @@ NOA         http://eida.gein.noa.gr
 ODC         http://www.orfeus-eu.org
 ORFEUS      http://www.orfeus-eu.org
 RASPISHAKE  https://fdsnws.raspberryshakedata.com
-RESIF       http://ws.resif.fr
+RESIF       https://ws.resif.fr
 SCEDC       http://service.scedc.caltech.edu
 TEXNET      http://rtserve.beg.utexas.edu
 UIB-NORSAR  http://eida.geo.uib.no

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -112,7 +112,7 @@ URL_MAPPINGS = {
     "NOA": "http://eida.gein.noa.gr",
     "ODC": "http://www.orfeus-eu.org",
     "ORFEUS": "http://www.orfeus-eu.org",
-    "RESIF": "http://ws.resif.fr",
+    "RESIF": "https://ws.resif.fr",
     "RASPISHAKE": "https://fdsnws.raspberryshakedata.com",
     "SCEDC": "http://service.scedc.caltech.edu",
     "TEXNET": "http://rtserve.beg.utexas.edu",

--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -49,7 +49,7 @@ NA * * * 2017-01-01T00:00:00 2017-01-01T00:10:00
 http://webservices.ingv.it/fdsnws/station/1/query
 NI * * * 2017-01-01T00:00:00 2017-01-01T00:10:00
 
-http://ws.resif.fr/fdsnws/station/1/query
+https://ws.resif.fr/fdsnws/station/1/query
 ND * * * 2017-01-01T00:00:00 2017-01-01T00:10:00
         """.strip()
         # This should return a dictionary that contains the root URL of each
@@ -67,7 +67,7 @@ ND * * * 2017-01-01T00:00:00 2017-01-01T00:10:00
                     "NA * * * 2017-01-01T00:00:00 2017-01-01T00:10:00"),
                 "http://webservices.ingv.it": (
                     "NI * * * 2017-01-01T00:00:00 2017-01-01T00:10:00"),
-                "http://ws.resif.fr": (
+                "https://ws.resif.fr": (
                     "ND * * * 2017-01-01T00:00:00 2017-01-01T00:10:00")})
 
         data = """


### PR DESCRIPTION
### What does this PR do?

It update the baseurl protocol used by RESIF webservice from http to https

### Why was it initiated?  Any relevant Issues?

RESIF redirect requests made to http to https but that creates an issue with Obspy.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [X] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .