### PR TITLE
Explicitly link extensions with math library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import sysconfig
 
 import setuptools
 
@@ -595,6 +596,8 @@ def get_extensions():
     if IS_MSVC:
         # get export symbols
         kwargs['export_symbols'] = export_symbols(path, 'gse_functions.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     extensions.append(Extension("gse2", files, **kwargs))
 
     # LIBMSEED
@@ -612,8 +615,10 @@ def get_extensions():
             export_symbols(path, 'libmseed', 'libmseed.def')
         kwargs['export_symbols'] += \
             export_symbols(path, 'obspy-readbuffer.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     if EXTERNAL_LIBMSEED:
-        kwargs['libraries'] = ['mseed']
+        kwargs.setdefault('libraries', []).append('mseed')
     extensions.append(Extension("mseed", files, **kwargs))
 
     # SEGY
@@ -624,6 +629,8 @@ def get_extensions():
     if IS_MSVC:
         # get export symbols
         kwargs['export_symbols'] = export_symbols(path, 'libsegy.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     extensions.append(Extension("segy", files, **kwargs))
 
     # SIGNAL
@@ -634,6 +641,8 @@ def get_extensions():
     if IS_MSVC:
         # get export symbols
         kwargs['export_symbols'] = export_symbols(path, 'libsignal.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     extensions.append(Extension("signal", files, **kwargs))
 
     # EVALRESP
@@ -649,8 +658,10 @@ def get_extensions():
         kwargs['define_macros'] = [('WIN32', '1')]
         # get export symbols
         kwargs['export_symbols'] = export_symbols(path, 'libevresp.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     if EXTERNAL_EVALRESP:
-        kwargs['libraries'] = ['evresp']
+        kwargs.setdefault('libraries', []).append('evresp')
     extensions.append(Extension("evresp", files, **kwargs))
 
     # TAU
@@ -661,6 +672,8 @@ def get_extensions():
     if IS_MSVC:
         # get export symbols
         kwargs['export_symbols'] = export_symbols(path, 'libtau.def')
+    if sysconfig.get_config_var('LIBM') == '-lm':
+        kwargs['libraries'] = ['m']
     extensions.append(Extension("tau", files, **kwargs))
 
     return extensions


### PR DESCRIPTION
### What does this PR do?

All of these extensions use math functions (`math.h`), so should link with the math library on Unix systems.

~~I'm not sure if this gets automatically ignored on e.g., MSVC, so this is draft for now.~~

### Why was it initiated?  Any relevant Issues?

Technically, the Python executable is already linked to the math library, but these extensions are not linked to Python (executable or library), and could theoretically be used without, so the linkage should be made explicit.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [n/a] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [n/a] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [n/a] Any new features or fixed regressions are covered via new tests.
- [n/a] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [n/a] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [n/a] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.