### PR TITLE
Improve _is_pickle check (>25 second test on windows)

### DIFF
--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3568,7 +3568,7 @@ def _is_pickle(filename):  # @UnusedVariable
     if isinstance(filename, str):
         try:
             with open(filename, 'rb') as fp:
-                if "obspy.core.stream" in fp.read(100):
+                if b"obspy.core.stream" in fp.read(100):
                     fp.seek(0)
                     st = pickle.load(fp)
                     return True

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3568,7 +3568,12 @@ def _is_pickle(filename):  # @UnusedVariable
     if isinstance(filename, str):
         try:
             with open(filename, 'rb') as fp:
-                st = pickle.load(fp)
+                if "obspy.core.stream" in fp.read(100):
+                    fp.seek(0)
+                    st = pickle.load(fp)
+                    return True
+                else:
+                    return False
         except Exception:
             return False
     else:


### PR DESCRIPTION
### What does this PR do?

Improves the `_is_pickle` method by checking for a known pattern (b``obspy.core.stream``) in the lead part of the read file. This way, we avoid to pass the content to `pickle.load`, which for no clear reason takes more than 25 seconds on Windows (only). 
Example: https://tests.obspy.org/115617/ -->
>33.182s | test_is_format (obspy.core.tests.test_waveform_plugins.WaveformPluginsTestCase)


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] All tests still pass.
