### PR TITLE
expanded channel information at station level 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ master
 ======
 
 Changes:
+ - obspy.core:
+   * Improved expanded channel information in string representation of Station,
+     e.g. when displaying station in IPython shell (see #3024)
  - obspy.db:
    * submodule removed completely, since mostly being used in discontinued
      seishub server (see #2994)

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -5,6 +5,7 @@ Ammon, Charles J.
 Antunes, Emanuel
 Armbruster, Daniel
 Arnarsson, Ólafur St.
+Assink, Jelle
 Bagagli, Matteo
 Bank, Markus
 Barsch, Robert
@@ -84,6 +85,7 @@ Nof, Ran Novitsky
 Panning, Mark P.
 Parker, Tom
 Pestourie, Romain
+Pickle, Robert
 Pourpoint, Maeva
 Rapagnani, Giovanni
 Reyes, Celso

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -81,9 +81,9 @@ Station RJOB (Jochberg, Bavaria, BW-Net)
     Channel Count: None/None (Selected/Total)
     2007-12-17T00:00:00.000000Z -
     Access: None
-    Latitude: 47.74, Longitude: 12.80, Elevation: 860.0 m
+    Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
     Available Channels:
-        RJOB..EHZ, RJOB..EHN, RJOB..EHE
+      ..EH[ZNE] 200 Hz 2007-12-17 to None
 
 >>> cha = sta[0]
 >>> print(cha)  # doctest: +NORMALIZE_WHITESPACE

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -90,7 +90,7 @@ Station RJOB (Jochberg, Bavaria, BW-Net)
 >>> print(cha)  # doctest: +NORMALIZE_WHITESPACE
 Channel 'EHZ', Location ''
    Time range: 2007-12-17T00:00:00.000000Z - --
-   Latitude: 47.74, Longitude: 12.80, Elevation: 860.0 m, Local Depth: 0.0 m
+   Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m, Local Depth: 0.0 m
    Azimuth: 0.00 degrees from north, clockwise
    Dip: -90.00 degrees down from horizontal
    Channel types: TRIGGERED, GEOPHYSICAL

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -83,7 +83,8 @@ Station RJOB (Jochberg, Bavaria, BW-Net)
     Access: None
     Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
     Available Channels:
-      ..EH[ZNE] 200 Hz 2007-12-17 to None
+     ..EH[ZNE]   200.0 Hz  2007-12-17 to None
+
 
 >>> cha = sta[0]
 >>> print(cha)  # doctest: +NORMALIZE_WHITESPACE

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -89,14 +89,14 @@ Station RJOB (Jochberg, Bavaria, BW-Net)
 >>> cha = sta[0]
 >>> print(cha)  # doctest: +NORMALIZE_WHITESPACE
 Channel 'EHZ', Location ''
-   Time range: 2007-12-17T00:00:00.000000Z - --
-   Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m, Local Depth: 0.0 m
-   Azimuth: 0.00 degrees from north, clockwise
-   Dip: -90.00 degrees down from horizontal
-   Channel types: TRIGGERED, GEOPHYSICAL
-   Sampling Rate: 200.00 Hz
-   Sensor (Description): Streckeisen STS-2/N seismometer (None)
-   Response information available
+    Time range: 2007-12-17T00:00:00.000000Z - --
+    Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m, Local Depth: 0.0 m
+    Azimuth: 0.00 degrees from north, clockwise
+    Dip: -90.00 degrees down from horizontal
+    Channel types: TRIGGERED, GEOPHYSICAL
+    Sampling Rate: 200.00 Hz
+    Sensor (Description): Streckeisen STS-2/N seismometer (None)
+    Response information available
 
 >>> print(cha.response)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
 Channel Response

--- a/obspy/core/inventory/channel.py
+++ b/obspy/core/inventory/channel.py
@@ -219,7 +219,7 @@ class Channel(BaseNode):
             "Channel '{id}', Location '{location}' {description}\n"
             "{availability}"
             "\tTime range: {start_date} - {end_date}\n"
-            "\tLatitude: {latitude:.2f}, Longitude: {longitude:.2f}, "
+            "\tLatitude: {latitude:.4f}, Longitude: {longitude:.4f}, "
             "Elevation: {elevation:.1f} m, Local Depth: {depth:.1f} m\n"
             "{azimuth}"
             "{dip}"

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -21,8 +21,7 @@ from obspy.core.util.obspy_types import (ObsPyException, ZeroSamplingRate,
 from obspy.geodetics import inside_geobounds
 
 from .util import (BaseNode, Equipment, Operator, Distance, Latitude,
-                   Longitude, _unified_content_strings, _textwrap, Site,
-                  _unified_content_strings_expanded)
+                   Longitude, Site, _unified_content_strings_expanded)
 
 
 class Station(BaseNode):
@@ -181,7 +180,7 @@ class Station(BaseNode):
             historical_code="historical Code: %s " % self.historical_code if
             self.historical_code else "")
         ret += "\tAvailable Channels:\n"
-        #ret += "\n".join(_textwrap(
+        # ret += "\n".join(_textwrap(
         #    ", ".join(_unified_content_strings(contents["channels"])),
         #    initial_indent="\t\t", subsequent_indent="\t\t",
         #    expand_tabs=False))

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -180,10 +180,6 @@ class Station(BaseNode):
             historical_code="historical Code: %s " % self.historical_code if
             self.historical_code else "")
         ret += "\tAvailable Channels:\n"
