### PR TITLE
github workflows: make sure contributor list is sorted

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,10 @@ jobs:
             reviewdog -f=pep8 -name=flake8 \
               -tee -reporter=github-check -filter-mode nofilter
 
+      # make sure contributor list stays sorted
+      - name: Contributor list sorting
+        run: sort -u -c CONTRIBUTORS.txt || (sort -u CONTRIBUTORS.txt > /tmp/CONTRIBUTORS_EXPECTED; diff -u CONTRIBUTORS.txt /tmp/CONTRIBUTORS_EXPECTED; echo 'Please sort CONTRIBUTORS.txt according to above diff.'; exit 1)
+
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:
     if: github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'no_ci')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,12 +85,11 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # go on through to reviewdog
           sort -u -o obspy/CONTRIBUTORS.txt obspy/CONTRIBUTORS.txt
           TMPFILE=$(mktemp)
           git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
           git stash -u && git stash drop
-          cat "${TMPFILE}" | clang-format-diff-10 -p1 | reviewdog -f=diff -f.diff.strip=0 -reporter=github-check -filter-mode nofilter -fail-on-error
+          reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check < "${TMPFILE}"
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           TMPFILE=$(mktemp)
           git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
           git stash -u && git stash drop
-          reviewdog -f=diff -f.diff.strip=1 -reporter=github-check -filter-mode nofilter < "${TMPFILE}"
+          reviewdog -f=diff -reporter=github-check -filter-mode nofilter < "${TMPFILE}"
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
           TMPFILE=$(mktemp)
           git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
           git stash -u && git stash drop
+          cat "${TMPFILE}"
           reviewdog -f=diff -reporter=github-check -filter-mode nofilter < "${TMPFILE}"
 
   # Runs the tests on combinations of the supported python/os matrix.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,15 @@ jobs:
 
       # make sure contributor list stays sorted
       - name: Contributor list sorting
-        run: sort -u -c CONTRIBUTORS.txt || (sort -u CONTRIBUTORS.txt > /tmp/CONTRIBUTORS_EXPECTED; diff -u CONTRIBUTORS.txt /tmp/CONTRIBUTORS_EXPECTED; echo 'Please sort CONTRIBUTORS.txt according to above diff.'; exit 1)
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # go on through to reviewdog
+          sort -u -o obspy/CONTRIBUTORS.txt obspy/CONTRIBUTORS.txt
+          TMPFILE=$(mktemp)
+          git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
+          git stash -u && git stash drop
+          reviewdog -f=diff -f.diff.strip=1 -reporter=github-check -filter-mode nofilter < "${TMPFILE}"
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,12 @@ jobs:
           TMPFILE=$(mktemp)
           git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
           git stash -u && git stash drop
-          reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check < "${TMPFILE}"
+          # with the following, reviewdog states the detected changes as
+          # "filtered findings" and reports success, and the lines that should
+          # be reported as diff are just links to the respective lines in the
+          # code base
+          # reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check < "${TMPFILE}"
+          reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check -filter-mode nofilter < "${TMPFILE}"
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
           # alternative without reviewdog
           TMPFILE=$(mktemp)
           # sort -c has non-zero return code if it finds a need to sort
-          sort -u -c obspy/CONTRIBUTORS.txt || (sort -u obspy/CONTRIBUTORS.txt > "${TMPFILE}"; diff -u obspy/CONTRIBUTORS.txt "${TMPFILE}"; echo 'Please sort CONTRIBUTORS.txt according to above diff.'; exit 1)
+          sort -u -c obspy/CONTRIBUTORS.txt || (sort -u obspy/CONTRIBUTORS.txt > "${TMPFILE}"; diff -u obspy/CONTRIBUTORS.txt "${TMPFILE}"; echo '::error::Please sort CONTRIBUTORS.txt according to above diff.'; exit 1)
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,8 +90,7 @@ jobs:
           TMPFILE=$(mktemp)
           git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
           git stash -u && git stash drop
-          cat "${TMPFILE}"
-          reviewdog -f=diff -reporter=github-check -filter-mode nofilter < "${TMPFILE}"
+          cat "${TMPFILE}" | clang-format-diff-10 -p1 | reviewdog -f=diff -f.diff.strip=0 -reporter=github-check -filter-mode nofilter -fail-on-error
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,19 +82,33 @@ jobs:
 
       # make sure contributor list stays sorted
       - name: Contributor list sorting
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # env:
+        #   REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sort -u -o obspy/CONTRIBUTORS.txt obspy/CONTRIBUTORS.txt
-          TMPFILE=$(mktemp)
-          git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
-          git stash -u && git stash drop
-          # with the following, reviewdog states the detected changes as
-          # "filtered findings" and reports success, and the lines that should
-          # be reported as diff are just links to the respective lines in the
-          # code base
+          # # this is how it should work, according to reviewdog README
+          # sort -u -o obspy/CONTRIBUTORS.txt obspy/CONTRIBUTORS.txt
+          # TMPFILE=$(mktemp)
+          # git diff obspy/CONTRIBUTORS.txt >"${TMPFILE}"
+          # git stash -u && git stash drop
+          # # with the following, reviewdog states the detected changes as
+          # # "filtered findings" and reports success, and the lines that should
+          # # be reported as diff are just links to the respective lines in the
+          # # code base
           # reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check < "${TMPFILE}"
-          reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check -filter-mode nofilter < "${TMPFILE}"
+          # # with setting "nofilter" to force reporting the one file we diff,
+          # # reviewdog errors out with:
+          # # reviewdog: post failed for diff: failed to post result: failed to
+          # # post annotations: PATCH
+          # # https://api.github.com/repos/obspy/obspy/check-runs/6159957608: 422
+          # # Validation Failed [{Resource:CheckRun Field:annotations
+          # # Code:invalid Message:}]
+          # reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-check -filter-mode nofilter < "${TMPFILE}"
+          # # it seems that we run into a bug described in reviewdog/reviewdog#924
+          #
+          # alternative without reviewdog
+          TMPFILE=$(mktemp)
+          # sort -c has non-zero return code if it finds a need to sort
+          sort -u -c obspy/CONTRIBUTORS.txt || (sort -u obspy/CONTRIBUTORS.txt > "${TMPFILE}"; diff -u obspy/CONTRIBUTORS.txt "${TMPFILE}"; echo 'Please sort CONTRIBUTORS.txt according to above diff.'; exit 1)
 
   # Runs the tests on combinations of the supported python/os matrix.
   run_tests:


### PR DESCRIPTION
### What does this PR do?

Make sure CONTRIBUTORS.txt stays sorted

### Why was it initiated?  Any relevant Issues?

CONTRIBUTORS.txt not staying sorted

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
