### PR TITLE
fix precision in location2degrees doctest

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -191,7 +191,7 @@ class UTCDateTimeTestCase(unittest.TestCase):
         self.assertEqual(dt, UTCDateTime(2009, 1, 1))
         # Compact day 360 - see issues #2868
         dt = UTCDateTime("2012360T")
-        self.assertEqual(dt, UTCDateTime(2012, 12, 25)) # Note leapyear
+        self.assertEqual(dt, UTCDateTime(2012, 12, 25))  # Note leapyear
         # w/ trailing Z
         dt = UTCDateTime("2009-365T12:23:34.5Z")
         self.assertEqual(dt, UTCDateTime(2009, 12, 31, 12, 23, 34, 500000))

--- a/obspy/geodetics/base.py
+++ b/obspy/geodetics/base.py
@@ -350,8 +350,8 @@ def locations2degrees(lat1, long1, lat2, long2):
     .. rubric:: Example
 
     >>> from obspy.geodetics import locations2degrees
-    >>> locations2degrees(5, 5, 10, 10)
-    7.0397014191753815
+    >>> locations2degrees(5, 5, 10, 10) # doctest: +ELLIPSIS
+    7.03970141917538...
     """
     # broadcast explicitly here so it raises once instead of somewhere in the
     # middle if things can't be broadcast


### PR DESCRIPTION
I didn't manage to reproduce this error, https://tests.obspy.org/115084/, but it's clearly a precision issue, and we don't need such small values

### What does this PR do?

Allows precision changes in the doctests of location2degrees

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just remove the space in the following string after the + sign: +DOCS
- [x] All tests still pass.
