### PR TITLE
GH2896 fix failing PEP-517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@
 # see PEP518: https://www.python.org/dev/peps/pep-0518/
 requires = [
     'numpy>=1.6.1',
-    'setuptools'
+    'setuptools<=58.4'
     ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes breakage caused by https://github.com/pypa/setuptools/issues/2849