### PR TITLE
fix upload of releases

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -81,8 +81,8 @@ jobs:
           path: dist/*.tar.gz
 
   publish_test:
-    name: publish tag or release to testpypi
-    if: github.event_name == 'push' && github.ref_type == 'tag' || github.event_name == 'release'
+    name: publish tag to testpypi
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
@@ -100,7 +100,7 @@ jobs:
   publish:
     name: publish release
     if: github.event_name == 'release'
-    needs: [build_wheels, build_sdist, publish_test]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
I missed on thing in #2943: Creating a release also triggers the push tag event, or a release is created from a tag created beforehand. Therefore, uploading to testpypi on release event is not necessary. It would even fail, because a distribution of the same version would have been uploaded by the push event. (The final upload to pypi would have been canceled in this case, too.) This PR fixes this issue.