### PR TITLE
Adding python 3.10 to CI testing

### DIFF
--- a/.github/test_conda_env-3.10.yml
+++ b/.github/test_conda_env-3.10.yml
@@ -1,0 +1,25 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - ca-certificates
+  - certifi
+  - coverage
+  - codecov
+  - cryptography
+  - decorator
+  - future
+  - greenlet
+  - kiwisolver
+  - lxml
+  - numpy<1.22
+  - pillow
+  - pip
+  - pyparsing
+  - requests
+  - scipy
+  - sqlalchemy
+  - pip:
+      - pyimgur
+      - -e..

--- a/.github/workflows/master_default_tests.yml
+++ b/.github/workflows/master_default_tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: ubuntu-latest
             label: linux-64

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: ubuntu-latest
             label: linux-64

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.10']
         include:
           - os: ubuntu-latest
             label: linux-64


### PR DESCRIPTION
### What does this PR do?

just testing PRs on python 3.10 and checking if all goes well

### Why was it initiated?  Any relevant Issues?

3.10.0 was released on 4 October 2021, and 3.10.1 on 6 December 2021.