### PR TITLE
Fix statements in macros

### DIFF
--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -589,22 +589,22 @@ typedef struct Selections_s {
  * pack byte orders */
 extern flag packheaderbyteorder;
 extern flag packdatabyteorder;
-#define MS_PACKHEADERBYTEORDER(X) (packheaderbyteorder = X);
-#define MS_PACKDATABYTEORDER(X) (packdatabyteorder = X);
+#define MS_PACKHEADERBYTEORDER(X) do { packheaderbyteorder = (X); } while(0)
+#define MS_PACKDATABYTEORDER(X) do { packdatabyteorder = (X); } while(0)
 
 /* Global variables (defined in unpack.c) and macros to set/force
  * unpack byte orders */
 extern flag unpackheaderbyteorder;
 extern flag unpackdatabyteorder;
-#define MS_UNPACKHEADERBYTEORDER(X) (unpackheaderbyteorder = X);
-#define MS_UNPACKDATABYTEORDER(X) (unpackdatabyteorder = X);
+#define MS_UNPACKHEADERBYTEORDER(X) do { unpackheaderbyteorder = (X); } while(0)
+#define MS_UNPACKDATABYTEORDER(X) do { unpackdatabyteorder = (X); } while(0)
 
 /* Global variables (defined in unpack.c) and macros to set/force
  * encoding and fallback encoding */
 extern int unpackencodingformat;
 extern int unpackencodingfallback;
-#define MS_UNPACKENCODINGFORMAT(X) (unpackencodingformat = X);
-#define MS_UNPACKENCODINGFALLBACK(X) (unpackencodingfallback = X);
+#define MS_UNPACKENCODINGFORMAT(X) do { unpackencodingformat = (X); } while(0)
+#define MS_UNPACKENCODINGFALLBACK(X) do { unpackencodingfallback = (X); } while(0)
 
 /* Mini-SEED record related functions */
 extern int           msr_parse (char *record, int recbuflen, MSRecord **ppmsr, int reclen,
@@ -824,10 +824,12 @@ extern void     ms_gswap4a ( void *data4 );
 extern void     ms_gswap8a ( void *data8 );
 
 /* Byte swap macro for the BTime struct */
-#define MS_SWAPBTIME(x) \
-  ms_gswap2 (x.year);   \
-  ms_gswap2 (x.day);    \
-  ms_gswap2 (x.fract);
+#define MS_SWAPBTIME(x)  \
+  do {                   \
+    ms_gswap2 (x.year);  \
+    ms_gswap2 (x.day);   \
+    ms_gswap2 (x.fract); \
+  } while (0)
 
 /* Platform portable functions */
 extern off_t lmp_ftello (FILE *stream);


### PR DESCRIPTION
Doing `#define foo(x) (y=x);` will break code like:
```
if (...)
    foo(0);
else
    foo(1);
```
because semicolon in the macro will be the end of the statement in the `if`, and the semicolon outside the macro will be an empty statement, meaning the `else` is no longer attached to the `if`.

Similarly, placing multiple statements into a macro will cause braceless `if` to break as only the first statement will be within the condition. This occurs a few times with `swapflag` in `parseutils.c`.

### Why was it initiated?  Any relevant Issues?

The incorrectly enclosed `MS_SWAPBTIME` is (correctly) warning on latest gcc as it is in a braceless `if`.

See also https://github.com/iris-edu/libmseed/pull/73

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
