### PR TITLE
Cartopy multiple plots

### DIFF
--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -75,12 +75,11 @@ def _plot_cartopy_into_axes(
     """
 
     fig = ax.figure
-    if bmap is None:
+    fig.bmap = ax
 
+    if not isinstance(getattr(ax, 'projection'), ccrs.Projection):
         if projection in ['global', 'ortho']:
-            bmap = ax
-        elif projection == 'ortho':
-            bmap = ax
+            pass
         elif projection == 'local':
             if min(lons) < -150 and max(lons) > 150:
                 max_lons = max(np.array(lons) % 360)
@@ -90,13 +89,12 @@ def _plot_cartopy_into_axes(
                 min_lons = min(lons)
 
             ax.set_extent([min_lons, max_lons, min(lats), max(lats)])
-            bmap = ax
 
         else:
             msg = "Projection '%s' not supported." % projection
             raise ValueError(msg)
-        bmap.gridlines()
-        bmap.coastlines()
+        ax.gridlines()
+        ax.coastlines()
         # draw coast lines, country boundaries, fill continents.
         # ax.set_facecolor(water_fill_color)
         # newer matplotlib errors out if called with empty coastline data (no
@@ -111,7 +109,6 @@ def _plot_cartopy_into_axes(
         # draw lat/lon grid lines every 30 degrees.
         # bmap.drawmeridians(np.arange(-180, 180, 30))
         # bmap.drawparallels(np.arange(-90, 90, 30))
-    fig.bmap = bmap
     ax.stock_img()
     ax.gridlines()
     ax.coastlines()
@@ -154,12 +151,12 @@ def _plot_cartopy_into_axes(
             x_ = np.array(x)[nan_points]
             y_ = np.array(y)[nan_points]
             size_ = np.array(size)[nan_points]
-            bmap.scatter(x_, y_, marker=marker, s=size_, c="0.3",
-                         zorder=10, cmap=None, transform=ccrs.Geodetic())
+            ax.scatter(x_, y_, marker=marker, s=size_, c="0.3",
+                       zorder=10, cmap=None, transform=ccrs.Geodetic())
     # Had to change transform to ccrs.PlateCarree, see:
     # https://stackoverflow.com/a/13657749/3645626
-    scatter = bmap.scatter(x, y, marker=marker, s=size, c=color, zorder=10,
-                           cmap=colormap, transform=ccrs.PlateCarree(),)
+    scatter = ax.scatter(x, y, marker=marker, s=size, c=color, zorder=10,
+                         cmap=colormap, transform=ccrs.PlateCarree(),)
 
     if title:
         ax.set_title(title)
@@ -171,7 +168,8 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
                  resolution='110m', continent_fill_color='0.8',
                  water_fill_color='1.0', colormap=None, colorbar=None,
                  marker="o", title=None, colorbar_ticklabel_format=None,
-                 show=True, proj_kwargs=None, **kwargs):  # @UnusedVariable
+                 show=True, proj_kwargs=None, fig=None,
+                 **kwargs):  # @UnusedVariable
     """
     Creates a Cartopy plot with a data point scatter plot.
 
@@ -256,144 +254,150 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
     else:
         datetimeplot = False
 
-    fig = plt.figure()
+    if fig is None:
+        fig = plt.figure()
 
-    # The colorbar should only be plotted if more then one event is
-    # present.
-    if colorbar is not None:
-        show_colorbar = colorbar
-    else:
-        if len(lons) > 1 and hasattr(color, "__len__") and \
-                not isinstance(color, str):
-            show_colorbar = True
+        # The colorbar should only be plotted if more then one event is
+        # present.
+        if colorbar is not None:
+            show_colorbar = colorbar
         else:
-            show_colorbar = False
+            if len(lons) > 1 and hasattr(color, "__len__") and \
+                    not isinstance(color, str):
+                show_colorbar = True
+            else:
+                show_colorbar = False
 
-    if projection == "local":
-        ax_x0, ax_width = 0.10, 0.80
-    elif projection == "global":
-        ax_x0, ax_width = 0.01, 0.98
-    else:
-        ax_x0, ax_width = 0.05, 0.90
-
-    proj_kwargs = proj_kwargs or {}
-    if projection == 'global':
-        proj_kwargs['central_longitude'] = np.mean(lons)
-        proj = ccrs.Mollweide(**proj_kwargs)
-    elif projection == 'ortho':
-        proj_kwargs['central_latitude'] = np.mean(lats)
-        proj_kwargs['central_longitude'] = mean_longitude(lons)
-        proj = ccrs.Orthographic(**proj_kwargs)
-    elif projection == 'local':
-        if min(lons) < -150 and max(lons) > 150:
-            max_lons = max(np.array(lons) % 360)
-            min_lons = min(np.array(lons) % 360)
-        else:
-            max_lons = max(lons)
-            min_lons = min(lons)
-        lat_0 = max(lats) / 2. + min(lats) / 2.
-        lon_0 = max_lons / 2. + min_lons / 2.
-        if lon_0 > 180:
-            lon_0 -= 360
-        deg2m_lat = 2 * np.pi * 6371 * 1000 / 360
-        deg2m_lon = deg2m_lat * np.cos(lat_0 / 180 * np.pi)
-        if len(lats) > 1:
-            height = (max(lats) - min(lats)) * deg2m_lat
-            width = (max_lons - min_lons) * deg2m_lon
-            margin = 0.2 * (width + height)
-            height += margin
-            width += margin
-        else:
-            height = 2.0 * deg2m_lat
-            width = 5.0 * deg2m_lon
-        # Do intelligent aspect calculation for local projection
-        # adjust to figure dimensions
-        w, h = fig.get_size_inches()
-        aspect = w / h
-        if show_colorbar:
-            aspect *= 1.2
-        if width / height < aspect:
-            width = height * aspect
-        else:
-            height = width / aspect
-
-        proj_kwargs['central_latitude'] = lat_0
-        proj_kwargs['central_longitude'] = lon_0
-        proj_kwargs['standard_parallels'] = [lat_0, lat_0]
-        proj = ccrs.AlbersEqualArea(**proj_kwargs)
-
-    # User-supplied projection.
-    elif isinstance(projection, type):
-        if 'central_longitude' in proj_kwargs:
-            if proj_kwargs['central_longitude'] == 'auto':
-                proj_kwargs['central_longitude'] = mean_longitude(lons)
-        if 'central_latitude' in proj_kwargs:
-            if proj_kwargs['central_latitude'] == 'auto':
-                proj_kwargs['central_latitude'] = np.mean(lats)
-        if 'pole_longitude' in proj_kwargs:
-            if proj_kwargs['pole_longitude'] == 'auto':
-                proj_kwargs['pole_longitude'] = np.mean(lons)
-        if 'pole_latitude' in proj_kwargs:
-            if proj_kwargs['pole_latitude'] == 'auto':
-                proj_kwargs['pole_latitude'] = np.mean(lats)
-
-        proj = projection(**proj_kwargs)
-
-    else:
-        msg = "Projection '%s' not supported." % projection
-        raise ValueError(msg)
-
-    if show_colorbar:
-        map_ax = fig.add_axes([ax_x0, 0.13, ax_width, 0.77], projection=proj)
-        cm_ax = fig.add_axes([ax_x0, 0.05, ax_width, 0.05])
-        plt.sca(map_ax)
-    else:
-        ax_y0, ax_height = 0.05, 0.85
         if projection == "local":
-            ax_y0 += 0.05
-            ax_height -= 0.05
-        map_ax = fig.add_axes([ax_x0, ax_y0, ax_width, ax_height],
-                              projection=proj)
+            ax_x0, ax_width = 0.10, 0.80
+        elif projection == "global":
+            ax_x0, ax_width = 0.01, 0.98
+        else:
+            ax_x0, ax_width = 0.05, 0.90
 
-    if projection == 'local':
-        x0, y0 = proj.transform_point(lon_0, lat_0, proj.as_geodetic())
-        map_ax.set_xlim(x0 - width / 2, x0 + width / 2)
-        map_ax.set_ylim(y0 - height / 2, y0 + height / 2)
+        proj_kwargs = proj_kwargs or {}
+        if projection == 'global':
+            proj_kwargs['central_longitude'] = np.mean(lons)
+            proj = ccrs.Mollweide(**proj_kwargs)
+        elif projection == 'ortho':
+            proj_kwargs['central_latitude'] = np.mean(lats)
+            proj_kwargs['central_longitude'] = mean_longitude(lons)
+            proj = ccrs.Orthographic(**proj_kwargs)
+        elif projection == 'local':
+            if min(lons) < -150 and max(lons) > 150:
+                max_lons = max(np.array(lons) % 360)
+                min_lons = min(np.array(lons) % 360)
+            else:
+                max_lons = max(lons)
+                min_lons = min(lons)
+            lat_0 = max(lats) / 2. + min(lats) / 2.
+            lon_0 = max_lons / 2. + min_lons / 2.
+            if lon_0 > 180:
+                lon_0 -= 360
+            deg2m_lat = 2 * np.pi * 6371 * 1000 / 360
+            deg2m_lon = deg2m_lat * np.cos(lat_0 / 180 * np.pi)
+            if len(lats) > 1:
+                height = (max(lats) - min(lats)) * deg2m_lat
+                width = (max_lons - min_lons) * deg2m_lon
+                margin = 0.2 * (width + height)
+                height += margin
+                width += margin
+            else:
+                height = 2.0 * deg2m_lat
+                width = 5.0 * deg2m_lon
+            # Do intelligent aspect calculation for local projection
+            # adjust to figure dimensions
+            w, h = fig.get_size_inches()
+            aspect = w / h
+            if show_colorbar:
+                aspect *= 1.2
+            if width / height < aspect:
+                width = height * aspect
+            else:
+                height = width / aspect
+
+            proj_kwargs['central_latitude'] = lat_0
+            proj_kwargs['central_longitude'] = lon_0
+            proj_kwargs['standard_parallels'] = [lat_0, lat_0]
+            proj = ccrs.AlbersEqualArea(**proj_kwargs)
+
+        # User-supplied projection.
+        elif isinstance(projection, type):
+            if 'central_longitude' in proj_kwargs:
+                if proj_kwargs['central_longitude'] == 'auto':
+                    proj_kwargs['central_longitude'] = mean_longitude(lons)
+            if 'central_latitude' in proj_kwargs:
+                if proj_kwargs['central_latitude'] == 'auto':
+                    proj_kwargs['central_latitude'] = np.mean(lats)
+            if 'pole_longitude' in proj_kwargs:
+                if proj_kwargs['pole_longitude'] == 'auto':
+                    proj_kwargs['pole_longitude'] = np.mean(lons)
+            if 'pole_latitude' in proj_kwargs:
+                if proj_kwargs['pole_latitude'] == 'auto':
+                    proj_kwargs['pole_latitude'] = np.mean(lats)
+
+            proj = projection(**proj_kwargs)
+
+        else:
+            msg = "Projection '%s' not supported." % projection
+            raise ValueError(msg)
+
+        if show_colorbar:
+            map_ax = fig.add_axes([ax_x0, 0.13, ax_width, 0.77],
+                                  projection=proj)
+            cm_ax = fig.add_axes([ax_x0, 0.05, ax_width, 0.05])
+            plt.sca(map_ax)
+        else:
+            ax_y0, ax_height = 0.05, 0.85
+            if projection == "local":
+                ax_y0 += 0.05
+                ax_height -= 0.05
+            map_ax = fig.add_axes([ax_x0, ax_y0, ax_width, ax_height],
+                                  projection=proj)
+
+        if projection == 'local':
+            x0, y0 = proj.transform_point(lon_0, lat_0, proj.as_geodetic())
+            map_ax.set_xlim(x0 - width / 2, x0 + width / 2)
+            map_ax.set_ylim(y0 - height / 2, y0 + height / 2)
+        else:
+            map_ax.set_global()
+
+        # Pick features at specified resolution.
+        resolution = _CARTOPY_RESOLUTIONS[resolution]
+        try:
+            borders, land, ocean = _CARTOPY_FEATURES[resolution]
+        except KeyError:
+            borders = cfeature.NaturalEarthFeature(
+                cfeature.BORDERS.category, cfeature.BORDERS.name, resolution,
+                edgecolor='none', facecolor='none')
+            land = cfeature.NaturalEarthFeature(
+                cfeature.LAND.category, cfeature.LAND.name, resolution,
+                edgecolor='face', facecolor='none')
+            ocean = cfeature.NaturalEarthFeature(
+                cfeature.OCEAN.category, cfeature.OCEAN.name, resolution,
+                edgecolor='face', facecolor='none')
+            _CARTOPY_FEATURES[resolution] = (borders, land, ocean)
+
+        # Draw coast lines, country boundaries, fill continents.
+        map_ax.set_facecolor(water_fill_color)
+        map_ax.add_feature(ocean, facecolor=water_fill_color)
+        map_ax.add_feature(land, facecolor=continent_fill_color)
+        map_ax.add_feature(borders, edgecolor='0.75')
+        map_ax.coastlines(resolution=resolution, color='0.4')
+
+        # Draw grid lines - TODO: draw_labels=True doesn't work yet.
+        if projection == 'local':
+            map_ax.gridlines()
+        else:
+            # Draw lat/lon grid lines every 30 degrees.
+            map_ax.gridlines(xlocs=range(-180, 181, 30),
+                             ylocs=range(-90, 91, 30))
+
+        fig.bmap = map_ax
+
     else:
-        map_ax.set_global()
-
-    # Pick features at specified resolution.
-    resolution = _CARTOPY_RESOLUTIONS[resolution]
-    try:
-        borders, land, ocean = _CARTOPY_FEATURES[resolution]
-    except KeyError:
-        borders = cfeature.NaturalEarthFeature(cfeature.BORDERS.category,
-                                               cfeature.BORDERS.name,
-                                               resolution,
-                                               edgecolor='none',
-                                               facecolor='none')
-        land = cfeature.NaturalEarthFeature(cfeature.LAND.category,
-                                            cfeature.LAND.name, resolution,
-                                            edgecolor='face', facecolor='none')
-        ocean = cfeature.NaturalEarthFeature(cfeature.OCEAN.category,
-                                             cfeature.OCEAN.name, resolution,
-                                             edgecolor='face',
-                                             facecolor='none')
-        _CARTOPY_FEATURES[resolution] = (borders, land, ocean)
-
-    # Draw coast lines, country boundaries, fill continents.
-    map_ax.set_facecolor(water_fill_color)
-    map_ax.add_feature(ocean, facecolor=water_fill_color)
-    map_ax.add_feature(land, facecolor=continent_fill_color)
-    map_ax.add_feature(borders, edgecolor='0.75')
-    map_ax.coastlines(resolution=resolution, color='0.4')
-
-    # Draw grid lines - TODO: draw_labels=True doesn't work yet.
-    if projection == 'local':
-        map_ax.gridlines()
-    else:
-        # Draw lat/lon grid lines every 30 degrees.
-        map_ax.gridlines(xlocs=range(-180, 181, 30), ylocs=range(-90, 91, 30))
+        map_ax = fig.bmap
+        show_colorbar = False
 
     # Plot labels
     if labels and len(lons) > 0:

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -34,17 +34,6 @@ if not HAS_CARTOPY:
     warnings.warn(msg)
 
 
-_BASEMAP_RESOLUTIONS = {
-    '110m': 'l',
-    '50m': 'i',
-    '10m': 'f',
-    'c': 'c',
-    'l': 'l',
-    'i': 'i',
-    'h': 'h',
-    'f': 'f',
-}
-
 _CARTOPY_RESOLUTIONS = {
     'c': '110m',
     'l': '110m',


### PR DESCRIPTION
### What does this PR do?

Makes it possible to do multiple map plots in the same axes with cartopy, like we used to be able to with basemap before. See e.g. last plot code in [1.3.0 docs for Inventory.plot()](https://docs.obspy.org/archive/1.3.0/packages/autogen/obspy.core.inventory.inventory.Inventory.plot.html) which should plot in one figure but shows two figures.

Should be able to do this in maintenance branch without disrupting anything I think.

### Why was it initiated?  Any relevant Issues?

We lost that functionality when dropping basemap, see #2680 and #2961 

Work in progress, we should get #2985 done before this one.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
