### PR TITLE
seedlink basic client, get_info(): terminate properly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,9 @@ Changes:
    * update RESIF URL mapping to use http and add RESIFPH5 (see #2938)
  - obspy.clients.filesystem:
    * add get_waveforms_bulk() method to SDS client (see #2616, #2626)
+ - obspy.clients.seedlink:
+   * basic client: properly terminate after finished get_info() request (see
+     #2996)
  - obspy.imaging:
    * fix section plot in case of a single trace only (see #2764)
    * removed basemap, now only cartopy is supported for maps (see #2961)

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -337,7 +337,7 @@ class Client(object):
             if self.debug:
                 print("Complete INFO:",
                       self._slclient.slconn.get_info_string())
-            return False
+            return True
 
         # process packet data
         trace = slpack.get_trace()


### PR DESCRIPTION
### What does this PR do?

Seems seedlink basic client in `get_info()` did not properly signal that everything was received
and ready to terminate. not sure why it worked before..


### Why was it initiated?  Any relevant Issues?

tries to fix #2995 


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