-        # ret += "\n".join(_textwrap(
-        #    ", ".join(_unified_content_strings(contents["channels"])),
-        #    initial_indent="\t\t", subsequent_indent="\t\t",
-        #    expand_tabs=False))
         for ele in _unified_content_strings_expanded(self.channels):
             ret += "\t%s\n" % ele
         return ret

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -380,8 +380,8 @@ class Station(BaseNode):
             Access: None
             Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
             Available Channels:
-              ..BH[Z] 20 Hz 2006-12-16 to None
-              ..LH[Z]  1 Hz 2006-12-16 to None
+             ..BHZ        20.0 Hz  2006-12-16 to None
+             ..LHZ         1.0 Hz  2006-12-16 to None            
 
         The `location` and `channel` selection criteria  may also contain UNIX
         style wildcards (e.g. ``*``, ``?``, ...; see

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -378,9 +378,10 @@ class Station(BaseNode):
             Channel Count: None/None (Selected/Total)
             2006-12-16T00:00:00.000000Z -
             Access: None
-            Latitude: 48.16, Longitude: 11.28, Elevation: 565.0 m
+            Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
             Available Channels:
-                FUR..BHZ, FUR..LHZ
+              ..BH[Z] 20 Hz 2006-12-16 to None
+              ..LH[Z]  1 Hz 2006-12-16 to None
 
         The `location` and `channel` selection criteria  may also contain UNIX
         style wildcards (e.g. ``*``, ``?``, ...; see

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -381,7 +381,7 @@ class Station(BaseNode):
             Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
             Available Channels:
              ..BHZ        20.0 Hz  2006-12-16 to None
-             ..LHZ         1.0 Hz  2006-12-16 to None            
+             ..LHZ         1.0 Hz  2006-12-16 to None
 
         The `location` and `channel` selection criteria  may also contain UNIX
         style wildcards (e.g. ``*``, ``?``, ...; see

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -21,7 +21,8 @@ from obspy.core.util.obspy_types import (ObsPyException, ZeroSamplingRate,
 from obspy.geodetics import inside_geobounds
 
 from .util import (BaseNode, Equipment, Operator, Distance, Latitude,
-                   Longitude, _unified_content_strings, _textwrap, Site)
+                   Longitude, _unified_content_strings, _textwrap, Site,
+                  _unified_content_strings_expanded)
 
 
 class Station(BaseNode):
@@ -164,7 +165,7 @@ class Station(BaseNode):
                "\tChannel Count: {selected}/{total} (Selected/Total)\n"
                "\t{start_date} - {end_date}\n"
                "\tAccess: {restricted} {alternate_code}{historical_code}\n"
-               "\tLatitude: {lat:.2f}, Longitude: {lng:.2f}, "
+               "\tLatitude: {lat:.4f}, Longitude: {lng:.4f}, "
                "Elevation: {elevation:.1f} m\n")
         ret = ret.format(
             station_name=contents["stations"][0],
@@ -180,10 +181,12 @@ class Station(BaseNode):
             historical_code="historical Code: %s " % self.historical_code if
             self.historical_code else "")
         ret += "\tAvailable Channels:\n"
-        ret += "\n".join(_textwrap(
-            ", ".join(_unified_content_strings(contents["channels"])),
-            initial_indent="\t\t", subsequent_indent="\t\t",
-            expand_tabs=False))
+        #ret += "\n".join(_textwrap(
+        #    ", ".join(_unified_content_strings(contents["channels"])),
+        #    initial_indent="\t\t", subsequent_indent="\t\t",
+        #    expand_tabs=False))
+        for ele in _unified_content_strings_expanded(self.channels):
+            ret += "\t%s\n" % ele
         return ret
 
     def _repr_pretty_(self, p, cycle):

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -965,7 +965,7 @@ def _unified_content_strings(contents):
 
 def _unified_content_strings_expanded(contents):
     contents2 = [["." + item.location_code, item.code,
-                  item.sample_rate, item.start_date, item.end_date, 
+                  item.sample_rate, item.start_date, item.end_date,
                   item.depth]
                  for item in contents]
 
@@ -980,12 +980,12 @@ def _unified_content_strings_expanded(contents):
 
     contents3 = []
     for u in uniques:
-        c = [e for e in contents2 if \
-            [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
+        c = [e for e in contents2 if
+                [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
         test = [[e[0], e[2], e[3], e[4], e[5]] for e in c]
         if all(test[0] == x for x in test) and len(test) > 1:
             mergedch = u[1] + '[' \
-                + ''.join(map(str,[e[1][-1] for e in c])) + ']'
+                + ''.join(map(str, [e[1][-1] for e in c])) + ']'
             c[0][1] = mergedch
         contents3.append(c[0])
 
@@ -1000,15 +1000,15 @@ def _unified_content_strings_expanded(contents):
     # if wanted to add local depth (when relevant)
     items = []
     for item in contents3:
-        if item[5] > 0:
-            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}" \
-                " to {end: <.10s}  Depth {ldepth: <.1f} m".format(l=item[0],
-                    c=item[1], sr=item[2], start=str(item[3]), 
-                    end=str(item[4]), ldepth=item[5]))
+        if item[5] != 0:
+            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
+                    " to {end: <.10s}  Depth {ldepth: <.1f} m"
+                    .format(l=item[0],c=item[1], sr=item[2],
+                        start=str(item[3]), end=str(item[4]), ldepth=item[5]))
         else:
-            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}" \
-                " to {end: <.10s}".format(l=item[0], c=item[1],
-                    sr=item[2], start=str(item[3]), end=str(item[4])))
+            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
+                    " to {end: <.10s}".format(l=item[0], c=item[1],
+                        sr=item[2], start=str(item[3]), end=str(item[4])))
 
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -969,7 +969,7 @@ def _unified_content_strings_expanded(contents):
                   item.depth]
                  for item in contents]
 
