### PR TITLE
Remove wrapper for numpy loadtxt

### DIFF
--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -17,6 +17,7 @@ import io
 import platform
 import sys
 from lxml import objectify
+import numpy as np
 
 if sys.version_info.major == 2:
     from urllib import urlencode
@@ -26,7 +27,7 @@ else:
     import urllib.request as urllib_request
 
 from obspy import Stream, UTCDateTime, __version__, read
-from obspy.core.util import NamedTemporaryFile, loadtxt
+from obspy.core.util import NamedTemporaryFile
 
 
 DEFAULT_USER_AGENT = "ObsPy/%s (%s, Python %s)" % (__version__,
@@ -1013,7 +1014,7 @@ class Client(object):
         else:
             # ASCII data
             if filename is None:
-                return loadtxt(io.BytesIO(data), ndmin=1)
+                return np.loadtxt(io.BytesIO(data), ndmin=1)
             else:
                 return self._to_file_or_data(filename, data, binary=True)
 

--- a/obspy/core/util/__init__.py
+++ b/obspy/core/util/__init__.py
@@ -33,7 +33,7 @@ from obspy.core.util.base import (ALL_MODULES, DEFAULT_MODULES,
                                   BASEMAP_VERSION, CARTOPY_VERSION,
                                   PROJ4_VERSION, CatchAndAssertWarnings)
 from obspy.core.util.misc import (BAND_CODE, CatchOutput, complexify_string,
-                                  guess_delta, loadtxt, score_at_percentile,
+                                  guess_delta, score_at_percentile,
                                   to_int_or_zero, SuppressOutput)
 from obspy.core.util.obspy_types import (ComplexWithUncertainties, Enum,
                                          FloatWithUncertainties)

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -208,39 +208,6 @@ def to_int_or_zero(value):
         return 0
 
 
-# import numpy loadtxt and check if ndmin parameter is available
-try:
-    from numpy import loadtxt
-    loadtxt(np.array([0]), ndmin=1)
-except TypeError:
-    # otherwise redefine loadtxt
-    def loadtxt(*args, **kwargs):
-        """
-        Replacement for older numpy.loadtxt versions not supporting ndmin
-        parameter.
-        """
-        if 'ndmin' not in kwargs:
-            return np.loadtxt(*args, **kwargs)
-        # ok we got a ndmin param
-        if kwargs['ndmin'] != 1:
-            # for now we support only one dimensional arrays
-            raise NotImplementedError('Upgrade your NumPy version!')
-        del kwargs['ndmin']
-        dtype = kwargs.get('dtype', None)
-        # lets get the data
-        try:
-            data = np.loadtxt(*args, **kwargs)
-        except IOError as e:
-            # raises in older versions if no data could be read
-            if 'reached before encountering data' in str(e):
-                # return empty array
-                return np.array([], dtype=dtype)
-            # otherwise just raise
-            raise
-        # ensures that an array is returned
-        return np.atleast_1d(data)
-
-
 def get_untracked_files_from_git():
     """
     Tries to return a list of files (absolute paths) that are untracked by git

--- a/obspy/io/ascii/core.py
+++ b/obspy/io/ascii/core.py
@@ -41,7 +41,7 @@ import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
-from obspy.core.util import AttribDict, loadtxt
+from obspy.core.util import AttribDict
 
 
 HEADER = ("TIMESERIES {network}_{station}_{location}_{channel}_{dataquality}, "
@@ -515,7 +515,7 @@ def _parse_data(data, data_type):
     if len(data.read(1)) == 0:
         return np.array([], dtype=dtype)
     data.seek(0)
-    return loadtxt(data, dtype=dtype, ndmin=1)
+    return np.loadtxt(data, dtype=dtype, ndmin=1)
 
 
 if __name__ == '__main__':

--- a/obspy/io/sh/core.py
+++ b/obspy/io/sh/core.py
@@ -21,7 +21,6 @@ import numpy as np
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core import Stats
 from obspy.core.compatibility import from_buffer
-from obspy.core.util import loadtxt
 
 
 MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP',
@@ -215,7 +214,7 @@ def _read_asc(filename, headonly=False, skip=0, delta=None, length=None,
             stream.append(Trace(header=header))
         else:
             # read data
-            data = loadtxt(data, dtype=np.float32, ndmin=1)
+            data = np.loadtxt(data, dtype=np.float32, ndmin=1)
 
             # cut data if requested
             if skip and length:


### PR DESCRIPTION
 <!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Removes obsolete wrapper around numpy loadtxt and changes all usages from the wrapped version to the original. This wrapper was causing import errors when using numpy 1.22. See #2912 for details.

As the issue caused an import error and all usages of loadtxt should anyhow have test coverage already, I did not add any new tests.

Some tests are failing, at least in my local installation, but from what I can tell this is unrelated.

### Why was it initiated?  Any relevant Issues?

#2912 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] If any network modules should be tested for the PR, add them as a comma separated list
      (e.g. `clients.fdsn,clients.arclink`) after the colon in the following magic string: "+TESTS:clients.iris"
      (you can also add "ALL" to just simply run all tests across all modules)
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.