### PR TITLE
clients.fdsn: trivial change to support status code 501 & 502

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,7 +39,7 @@ Changes:
    * fix iso8601 regex for issue #2868 to cope with day 360 properly
    * fix crash when resampling very short traces (see #2926)
  - obspy.clients.fdsn:
-   * introduce fine-grained FDSN client exceptions (see #2653)
+   * introduce fine-grained FDSN client exceptions (see #2653, #2964)
    * support for "eventtype" parameter in get_events(), as specified in version
      1.2 of the FDSN event web service (see #2780)
    * Hostnames with hyphens and long TLDs are no longer rejected as invalid

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -34,7 +34,10 @@ from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      FDSNTimeoutException,
                      FDSNNoAuthenticationServiceException,
                      FDSNBadRequestException, FDSNNoServiceException,
-                     FDSNInternalServerException, FDSNTooManyRequestsException,
+                     FDSNInternalServerException,
+                     FDSNNotImplementedException,
+                     FDSNBadGatewayException,
+                     FDSNTooManyRequestsException,
                      FDSNRequestTooLargeException,
                      FDSNServiceUnavailableException,
                      FDSNUnauthorizedException,
@@ -1771,6 +1774,12 @@ def raise_on_error(code, data):
     elif code == 500:
         raise FDSNInternalServerException("Service responds: Internal server "
                                           "error", server_info)
+    elif code == 501:
+        raise FDSNNotImplementedException("Service responds: Not implemented ",
+                                          server_info)
+    elif code == 502:
+        raise FDSNBadGatewayException("Service responds: Bad gateway ",
+                                      server_info)
     elif code == 503:
         raise FDSNServiceUnavailableException("Service temporarily "
                                               "unavailable",

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -60,6 +60,14 @@ class FDSNInternalServerException(FDSNException):
     status_code = 500
 
 
+class FDSNNotImplementedException(FDSNException):
+    status_code = 501
+
+
+class FDSNBadGatewayException(FDSNException):
+    status_code = 502
+
+
 class FDSNServiceUnavailableException(FDSNException):
     status_code = 503
 

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -40,6 +40,8 @@ from obspy.clients.fdsn.header import (DEFAULT_USER_AGENT, URL_MAPPINGS,
                                        FDSNNoServiceException,
                                        FDSNInternalServerException,
                                        FDSNTooManyRequestsException,
+                                       FDSNNotImplementedException,
+                                       FDSNBadGatewayException,
                                        FDSNServiceUnavailableException,
                                        FDSNUnauthorizedException,
                                        FDSNForbiddenException,
@@ -1539,6 +1541,26 @@ class ClientTestCase(unittest.TestCase):
         """
         self.assertRaises(FDSNNoServiceException, Client,
                           "http://nofdsnservice.org")
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_not_implemented_exception(self, download_url_mock):
+        """
+        Verify that a client receiving a 501 'Not Implemented' status
+        raises an identifiable exception
+        """
+        download_url_mock.return_value = (501, None)
+        self.assertRaises(FDSNNotImplementedException,
+                          self.client.get_stations)
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_bad_gateway_exception(self, download_url_mock):
+        """
+        Verify that a client receiving a 502 'Bad Gateway' status
+        raises an identifiable exception
+        """
+        download_url_mock.return_value = (502, None)
+        self.assertRaises(FDSNBadGatewayException,
+                          self.client.get_stations)
 
     @mock.patch("obspy.clients.fdsn.client.download_url")
     def test_service_unavailable_exception(self, download_url_mock):


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Enable proper handling of HTTP status code 502 (and 501 for completeness) in fdsnws requests

### Why was it initiated?  Any relevant Issues?

Some real-world fdsnws nodes may return status code 502 (Bad Gateway). Not sure about 501, but being a valid HTTP status code the client should anyway be prepared for it and raise a proper exception rather than "Unknown Error".

Note that this is difficult to test explicitly but the change is so trivial that this shouldn't be an issue here. I have of course tested it here when the GFZ node was temporarily down (which is what motivated this PR).

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [X] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [X] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [X] Add the "ready for review" tag when you are ready for the PR to be reviewed.
