### PR TITLE
fix wav rescale with default width=None

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,7 +189,7 @@ jobs:
       # try to remove when min dep versions are upped
       - name: remove cartopy for mindepversion MacOS
         shell: bash -l {0}
-        if: startsWith(matrix.os, 'macos') && contains(matrix.python-version, '3.7') && contains(matrix.options, 'mindepversion')
+        if: startsWith(matrix.os, 'macos') && contains(matrix.python-version, '3.7') && contains(matrix.options, 'mindepversion') && steps.cache.outputs.cache-hit != 'true'
         run: conda uninstall --force cartopy shapely
 
       - name: run tests

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ maintenance_1.3.x
 =================
 
 Changes:
+ - obspy.io.wav:
+   * fix writing of wav files with rescale=True and default width=None
+     (see #3029)
 
 
 1.3.0 (doi: 10.5281/zenodo.6327346)

--- a/obspy/io/wav/core.py
+++ b/obspy/io/wav/core.py
@@ -158,7 +158,7 @@ def _write_wav(stream, filename, framerate=7000, rescale=False, width=None,
             dtype = WIDTH2DTYPE[tr_width]
             if rescale:
                 # optimal scale, account for +/- and the zero
-                maxint = 2 ** (width * 8 - 1) - 1
+                maxint = 2 ** (tr_width * 8 - 1) - 1
                 # upcast for following rescaling
                 data = data.astype(np.float64)
                 data = data / abs(data).max() * maxint

--- a/obspy/io/wav/tests/test_core.py
+++ b/obspy/io/wav/tests/test_core.py
@@ -18,6 +18,7 @@ class CoreTestCase(unittest.TestCase):
     """
     Test cases for audio WAV support
     """
+
     def setUp(self):
         # directory where the test files are located
         self.path = os.path.join(os.path.dirname(__file__), 'data')
@@ -78,16 +79,17 @@ class CoreTestCase(unittest.TestCase):
             testfile = fh.name
             self.file = os.path.join(self.path, '3cssan.reg.8.1.RNON.wav')
             tr = read(self.file, format='WAV')[0]
-            for width in (1, 2, 4):
+            for width in (1, 2, 4, None):
                 tr.write(testfile, format='WAV', framerate=7000, width=width,
                          rescale=True)
-                tr2 = read(testfile, format='WAV')[0]
-                maxint = 2 ** (8 * width - 1) - 1
-                dtype = WIDTH2DTYPE[width]
-                self.assertEqual(maxint, abs(tr2.data).max())
-                expected = (tr.data / abs(tr.data).max() *
-                            maxint).astype(dtype)
-                np.testing.assert_array_almost_equal(tr2.data, expected)
+                if width is not None:
+                    tr2 = read(testfile, format='WAV')[0]
+                    maxint = 2 ** (8 * width - 1) - 1
+                    dtype = WIDTH2DTYPE[width]
+                    self.assertEqual(maxint, abs(tr2.data).max())
+                    expected = (tr.data / abs(tr.data).max() *
+                                maxint).astype(dtype)
+                    np.testing.assert_array_almost_equal(tr2.data, expected)
 
     def test_write_stream_via_obspy(self):
         """


### PR DESCRIPTION
### What does this PR do?

Fix wav rescale with default width=None

### Why was it initiated?  Any relevant Issues?
Fix error with updated test in this PR:

```
=================================== FAILURES ===================================
______________________ CoreTestCase.test_rescale_on_write ______________________
Traceback (most recent call last):
  File "/home/eule/dev/obspy/obspy/io/wav/tests/test_core.py", line 82, in test_rescale_on_write
    tr.write(testfile, format='WAV', framerate=7000, width=width,
  File "/home/eule/dev/obspy/obspy/core/trace.py", line 999, in write
    Stream([self]).write(filename, format, **kwargs)
  File "/home/eule/dev/obspy/obspy/core/stream.py", line 1456, in write
    write_format(self, filename, **kwargs)
  File "/home/eule/dev/obspy/obspy/io/wav/core.py", line 161, in _write_wav
    maxint = 2 ** (width * 8 - 1) - 1
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
=========================== short test summary info ============================
FAILED io/wav/tests/test_core.py::CoreTestCase::test_rescale_on_write - TypeE...
==================== 1 failed, 6 passed, 1 skipped in 0.42s ====================
```

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
