### PR TITLE
Fix dayplot with small interval

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changes:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
  - obspy.imaging:
    * fix section plot in case of a single trace only (see #2764)
+   * fix day plot when passed a small interval (see #2967)
  - obspy.clients.filesystem.tsindex:
    * improvements to leap second file setup and other small fixes (see #2776)
  - obspy.clients.seedlink:

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -431,6 +431,14 @@ class TestWaveformPlot:
         st.plot(outfile=image_path, type='dayplot',
                 timezone='EST', time_offset=-5)
 
+    @pytest.mark.parametrize('interval', [2, 10, 23, 25])
+    def test_plot_day_plot_interval(self, interval):
+        """Plot day plot, with different intervals."""
+        start = UTCDateTime(0)
+        st = self._create_stream(start, start + 3 * 3600, 100)
+        st.plot(type='dayplot', timezone='EST', time_offset=-5,
+                interval=interval)
+
     def test_plot_day_plot_explicit_event(self, image_path):
         """
         Plots day plot, starting Jan 1970, with several events.

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1001,7 +1001,7 @@ class WaveformPlotting(object):
         if not count:
             # Up to 15 time units and if it's a full number, show every unit.
             if time_value <= 15 and time_value % 1 == 0:
-                count = time_value
+                count = int(time_value)
             # Otherwise determine whether they are divisible for numbers up to
             # 15. If a number is not divisible just show 10 units.
             else:


### PR DESCRIPTION
### What does this PR do?

A small `interval` triggers a different code path that tries to pass a float to the `linspace` count. In fact, it specifically checks that the float is a whole number, but is missing the explicit cast.

### Why was it initiated?  Any relevant Issues?

See https://discourse.obspy.org/t/problem-with-plot-dayplot/1344

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [n/a] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [n/a] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [n/a] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [n/a] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
