### PR TITLE
Remove use of distutils

### DIFF
--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -8,10 +8,10 @@
     (https://www.gnu.org/copyleft/lesser.html)
 """
 import collections
-from distutils.version import LooseVersion
 import unittest
 from unittest import mock
 
+from packaging.version import parse as parse_version
 import pytest
 
 import obspy
@@ -34,8 +34,8 @@ class EIDAWSRoutingClientTestCase(unittest.TestCase):
         # At the time of test writing the version is 1.1.1. Here we just
         # make sure it is larger.
         self.assertGreaterEqual(
-            LooseVersion(self.client.get_service_version()),
-            LooseVersion("1.1.1"))
+            parse_version(self.client.get_service_version()),
+            parse_version("1.1.1"))
 
     def test_response_splitting(self):
         data = """

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -8,10 +8,10 @@
     (https://www.gnu.org/copyleft/lesser.html)
 """
 import collections
-from distutils.version import LooseVersion
 import unittest
 from unittest import mock
 
+from packaging.version import parse as parse_version
 import pytest
 
 import obspy
@@ -33,8 +33,8 @@ class FederatorRoutingClientTestCase(unittest.TestCase):
         # At the time of test writing the version is 1.1.1. Here we just
         # make sure it is larger.
         self.assertGreaterEqual(
-            LooseVersion(self.client.get_service_version()),
-            LooseVersion("1.1.1"))
+            parse_version(self.client.get_service_version()),
+            parse_version("1.1.1"))
 
     def test_response_splitting(self):
         data = """

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import warnings
 from unittest import mock
 
+from packaging.version import parse as parse_version
 import numpy as np
 import numpy.ma as ma
 
@@ -1414,7 +1415,6 @@ class TestTrace:
         Test if the correct times array is returned for normal traces and
         traces with gaps.
         """
-        from distutils.version import LooseVersion
         from matplotlib import __version__
         tr = Trace(data=np.ones(100))
         tr.stats.sampling_rate = 20
@@ -1455,7 +1455,7 @@ class TestTrace:
         expected = np.array([
                 10957.000000000000, 10957.000000578704, 10957.000001157407,
                 10957.000001736111, 10957.000002314815])
-        if LooseVersion(__version__) < LooseVersion('3.3'):
+        if parse_version(__version__) < parse_version('3.3'):
             expected = np.array([
                 730120.00000000000000000000, 730120.00000057870056480169,
                 730120.00000115740112960339, 730120.00000173610169440508,

--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -6,6 +6,7 @@ import warnings
 from functools import partial
 from operator import ge, eq, lt, le, gt, ne
 
+from packaging.version import parse as parse_version
 import numpy as np
 
 from obspy import UTCDateTime as UTC
@@ -1061,7 +1062,6 @@ class TestUTCDateTime:
         Test convenience method and property for conversion to matplotlib
         datetime float numbers.
         """
-        from distutils.version import LooseVersion
         from matplotlib import __version__
 
         for t_, expected_old, expected in zip(
@@ -1071,7 +1071,7 @@ class TestUTCDateTime:
                 (5965.57236768, 14480.013978, 20784.1338588),
                 ):
             t = UTC(t_)
-            if LooseVersion(__version__) < LooseVersion('3.3'):
+            if parse_version(__version__) < parse_version('3.3'):
                 expected = expected_old
             np.testing.assert_almost_equal(
                 t.matplotlib_date, expected, decimal=8)

--- a/obspy/core/util/requirements.py
+++ b/obspy/core/util/requirements.py
@@ -17,6 +17,7 @@ INSTALL_REQUIRES = [
 
 # The modules needed for running ObsPy's test suite.
 PYTEST_REQUIRES = [
+    'packaging',
     'pytest',
     'pytest-cov',
     'pytest-json-report',


### PR DESCRIPTION
### What does this PR do?

In main code, `distutils` can be dropped, as the version check is no longer necessary. In tests, it can be replaced by `packaging.version`.

### Why was it initiated?  Any relevant Issues?

`distutils` is deprecated and will be removed in Python 3.12.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