-    # sorting this to keep the channels Z-N-E
+    # sorts by sample rate, startdate, and channel code (ZNE321)
     contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
                        reverse=True)
 
@@ -992,12 +992,6 @@ def _unified_content_strings_expanded(contents):
     contents3 = sorted(contents3, key=lambda x: (x[2], x[3], x[5]),
                        reverse=True)
 
-    # now work out formatting (easy way)
-    # items = ["{l: >7s}.{c: <6s}{sr: 6.1f} Hz  {start: <.10s} to {end: <.10s}"
-    #          .format(l=item[0], c=item[1], sr=item[2],
-    #             start=str(item[3]), end=str(item[4])) for item in contents3]
-
-    # if wanted to add local depth (when relevant)
     items = []
     for item in contents3:
         if item[5] != 0:

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -962,15 +962,16 @@ def _unified_content_strings(contents):
              for item, count in contents_counts]
     return items
 
+
 def _unified_content_strings_expanded(contents):
-    contents2 = [["."+item.location_code,item.code,item.sample_rate,
-                  item.start_date,item.end_date]
-                  for item in contents]
-    contents2 = sorted(contents2, key = lambda x:(x[2],x[1],x[3]),
+    contents2 = [["." + item.location_code, item.code,
+                item.sample_rate, item.start_date, item.end_date]
+                for item in contents]
+    contents2 = sorted(contents2, key = lambda x:(x[2], x[1], x[3]),
                 reverse=True)
     items = ["{l:>7s}.{c:6s}{sr:6.2f} Hz   {start:.10s} to {end:.10s}"
-            .format(l=item[0],c=item[1],sr=item[2],
-                start=str(item[3]),end=str(item[4]))
+            .format(l=item[0], c=item[1], sr=item[2],
+            start=str(item[3]), end=str(item[4]))
             for item in contents2]
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -962,6 +962,17 @@ def _unified_content_strings(contents):
              for item, count in contents_counts]
     return items
 
