### PR TITLE
Fix remaining network test fails in clients.earthworm

### DIFF
--- a/obspy/clients/earthworm/__init__.py
+++ b/obspy/clients/earthworm/__init__.py
@@ -24,8 +24,8 @@ Basic Usage
       'AKV',
       '--',
       'BHE',
-      2021-12-30T14:36:15.761000Z,
-      2022-02-28T14:35:57.199000Z)]
+      UTCDateTime(2021, 10, 30, 12, 2, 27, 473000),
+      UTCDateTime(2021, 12, 29, 12, 2, 16, 899000)]
     >>> t = response[0][4]
     >>> st = client.get_waveforms('AV', 'AKV', '', 'BH*', t + 100, t + 130)
     >>> st.plot()  # doctest: +SKIP

--- a/obspy/clients/earthworm/__init__.py
+++ b/obspy/clients/earthworm/__init__.py
@@ -18,16 +18,16 @@ Basic Usage
 
     >>> from obspy.clients.earthworm import Client
     >>> client = Client("pubavo1.wr.usgs.gov", 16022)
-    >>> response = client.get_availability('AV', 'KCG', channel='EHE')
+    >>> response = client.get_availability('AV', 'AKV', channel='BHE')
     >>> print(response)  # doctest: +SKIP
     [('AV',
-      'ACH',
+      'AKV',
       '--',
       'BHE',
-      UTCDateTime(2020, 4, 30, 12, 2, 27, 473000),
-      UTCDateTime(2020, 6, 29, 12, 2, 16, 899000)]
+      2021-12-30T14:36:15.761000Z,
+      2022-02-28T14:35:57.199000Z)]
     >>> t = response[0][4]
-    >>> st = client.get_waveforms('AV', 'KCG', '', 'EH*', t + 100, t + 130)
+    >>> st = client.get_waveforms('AV', 'AKV', '', 'BH*', t + 100, t + 130)
     >>> st.plot()  # doctest: +SKIP
 
     .. plot::
@@ -35,9 +35,9 @@ Basic Usage
         from obspy.clients.earthworm import Client
         from obspy import UTCDateTime
         client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
-        response = client.get_availability('AV', 'KCG', channel='EHE')
+        response = client.get_availability('AV', 'AKV', channel='BHE')
         t = response[0][4]
-        st = client.get_waveforms('AV', 'KCG', '', 'EH*', t + 100, t + 130)
+        st = client.get_waveforms('AV', 'AKV', '', 'BH*', t + 100, t + 130)
         st.plot()
 """
 from obspy.clients.earthworm.client import Client  # NOQA

--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -74,7 +74,7 @@ class Client(object):
 
         >>> from obspy.clients.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
-        >>> dt = UTCDateTime() - 10000  # now - 10000 seconds
+        >>> dt = UTCDateTime() - 15000  # now - 15000 seconds
         >>> st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
         >>> st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)
@@ -85,7 +85,7 @@ class Client(object):
             from obspy.clients.earthworm import Client
             from obspy import UTCDateTime
             client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
-            dt = UTCDateTime() - 10000  # now - 10000 seconds
+            dt = UTCDateTime() - 15000  # now - 15000 seconds
             st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
             st.plot()
             st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)

--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -74,7 +74,7 @@ class Client(object):
 
         >>> from obspy.clients.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
-        >>> dt = UTCDateTime() - 2000  # now - 2000 seconds
+        >>> dt = UTCDateTime() - 10000  # now - 10000 seconds
         >>> st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
         >>> st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)
@@ -85,7 +85,7 @@ class Client(object):
             from obspy.clients.earthworm import Client
             from obspy import UTCDateTime
             client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
-            dt = UTCDateTime() - 2000  # now - 2000 seconds
+            dt = UTCDateTime() - 10000  # now - 10000 seconds
             st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
             st.plot()
             st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)

--- a/obspy/clients/earthworm/client.py
+++ b/obspy/clients/earthworm/client.py
@@ -75,9 +75,9 @@ class Client(object):
         >>> from obspy.clients.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
         >>> dt = UTCDateTime() - 2000  # now - 2000 seconds
-        >>> st = client.get_waveforms('AV', 'ACH', '', 'BHE', dt, dt + 10)
+        >>> st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
-        >>> st = client.get_waveforms('AV', 'ACH', '', 'BH*', dt, dt + 10)
+        >>> st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)
         >>> st.plot()  # doctest: +SKIP
 
         .. plot::
@@ -86,9 +86,9 @@ class Client(object):
             from obspy import UTCDateTime
             client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
             dt = UTCDateTime() - 2000  # now - 2000 seconds
-            st = client.get_waveforms('AV', 'ACH', '', 'BHE', dt, dt + 10)
+            st = client.get_waveforms('AV', 'AKV', '', 'BHE', dt, dt + 10)
             st.plot()
-            st = client.get_waveforms('AV', 'ACH', '', 'BH*', dt, dt + 10)
+            st = client.get_waveforms('AV', 'AKV', '', 'BH*', dt, dt + 10)
             st.plot()
         """
         # replace wildcards in last char of channel and fetch all 3 components
