### PR TITLE
Fix a typo in xseed documentation

### DIFF
--- a/obspy/io/xseed/__init__.py
+++ b/obspy/io/xseed/__init__.py
@@ -70,7 +70,7 @@ parsed in a :class:`~obspy.io.xseed.parser.Parser` structure.
   headers will be written in case they are needed by SEED/XSEED conventions.)
 
 After parsing a `SEED` or `XML-SEED` file the Blockette objects for each
-volume will be stored in the attributes``Parser.volume``,
+volume will be stored in the attributes ``Parser.volume``,
 ``Parser.abbreviations`` and ``Parser.stations``. Each item is a list of all
 related Blockettes and ``Parser.stations`` is a list of stations which contains
 all related Blockettes.


### PR DESCRIPTION
### What does this PR do?

Fix a typo in xseed documentation so that the documentation looks better.

<img width="885" alt="image" src="https://user-images.githubusercontent.com/3974108/163744228-1198cb50-d8ae-49c7-b2ab-a5bd3e330d69.png">


### Why was it initiated?  Any relevant Issues?

No relevant issue.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