+def _unified_content_strings_expanded(contents):
+    contents2 = [["."+item.location_code,item.code,item.sample_rate,
+                  item.start_date,item.end_date]
+                  for item in contents]
+    contents2 = sorted(contents2, key = lambda x:(x[2],x[1],x[3]),
+                reverse=True)
+    items = ["{l:>7s}.{c:6s}{sr:6.2f} Hz   {start:.10s} to {end:.10s}"
+            .format(l=item[0],c=item[1],sr=item[2],
+                start=str(item[3]),end=str(item[4]))
+            for item in contents2]
+    return items
 
 # make TextWrapper only split on colons, so that we avoid splitting in between
 # e.g. network code and network code occurence count (can be controlled with

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -965,15 +965,15 @@ def _unified_content_strings(contents):
 
 def _unified_content_strings_expanded(contents):
     contents2 = [["." + item.location_code, item.code,
-                item.sample_rate, item.start_date, item.end_date]
-                for item in contents]
+                  item.sample_rate, item.start_date, item.end_date]
+                 for item in contents]
     contents2 = sorted(contents2, key = lambda x:(x[2], x[1], x[3]),
-                reverse=True)
-    items = ["{l:>7s}.{c:6s}{sr:6.2f} Hz   {start:.10s} to {end:.10s}"
-            .format(l=item[0], c=item[1], sr=item[2],
-            start=str(item[3]), end=str(item[4]))
-            for item in contents2]
+                       reverse=True)
+    items = ["{l: >7s}.{c: 6s}{sr: 6.2f} Hz   {start: .10s} to {end: .10s}"
+             .format(l=item[0], c=item[1], sr=item[2],start=str(item[3]),
+                     end=str(item[4])) for item in contents2]
     return items
+
 
 # make TextWrapper only split on colons, so that we avoid splitting in between
 # e.g. network code and network code occurence count (can be controlled with

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -963,24 +963,13 @@ def _unified_content_strings(contents):
     return items
 
 
-def _unified_content_strings_expanded_simple(contents):
-    contents2 = [["." + item.location_code, item.code,
-                  item.sample_rate, item.start_date, item.end_date]
-                 for item in contents]
-    contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
-                       reverse=True)
-    items = ["{l: >7s}.{c: <6s}{sr: 6.2f} Hz   {start: <.10s} to {end: <.10s}"
-             .format(l=item[0], c=item[1], sr=item[2], start=str(item[3]),
-                     end=str(item[4])) for item in contents2]
-    return items
-
 def _unified_content_strings_expanded(contents):
     contents2 = [["." + item.location_code, item.code,
                   item.sample_rate, item.start_date, item.end_date, 
                   item.depth]
                  for item in contents]
 
-    #sorting this to keep the channels Z-N-E
+    # sorting this to keep the channels Z-N-E
     contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
                        reverse=True)
 
