### PR TITLE
trigger: try to fix a bug when characteristic function does not fall below off threshold at end of trace

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,10 @@ Changes:
  - obspy.io.wav:
    * fix writing of wav files with rescale=True and default width=None
      (see #3029)
+ - obspy.signal:
+   * trigger_onset(): fix a bug when trigger off threshold is higher than
+     trigger on threshold and a trigger is active at the end of the
+     characteristic function (see #2891, #3013)
  - obspy.taup:
    * Fix cycling through colors in ray path plots, now also fixes cartesian
      plot version (see #2470, #2478, #3041)

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -213,6 +213,22 @@ class TriggerTestCase(unittest.TestCase):
             plt.legend()
             plt.show()
 
+    def test_trigger_onset_issue_2891(self):
+        """
+        Regression test for issue 2891
+
+        This used to raise an error if a trigger was activated near the end of
+        the trace, and all sample values after that trigger on threshold are
+        above the designated off threshold. So basically this can only happen
+        if the on threshold is below the off threshold, which is kind of
+        unusual, but we fixed it nevertheless, since people can run into this
+        playing around with different threshold settings
+        """
+        tr = read(os.path.join(
+            self.path, 'BW.UH1._.EHZ.D.2010.147.a.slist.gz'))[0]
+        cft = recursive_sta_lta(tr.data, 5, 30)
+        trigger_onset(cft, 2.5, 3.2)
+
     def test_coincidence_trigger(self):
         """
         Test network coincidence trigger.

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -348,6 +348,10 @@ def trigger_onset(charfct, thres1, thres2, max_len=9e99, max_len_delete=False):
     else:
         # include it
         of.extend([ind2[-1]])
+
+    # add last sample to ensure trigger gets switched off if ctf does not fall
+    # below off-threshold before hitting the end
+    of.append(len(charfct))
     #
     pick = []
     while on[-1] > of[0]:


### PR DESCRIPTION


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Tries to fix #2891

### Why was it initiated?  Any relevant Issues?

See #2891, trigger routine runs into an error while evaluating the event triggers if trigger is active but does not fall below off-threshold before hitting the end of the trace


### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
