### PR TITLE
Rewriting the CI recipes to make use of mamba + cache

### DIFF
--- a/.github/workflows/master_default_tests.yml
+++ b/.github/workflows/master_default_tests.yml
@@ -13,21 +13,51 @@ env:
 jobs:
   run_tests:
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ '3.7', '3.8', '3.9' ]
+        include:
+          - os: ubuntu-latest
+            label: linux-64
+            prefix: /usr/share/miniconda3/envs/test
+
+          - os: macos-latest
+            label: osx-64
+            prefix: /Users/runner/miniconda3/envs/test
+
+          - os: windows-latest
+            label: win-64
+            prefix: C:\Miniconda3\envs\test
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: 'latest'
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test${{ matrix.python-version }}
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          environment-file: .github/test_conda_env-${{ matrix.python-version }}.yml
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.prefix }}${{ matrix.python-version }}
+          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml') }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n test${{ matrix.python-version }} -f .github/test_conda_env-${{ matrix.python-version }}.yml
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: print package info
         shell: bash -l {0}

--- a/.github/workflows/master_network_tests.yml
+++ b/.github/workflows/master_network_tests.yml
@@ -17,14 +17,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: 'latest'
-          python-version: 3.7
-          activate-environment: test
-          environment-file: .github/test_conda_env.yml
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test3.9
+          use-mamba: true
+          python-version: 3.9
+
+      - uses: actions/cache@v2
+        with:
+          path: /usr/share/miniconda3/envs/test3.9
+          key: ${{ matrix.label }}-conda-py3.9-${{ hashFiles('.github/test_conda_env-3.9.yml') }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n test3.9 -f .github/test_conda_env-3.9.yml
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: install obspy
         shell: bash -l {0}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,14 @@ env:
 
 
 jobs:
+  check_running_or_queue_jobs_to_cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs in the same PR
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
   # Parse the comments from the PR and uploads a json with selected options
   get_ci_config:
     runs-on: ubuntu-latest
@@ -96,10 +104,6 @@ jobs:
             prefix: C:\Miniconda3\envs\test
 
     steps:
-      - name: Cancel Previous Runs in the same PR
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
 
       - name: Get current date

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -96,7 +96,7 @@ jobs:
             prefix: C:\Miniconda3\envs\test
 
     steps:
-      - name: Cancel Previous Runs
+      - name: Cancel Previous Runs in the same PR
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,6 @@ env:
 
 
 jobs:
-  check_running_or_queue_jobs_to_cancel:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs in the same PR
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
   # Parse the comments from the PR and uploads a json with selected options
   get_ci_config:
     runs-on: ubuntu-latest
@@ -90,18 +82,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9']
-        include:
-          - os: ubuntu-latest
-            label: linux-64
-            prefix: /usr/share/miniconda3/envs/test
+      include:
+        - os: ubuntu-latest
+          label: linux-64
+          prefix: /usr/share/miniconda3/envs/anaconda-client-env
 
-          - os: macos-latest
-            label: osx-64
-            prefix: /Users/runner/miniconda3/envs/test
+        - os: macos-latest
+          label: osx-64
+          prefix: /Users/runner/miniconda3/envs/anaconda-client-env
 
-          - os: windows-latest
-            label: win-64
-            prefix: C:\Miniconda3\envs\test
+        - os: windows-latest
+          label: win-64
+          prefix: C:\Miniconda3\envs\anaconda-client-env
 
     steps:
       - uses: actions/checkout@v2
@@ -120,8 +112,8 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.prefix }}${{ matrix.python-version }}
-          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml') }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+          path: ${{ matrix.prefix }}
+          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,18 +82,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9']
-      include:
-        - os: ubuntu-latest
-          label: linux-64
-          prefix: /usr/share/miniconda3/envs/anaconda-client-env
+        include:
+          - os: ubuntu-latest
+            label: linux-64
+            prefix: /usr/share/miniconda3/envs/anaconda-client-env
 
-        - os: macos-latest
-          label: osx-64
-          prefix: /Users/runner/miniconda3/envs/anaconda-client-env
+          - os: macos-latest
+            label: osx-64
+            prefix: /Users/runner/miniconda3/envs/anaconda-client-env
 