@@ -992,36 +981,37 @@ def _unified_content_strings_expanded(contents):
     contents3 = []
     for u in uniques:
         c = [e for e in contents2 if \
-        [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
+            [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
         test = [[e[0], e[2], e[3], e[4], e[5]] for e in c]
-        if all(test[0]==x for x in test) and len(test) > 1:
+        if all(test[0] == x for x in test) and len(test) > 1:
             mergedch = u[1] + '[' \
-            + ''.join(map(str,[e[1][-1] for e in c])) + ']'
+                + ''.join(map(str,[e[1][-1] for e in c])) + ']'
             c[0][1] = mergedch
         contents3.append(c[0])
 
     contents3 = sorted(contents3, key=lambda x: (x[2], x[3], x[5]),
-                       reverse=True)   
+                       reverse=True)
 
-    #now work out formatting (easy way)
-    #items = ["{l: >7s}.{c: <6s}{sr: 6.1f} Hz  {start: <.10s} to {end: <.10s}"
-    #         .format(l=item[0], c=item[1], sr=item[2],
-    #            start=str(item[3]), end=str(item[4])) for item in contents3]
- 
-    #hard way... if wanted to add local depth (when relevant)
+    # now work out formatting (easy way)
+    # items = ["{l: >7s}.{c: <6s}{sr: 6.1f} Hz  {start: <.10s} to {end: <.10s}"
+    #          .format(l=item[0], c=item[1], sr=item[2],
+    #             start=str(item[3]), end=str(item[4])) for item in contents3]
+
+    # if wanted to add local depth (when relevant)
     items = []
     for item in contents3:
         if item[5] > 0:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}" \
-                " to {end: <.10s}  Depth {ldepth: <.1f} m".format(l=item[0], 
+                " to {end: <.10s}  Depth {ldepth: <.1f} m".format(l=item[0],
                     c=item[1], sr=item[2], start=str(item[3]), 
                     end=str(item[4]), ldepth=item[5]))
         else:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}" \
-                " to {end: <.10s}".format(l=item[0], c=item[1], sr=item[2],
-                start=str(item[3]), end=str(item[4])))
+                " to {end: <.10s}".format(l=item[0], c=item[1],
+                    sr=item[2], start=str(item[3]), end=str(item[4])))
 
     return items
+
 
 # make TextWrapper only split on colons, so that we avoid splitting in between
 # e.g. network code and network code occurence count (can be controlled with

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -981,7 +981,7 @@ def _unified_content_strings_expanded(contents):
     contents3 = []
     for u in uniques:
         c = [e for e in contents2 if
-            [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
+             [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
         test = [[e[0], e[2], e[3], e[4], e[5]] for e in c]
         if all(test[0] == x for x in test) and len(test) > 1:
             mergedch = u[1] + '[' \
@@ -1003,12 +1003,15 @@ def _unified_content_strings_expanded(contents):
         if item[5] != 0:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
                          " to {end: <.10s}  Depth {ldepth: <.1f} m"
-                         .format(l=item[0], c=item[1], sr=item[2], 
-                         start=str(item[3]), end=str(item[4]), ldepth=item[5]))
+                         .format(l=item[0], c=item[1], sr=item[2],
+                                 start=str(item[3]), end=str(item[4]),
+                                 ldepth=item[5]))
         else:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
                          " to {end: <.10s}".format(l=item[0], c=item[1],
-                         sr=item[2], start=str(item[3]), end=str(item[4])))
+                                                   sr=item[2],
+                                                   start=str(item[3]),
+                                                   end=str(item[4])))
 
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -1007,12 +1007,13 @@ def _unified_content_strings_expanded(contents):
     items2 = []
     for item in contents3:
         if item[5] > 1:
-            items2.append("{l: >7s}.{c: <6s}{sr: 6.0f} Hz  {start: <.10s} to \
-    {end: <.10s}  depth {ldepth: <.1f} m".format(l=item[0], c=item[1], sr=item[2],
-                start=str(item[3]), end=str(item[4]), ldepth=item[5]))
+            items2.append("{l: >7s}.{c: <6s}{sr: 6.0f} Hz  {start: <.10s} to " \
+                "{end: <.10s}  depth {ldepth: <.1f} m".format(l=item[0], 
+                    c=item[1], sr=item[2], start=str(item[3]), end=str(item[4]),
+                    ldepth=item[5]))
         else:
