### PR TITLE
Fix deprecations from Matplotlib 3.5

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -119,6 +119,7 @@ Changes:
  - obspy.signal.spectral_estimation.PPSD:
    * Added special handling option for infrasound data and global infrasound noise
      models for plotting (see #2740)
+   * Replaced use of deprecated Matplotlib functionality (see #2951)
  - obspy.signal.trigger:
    * Improved clarity and speed of several STA/LTA triggers methods, namely
      classic_sta_lta_py, z_detector, and recursive_sta_lta_py (see #2892)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -2087,7 +2087,7 @@ class PPSD(object):
         ax = fig.axes[0]
         xlim = ax.get_xlim()
         if "quadmesh" in fig.ppsd:
-            ax.collections.remove(fig.ppsd.pop("quadmesh"))
+            fig.ppsd.pop("quadmesh").remove()
 
         if fig.ppsd.cumulative:
             data = self.current_histogram_cumulative * 100.0
@@ -2122,8 +2122,8 @@ class PPSD(object):
                 color = {"color": "0.7"}
             else:
                 color = {}
-            ax.grid(b=True, which="major", **color)
-            ax.grid(b=True, which="minor", **color)
+            ax.grid(True, which="major", **color)
+            ax.grid(True, which="minor", **color)
 
         ax.set_xlim(*xlim)
 


### PR DESCRIPTION
### What does this PR do?

The first argument to `grid` was renamed, and Axes collections should not be modified directly.

### Why was it initiated?  Any relevant Issues?

This fixes the two warnings:

>  The modification of the Axes.collections property was deprecated in
> Matplotlib 3.5 and will be removed two minor releases later. Use
> Artist.remove() instead.

> The 'b' parameter of grid() has been renamed 'visible' since
> Matplotlib 3.5; support for the old name will be dropped two minor
> releases later.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
