### PR TITLE
Simulate with inventory

### DIFF
--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -407,6 +407,8 @@ def invert_spectrum(spec, wlev):
     :param wlev: Water level to use
     """
     # Calculated water level in the scale of spec
+    if wlev is None:
+        wlev = np.inf
     swamp = waterlevel(spec, wlev)
 
     # Find length in real fft frequency domain, spec is complex

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -524,6 +524,8 @@ def simulate_seismometer(
         raise TypeError(msg)
 
     for d in [paz_remove, paz_simulate]:
+        if not isinstance(d, dict):
+            continue
         if d is None:
             continue
         for key in ['poles', 'zeros', 'gain']:
@@ -556,9 +558,13 @@ def simulate_seismometer(
     data = np.fft.rfft(data, n=nfft)
     # Inverse filtering = Instrument correction
     if paz_remove:
-        freq_response, freqs = paz_to_freq_resp(
-            paz_remove['poles'], paz_remove['zeros'], paz_remove['gain'],
-            delta, nfft, freq=True)
+        if isinstance(paz_remove, dict):
+            freq_response, freqs = paz_to_freq_resp(
+                paz_remove['poles'], paz_remove['zeros'], paz_remove['gain'],
+                delta, nfft, freq=True)
+        elif isinstance(paz_remove, Response):
+            freq_response, freqs = paz_remove.get_evalresp_response(
+                delta, nfft)
     if seedresp:
         freq_response, freqs = evalresp(delta, nfft, seedresp['filename'],
                                         seedresp['date'],
@@ -600,7 +606,7 @@ def simulate_seismometer(
         # detrend using least squares
         data = scipy.signal.detrend(data, type="linear")
     # correct for involved overall sensitivities
-    if paz_remove and remove_sensitivity and not seedresp:
+    if isinstance(paz_remove, dict) and remove_sensitivity and not seedresp:
         data /= paz_remove['sensitivity']
     if paz_simulate and simulate_sensitivity:
         data *= paz_simulate['sensitivity']


### PR DESCRIPTION
### What does this PR do?

Makes it possible to use `Inventory`/`Response` objects as input in `Stream/Trace.simulate()` and `obspy.signal.invsim.simulate_seismometer`.

### Why was it initiated?  Any relevant Issues?

These routines are very old, from before these new objects and when mostly poles and zeros dictionaries and the like were used to describe instrument responses.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