-            items2.append("{l: >7s}.{c: <6s}{sr: 6.0f} Hz  {start: <.10s} to \
-    {end: <.10s}".format(l=item[0], c=item[1], sr=item[2],
+            items2.append("{l: >7s}.{c: <6s}{sr: 6.0f} Hz  {start: <.10s} to " \
+                "{end: <.10s}".format(l=item[0], c=item[1], sr=item[2],
                 start=str(item[3]), end=str(item[4])))
 
     return items2

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -981,7 +981,7 @@ def _unified_content_strings_expanded(contents):
     contents3 = []
     for u in uniques:
         c = [e for e in contents2 if
-                [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
+            [e[0], e[1][0:2], e[3], e[4], e[5]] == u]
         test = [[e[0], e[2], e[3], e[4], e[5]] for e in c]
         if all(test[0] == x for x in test) and len(test) > 1:
             mergedch = u[1] + '[' \
@@ -1002,13 +1002,13 @@ def _unified_content_strings_expanded(contents):
     for item in contents3:
         if item[5] != 0:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
-                    " to {end: <.10s}  Depth {ldepth: <.1f} m"
-                    .format(l=item[0],c=item[1], sr=item[2],
-                        start=str(item[3]), end=str(item[4]), ldepth=item[5]))
+                         " to {end: <.10s}  Depth {ldepth: <.1f} m"
+                         .format(l=item[0], c=item[1], sr=item[2], 
+                         start=str(item[3]), end=str(item[4]), ldepth=item[5]))
         else:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
-                    " to {end: <.10s}".format(l=item[0], c=item[1],
-                        sr=item[2], start=str(item[3]), end=str(item[4])))
+                         " to {end: <.10s}".format(l=item[0], c=item[1],
+                         sr=item[2], start=str(item[3]), end=str(item[4])))
 
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -969,7 +969,7 @@ def _unified_content_strings_expanded(contents):
                  for item in contents]
     contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
                        reverse=True)
