### PR TITLE
Add warning for metadata truncation when writing to mseed

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -113,6 +113,7 @@ Wassermann, Joachim
 van Wijk, Kasper
 Williams, Mark C.
 Winkelman, Andrew
+Woollam, Jack
 Zaccarelli, Riccardo
 Zad, Seyed Kasra Hosseini
 Zhu, Lijun

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -997,6 +997,15 @@ class MST(object):
         self.mst.contents.numsamples = trace.stats.npts
         self.mst.contents.sampletype = sampletype.encode('ascii', 'strict')
 
+        # Check fields will not be truncated.
+        _trunk_fields = {
+            'network': 2, 'station': 5, 'location': 2, 'channel': 3
+        }
+
+        for field_type, limit in _trunk_fields.items():
+            field_size = len(getattr(self.mst.contents, field_type))
+            self._check_truncated_field(field_size, field_type, trace, limit)
+
         # libmseed expects data in the native byte order.
         if data.dtype.byteorder != "=":
             data = data.byteswap()
@@ -1008,6 +1017,16 @@ class MST(object):
         self.mst.contents.datasamples = clibmseed.allocate_bytes(bytecount)
         C.memmove(self.mst.contents.datasamples, data.ctypes.data,
                   bytecount)
+
+    def _check_truncated_field(self, field_size, field_type, trace, limit):
+        if field_size > limit:
+            msg = (
+                "Information loss will be present when writing '%s' field for"
+                "'%s' as field is truncated to %d characters upon conversion "
+                "to mseed.\n'%s' is size %d"
+            ) % (field_type, trace.id, limit, field_type, field_size)
+
+            warnings.warn(msg)
 
     def __del__(self):
         """

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1611,6 +1611,28 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         del tr2.stats["mseed"]
         self.assertEqual(tr, tr2)
 
+    def test_truncation_warning_captured(self):
+        """
+        Certain metadata fields such as: network, station, location, channel
+        are truncated to lengths < size allowed in C-Struct.
+        """
+        tr = Trace(
+            data=np.linspace(0, 1, 10),
+            header={
+                'network': 'AAAAAAA',
+                'station': 'BBBBBBB',
+                'location': '0000000',
+                'channel': 'CCCCCCC'
+            })
+        st = Stream([tr])
+
+        # Check for expected UserWarning
+        with NamedTemporaryFile() as tf:
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter('error', UserWarning)
+                with self.assertRaises(UserWarning):
+                    st.write(tf, format="MSEED")
+
 
 def suite():
     return unittest.makeSuite(MSEEDReadingAndWritingTestCase, 'test')


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Changes default behaviour when writing to mseed files to now log a warning if the provided metadata would be truncated during writing.

### Why was it initiated?  Any relevant Issues?

See issues/questions (#2971, #2588).

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
