### PR TITLE
dependabot to target maintenance branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "maintenance_1.3.x"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### What does this PR do?

Set target_branch to maintenance for dependabot.

### Why was it initiated?  Any relevant Issues?

See discussion in #3025.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