-    items = ["{l: >7s}.{c: 6s}{sr: 6.2f} Hz   {start: .10s} to {end: .10s}"
+    items = ["{l: >7s}.{c: <6s}{sr: 6.2f} Hz   {start: <.10s} to {end: <.10s}"
              .format(l=item[0], c=item[1], sr=item[2], start=str(item[3]),
                      end=str(item[4])) for item in contents2]
     return items

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -964,13 +964,13 @@ def _unified_content_strings(contents):
 
 
 def _unified_content_strings_expanded(contents):
-    contents2 = [["." + item.location_code, item.code,
+    contents2 = [["." + item.location_code, item.code, 
                   item.sample_rate, item.start_date, item.end_date]
                  for item in contents]
-    contents2 = sorted(contents2, key = lambda x:(x[2], x[1], x[3]),
+    contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
                        reverse=True)
     items = ["{l: >7s}.{c: 6s}{sr: 6.2f} Hz   {start: .10s} to {end: .10s}"
-             .format(l=item[0], c=item[1], sr=item[2],start=str(item[3]),
+             .format(l=item[0], c=item[1], sr=item[2],start=str(item[3]), 
                      end=str(item[4])) for item in contents2]
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -964,13 +964,13 @@ def _unified_content_strings(contents):
 
 
 def _unified_content_strings_expanded(contents):
-    contents2 = [["." + item.location_code, item.code, 
+    contents2 = [["." + item.location_code, item.code,
                   item.sample_rate, item.start_date, item.end_date]
                  for item in contents]
     contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
                        reverse=True)
     items = ["{l: >7s}.{c: 6s}{sr: 6.2f} Hz   {start: .10s} to {end: .10s}"
-             .format(l=item[0], c=item[1], sr=item[2],start=str(item[3]), 
+             .format(l=item[0], c=item[1], sr=item[2], start=str(item[3]),
                      end=str(item[4])) for item in contents2]
     return items
 

--- a/obspy/core/tests/test_channel.py
+++ b/obspy/core/tests/test_channel.py
@@ -40,7 +40,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n")
@@ -50,7 +50,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -61,7 +61,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -73,7 +73,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -87,7 +87,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -102,7 +102,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -117,7 +117,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"
@@ -132,7 +132,7 @@ class TestChannel:
         assert str(c) == (
             "Channel 'BHE', Location '10' \n"
             "\tTime range: -- - --\n"
-            "\tLatitude: 1.00, Longitude: 2.00, Elevation: 3.0 m, "
+            "\tLatitude: 1.0000, Longitude: 2.0000, Elevation: 3.0 m, "
             "Local Depth: 4.0 m\n"
             "\tAzimuth: 5.00 degrees from north, clockwise\n"
             "\tDip: 6.00 degrees down from horizontal\n"

--- a/obspy/io/kml/tests/data/inventory.kml
+++ b/obspy/io/kml/tests/data/inventory.kml
@@ -66,10 +66,13 @@
 	Channel Count: None/None (Selected/Total)
 	2006-12-16T00:00:00.000000Z - 
 	Access: None 
-	Latitude: 48.16, Longitude: 11.28, Elevation: 565.0 m
+	Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
 	Available Channels:
-		FUR..BHZ, FUR..BHN, FUR..BHE, FUR..HHZ, FUR..HHN, FUR..HHE, FUR..LHZ
-		FUR..LHN, FUR..LHE, FUR..VHZ, FUR..VHN, FUR..VHE</description>
+		..HH[ZNE]   100.0 Hz  2006-12-16 to None
+		..BH[ZNE]    20.0 Hz  2006-12-16 to None
+		..LH[ZNE]     1.0 Hz  2006-12-16 to None
+		..VH[ZNE]     0.1 Hz  2006-12-16 to None
+    </description>
         <TimeSpan>
           <begin>2006-12-16T00:00:00.000000Z</begin>
         </TimeSpan>
@@ -86,10 +89,12 @@
 	Channel Count: None/None (Selected/Total)
 	2007-02-02T00:00:00.000000Z - 
 	Access: None 
-	Latitude: 49.14, Longitude: 12.88, Elevation: 613.0 m
+	Latitude: 49.1440, Longitude: 12.8782, Elevation: 613.0 m
 	Available Channels:
-		WET..BHZ, WET..BHN, WET..BHE, WET..HHZ, WET..HHN, WET..HHE, WET..LHZ
-		WET..LHN, WET..LHE</description>
+		..HH[ZNE]   100.0 Hz  2007-02-02 to None
+		..BH[ZNE]    20.0 Hz  2007-02-02 to None
+		..LH[ZNE]     1.0 Hz  2007-02-02 to None
+   </description>
         <TimeSpan>
           <begin>2007-02-02T00:00:00.000000Z</begin>
         </TimeSpan>
@@ -126,9 +131,10 @@
 	Channel Count: None/None (Selected/Total)
 	2001-05-15T00:00:00.000000Z - 2006-12-12T00:00:00.000000Z
 	Access: None 
-	Latitude: 47.74, Longitude: 12.80, Elevation: 860.0 m
+	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-		RJOB..EHZ, RJOB..EHN, RJOB..EHE</description>
+	..EH[ZNE]   200.0 Hz  2001-05-15 to 2006-12-12
+  </description>
         <TimeSpan>
           <begin>2001-05-15T00:00:00.000000Z</begin>
           <end>2006-12-12T00:00:00.000000Z</end>
@@ -146,9 +152,10 @@
 	Channel Count: None/None (Selected/Total)
 	2006-12-13T00:00:00.000000Z - 2007-12-17T00:00:00.000000Z
 	Access: None 
-	Latitude: 47.74, Longitude: 12.80, Elevation: 860.0 m
+	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-		RJOB..EHZ, RJOB..EHN, RJOB..EHE</description>
+	..EH[ZNE]   200.0 Hz  2006-12-13 to 2007-12-17
+	</description>
         <TimeSpan>
           <begin>2006-12-13T00:00:00.000000Z</begin>
           <end>2007-12-17T00:00:00.000000Z</end>
@@ -166,9 +173,10 @@
 	Channel Count: None/None (Selected/Total)
 	2007-12-17T00:00:00.000000Z - 
 	Access: None 
-	Latitude: 47.74, Longitude: 12.80, Elevation: 860.0 m
+	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-		RJOB..EHZ, RJOB..EHN, RJOB..EHE</description>
+	..EH[ZNE]   200.0 Hz  2007-12-17 to None
+	</description>
         <TimeSpan>
           <begin>2007-12-17T00:00:00.000000Z</begin>
         </TimeSpan>


### PR DESCRIPTION
### What does this PR do?

1) expands the decimal places in the lat/lon at both the station and channel level from 2 to 4. if you have stations that have moved only a few hundred meters this can make keeping track a lot easier plus its just easier to copy/paste. 

2) changing this printout

```
Station MCQ (Macquarie Island)
	Station Code: MCQ
	Channel Count: 30/30 (Selected/Total)
	2004-06-28T00:00:00.000000Z -
	Access: open
	Latitude: -54.50, Longitude: 158.96, Elevation: 14.0 m
	Available Channels:
		MCQ..AX0, MCQ..BHZ (2x), MCQ..BHN (2x), MCQ..BHE (2x), MCQ..LCE,
		MCQ..LCQ, MCQ..VCO, MCQ..VEA, MCQ..VEC, MCQ..VEP, MCQ..VKI, MCQ..VMU
		MCQ..VMV, MCQ..VMW, MCQ..VPB, MCQ.00.BHZ, MCQ.00.BHN, MCQ.00.BHE,
		MCQ.00.BNZ, MCQ.00.BNN, MCQ.00.BNE, MCQ.00.HHZ, MCQ.00.HHN,
		MCQ.00.HHE, MCQ.00.HNZ, MCQ.00.HNN, MCQ.00.HNE
```
to this

```
Station MCQ (Macquarie Island)
	Station Code: MCQ
	Channel Count: 30/30 (Selected/Total)
	2004-06-28T00:00:00.000000Z -
	Access: open
	Latitude: -54.4986, Longitude: 158.9561, Elevation: 14.0 m
	Available Channels:
	    .00.HNZ   200.00 Hz   2020-03-15 to None
	    .00.HNN   200.00 Hz   2020-03-15 to None
	    .00.HNE   200.00 Hz   2020-03-15 to None
	    .00.HHZ   200.00 Hz   2020-03-15 to None
	    .00.HHN   200.00 Hz   2020-03-15 to None
	    .00.HHE   200.00 Hz   2020-03-15 to None
	    .00.BNZ    40.00 Hz   2020-03-15 to None
	    .00.BNN    40.00 Hz   2020-03-15 to None
	    .00.BNE    40.00 Hz   2020-03-15 to None
	    .00.BHZ    40.00 Hz   2020-03-15 to None
	      ..BHZ    40.00 Hz   2008-04-28 to None
	    .00.BHN    40.00 Hz   2020-03-15 to None
	      ..BHN    40.00 Hz   2008-04-28 to None
	    .00.BHE    40.00 Hz   2020-03-15 to None
	      ..BHE    40.00 Hz   2008-04-28 to None
	      ..BHZ    20.00 Hz   2004-06-28 to 2008-04-27
	      ..BHN    20.00 Hz   2004-06-28 to 2008-04-27
	      ..BHE    20.00 Hz   2004-06-28 to 2008-04-27
	      ..LCQ     1.00 Hz   2008-04-28 to None
	      ..LCE     1.00 Hz   2008-04-28 to None
	      ..AX0     1.00 Hz   2008-04-28 to None
	      ..VPB     0.10 Hz   2008-04-28 to None
	      ..VMW     0.10 Hz   2008-04-28 to None
	      ..VMV     0.10 Hz   2008-04-28 to None
	      ..VMU     0.10 Hz   2008-04-28 to None
	      ..VKI     0.10 Hz   2008-04-28 to None
	      ..VEP     0.10 Hz   2008-04-28 to None
	      ..VEC     0.10 Hz   2008-04-28 to None
	      ..VEA     0.10 Hz   2008-04-28 to None
	      ..VCO     0.10 Hz   2008-04-28 to None
```

the view from "inventory" or "network" is the same

EDIT// alternatively perhaps the channels can be consolidated somewhat but it does make the sorting a bit of a puzzle

```
Station MCQ (Macquarie Island)
	Station Code: MCQ
	Channel Count: 30/30 (Selected/Total)
	2004-06-28T00:00:00.000000Z -
	Access: open
	Latitude: -54.4986, Longitude: 158.9561, Elevation: 14.0 m
	Available Channels:
	    .00.HN[ENZ]   200.00 Hz   2020-03-15 to None
	    .00.BN[ENZ]    40.00 Hz   2020-03-15 to None
	      ..BH[ENZ]    40.00 Hz   2008-04-28 to None
	      ..BH[ENZ]    20.00 Hz   2004-06-28 to 2008-04-27
	      ..LC[EQ]      1.00 Hz   2008-04-28 to None
	      ..AX0         1.00 Hz   2008-04-28 to None
	      ..VPB         0.10 Hz   2008-04-28 to None
	      ..VM[UVW]     0.10 Hz   2008-04-28 to None
	      ..VKI         0.10 Hz   2008-04-28 to None
	      ..VE[ACP]     0.10 Hz   2008-04-28 to None
	      ..VCO         0.10 Hz   2008-04-28 to None
```



just sort of spitballing as to what data should actually be included but the important ones for me are sample rate and span. sensor type/make may also be good? comments appreciated. 

(also added contributors from previous seiscomp xml PR that accidentally got dropped)


EDIT: tests of course will need updating 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
