### PR TITLE
return `self` from st.merge(method=-1)

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -112,6 +112,7 @@ Wang, Yinzhi
 Wassermann, Joachim
 van Wijk, Kasper
 Williams, Mark C.
+Winder, Tom
 Winkelman, Andrew
 Zaccarelli, Riccardo
 Zad, Seyed Kasra Hosseini

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2008,7 +2008,7 @@ class Stream(object):
 
         self._cleanup(**kwargs)
         if method == -1:
-            return
+            return self
         # check sampling rates and dtypes
         self._merge_checks()
         # remember order of traces


### PR DESCRIPTION
Explicitly return the `Stream` object for `st.merge(method=-1)`

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Makes the behaviour of `st.merge()` consistent when using `method=-1`; previously the `Stream` object was not explicitly returned in this case.

### Why was it initiated?  Any relevant Issues?

fixes #3004

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
