### PR TITLE
libmseed updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -328,6 +328,8 @@ Changes:
    * The recordanalyzer can now detect calibration blockettes 300, 310,
      and 320 (see #2370).
    * Can now write zero sampling-rate traces. (see #2488, 2509)
+   * Updated to libmseed 2.19.6. (see #2966)
+   * Fixed byte swapping of data. (see #2966)
  - obspy.io.nordic:
    * Add ability to read and write focal mechanisms and moment tensor
      information. (see #1924)

--- a/obspy/io/mseed/src/libmseed/ChangeLog
+++ b/obspy/io/mseed/src/libmseed/ChangeLog
@@ -1,3 +1,8 @@
+2018.240: 2.19.6
+	- Allow ms_readleapsecondfile() to be called multiple times, by @pn2200
+	- Fix compiler warning in mst_printsynclist().
+	- Fix memory leak (on error) in msr_duplicate() and other fixes by @pn2200.
+
 2017.283: 2.19.5
 	- msr_endtime(): calculate correct end time during a leap second.
 	- Fixed signedness comparison warning.

--- a/obspy/io/mseed/src/libmseed/doc/ms_gswap.3
+++ b/obspy/io/mseed/src/libmseed/doc/ms_gswap.3
@@ -23,13 +23,11 @@ ms_gswap - Generalized, in-place byte swapping routines
 
 .SH DESCRIPTION
 These routines swap between LSBF (little-endian) and MSBF (big-endian)
-byte orders.  The specified quantities are swapped in-place.  There
-are two versions of most routines: a generic one that works on
-quantities regardless of memory alignment (ms_gswap#) and one that works
-on memory aligned quantities (ms_gswap#a).  The versions for memory
-aligned quantities are much faster than their generic versions, but
-the memory *must* be aligned.  You have been warned. There is only a
-generic version for 3-byte quantities.
+byte orders.  The specified quantities are swapped in-place.
+
+The \fBms_gswap*a\fP routines are provided for backwards compatibility, but
+should not be used in new code. They are aliases for the regular versions
+above.
 
 .SH AUTHOR
 .nf

--- a/obspy/io/mseed/src/libmseed/doc/ms_log.3
+++ b/obspy/io/mseed/src/libmseed/doc/ms_log.3
@@ -23,13 +23,13 @@ all output from libmseed functions.  They are also intended to be used
 by libmseed based programs if desired.
 
 Three message levels are recognized:
- 0  : Normal log messgaes, printed using log_print with logprefix
+ 0  : Normal log messages, printed using log_print with logprefix
  1  : Diagnostic messages, printed using diag_print with logprefix
  2+ : Error messages, printed using diag_print with errprefix
 
 It is the task of the \fBms_log\fP functions to format a message using
 \fBprintf\fP conventions and pass the formatted string to the
-appropriate printing function (\fIlog_print\fP or \fIdiag_print\fP)
+appropriate printing function (\fIlog_print\fP or \fIdiag_print\fP).
 
 \fBms_log\fP will process messages using the global logging
 parameters.
@@ -63,11 +63,11 @@ The default values for the logging parameters are:
   log_print  = fprintf  (printing to standard out)
   log_prefix = ""
   diag_print = fprintf  (printing to standard error)
-  err_prefix = "error: "
+  err_prefix = "Error: "
 
 By setting the printing functions it is possible to re-direct all of
 the output from these logging routines.  This is useful when the
-libmseed based software is embedded in a system with it's own logging
+libmseed based software is embedded in a system with its own logging
 facilities.
 
 Most of the libmseed internal messages are logged at either the
@@ -100,8 +100,8 @@ main () {
   /* Normal log message, "LOG: " will be prefixed */
   ms_log (0, "Normal log message for %s\n", argv[0]);
 
-  /* Diognostic message, "LOG: " will be prefixed */
-  ms_log (1, "Diagnositc message for %s\n", argv[0]);
+  /* Diagnostic message, "LOG: " will be prefixed */
+  ms_log (1, "Diagnostic message for %s\n", argv[0]);
 
   /* Error message, "ERR: " will be prefixed */
   ms_log (2, "Error message for %s\n", argv[0]);

--- a/obspy/io/mseed/src/libmseed/doc/ms_readmsr.3
+++ b/obspy/io/mseed/src/libmseed/doc/ms_readmsr.3
@@ -125,13 +125,13 @@ source name and time window parameters, see \fBms_selection(3)\fP for
 more information.
 
 .SH RETURN VALUES
-On the sucessful read and parsing of a record \fBms_readmsr\fP and
+On the successful read and parsing of a record \fBms_readmsr\fP and
 \fBms_readmsr_r\fP return MS_NOERROR and populate the MSRecord struct
 at \fI*ppmsr\fP.  Upon reaching the end of the input file these
 routines return MS_ENDOFFILE.  On error these routines return a
 libmseed error code (defined in libmseed.h)
 
-On the sucessful read and parsing of a file \fBms_readtraces\fP and
+On the successful read and parsing of a file \fBms_readtraces\fP and
 \fBms_readtracelist\fP return MS_NOERROR and populate the MSTraceGroup
 or MSTraceList struct.  On error these routines return a libmseed
 error code (defined in libmseed.h)

--- a/obspy/io/mseed/src/libmseed/doc/msr_duplicate.3
+++ b/obspy/io/mseed/src/libmseed/doc/msr_duplicate.3
@@ -17,7 +17,7 @@ otherwise the copy MSRecord will not have any associated data sample
 array regardless if the source MSRecord had any.
 
 .SH RETURN VALUE
-\fBmsr_dupliate\fP returns a pointer to an MSRecord on success and
+\fBmsr_duplicate\fP returns a pointer to an MSRecord on success and
 NULL on error.
 
 .SH SEE ALSO

--- a/obspy/io/mseed/src/libmseed/doc/msr_unpack.3
+++ b/obspy/io/mseed/src/libmseed/doc/msr_unpack.3
@@ -89,7 +89,7 @@ these records is included only to support legacy data.
 
 .SH RETURN VALUE
 
-On the sucessful parsing of a record \fBmsr_unpack\fP returns
+On the successful parsing of a record \fBmsr_unpack\fP returns
 MS_NOERROR and populates the MSRecord struct at *ppmsr.  On error
 \fBmsr_unpack\fP returns a libmseed error code (defined in libmseed.h)
 

--- a/obspy/io/mseed/src/libmseed/genutils.c
+++ b/obspy/io/mseed/src/libmseed/genutils.c
@@ -1192,6 +1192,14 @@ ms_readleapsecondfile (char *filename)
     return -1;
   }
 
+  /* Free existing leapsecondlist */
+  while (leapsecondlist != NULL)
+  {
+    LeapSecond *next = leapsecondlist->next;
+    free(leapsecondlist);
+    leapsecondlist = next;
+  }
+
   while (fgets (readline, sizeof (readline) - 1, fp))
   {
     /* Guarantee termination */
@@ -1247,6 +1255,7 @@ ms_readleapsecondfile (char *filename)
       ls->leapsecond = MS_EPOCH2HPTIME ((leapsecond - NTPPOSIXEPOCHDELTA));
       ls->TAIdelta   = TAIdelta;
       ls->next       = NULL;
+      count++;
 
       /* Add leap second to global list */
       if (!leapsecondlist)

--- a/obspy/io/mseed/src/libmseed/gswap.c
+++ b/obspy/io/mseed/src/libmseed/gswap.c
@@ -6,14 +6,12 @@
  *
  * Some standard integer types are needed, namely uint8_t and
  * uint32_t, (these are normally declared by including inttypes.h or
- * stdint.h).  Each function expects it's input to be a void pointer
+ * stdint.h).  Each function expects its input to be a void pointer
  * to a quantity of the appropriate size.
  *
- * There are two versions of most routines, one that works on
- * quantities regardless of alignment (gswapX) and one that works on
- * memory aligned quantities (gswapXa).  The memory aligned versions
- * (gswapXa) are much faster than the other versions (gswapX), but the
- * memory *must* be aligned.
+ * There are two versions of most routines.  The memory aligned versions
+ * (gswapXa) are aliases of the other versions (gswapX) provided for backwards
+ * compatibility.  There is no difference between them.
  *
  * Written by Chad Trabant,
  *   IRIS Data Management Center
@@ -28,115 +26,73 @@
 void
 ms_gswap2 (void *data2)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[2];
-  } dat;
+  uint16_t dat;
 
   memcpy (&dat, data2, 2);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[1];
-  dat.c[1] = temp;
+
+  dat = ((dat & 0xff00) >> 8) | ((dat & 0x00ff) << 8);
+
   memcpy (data2, &dat, 2);
 }
 
 void
 ms_gswap3 (void *data3)
 {
+  uint8_t dat[3];
   uint8_t temp;
 
-  union {
-    uint8_t c[3];
-  } dat;
-
   memcpy (&dat, data3, 3);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[2];
-  dat.c[2] = temp;
+  temp   = dat[0];
+  dat[0] = dat[2];
+  dat[2] = temp;
   memcpy (data3, &dat, 3);
 }
 
 void
 ms_gswap4 (void *data4)
 {
-  uint8_t temp;
-
-  union {
-    uint8_t c[4];
-  } dat;
+  uint32_t dat;
 
   memcpy (&dat, data4, 4);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[3];
-  dat.c[3] = temp;
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[2];
-  dat.c[2] = temp;
+
+  dat = ((dat & 0xff000000) >> 24) | ((dat & 0x000000ff) << 24) |
+        ((dat & 0x00ff0000) >>  8) | ((dat & 0x0000ff00) <<  8);
+
   memcpy (data4, &dat, 4);
 }
 
 void
 ms_gswap8 (void *data8)
 {
-  uint8_t temp;
+  uint64_t dat;
 
-  union {
-    uint8_t c[8];
-  } dat;
+  memcpy (&dat, data8, sizeof(uint64_t));
 
-  memcpy (&dat, data8, 8);
-  temp     = dat.c[0];
-  dat.c[0] = dat.c[7];
-  dat.c[7] = temp;
+  dat = ((dat & 0xff00000000000000) >> 56) | ((dat & 0x00000000000000ff) << 56) |
+        ((dat & 0x00ff000000000000) >> 40) | ((dat & 0x000000000000ff00) << 40) |
+        ((dat & 0x0000ff0000000000) >> 24) | ((dat & 0x0000000000ff0000) << 24) |
+        ((dat & 0x000000ff00000000) >>  8) | ((dat & 0x00000000ff000000) <<  8);
 
-  temp     = dat.c[1];
-  dat.c[1] = dat.c[6];
-  dat.c[6] = temp;
-
-  temp     = dat.c[2];
-  dat.c[2] = dat.c[5];
-  dat.c[5] = temp;
-
-  temp     = dat.c[3];
-  dat.c[3] = dat.c[4];
-  dat.c[4] = temp;
-  memcpy (data8, &dat, 8);
+  memcpy (data8, &dat, sizeof(uint64_t));
 }
 
-/* Swap routines that work on memory aligned quantities */
+/* Swap routines that work on memory aligned quantities are the same as the
+ * generic routines. The symbols below exist for backwards compatibility. */
 
 void
 ms_gswap2a (void *data2)
 {
-  uint16_t *data = data2;
-
-  *data = (((*data >> 8) & 0xff) | ((*data & 0xff) << 8));
+  ms_gswap2 (data2);
 }
 
 void
 ms_gswap4a (void *data4)
 {
-  uint32_t *data = data4;
-
-  *data = (((*data >> 24) & 0xff) | ((*data & 0xff) << 24) |
-           ((*data >> 8) & 0xff00) | ((*data & 0xff00) << 8));
+  ms_gswap4 (data4);
 }
 
 void
 ms_gswap8a (void *data8)
 {
-  uint32_t *data4 = data8;
-  uint32_t h0, h1;
-
-  h0 = data4[0];
-  h0 = (((h0 >> 24) & 0xff) | ((h0 & 0xff) << 24) |
-        ((h0 >> 8) & 0xff00) | ((h0 & 0xff00) << 8));
-
-  h1 = data4[1];
-  h1 = (((h1 >> 24) & 0xff) | ((h1 & 0xff) << 24) |
-        ((h1 >> 8) & 0xff00) | ((h1 & 0xff00) << 8));
-
-  data4[0] = h1;
-  data4[1] = h0;
+  ms_gswap8 (data8);
 }

--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBMSEED_VERSION "2.19.5"
-#define LIBMSEED_RELEASE "2017.283"
+#define LIBMSEED_VERSION "2.19.6"
+#define LIBMSEED_RELEASE "2018.240"
 
 /* C99 standard headers */
 #include <stdlib.h>
@@ -68,10 +68,7 @@ extern "C" {
 #endif
 
 /* Set platform specific features */
-#if defined(LMP_LINUX) || defined(LMP_BSD) || defined(LMP_SOLARIS)
-  #include <unistd.h>
-  #include <inttypes.h>
-#elif defined(LMP_WIN)
+#if defined(LMP_WIN)
   #include <windows.h>
   #include <sys/types.h>
 
@@ -115,6 +112,7 @@ extern "C" {
     #define stat _stat
   #endif
 #else
+  #include <unistd.h>
   #include <inttypes.h>
 #endif
 

--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -587,22 +587,22 @@ typedef struct Selections_s {
  * pack byte orders */
 extern flag packheaderbyteorder;
 extern flag packdatabyteorder;
-#define MS_PACKHEADERBYTEORDER(X) (packheaderbyteorder = X);
-#define MS_PACKDATABYTEORDER(X) (packdatabyteorder = X);
+#define MS_PACKHEADERBYTEORDER(X) do { packheaderbyteorder = (X); } while(0)
+#define MS_PACKDATABYTEORDER(X) do { packdatabyteorder = (X); } while(0)
 
 /* Global variables (defined in unpack.c) and macros to set/force
  * unpack byte orders */
 extern flag unpackheaderbyteorder;
 extern flag unpackdatabyteorder;
-#define MS_UNPACKHEADERBYTEORDER(X) (unpackheaderbyteorder = X);
-#define MS_UNPACKDATABYTEORDER(X) (unpackdatabyteorder = X);
+#define MS_UNPACKHEADERBYTEORDER(X) do { unpackheaderbyteorder = (X); } while(0)
+#define MS_UNPACKDATABYTEORDER(X) do { unpackdatabyteorder = (X); } while(0)
 
 /* Global variables (defined in unpack.c) and macros to set/force
  * encoding and fallback encoding */
 extern int unpackencodingformat;
 extern int unpackencodingfallback;
-#define MS_UNPACKENCODINGFORMAT(X) (unpackencodingformat = X);
-#define MS_UNPACKENCODINGFALLBACK(X) (unpackencodingfallback = X);
+#define MS_UNPACKENCODINGFORMAT(X) do { unpackencodingformat = (X); } while(0)
+#define MS_UNPACKENCODINGFALLBACK(X) do { unpackencodingfallback = (X); } while(0)
 
 /* Mini-SEED record related functions */
 extern int           msr_parse (char *record, int recbuflen, MSRecord **ppmsr, int reclen,
@@ -822,10 +822,12 @@ extern void     ms_gswap4a ( void *data4 );
 extern void     ms_gswap8a ( void *data8 );
 
 /* Byte swap macro for the BTime struct */
-#define MS_SWAPBTIME(x) \
-  ms_gswap2 (x.year);   \
-  ms_gswap2 (x.day);    \
-  ms_gswap2 (x.fract);
+#define MS_SWAPBTIME(x)  \
+  do {                   \
+    ms_gswap2 (x.year);  \
+    ms_gswap2 (x.day);   \
+    ms_gswap2 (x.fract); \
+  } while (0)
 
 /* Platform portable functions */
 extern off_t lmp_ftello (FILE *stream);

--- a/obspy/io/mseed/src/libmseed/libmseed.h
+++ b/obspy/io/mseed/src/libmseed/libmseed.h
@@ -816,10 +816,27 @@ extern void     ms_gswap3 ( void *data3 );
 extern void     ms_gswap4 ( void *data4 );
 extern void     ms_gswap8 ( void *data8 );
 
-/* Generic byte swapping routines for memory aligned quantities */
+/* Generic byte swapping routines for memory aligned quantities; names exist
+ * for backwards compatibility, but are the same as the generic routines. */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) || defined (__clang__)
+__attribute__ ((deprecated("Use ms_gswap2 instead.")))
+extern void     ms_gswap2a ( void *data2 );
+__attribute__ ((deprecated("Use ms_gswap4 instead.")))
+extern void     ms_gswap4a ( void *data4 );
+__attribute__ ((deprecated("Use ms_gswap8 instead.")))
+extern void     ms_gswap8a ( void *data8 );
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
+__declspec(deprecated("Use ms_gswap2 instead."))
+extern void     ms_gswap2a ( void *data2 );
+__declspec(deprecated("Use ms_gswap4 instead."))
+extern void     ms_gswap4a ( void *data4 );
+__declspec(deprecated("Use ms_gswap8 instead."))
+extern void     ms_gswap8a ( void *data8 );
+#else
 extern void     ms_gswap2a ( void *data2 );
 extern void     ms_gswap4a ( void *data4 );
 extern void     ms_gswap8a ( void *data8 );
+#endif
 
 /* Byte swap macro for the BTime struct */
 #define MS_SWAPBTIME(x)  \

--- a/obspy/io/mseed/src/libmseed/logging.c
+++ b/obspy/io/mseed/src/libmseed/logging.c
@@ -120,7 +120,7 @@ ms_loginit_main (MSLogParam *logp,
   {
     if (strlen (logprefix) >= MAX_LOG_MSG_LENGTH)
     {
-      ms_log_l (logp, 2, 0, "log message prefix is too large\n");
+      ms_log_l (logp, 2, "%s", "log message prefix is too large\n");
     }
     else
     {
@@ -135,7 +135,7 @@ ms_loginit_main (MSLogParam *logp,
   {
     if (strlen (errprefix) >= MAX_LOG_MSG_LENGTH)
     {
-      ms_log_l (logp, 2, 0, "error message prefix is too large\n");
+      ms_log_l (logp, 2, "%s", "error message prefix is too large\n");
     }
     else
     {

--- a/obspy/io/mseed/src/libmseed/msrutils.c
+++ b/obspy/io/mseed/src/libmseed/msrutils.c
@@ -388,6 +388,12 @@ msr_duplicate (MSRecord *msr, flag datadup)
   /* Copy MSRecord structure */
   memcpy (dupmsr, msr, sizeof (MSRecord));
 
+  /* Reset pointers to not alias memory held by other structures */
+  dupmsr->fsdh = NULL;
+  dupmsr->blkts = NULL;
+  dupmsr->datasamples = NULL;
+  dupmsr->ststate = NULL;
+
   /* Copy fixed-section data header structure */
   if (msr->fsdh)
   {
@@ -395,7 +401,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     if ((dupmsr->fsdh = (struct fsdh_s *)malloc (sizeof (struct fsdh_s))) == NULL)
     {
       ms_log (2, "msr_duplicate(): Error allocating memory\n");
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 
@@ -437,7 +443,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     {
       ms_log (2, "msr_duplicate(): unrecognized sample type: '%c'\n",
               msr->sampletype);
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 
@@ -445,7 +451,7 @@ msr_duplicate (MSRecord *msr, flag datadup)
     if ((dupmsr->datasamples = (void *)malloc ((size_t) (msr->numsamples * samplesize))) == NULL)
     {
       ms_log (2, "msr_duplicate(): Error allocating memory\n");
-      free (dupmsr);
+      msr_free (&dupmsr);
       return NULL;
     }
 

--- a/obspy/io/mseed/src/libmseed/packdata.c
+++ b/obspy/io/mseed/src/libmseed/packdata.c
@@ -74,7 +74,7 @@ msr_encode_int16 (int32_t *input, int samplecount, int16_t *output,
     output[idx] = (int16_t)input[idx];
 
     if (swapflag)
-      ms_gswap2a (&output[idx]);
+      ms_gswap2 (&output[idx]);
 
     outputlength -= sizeof (int16_t);
   }
@@ -111,7 +111,7 @@ msr_encode_int32 (int32_t *input, int samplecount, int32_t *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (int32_t);
   }
@@ -148,7 +148,7 @@ msr_encode_float32 (float *input, int samplecount, float *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&output[idx]);
+      ms_gswap4 (&output[idx]);
 
     outputlength -= sizeof (float);
   }
@@ -185,7 +185,7 @@ msr_encode_float64 (double *input, int samplecount, double *output,
     output[idx] = input[idx];
 
     if (swapflag)
-      ms_gswap8a (&output[idx]);
+      ms_gswap8 (&output[idx]);
 
     outputlength -= sizeof (double);
   }
@@ -287,7 +287,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         ms_log (1, "Frame %d: X0=%d\n", frameidx, frameptr[1]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = &frameptr[2];
 
@@ -360,8 +360,8 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         /* 2-bit nibble is 0b10 (0x2) */
@@ -378,7 +378,7 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
         frameptr[widx] = diffs[0];
 
         if (swapflag)
-          ms_gswap4a (&frameptr[widx]);
+          ms_gswap4 (&frameptr[widx]);
 
         /* 2-bit nibble is 0b11 (0x3) */
         frameptr[0] |= 0x3ul << (30 - 2 * widx);
@@ -392,14 +392,14 @@ msr_encode_steim1 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   /* Pad any remaining bytes */
   if ((frameidx * 64) < outputlength)
@@ -478,7 +478,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
         ms_log (1, "Frame %d: X0=%d\n", frameidx, frameptr[1]);
 
       if (swapflag)
-        ms_gswap4a (&frameptr[1]);
+        ms_gswap4 (&frameptr[1]);
 
       Xnp = (int32_t *)&frameptr[2];
 
@@ -687,7 +687,7 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
       /* Swap encoded word except for 4x8-bit samples */
       if (swapflag && packedsamples != 4)
-        ms_gswap4a (&frameptr[widx]);
+        ms_gswap4 (&frameptr[widx]);
 
       diffcount -= packedsamples;
       outputsamples += packedsamples;
@@ -695,14 +695,14 @@ msr_encode_steim2 (int32_t *input, int samplecount, int32_t *output,
 
     /* Swap word with nibbles */
     if (swapflag)
-      ms_gswap4a (&frameptr[0]);
+      ms_gswap4 (&frameptr[0]);
   } /* Done with frames */
 
   /* Set Xn (reverse integration constant) in first frame to last sample */
   if (Xnp)
     *Xnp = *(input + outputsamples - 1);
   if (swapflag)
-    ms_gswap4a (Xnp);
+    ms_gswap4 (Xnp);
 
   /* Pad any remaining bytes */
   if ((frameidx * 64) < outputlength)

--- a/obspy/io/mseed/src/libmseed/parseutils.c
+++ b/obspy/io/mseed/src/libmseed/parseutils.c
@@ -396,12 +396,12 @@ ms_parse_raw (char *record, int maxreclen, flag details, flag swapflag)
   if (swapflag)
   {
     MS_SWAPBTIME (&fsdh->start_time);
-    ms_gswap2a (&fsdh->numsamples);
-    ms_gswap2a (&fsdh->samprate_fact);
-    ms_gswap2a (&fsdh->samprate_mult);
-    ms_gswap4a (&fsdh->time_correct);
-    ms_gswap2a (&fsdh->data_offset);
-    ms_gswap2a (&fsdh->blockette_offset);
+    ms_gswap2 (&fsdh->numsamples);
+    ms_gswap2 (&fsdh->samprate_fact);
+    ms_gswap2 (&fsdh->samprate_mult);
+    ms_gswap4 (&fsdh->time_correct);
+    ms_gswap2 (&fsdh->data_offset);
+    ms_gswap2 (&fsdh->blockette_offset);
   }
 
   /* Validate fixed section header fields */

--- a/obspy/io/mseed/src/libmseed/traceutils.c
+++ b/obspy/io/mseed/src/libmseed/traceutils.c
@@ -171,7 +171,7 @@ mst_findmatch (MSTrace *startmst, char dataquality,
 {
   int idx;
 
-  if (!startmst)
+  if (!startmst || !network || !station || !location || !channel)
     return 0;
 
   while (startmst)
@@ -279,7 +279,7 @@ mst_findadjacent (MSTraceGroup *mstg, flag *whence, char dataquality,
   hptime_t nhptimetol = 0;
   int idx;
 
-  if (!mstg)
+  if (!mstg || !whence || !network || !station || !location || !channel)
     return 0;
 
   *whence = 0;
@@ -1445,7 +1445,7 @@ mst_printsynclist (MSTraceGroup *mstg, char *dccid, flag subsecond)
   MSTrace *mst = 0;
   char stime[30];
   char etime[30];
-  char yearday[10];
+  char yearday[32];
   time_t now;
   struct tm *nt;
 

--- a/obspy/io/mseed/src/libmseed/unpack.c
+++ b/obspy/io/mseed/src/libmseed/unpack.c
@@ -156,12 +156,12 @@ msr_unpack (char *record, int reclen, MSRecord **ppmsr,
   if (headerswapflag)
   {
     MS_SWAPBTIME (&msr->fsdh->start_time);
-    ms_gswap2a (&msr->fsdh->numsamples);
-    ms_gswap2a (&msr->fsdh->samprate_fact);
-    ms_gswap2a (&msr->fsdh->samprate_mult);
-    ms_gswap4a (&msr->fsdh->time_correct);
-    ms_gswap2a (&msr->fsdh->data_offset);
-    ms_gswap2a (&msr->fsdh->blockette_offset);
+    ms_gswap2 (&msr->fsdh->numsamples);
+    ms_gswap2 (&msr->fsdh->samprate_fact);
+    ms_gswap2 (&msr->fsdh->samprate_mult);
+    ms_gswap4 (&msr->fsdh->time_correct);
+    ms_gswap2 (&msr->fsdh->data_offset);
+    ms_gswap2 (&msr->fsdh->blockette_offset);
   }
 
   /* Populate some of the common header fields */

--- a/obspy/io/mseed/src/libmseed/unpack.c
+++ b/obspy/io/mseed/src/libmseed/unpack.c
@@ -12,8 +12,6 @@
  * Written by Chad Trabant,
  *   ORFEUS/EC-Project MEREDIAN
  *   IRIS Data Management Center
- *
- * modified: 2016.273
  ***************************************************************************/
 #include <ctype.h>
 #include <stdio.h>
@@ -824,7 +822,14 @@ msr_unpack_data (MSRecord *msr, int swapflag, flag verbose)
       ms_log (1, "%s: Found ASCII data\n", srcname);
 
     nsamples = (int)msr->samplecnt;
-    memcpy (msr->datasamples, dbuf, nsamples);
+    if (nsamples > 0)
+    {
+      memcpy (msr->datasamples, dbuf, nsamples);
+    }
+    else
+    {
+      nsamples = 0;
+    }
     msr->sampletype = 'a';
     break;
 

--- a/obspy/io/mseed/src/libmseed/unpackdata.c
+++ b/obspy/io/mseed/src/libmseed/unpackdata.c
@@ -50,7 +50,7 @@ msr_decode_int16 (int16_t *input, int samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap2a (&sample);
+      ms_gswap2 (&sample);
 
     output[idx] = (int32_t)sample;
 
@@ -86,7 +86,7 @@ msr_decode_int32 (int32_t *input, int samplecount, int32_t *output,
     sample = input[idx];
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -122,7 +122,7 @@ msr_decode_float32 (float *input, int samplecount, float *output,
     memcpy (&sample, &input[idx], sizeof (float));
 
     if (swapflag)
-      ms_gswap4a (&sample);
+      ms_gswap4 (&sample);
 
     output[idx] = sample;
 
@@ -158,7 +158,7 @@ msr_decode_float64 (double *input, int samplecount, double *output,
     memcpy (&sample, &input[idx], sizeof (double));
 
     if (swapflag)
-      ms_gswap8a (&sample);
+      ms_gswap8 (&sample);
 
     output[idx] = sample;
 
@@ -220,8 +220,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -242,7 +242,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -273,8 +273,8 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
 
         if (swapflag)
         {
-          ms_gswap2a (&word->d16[0]);
-          ms_gswap2a (&word->d16[1]);
+          ms_gswap2 (&word->d16[0]);
+          ms_gswap2 (&word->d16[1]);
         }
 
         if (decodedebug)
@@ -284,7 +284,7 @@ msr_decode_steim1 (int32_t *input, int inputlength, int samplecount,
       case 3: /* 11: One 4-byte difference */
         diffcount = 1;
         if (swapflag)
-          ms_gswap4a (&word->d32);
+          ms_gswap4 (&word->d32);
 
         if (decodedebug)
           ms_log (1, "  W%02d: 11=1x32b  %d\n", widx, word->d32);
@@ -375,8 +375,8 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
     {
       if (swapflag)
       {
-        ms_gswap4a (&frame[1]);
-        ms_gswap4a (&frame[2]);
+        ms_gswap4 (&frame[1]);
+        ms_gswap4 (&frame[2]);
       }
 
       X0 = frame[1];
@@ -397,7 +397,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
     /* Swap 32-bit word containing the nibbles */
     if (swapflag)
-      ms_gswap4a (&frame[0]);
+      ms_gswap4 (&frame[0]);
 
     /* Decode each 32-bit word according to nibble */
     for (widx = startnibble; widx < 16 && samplecount > 0; widx++)
@@ -428,7 +428,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
       case 2: /* nibble=10: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -480,7 +480,7 @@ msr_decode_steim2 (int32_t *input, int inputlength, int samplecount,
 
       case 3: /* nibble=11: Must consult dnib, the high order two bits */
         if (swapflag)
-          ms_gswap4a (&frame[widx]);
+          ms_gswap4 (&frame[widx]);
         dnib = EXTRACTBITRANGE (frame[widx], 30, 2);
 
         switch (dnib)
@@ -638,7 +638,7 @@ msr_decode_geoscope (char *input, int samplecount, float *output,
     case DE_GEOSCOPE163:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -655,7 +655,7 @@ msr_decode_geoscope (char *input, int samplecount, float *output,
     case DE_GEOSCOPE164:
       memcpy (&sint, input, sizeof (int16_t));
       if (swapflag)
-        ms_gswap2a (&sint);
+        ms_gswap2 (&sint);
 
       /* Recover mantissa and gain range factor */
       mantissa  = (sint & GEOSCOPE_MANTISSA_MASK);
@@ -751,7 +751,7 @@ msr_decode_cdsn (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & CDSN_MANTISSA_MASK);
@@ -844,7 +844,7 @@ msr_decode_sro (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (int16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
 
     /* Recover mantissa and gain range factor */
     mantissa  = (sint & SRO_MANTISSA_MASK);
@@ -898,7 +898,7 @@ msr_decode_dwwssn (int16_t *input, int samplecount, int32_t *output,
   {
     memcpy (&sint, &input[idx], sizeof (uint16_t));
     if (swapflag)
-      ms_gswap2a (&sint);
+      ms_gswap2 (&sint);
     sample = (int32_t)sint;
 
     /* Take 2's complement for sample */


### PR DESCRIPTION
### What does this PR do?

Updates libmseed to 2.19.6, which has a few minor bug fixes. Additionally, it backports some bug fixes in the byteswapping code that I sent upstream at iris-edu/libmseed#73 and iris-edu/libmseed#74.

### Why was it initiated?  Any relevant Issues?

The mseed byteswapping tests randomly break, depending on compiler due to the undefined behaviour triggered in that code.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [n/a] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [n/a] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [n/a] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [n/a] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.