-        - os: windows-latest
-          label: win-64
-          prefix: C:\Miniconda3\envs\anaconda-client-env
+          - os: windows-latest
+            label: win-64
+            prefix: C:\Miniconda3\envs\anaconda-client-env
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ matrix.prefix }}
-          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml') }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,17 +82,46 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9']
+      include:
+        - os: ubuntu-latest
+          label: linux-64
+          prefix: /usr/share/miniconda3/envs/anaconda-client-env
+
+        - os: macos-latest
+          label: osx-64
+          prefix: /Users/runner/miniconda3/envs/anaconda-client-env
+
+        - os: windows-latest
+          label: win-64
+          prefix: C:\Miniconda3\envs\anaconda-client-env
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: 'latest'
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: test${{ matrix.python-version }}
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          environment-file: .github/test_conda_env-${{ matrix.python-version }}.yml
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.prefix }}
+          key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n test${{ matrix.python-version }} -f .github/test_conda_env-${{ matrix.python-version }}.yml
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: print package info
         shell: bash -l {0}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -85,15 +85,15 @@ jobs:
         include:
           - os: ubuntu-latest
             label: linux-64
-            prefix: /usr/share/miniconda3/envs/anaconda-client-env
+            prefix: /usr/share/miniconda3/envs/test
 
           - os: macos-latest
             label: osx-64
-            prefix: /Users/runner/miniconda3/envs/anaconda-client-env
+            prefix: /Users/runner/miniconda3/envs/test
 
           - os: windows-latest
             label: win-64
-            prefix: C:\Miniconda3\envs\anaconda-client-env
+            prefix: C:\Miniconda3\envs\test
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,7 +112,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.prefix }}
+          path: ${{ matrix.prefix }}${{ matrix.python-version }}
           key: ${{ matrix.label }}-conda-py${{ matrix.python-version }}-${{ hashFiles('.github/test_conda_env-${{ matrix.python-version }}.yml') }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -96,6 +96,10 @@ jobs:
             prefix: C:\Miniconda3\envs\test
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
 
       - name: Get current date

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes:
      to solve test issues (#2900)
    * added python 3.9 tests for all platforms, required to disable image
      comparisons for 3.9 (#2925)
+   * rewrote CI tests to make use of cache (#2936)
    * removed individual logging configurations in Obspy, logging can be
      configured by the user, see documentation of Pythons logging module,
      only the FDSN mass downloader automatically configures logging as before,

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,7 +8,7 @@ Changes:
      to solve test issues (#2900)
    * added python 3.9 tests for all platforms, required to disable image
      comparisons for 3.9 (#2925)
-   * rewrote CI tests to make use of cache (see #2936)
+   * rewrote CI tests to make use of cache (#2936)
    * removed individual logging configurations in Obspy, logging can be
      configured by the user, see documentation of Pythons logging module,
      only the FDSN mass downloader automatically configures logging as before,

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,7 +8,7 @@ Changes:
      to solve test issues (#2900)
    * added python 3.9 tests for all platforms, required to disable image
      comparisons for 3.9 (#2925)
-   * rewrote CI tests to make use of cache (#2936)
+   * rewrote CI tests to make use of cache (see #2936)
    * removed individual logging configurations in Obspy, logging can be
      configured by the user, see documentation of Pythons logging module,
      only the FDSN mass downloader automatically configures logging as before,


### PR DESCRIPTION
# What does this PR do?
- It implements a new way to create the environments for CI testing on github-actions.
- The recipes have been modified to install mamba & to save/reuse daily snapshots of the environments.
- There is also a new job that checks for existing "running" or "queued" jobs in _the same PR_ (!!) and cancels them, to save CI energy for the latest push, and discard outdated content.

Using cached environments saves at least 2 minutes on Ubuntu, could save up to 10 min on macOS & Windows for the environment solving step. This comes at a price: every day, the first CI run will need to cache the environment (tar-gz it and save it remotely, which is almost instantaneous on *nux, takes 2min on windows).