@@ -154,8 +154,8 @@ class Client(object):
         >>> from obspy.clients.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022)
         >>> t = UTCDateTime() - 2000  # now - 2000 seconds
-        >>> client.save_waveforms('AV.ACH.--.BHE.mseed',
-        ...                       'AV', 'ACH', '', 'BHE',
+        >>> client.save_waveforms('AV.AKV.--.BHE.mseed',
+        ...                       'AV', 'AKV', '', 'BHE',
         ...                       t, t + 10, format='MSEED')  # doctest: +SKIP
         """
         st = self.get_waveforms(network, station, location, channel, starttime,
@@ -190,22 +190,22 @@ class Client(object):
         >>> from obspy.clients.earthworm import Client
         >>> client = Client("pubavo1.wr.usgs.gov", 16022, timeout=5)
         >>> response = client.get_availability(
-        ...     network="AV", station="ACH", channel="BH*")
+        ...     network="AV", station="AKV", channel="BH*")
         >>> print(response)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
         [('AV',
-          'ACH',
+          'AKV',
           '--',
           'BHE',
           UTCDateTime(...),
           UTCDateTime(...)),
          ('AV',
-          'ACH',
+          'AKV',
           '--',
           'BHN',
           UTCDateTime(...),
           UTCDateTime(...)),
          ('AV',
-          'ACH',
+          'AKV',
           '--',
           'BHZ',
           UTCDateTime(...),

--- a/obspy/clients/earthworm/tests/test_client.py
+++ b/obspy/clients/earthworm/tests/test_client.py
@@ -56,7 +56,7 @@ class TestEWClient:
         # example 1 -- 1 channel, cleanup
         kwargs = dict(
             network='AV',
-            station='ACH',
+            station='AKV',
             channel='BHE',
         )
         return self.try_get_stream(ew_client, kwargs)
@@ -66,7 +66,7 @@ class TestEWClient:
         """Return a stream fetched from the test ew client with no cleanup."""
         kwargs = dict(
             network='AV',
-            station='ACH',
+            station='AKV',
             channel='BHE',
             cleanup=False,
         )
@@ -77,7 +77,7 @@ class TestEWClient:
         """Return a stream fetched from the test ew client with wildcard."""
         kwargs = dict(
             network='AV',
-            station='ACH',
+            station='AKV',
             channel='BH?',
         )
         return self.try_get_stream(ew_client, kwargs)
@@ -96,7 +96,7 @@ class TestEWClient:
         assert trace.stats.endtime >= self.end - delta
         assert trace.stats.endtime <= self.end + delta
         assert trace.stats.network == 'AV'
-        assert trace.stats.station == 'ACH'
+        assert trace.stats.station == 'AKV'
         assert trace.stats.location in ('--', '')
         assert trace.stats.channel == 'BHE'
 
@@ -117,7 +117,7 @@ class TestEWClient:
         assert ew_stream[-1].stats.endtime <= self.end + delta
         for trace in ew_stream:
             assert trace.stats.network == 'AV'
-            assert trace.stats.station == 'ACH'
+            assert trace.stats.station == 'AKV'
             assert trace.stats.location in ('--', '')
             assert trace.stats.channel == 'BHE'
 
@@ -137,7 +137,7 @@ class TestEWClient:
             assert trace.stats.endtime >= self.end - delta
             assert trace.stats.endtime <= self.end + delta
             assert trace.stats.network == 'AV'
-            assert trace.stats.station == 'ACH'
+            assert trace.stats.station == 'AKV'
             assert trace.stats.location in ('--', '')
         assert stream[0].stats.channel == 'BHZ'
         assert stream[1].stats.channel == 'BHN'
@@ -155,7 +155,7 @@ class TestEWClient:
             ew_client.save_waveforms(
                 testfile,
                 'AV',
-                'ACH',
+                'AKV',
                 '--',
                 'BHE',
                 self.start,
@@ -172,7 +172,7 @@ class TestEWClient:
         assert trace.stats.endtime >= self.end - delta
         assert trace.stats.endtime <= self.end + delta
         assert trace.stats.network == 'AV'
-        assert trace.stats.station == 'ACH'
+        assert trace.stats.station == 'AKV'
         assert trace.stats.location in ('--', '')
         assert trace.stats.channel == 'BHE'
 
@@ -180,4 +180,4 @@ class TestEWClient:
     def test_availability(self, ew_client):
         data = ew_client.get_availability()
         seeds = ["%s.%s.%s.%s" % (d[0], d[1], d[2], d[3]) for d in data]
-        assert 'AV.ACH.--.BHZ' in seeds
+        assert 'AV.AKV.--.BHZ' in seeds

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -59,6 +59,7 @@ class CustomRedirectHandler(urllib_request.HTTPRedirectHandler):
     Custom redirection handler to also do it for POST requests which the
     standard library does not do by default.
     """
+
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         """
         Copied and modified from the standard library.
@@ -89,6 +90,7 @@ class NoRedirectionHandler(urllib_request.HTTPRedirectHandler):
     """
     Handler that does not direct!
     """
+
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         """
         Copied and modified from the standard library.
@@ -236,7 +238,6 @@ class Client(object):
                       .format(base_url)
                 raise ValueError(msg)
             url_subpath = URL_DEFAULT_SUBPATH
-
         # Make sure the base_url does not end with a slash.
         base_url = base_url.strip("/")
         # Catch invalid URLs to avoid confusing error messages
@@ -1451,7 +1452,6 @@ class Client(object):
         if "event" in services:
             urls.append(self._build_url("event", "catalogs"))
             urls.append(self._build_url("event", "contributors"))
-
         # Access cache if available.
         url_hash = frozenset(urls)
         if url_hash in self.__service_discovery_cache:
@@ -1502,7 +1502,6 @@ class Client(object):
             thread.start()
         for thread in threads:
             thread.join(15)
-
         self.services = {}
 
         # Collect the redirection exceptions to be able to raise nicer
@@ -1570,7 +1569,6 @@ class Client(object):
                    "be due to a temporary service outage or an invalid FDSN "
                    "service address." % self.base_url)
             raise FDSNNoServiceException(msg)
