### PR TITLE
Fixes crash when resampling very short traces (duplicate of #2885)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -88,6 +88,7 @@ Changes:
    * Removed obsolete wrapper around numpy.loadtxt causing import error with
      numpy 1.22 (see #2912, #2913)
    * Fix iso8601 regex for issue #2868 to cope with day 360 properly.
+   * Fix crash when resampling very short traces (see #2885)
  - obspy.clients.fdsn:
    * add URL mapping for IRISPH5 (see #2739)
    * update RESIF URL mapping to use https

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -88,7 +88,7 @@ Changes:
    * Removed obsolete wrapper around numpy.loadtxt causing import error with
      numpy 1.22 (see #2912, #2913)
    * Fix iso8601 regex for issue #2868 to cope with day 360 properly.
-   * Fix crash when resampling very short traces (see #2885)
+   * Fix crash when resampling very short traces (see #2926)
  - obspy.clients.fdsn:
    * add URL mapping for IRISPH5 (see #2739)
    * update RESIF URL mapping to use https

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2781,6 +2781,15 @@ class TraceTestCase(unittest.TestCase):
         self.assertEqual(sr1, 1e5)
         self.assertEqual(sr2, sr1)
 
+    def test_resample_short_traces(self):
+        """
+        Tests that resampling of short traces leaves at least one sample
+        """
+        tr = Trace(data=np.ones(2), header={'sampling_rate': 100})
+        tr.resample(30)
+        self.assertEqual(tr.stats.sampling_rate, 30)
+        self.assertEqual(tr.data.shape[0], 1)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2786,7 +2786,14 @@ class TraceTestCase(unittest.TestCase):
         Tests that resampling of short traces leaves at least one sample
         """
         tr = Trace(data=np.ones(2), header={'sampling_rate': 100})
-        tr.resample(30)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", UserWarning)
+            tr.resample(30)
+
+        self.assertEqual(len(w), 1)
+        self.assertEqual(w[0].category, UserWarning)
+
         self.assertEqual(tr.stats.sampling_rate, 30)
         self.assertEqual(tr.data.shape[0], 1)
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1743,7 +1743,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             x_i *= large_w[:self.stats.npts // 2 + 1]
 
         # interpolate
-        num = int(self.stats.npts / factor)
+        num = max(1, int(self.stats.npts / factor))
         df = 1.0 / (self.stats.npts * self.stats.delta)
         d_large_f = 1.0 / num * sampling_rate
         f = df * np.arange(0, self.stats.npts // 2 + 1, dtype=np.int32)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -1743,7 +1743,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             x_i *= large_w[:self.stats.npts // 2 + 1]
 
         # interpolate
-        num = max(1, int(self.stats.npts / factor))
+        num = int(self.stats.npts / factor)
+        if num == 0:
+            msg = ("Resampled trace would have less than one sample. "
+                   "Retaining exactly one sample.")
+            warnings.warn(msg)
+            num = 1
+
         df = 1.0 / (self.stats.npts * self.stats.delta)
         d_large_f = 1.0 / num * sampling_rate
         f = df * np.arange(0, self.stats.npts // 2 + 1, dtype=np.int32)


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

This PR is a duplicate of #2885, but targeting `master` instead of `maintenance_1.2.x`. It was necessary to create as the source branch of a PR can not be changed (while the target can) and rebasing the branch onto `master` seemed considerably more error prone than cherry picking the commit onto a fresh `master` branch.

### What does this PR do?

When working with a few very fragmented traces I stumbled across a corner case in the resampling logic that caused a crash. When resampling very short traces to a lower sampling rate, obspy inferred an output length of zero samples, leading to a ZeroDivisionError. This PR changes the behavior to always keep at least one sample when resampling a non-empty trace. Also adds a unit test for the bug.

### Why was it initiated?  Any relevant Issues?

see above

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Significant changes have been added to `CHANGELOG.txt` .
