### PR TITLE
SEG2 date/time separator support

### DIFF
--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -18,6 +18,7 @@ from future.utils import PY2
 from copy import deepcopy
 from struct import unpack, unpack_from
 import warnings
+import re
 
 import numpy as np
 
@@ -179,8 +180,12 @@ class SEG2(object):
                 and "ACQUISITION_DATE" in self.stream.stats.seg2:
             time = self.stream.stats.seg2.ACQUISITION_TIME
             date = self.stream.stats.seg2.ACQUISITION_DATE
-            time = time.strip().split(':')
-            date = date.strip().split('/')
+            
+            # Split on any non numeric character
+            time = list(filter(None, re.split(r'\D+', time)))  
+            # Split on space, dot (.), slash (/), and dash (-)
+            date = list(filter(None, re.split("[, ./-]+", date)))  
+            
             hour, minute, second = int(time[0]), int(time[1]), float(time[2])
             day, month, year = int(date[0]), MONTHS[date[1].lower()], \
                 int(date[2])


### PR DESCRIPTION
### What does this PR do?
Added a regular expression for separating the date and time strings. Before these were hardcoded with separators, but across the world different standard separators for date and time are being used. I changed it with a regex that will split the time string on any non-numeric character, which will split on any default separator as well as on hms. For the date I used a regex that will split on the worldwide accepted separators: oblique stroke (slash), full stop, dot or point (period), hyphen (dash), and space.

I am not really sure how these pull requests work, please correct me if I am wrong!

### Why was it initiated?  Any relevant Issues?

As a happy obspy user I was stumbling upon some seg data that could not be read by obspy. Therefore digged into the date and time stripping methods.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [ ] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
