### PR TITLE
Nrl v2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,9 @@ Changes:
      #3117)
  - obspy.clients.fdsn:
    * add URL mapping 'EIDA' for http://eida-federator.ethz.ch (see #3050)
+ - obspy.clients.nrl:
+   * enable reading from a downloaded full copy of the NRLv2 at
+     http://ds.iris.edu/ds/nrl/ (see #3058)
  - obspy.imaging:
    * Scanner/obspy-scan: skip directories without read permission (see #3115)
  - obspy.io.gse2:

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -16,7 +16,7 @@ import codecs
 import io
 import os
 import warnings
-from configparser import ConfigParser
+from configparser import ConfigParser, DuplicateSectionError
 from urllib.parse import urlparse
 
 import requests
@@ -295,9 +295,17 @@ class LocalNRL(NRL):
         """
         Returns a configparser from a path to an index.txt
         """
-        cp = ConfigParser()
-        with codecs.open(path, mode='r', encoding='UTF-8') as f:
-            cp.read_file(f)
+        try:
+            cp = ConfigParser()
+            with codecs.open(path, mode='r', encoding='UTF-8') as f:
+                cp.read_file(f)
+        # it seems requesting a full RESP archive of NRL version 2 has all
+        # items duplicated in the index.txt files. expecting this to be fixed
+        # upstream so this is just for now
+        except DuplicateSectionError:
+            cp = ConfigParser(strict=False)
+            with codecs.open(path, mode='r', encoding='UTF-8') as f:
+                cp.read_file(f)
         return cp
 
     def _read_resp(self, path):


### PR DESCRIPTION
### What does this PR do?

Work on getting our NRL client ready for [new NRL v2](https://ds.iris.edu/ds/nrl/). This won't change API or semantics, so I think basing on maintenance branch should be OK. In any case we definitely want this in the next release.

[Changes in the actual response files from v1 to v2](https://ds.iris.edu/files/nrl/NominalResponseLibraryVersions.pdf) are not that big actually. For the most part, v2 does not have sensor/datalogger dummy stages in datalogger/sensor responses anymore (and vice versa), so no need to drop some stages when combining both anymore, for the most part only concatenate and fix stage sequence numbering (and same as before recalculate overall sensitivity).

New NRL v2 can also be downloaded as StationXML files (instead of RESP), reading that has also been added here.

NRL v2 has slightly changed the naming on the base nodes "sensors" -> "sensor" and vice versa. That can be used to distinguish v1 and v2.

NRL v2 has some weird units in most dataloggers first stage input units. 2/3 of the files have "counts" when it probably should be "V" (all sensor responses have "V" as output).

check list:
 - [x] read offline copy NRLv2
 - [ ] revert a commit fixing duplicated sections in downloaded NRL v2
 - [ ] read NRL v2 online? at the moment not really possible, new online version does not serve the txt files with the traversal through the structure. In principle possible to parse the html files, but.. let's not
 - [ ] add tests (for offline version)? current tests only use NRL v1 online
 - [ ] NRL v2 has additional base nodes "integrated" and "soh" (in addition to "sensor" and "datalogger"), maybe check if we want to implement that too, but might be for another PR
 - [ ] ...
 - [ ] ...
 - [ ] add changelog

In the long term it might be worth to also add a client for IRIS new NRL WS too: http://service.iris.edu/irisws/nrl/1/

### Why was it initiated?  Any relevant Issues?

The [old NRL (v1) website](https://ds.iris.edu/NRL/) states "will be maintained through spring 2023 and then retired", so we want to make sure to get the NRL client future ready in the next release.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
