### PR TITLE
Use standard library to parse GCF files

### DIFF
--- a/.github/test_conda_env-3.10.yml
+++ b/.github/test_conda_env-3.10.yml
@@ -13,7 +13,7 @@ dependencies:
   - greenlet
   - kiwisolver
   - lxml
-  - numpy<1.22
+  - numpy
   - pillow
   - pip
   - pyparsing

--- a/.github/test_conda_env-3.7.yml
+++ b/.github/test_conda_env-3.7.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy<1.22
+  - numpy
   - scipy
   - matplotlib>3.2.0
   - pip

--- a/.github/test_conda_env-3.8.yml
+++ b/.github/test_conda_env-3.8.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy<1.22
+  - numpy
   - scipy
   - matplotlib
   - pip

--- a/.github/test_conda_env-3.9.yml
+++ b/.github/test_conda_env-3.9.yml
@@ -13,7 +13,7 @@ dependencies:
   - greenlet
   - kiwisolver
   - lxml
-  - numpy<1.22
+  - numpy
   - pillow
   - pip
   - pyparsing

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy<1.22
+  - numpy
   - scipy
   - matplotlib>3.2.0
   - pip


### PR DESCRIPTION
### What does this PR do?

Most byte-to-int conversion is for a single value, so NumPy is not a
huge help. The final data buffer is at most 255 bytes, and needs to be
copied for the `cumsum` anyway, so this shouldn't be too bad.

### Why was it initiated?  Any relevant Issues?

Fixes #2921

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
