### PR TITLE
simple AIC by Maeda 1985

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -129,6 +129,7 @@ Changes:
  - obspy.signal.trigger:
    * Improved clarity and speed of several STA/LTA triggers methods, namely
      classic_sta_lta_py, z_detector, and recursive_sta_lta_py (see #2892)
+   * Added simple AIC method by Maeda (1985)
 
 1.2.2 (doi: 10.5281/zenodo.3921997)
 ===================================

--- a/misc/docs/source/bibliography/Maeda1985.bib
+++ b/misc/docs/source/bibliography/Maeda1985.bib
@@ -1,0 +1,10 @@
+@article{Maeda1985,
+  title={A method for reading and checking phase times in autoprocessing system of seismic wave data},
+  author={Maeda, Naoki},
+  journal={Zisin},
+  volume={38},
+  pages={365--379},
+  year={1985},
+  doi={10.4294/zisin1948.38.3_365},
+  url={https://doi.org/10.4294/zisin1948.38.3_365}
+}

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial.rst
@@ -406,6 +406,31 @@ For :func:`~obspy.signal.trigger.ar_pick`, input and output are in seconds.
 This gives the output 30.6350002289 and 31.2800006866, meaning that a P pick at
 30.64s and an S pick at 31.28s were identified.
 
+
+AIC - Akaike Information Criterion by Maeda (1985)
+==================================================
+
+Credits: mbagagli
+
+The :func:`~obspy.signal.trigger.aic_simple` function estimates the Akaike
+Information directly from data (see [Maeda1985]_).
+
+    >>> from obspy.core import read, UTCDateTime
+    >>> from obspy.signal.trigger import aic_simple
+    >>> trace = read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+    >>> df = trace.stats.sampling_rate
+    >>> trace_s = trace.slice(UTCDateTime('1970-01-01T01:00:31.6'),
+    ...                       UTCDateTime('1970-01-01T01:00:34.3'))
+    >>> aic_f = aic_simple(trace_s.data)
+    >>> p_idx = aic_f.argmin()
+    >>> print(p_idx / df)
+    1.625
+    >>> print(UTCDateTime('1970-01-01T01:00:31.6') + (p_idx / df))
+    1970-01-01T01:00:33.225000Z
+
+This yields the output of 4.225 seconds from the sliced trace start time.
+In UTC time this results in 1970-01-01T01:00:33.225.
+
 ----------------
 Advanced Example
 ----------------

--- a/misc/docs/source/tutorial/code_snippets/trigger_tutorial_aic_simple.py
+++ b/misc/docs/source/tutorial/code_snippets/trigger_tutorial_aic_simple.py
@@ -1,0 +1,16 @@
+"""
+Credits: mbagagli
+"""
+
+from obspy.core import read, UTCDateTime
+from obspy.signal.trigger import aic_simple
+
+
+trace = read("https://examples.obspy.org/ev0_6.a01.gse2")[0]
+df = trace.stats.sampling_rate
+trace_s = trace.slice(UTCDateTime('1970-01-01T01:00:31.6'),
+                      UTCDateTime('1970-01-01T01:00:34.3'))
+aic_f = aic_simple(trace_s.data)
+p_idx = aic_f.argmin()
+print(p_idx / df)
+print(UTCDateTime('1970-01-01T01:00:31.6') + (p_idx / df))

--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -147,6 +147,14 @@ clibsignal.calculate_kernel.argtypes = [
     C.c_int]
 clibsignal.calculate_kernel.restype = None
 
+clibsignal.aic_simple.argtypes = [
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags='C_CONTIGUOUS'),
+    np.ctypeslib.ndpointer(dtype=np.float64, ndim=1,
+                           flags='C_CONTIGUOUS'),
+    C.c_uint32]
+clibsignal.recstalta.restype = C.c_void_p
+
 STALEN = 64
 NETLEN = 64
 CHALEN = 64

--- a/obspy/signal/src/aic_simple.c
+++ b/obspy/signal/src/aic_simple.c
@@ -1,0 +1,52 @@
+/**
+ * Simple AIC (Akaike information criterion) by Maeda (1985).
+ * Author: Danylo Ulianych
+ * Copyright (C) 2022 D. Ulianych
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+
+typedef struct {
+	double mean;
+	double varsum;  // variance sum
+	uint32_t count;
+} OnlineMean;
+
+
+void OnlineMean_Init(OnlineMean *oMean, double firstVal) {
+    oMean->mean = firstVal;
+    oMean->varsum = 0;
+    oMean->count = 1;
+}
+
+/**
+ * Welford's online algorithm of estimation the population mean & variance.
+ */
+void OnlineMean_Update(OnlineMean *oMean, double newVal) {
+    oMean->count++;
+    double delta = newVal - oMean->mean;
+    oMean->mean += delta / oMean->count;
+    oMean->varsum += delta * (newVal - oMean->mean);
+}
+
+
+void aic_simple(double *aic, const double *arr, uint32_t size) {
+    OnlineMean oMean;
+
+    OnlineMean_Init(&oMean, arr[0]);
+    for (uint32_t i = 1; i < size - 1; i++) {
+        OnlineMean_Update(&oMean, arr[i]);
+        aic[i + 1] = oMean.count * log(oMean.varsum / oMean.count);
+    }
+
+    OnlineMean_Init(&oMean, arr[size - 1]);
+    for (uint32_t i = size - 2; i > 0; i--) {
+        OnlineMean_Update(&oMean, arr[i]);
+        aic[i] += (oMean.count - 1) * log(oMean.varsum / oMean.count);
+    }
+
+    aic[0] = aic[1];
+}

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -9,12 +9,31 @@ import warnings
 from ctypes import ArgumentError
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from obspy import Stream, UTCDateTime, read
 from obspy.signal.trigger import (
     ar_pick, classic_sta_lta, classic_sta_lta_py, coincidence_trigger, pk_baer,
-    recursive_sta_lta, recursive_sta_lta_py, trigger_onset)
+    recursive_sta_lta, recursive_sta_lta_py, trigger_onset, aic_simple)
 from obspy.signal.util import clibsignal