-
         # Cache.
         if self.debug is True:
             print("Storing discovered services in cache.")
@@ -1817,13 +1815,11 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
             print("-" * 70)
             print(data.decode())
             print("-" * 70)
-
     try:
         request = urllib_request.Request(url=url, headers=headers)
         # Request gzip encoding if desired.
         if use_gzip:
             request.add_header("Accept-encoding", "gzip")
-
         url_obj = opener.open(request, timeout=timeout, data=data)
     # Catch HTTP errors.
     except urllib_request.HTTPError as e:
@@ -1831,6 +1827,9 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
             msg = "HTTP error %i, reason %s, while downloading '%s': %s" % \
                   (e.code, str(e.reason), url, e.read())
             print(msg)
+        else:
+            # Without this line we will get unclosed sockets
+            e.read()
         return e.code, e
     except Exception as e:
         if debug is True:

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1393,27 +1393,24 @@ class ClientTestCase(unittest.TestCase):
 
         # The error will already be raised during the initialization in most
         # cases.
-        self.assertRaises(
-            FDSNRedirectException,
-            Client, "IRIS", service_mappings={
-                "station": "http://ds.iris.edu/files/redirect/307/station/1",
-                "dataselect":
-                    "http://ds.iris.edu/files/redirect/307/dataselect/1",
-                "event": "http://ds.iris.edu/files/redirect/307/event/1"},
-            user="nobody@iris.edu", password="anonymous",
-            user_agent=USER_AGENT)
-
-        # The force_redirect flag overwrites that behaviour.
-        c_auth = Client("IRIS", service_mappings={
-            "station":
-                "http://ds.iris.edu/files/redirect/307/station/1",
-            "dataselect":
-                "http://ds.iris.edu/files/redirect/307/dataselect/1",
-            "event":
-                "http://ds.iris.edu/files/redirect/307/event/1"},
-            user="nobody@iris.edu", password="anonymous",
-            user_agent=USER_AGENT, force_redirect=True)
-
+        service_mappings = {
+            "station": "http://ds.iris.edu/files/redirect/307/station/1",
+            "dataselect": "http://ds.iris.edu/files/redirect/307/dataselect/1",
+            "event": "http://ds.iris.edu/files/redirect/307/event/1"}
+        with warnings.catch_warnings():
+            # ignore warnings about unclosed sockets
+            # These occur when rasing the FDSNRedirectException, but
+            # I was not able to fix in the code
+            warnings.filterwarnings('ignore', 'unclosed')
+            self.assertRaises(
+                FDSNRedirectException,
+                Client, "IRIS", service_mappings=service_mappings,
+                user="nobody@iris.edu", password="anonymous",
+                user_agent=USER_AGENT)
+            # The force_redirect flag overwrites that behaviour.
+            c_auth = Client("IRIS", service_mappings=service_mappings,
+                            user="nobody@iris.edu", password="anonymous",
+                            user_agent=USER_AGENT, force_redirect=True)
         st = c_auth.get_waveforms(
             network="IU", station="ANMO", location="00", channel="BHZ",
             starttime=UTCDateTime("2010-02-27T06:30:00.000"),


### PR DESCRIPTION
Try to fix the remaining fails in network tests (earthworm). It's branched from #2981 and should be merged after this PR.

~~Some warnings about sockets in clients.fdsn module remain. One warning only occurs when initializing `Client('IRISPH5')`.~~