### PR TITLE
Fixed a bug in _load_cdll exception handling

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -113,3 +113,4 @@ Winkelman, Andrew
 Zaccarelli, Riccardo
 Zad, Seyed Kasra Hosseini
 Zhu, Lijun
+Ulianych, Danylo

--- a/obspy/core/util/libnames.py
+++ b/obspy/core/util/libnames.py
@@ -11,7 +11,6 @@ Library name handling for ObsPy.
 # NO IMPORTS FROM OBSPY OR FUTURE IN THIS FILE! (file gets used at
 # installation time)
 import ctypes
-import os
 from pathlib import Path
 import platform
 import re
@@ -88,23 +87,21 @@ def _load_cdll(name):
     """
     # our custom defined part of the extension file name
     libname = _get_lib_name(name, add_extension_suffix=True)
-    libdir = Path(__file__).parent / os.pardir / os.pardir / 'lib'
+    libdir = Path(__file__).parent.parent.parent / 'lib'
     libpath = (libdir / libname).resolve()
     try:
         cdll = ctypes.CDLL(str(libpath))
     except Exception as e:
-        import textwrap
-        dirlisting = textwrap.wrap(
-            ', '.join(sorted(libpath.parent)))
+        dirlisting = sorted(libpath.parent.iterdir())
+        dirlisting = '  \n'.join(map(str, dirlisting))
         msg = ['Could not load shared library "%s"' % libname,
                'Path: %s' % libpath,
-               'Current directory: %s' % Path(os.curdir).resolve(),
+               'Current directory: %s' % Path().resolve(),
                'ctypes error message: %s' % str(e),
                'Directory listing of lib directory:',
-               '  ',
+               '   %s' % dirlisting,
                ]
         msg = '\n  '.join(msg)
-        msg = msg + '\n    '.join(dirlisting)
         raise ImportError(msg)
     return cdll
 


### PR DESCRIPTION
### What does this PR do?

I was trying to import `obspy` when I hit an error inside the import error.

```python
from obspy.core import read
from obspy.signal.trigger import plot_trigger
```

To reproduce the bug and get a feel what the exception was, run the following equivalent script:

```python
import ctypes
from pathlib import Path
try:
    cdll = ctypes.CDLL("some")
except Exception as e:
    dirlisting = ', '.join(sorted(Path().parent))

Traceback (most recent call last):
  File "<ipython-input-2-ca3986e97d34>", line 4, in <module>
    cdll = ctypes.CDLL("some")
  File "/media/dizcza/media/miniconda3/envs/obspy/lib/python3.9/ctypes/__init__.py", line 382, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: some: cannot open shared object file: No such file or directory
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/media/dizcza/media/miniconda3/envs/obspy/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-ca3986e97d34>", line 6, in <module>
    dirlisting = ', '.join(sorted(Path().parent))
TypeError: 'PosixPath' object is not iterable
```


The previous PR #2833 has got rid of most of the legacy `os` library... but not quite so. I did the rest for him.

### Why was it initiated?  Any relevant Issues?

The issue has not been reported. Perhaps, because since I'm a newcomer and I didn't know that git-clonning and installing the requirements is not enough to get the obspy ready, I've triggered the bug that otherwise no one would.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
       Guys, please either update the GitHub template or do provide a maintenance branch. Merging into `maintanence_1.2.x` would pull a dozen of others' commits.
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+ DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:"
      (you can also add "ALL" to just simply run all tests across all modules)
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
     All the tests, I presume, are run *after* the installation of the package, so I don't know how to test this function prior to installing the package. In fact, that's precisely the reason why this bug has not been discovered yet.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .


-----

Other things I noted in `libnames.py`:
* python2 doesn't have the `pathlib` lib built-in and I don't see this in the requirements, and py2.7 is claimed to be supported in the README.
* There is a nice feature available since python 3: `raise Exception from e`. Such syntaxis would make the error I got more understandable in the first place.