+
+
+def aic_simple_python(a):
+    if len(a) <= 2:
+        return np.zeros(len(a), dtype=np.float64)
+    a = np.asarray(a)
+    aic_cf = np.zeros(a.size - 1)
+    with np.errstate(divide='ignore'):
+        aic_cf[0] = (a.size - 2) * np.log(np.var(a[1:]))
+        aic_cf[-1] = (a.size - 1) * np.log(np.var(a[:-1]))
+        for ii in range(2, a.size - 1):
+            var1 = np.log(np.var(a[:ii]))
+            var2 = np.log(np.var(a[ii:]))
+            val1 = ii * var1
+            val2 = (a.size - ii - 1) * var2
+            aic_cf[ii - 1] = (val1 + val2)
+    aic_cf = np.r_[aic_cf[0], aic_cf]
+    return aic_cf
 
 
 class TriggerTestCase(unittest.TestCase):
@@ -90,6 +109,23 @@ class TriggerTestCase(unittest.TestCase):
         self.assertEqual(nptime, 17545)
         self.assertEqual(pfm, 'IPU0')
         self.assertEqual(len(cf), 119999)
+
+    def test_aic_simple_constant_data(self):
+        data = [1] * 10
+        # all negative inf
+        assert_array_equal(aic_simple(data), -np.inf)
+
+    def test_aic_simple_small_size(self):
+        data = [3, 4]
+        assert_array_equal(aic_simple(data), [0, 0])
+
+    def test_aic_simple(self):
+        np.random.seed(0)
+        data = np.random.rand(100)
+        aic = aic_simple(data)
+        self.assertEqual(len(aic), len(data))
+        aic_true = aic_simple_python(data)
+        assert_array_almost_equal(aic, aic_true)
 
     def test_ar_pick(self):
         """

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -415,6 +415,33 @@ def pk_baer(reltrc, samp_int, tdownmax, tupevent, thr1, thr2, preset_len,
         return pptime.value + 1, pfm.value.decode('utf-8')
 
 
+def aic_simple(a):
+    r"""
+    Simple Akaike Information Criterion [Maeda1985]_.
+
+    It's computed directly from data and defined as
+
+    .. math::
+        AIC(k) = k\log(\var{x_{1..k}}) + (N-k-1)\log(\var{x_{k+1..N}})
+
+    The true output is one data sample less. To make it convenient with other
+    metrics in this module, where the output length is preserved, the first
+    element is prepended to the output: ``aic[0] == aic[1]``.
+
+    :type a: :class:`numpy.ndarray` or list
+    :param a: Input time series
+    :rtype: :class:`numpy.ndarray`
+    :return: aic - Akaike Information Criterion array
+    """
+    n = len(a)
+    if n <= 2:
+        return np.zeros(n, dtype=np.float64)
+    a = np.ascontiguousarray(a, np.float64)
+    aic_res = np.empty(n, dtype=np.float64)
+    clibsignal.aic_simple(aic_res, a, n)
+    return aic_res
+
+
 def ar_pick(a, b, c, samp_rate, f1, f2, lta_p, sta_p, lta_s, sta_s, m_p, m_s,
             l_p, l_s, s_pick=True):
     """


### PR DESCRIPTION
### What does this PR do?

This is a C implementation of AIC by Maeda 1985. Based on https://github.com/obspy/obspy/pull/2347. It's sad that this PR has not been merged for years.

It's faster not only because it's in C, but also because the time complexity is `O(N)` while the abovementioned PR makes it in `O(N^2)`.

Welford's online algorithm is used to avoid computing variances again and again. You can reuse this code when the online population mean and variance is needed.

### Why was it initiated?  Any relevant Issues?

The AIC by Maeda implementation is missing.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [-] Significant changes have been added to `CHANGELOG.txt` .
- [-] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [-] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
