### PR TITLE
Skipping coverage run for macOS test runner

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -23,6 +23,7 @@ dependencies:
   - requests
   - sqlalchemy
   - cryptography
+  - setuptools<58.1
   - pip:
       - pyimgur
       - -e..

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy
+  - numpy==1.21.2
   - scipy
   - matplotlib>3.2.0
   - basemap>=1.2.1

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy==1.21.2
+  - numpy
   - scipy
   - matplotlib>3.2.0
   - basemap>=1.2.1
@@ -23,7 +23,6 @@ dependencies:
   - requests
   - sqlalchemy
   - cryptography
-  - setuptools<58.1
   - pip:
       - pyimgur
       - -e..

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -127,7 +127,7 @@ jobs:
           fi
 
       - name: upload coverage
-        if: runner.os != "macOS"
+        if: runner.os != 'macOS'
         uses: codecov/codecov-action@v1
         with:
           flags: unittests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -127,7 +127,7 @@ jobs:
           fi
 
       - name: upload coverage
-        if: "$RUNNER_OS" != "macOS"
+        if: runner.os != "macOS"
         uses: codecov/codecov-action@v1
         with:
           flags: unittests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -121,13 +121,13 @@ jobs:
           export MODULELISTSPACES=`obshub read-config-value module_list_spaces --path=${CONFIG_PATH}`
           if [ "$RUNNER_OS" == "macOS" ]; then
               python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
-              touch coverage.xml
           else
               coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
               coverage xml -o coverage.xml
           fi
 
       - name: upload coverage
+        if: "$RUNNER_OS" != "macOS"
         uses: codecov/codecov-action@v1
         with:
           flags: unittests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,8 +119,9 @@ jobs:
         run: |
           export MODULELIST=`obshub read-config-value module_list --path=${CONFIG_PATH}`
           export MODULELISTSPACES=`obshub read-config-value module_list_spaces --path=${CONFIG_PATH}`
-          if [ "$RUNNER_OS" != "macOS" ]; then
+          if [ "$RUNNER_OS" == "macOS" ]; then
               python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+              touch coverage.xml
           else
               coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
               coverage xml -o coverage.xml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,7 +79,7 @@ jobs:
     needs: get_ci_config
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest]
         python-version: [3.7, 3.8]
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,17 +119,16 @@ jobs:
         run: |
           export MODULELIST=`obshub read-config-value module_list --path=${CONFIG_PATH}`
           export MODULELISTSPACES=`obshub read-config-value module_list_spaces --path=${CONFIG_PATH}`
-          coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
-          coverage xml -o coverage.xml
+          python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
 
-      - name: upload coverage
-        uses: codecov/codecov-action@v1
-        with:
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-umbrella
-          fail_ci_if_error: false
-          file: coverage.xml
+#      - name: upload coverage
+#        uses: codecov/codecov-action@v1
+#        with:
+#          flags: unittests
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          name: codecov-umbrella
+#          fail_ci_if_error: false
+#          file: coverage.xml
 
 
 # This is a very useful step for debugging, it allows you to ssh into the CI

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,7 +79,7 @@ jobs:
     needs: get_ci_config
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8]
 
     steps:
@@ -119,16 +119,21 @@ jobs:
         run: |
           export MODULELIST=`obshub read-config-value module_list --path=${CONFIG_PATH}`
           export MODULELISTSPACES=`obshub read-config-value module_list_spaces --path=${CONFIG_PATH}`
-          python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+          if [ "$RUNNER_OS" != "macOS" ]; then
+              python -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+          else
+              coverage run --rcfile=.coveragerc --source=${MODULELIST} -m obspy.scripts.runtests --no-flake8 -n gh-actions -r --ci-url="${CI_URL}" --pr-url="${PR_URL}" $MODULELISTSPACES
+              coverage xml -o coverage.xml
+          fi
 
-#      - name: upload coverage
-#        uses: codecov/codecov-action@v1
-#        with:
-#          flags: unittests
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          name: codecov-umbrella
-#          fail_ci_if_error: false
-#          file: coverage.xml
+      - name: upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          file: coverage.xml
 
 
 # This is a very useful step for debugging, it allows you to ssh into the CI

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ master
 Changes:
  - obspy.*
    * removed os.path calls with pathlib library calls (see #2751).
+   * temporarily removed macOS coverage reporting in github actions (see #2920)
+     to solve test issues (#2900)
  - obspy.clients.seishub:
    * added deprecation message
  - obspy.db:


### PR DESCRIPTION
this test passed: https://tests.obspy.org/114612/
this not: https://tests.obspy.org/114654/

although very close in time, so maybe setuptools version is culprit?


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is related to #2722 #2489 #2900
- [x] All tests still pass (well, we didn't know some didn't pass (e.g. the windows ones, so... back to work!)
- [x] Significant changes have been added to `CHANGELOG.txt` .
