### PR TITLE
Response removal prevented unneccessarily for response list type response in some cases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,12 @@ Changes:
      numpy 1.22 (see #2912, #2913)
    * fix iso8601 regex for issue #2868 to cope with day 360 properly
    * fix crash when resampling very short traces (see #2926)
+   * response list stages: do not raise an exception if response calculation
+     involves extrapolation outside of frequency range defined by the response
+     list stage but rather only show a warning. raising an exception is the
+     safe route but it also prevents valid calculations as it is up to the user
+     to make sure that signal spectrum is properly suppressed in those
+     frequency ranges outside of the valid response information (see #2988)
  - obspy.clients.fdsn:
    * introduce fine-grained FDSN client exceptions (see #2653, #2964)
    * support for "eventtype" parameter in get_events(), as specified in version

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1386,12 +1386,16 @@ class Response(ComparingObject):
 
                 if min_f < min_f_avail or max_f > max_f_avail:
                     msg = (
-                        "Cannot calculate the response as it contains a "
+                        "The response contains a "
                         "response list stage with frequencies only from "
                         "%.4f - %.4f Hz. You are requesting a response from "
-                        "%.4f - %.4f Hz.")
-                    raise ValueError(msg % (min_f_avail, max_f_avail, min_f,
-                                            max_f))
+                        "%.4f - %.4f Hz. The calculated response will contain "
+                        "extrapolation beyond the frequency band constrained "
+                        "by the response list stage. Please consider "
+                        "adjusting 'pre_filt' and/or 'water_level' during "
+                        "response removal accordingly.")
+                    warnings.warn(
+                        msg % (min_f_avail, max_f_avail, min_f, max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
                     f, amp, k=3)(frequencies)

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1378,12 +1378,6 @@ class Response(ComparingObject):
                 min_f_avail = min(f)
                 max_f_avail = max(f)
 
-                # Allow interpolation for at most two samples.
-                _d = np.abs(np.diff(f))
-                _d = _d[_d > 0].min() * 2
-                min_f_avail -= _d
-                max_f_avail += _d
-
                 if min_f < min_f_avail or max_f > max_f_avail:
                     msg = (
                         "The response contains a "

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -20,7 +20,9 @@ import scipy.interpolate
 
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
-    _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, Response)
+    _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, Response,
+    ResponseListResponseStage, ResponseListElement, InstrumentSensitivity)
+from obspy.core.util import CatchAndAssertWarnings
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
 from obspy.core.util.testing import WarningsCapture
@@ -207,29 +209,6 @@ class TestResponse:
         # but visually quite a bit better interpolation.
         np.testing.assert_allclose(amp, exp_amp, rtol=1E-3)
         np.testing.assert_allclose(phase, exp_ph, rtol=1E-3)
-
-    def test_response_list_raises_error_if_out_of_range(self):
-        """
-        If extrpolating a lot it should raise an error.
-        """
-        inv = read_inventory(os.path.join(self.data_dir, "IM_IL31__BHZ.xml"))
-
-        # The true sampling rate is 40 - this will thus request data that is
-        # too high frequent and thus cannot be extracted from the response
-        # list.
-        sampling_rate = 45.0
-        t_samp = 1.0 / sampling_rate
-        nfft = 100
-
-        msg = '' \
-            "Cannot calculate the response as it contains a response list " \
-            "stage with frequencies only from -0.0096 - 20.0096 Hz. You are " \
-            "requesting a response from 0.4500 - 22.5000 Hz."
-
-        with pytest.raises(ValueError, match=msg):
-            inv[0][0][0].response.get_evalresp_response(
-                t_samp=t_samp, nfft=nfft, output="VEL", start_stage=None,
-                end_stage=None)
 
     def test_response_with_no_units_in_stage_1(self):
         """
@@ -515,3 +494,27 @@ class TestResponse:
         np.testing.assert_allclose(
             resp.instrument_sensitivity.frequency,
             1.0)
+
+    def test_warning_response_list_extrapolation(self):
+        """
+        Tests that a warning message is shown when a response calculation
+        involving a response list stage includes (spline) extrapolation into
+        frequency ranges outside of the band defined by the response list stage
+        elements (frequency-amplitude-phase pairs).
+        """
+        # create some bogus response list stage for the test
+        elems = [
+            ResponseListElement(x, 1, 0) for x in (1, 2, 5, 10, 20, 40, 50)]
+        stage = ResponseListResponseStage(
+            1, 1, 10, "M/S", "M/S", response_list_elements=elems)
+        sens = InstrumentSensitivity(1, 10, "M/S", "M/S")
+        resp = Response(response_stages=[stage], instrument_sensitivity=sens)
+        msg = ("The response contains a response list stage with frequencies "
+               "only from 1.0000 - 50.0000 Hz. You are requesting a response "
+               "from 25.0000 - 100.0000 Hz. The calculated response will "
+               "contain extrapolation beyond the frequency band constrained "
+               "by the response list stage. Please consider adjusting "
+               "'pre_filt' and/or 'water_level' during response removal "
+               "accordingly.")
+        with CatchAndAssertWarnings(expected=[(UserWarning, msg)]):
+            resp.get_evalresp_response(0.005, 2**3)

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -224,7 +224,7 @@ class TestResponse:
         # files...
         assert r.response_stages[0].input_units == "M/S"
         assert r.response_stages[0].input_units_description == \
-               "Meters per second"
+            "Meters per second"
         assert r.response_stages[0].output_units == "V"
         assert r.response_stages[0].output_units_description == "VOLTS"
 

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -182,9 +182,10 @@ class TestResponse:
         t_samp = 1.0 / sampling_rate
         nfft = 100
 
-        cpx_response, freq = inv[0][0][0].response.get_evalresp_response(
-            t_samp=t_samp, nfft=nfft, output="VEL", start_stage=None,
-            end_stage=None)
+        with WarningsCapture():
+            cpx_response, freq = inv[0][0][0].response.get_evalresp_response(
+                t_samp=t_samp, nfft=nfft, output="VEL", start_stage=None,
+                end_stage=None)
 
         # Cut of the zero frequency.
         cpx_response = cpx_response[1:]


### PR DESCRIPTION
<!--

**GitHub should mainly be used for bug reports and code developments/discussions. For generic questions, please use either the [[obspy-users] mailing list](http://lists.swapbytes.de/mailman/listinfo/obspy-users) (for scientific questions to the general ObsPy community) or our [gitter chat](https://gitter.im/obspy/obspy) (for technical questions and direct contact to the developers).**

Before submitting an Issue, please review the [Issue Guidelines](https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-an-issue).

-->

In the case of Responses containing (or well, sometimes solely built of) a Response list type stage (Frequency-Amplitude-Phase tuples), we are forcefully raising an exception if an extrapolation would have to occur, i.e. the given response list stage does not span the full range of frequencies needed for response removal.

https://github.com/obspy/obspy/blob/38d86b1b61a9875350b9fde11fb8c9aa3410184c/obspy/core/inventory/response.py#L1387-L1394

```python
File .../lib/python3.9/site-packages/obspy/core/inventory/response.py:1385, in Response._call_eval_resp_for_frequencies(self, frequencies, output, start_stage, end_stage, hide_sensitivity_mismatch_warning)
   1379 if min_f < min_f_avail or max_f > max_f_avail:
   1380     msg = (
   1381         "Cannot calculate the response as it contains a "
   1382         "response list stage with frequencies only from "
   1383         "%.4f - %.4f Hz. You are requesting a response from "
   1384         "%.4f - %.4f Hz.")
-> 1385     raise ValueError(msg % (min_f_avail, max_f_avail, min_f,
   1386                             max_f))
   1388 amp = scipy.interpolate.InterpolatedUnivariateSpline(
   1389     f, amp, k=3)(frequencies)
   1390 phase = scipy.interpolate.InterpolatedUnivariateSpline(
   1391     f, phase, k=3)(frequencies)

ValueError: Cannot calculate the response as it contains a response list stage with frequencies only from 0.1000 - 80.4000 Hz. You are requesting a response from 0.0038 - 125.0000 Hz.
```

When this was implemented this was probably chosen just as the easiest and safest route possible, however it prevents response removal in some very valid scenarios. Even if the response list stage does not cover all frequencies technically needed, it may well cover the frequency range of interest (a lot of times a bandpass is applied later on anyway) and in any case it is very easy to ensure there are no problems by using `pre_filt`  (or `water_level`) to suppress out-of-range frequencies.

I think we should change this exception into a warning. If we want, we could even make the warning conditional and check in the high level routines (probably just need it in `Trace.remove_response`) if `water_level`/`pre_filt` seem sufficient to prevent problems.


This is a (simplified) example response to illustrate the issue, green box with red borders is the frequency range defined in the response list stage:

![resp_list](https://user-images.githubusercontent.com/1842780/155506016-7e3874a4-a241-477d-a89a-ce8e77e64132.png)

When interested in e.g. 1-20 Hz, there really isn't a problem why the response shouldn't be usable, a simple `pre_filt=(0.1, 0.3, 50, 80)` can make sure there are no problems in the deconvolution.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.