### PR TITLE
Improved several trigger functions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,9 @@ Changes:
  - obspy.signal.spectral_estimation.PPSD:
    * Added special handling option for infrasound data and global infrasound noise
      models for plotting (see #2740)
+ - obspy.signal.trigger:
+   * Improved clarity and speed of several STA/LTA triggers methods, namely
+     classic_sta_lta_py, z_detector, and recursive_sta_lta_py (see #2892)
 
 maintenance_1.2.x
 =================

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
@@ -8,7 +8,17 @@ course on triggering. Test data used in this tutorial can be downloaded here:
 
 The triggers are implemented as described in [Withers1998]_. Information on
 finding the right trigger parameters for STA/LTA type triggers can be found in
-[Trnkoczy2012]_.
+[Trnkoczy2012]_. The list includes (but not limited to):
+
+* Generally, STA duration must be longer than a few periods (zero-crossings of
+  the main frequency) of a typically expected seismic signal. On the other
+  hand, STA duration must be shorter than the shortest events (trigger on/off,
+  the envelope duration) we expect to capture.
+* STA duration must be longer than the inverse frequency of noisy spikes.
+  Otherwise, false alarms will be captured.
+* The LTA window should be longer than a few 'periods' of typically irregular
+  (slow) seismic noise fluctuations. Typically, it's an order of magnitude
+  larger than the STA duration.
 
 .. seealso::
     Please note the convenience method of ObsPy's

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -273,11 +273,11 @@ def z_detect(a, nsta):
     .. seealso:: [Withers1998]_, p. 99
     """
     # Z-detector given by Swindell and Snell (1977)
-    sta = np.zeros(len(a), dtype=np.float64)
-    a_squared = np.square(a)
-    # Standard Sta
-    for i in range(nsta):  # window size to smooth over
-        sta[nsta:] += a_squared[i:-nsta + i]
+    # Standard Sta shifted by 1
+    sta = np.cumsum(a ** 2, dtype=np.float64)
+    sta[nsta + 1:] = sta[nsta:-1] - sta[:-nsta - 1]
+    sta[nsta] = sta[nsta - 1]
+    sta[:nsta] = 0
     a_mean = np.mean(sta)
     a_std = np.std(sta)
     _z = (sta - a_mean) / a_std

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -91,7 +91,7 @@ def recursive_sta_lta_py(a, nsta, nlta):
     sta = 0.
     lta = np.finfo(0.0).tiny  # avoid zero division
     a = np.square(a)
-    charfct = np.zeros_like(a)
+    charfct = np.zeros(ndat, dtype=np.float64)
     icsta = 1 - csta
     iclta = 1 - clta
     for i in range(1, ndat):


### PR DESCRIPTION
### What does this PR do?

Improves clarity and speed of several STA/LTA triggers methods, namely
* classic_sta_lta_py
* z_detector
* recursive_sta_lta_py

### Why was it initiated?  Any relevant Issues?

I've been looking for STA/LTA methods and have come upon your project. Some of the functions have outdated implementation (like `try a = a.tolist() except pass` for no reason), and I decided to improve them a little.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: "+DOCS"
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS: `signal.trigger`"
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt`. (No significant changes.)
- [x] First time contributors have added your name to `CONTRIBUTORS.txt`. (I've already added myself as a contributor in the previous PR.)

### Remaining issues and further improvements

There is a number of other things related to the trigger methods that I'm willing to work on if we agree upon how to proceed. In either case, their implementation should be detached from this PR. Choose the items that you think make sense (sorted by severity):
1. `delayed_sta_lta` function is VERY strange. Not only misses it the `delay` parameter but also messes up with the indexing for all `i < nsta + nlta`. The implementation looks to be blindly taken from Withers1998, eq. 8 and 9. Instead, it should be rather similar to the `classic_sta_lta` function, where STA is defined as the sum of squared elements, not their differences.
2. Z-detector:
    1. `z_detector` logic, which I left unchanged, differs from what there should be according to Swindell and Snell (1977) that the function refers to. According to it, the Z-detector incorporates a logarithm of STA/LTA, and the mean and std are updated in a recursive fashion. Take a look at [Seismic Detectors (1981)](https://apps.dtic.mil/sti/pdfs/ADA099446.pdf) paper, page 27.
    2. Even if we decide to leave the Z-detector logic as it is, the version you have in master outputs a vector shifted by 1 index to the right. I've intentionally not changed the behavior to perform exactly the same as it's currently done in master (but much faster), and you can clearly see that the output vector is shifted by 1 (when, in fact, it shouldn't).
    3. Write Z-detector implementation in C. Unless we decide to change the logic according to the book I referred to, implementing an optimized version in C is really obsolete because now the Z-detector is vectorized and optimal (you can't improve it further in Python), and compared to C it's only ~5 times slower which is bearable.
4. Some functions like `classic_sta_lta` throw exceptions when `len(data) < nlta` while others, their pythonic counterparts, don't.
5. Trnkoczy2012 proposes a `frozen` boolean parameter to "freeze" the LTA updates until STA/LTA < threshold (see Fig. 6). Implementing this would require an additional argument, a dict, let's call it `lta_freeze`, `None` by default, with the following keys, if set:
    * `'trigger_threshold'` - the STA/LTA trigger ON threshold.
       Essentially, it's the same as `thres1` in the `trigger_onset` function;
    * `'lta_damping'` - the "bleeding" constant of LTA updates.
  
   Whenever provided, the logic may look something like:
   ```c
   if (sta/lta > trigger_threshold) lta[i] = (lta[i] + a[i] ** 2 / lta_damping) / nlta;
   else lta[i] = (lta[i] + a[i] ** 2) / nlta;  // no changes, old way
   ```
6. Frequency-domain trigger methods incorporating PSD estimates are missing. Would you be interested in having them? I'll try implementing them in either case, and a proper review won't hurt.