### PR TITLE
update conda env files for ci tests

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -18,9 +18,7 @@ dependencies:
   - pyshp
   # tests
   - packaging
-  - pip
-  - pip:
-    - pytest-json-report
   - pyproj
   - pytest
   - pytest-cov
+  - pytest-json-report >= 1.4

--- a/.github/test_mindep_conda_env.yml
+++ b/.github/test_mindep_conda_env.yml
@@ -13,8 +13,6 @@ dependencies:
   - setuptools
   - sqlalchemy
   # tests
-  - pip
-  - pip:
-    - pytest-json-report
   - pytest
   - pytest-cov
+  - pytest-json-report >= 1.4


### PR DESCRIPTION
Now that the feedstock for pytest-json-report was updated it can be installed from conda-forge for the ci tests.