### PR TITLE
Fix for "TauBranch depths not compatible with slowness sampling" errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,8 @@ Changes:
  - obspy.taup:
    * Fix cycling through colors in ray path plots, now also fixes cartesian
      plot version (see #2470, #2478, #3041)
+   * Fix slowness layer splits to avoid "TauBranch depths not compatible with
+     slowness sampling." errors. (see #3062, #2682, #1938)
 
 
 1.3.0 (doi: 10.5281/zenodo.6327346)

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -88,6 +88,7 @@ Rapagnani, Giovanni
 Reyes, Celso
 Ringler, Adam
 Rothenhäusler, Nicolas
+Rudge, John F.
 Russo, Emiliano
 Sales de Andrade, Elliott
 Satriano, Claudio

--- a/obspy/taup/slowness_model.py
+++ b/obspy/taup/slowness_model.py
@@ -1800,6 +1800,7 @@ class SlownessModel(object):
             out[other_index[0]] = new_bot_layer
             out = np.insert(out, other_index[0], new_top_layer)
 
+        number_added = 0
         for other_layer_num, s_layer in enumerate(out.copy()):
             if (s_layer['top_p'] - p) * (p - s_layer['bot_p']) > 0:
                 # Found a slowness layer with the other wave type that
@@ -1810,12 +1811,13 @@ class SlownessModel(object):
                     dtype=SlownessLayer)
                 bot_layer = (p, top_layer['bot_depth'],
                              s_layer['bot_p'], s_layer['bot_depth'])
-                out[other_layer_num] = bot_layer
-                out = np.insert(out, other_layer_num, top_layer)
+                out[other_layer_num+number_added] = bot_layer
+                out = np.insert(out, other_layer_num+number_added, top_layer)
                 # Fix critical layers since we have added a slowness layer.
                 _fix_critical_depths(critical_depths,
                                      other_layer_num, not is_p_wave)
                 # Skip next layer as it was just added: achieved by slicing
                 # the list iterator.
+                number_added += 1
 
         return out

--- a/obspy/taup/tests/test_ray_paths.py
+++ b/obspy/taup/tests/test_ray_paths.py
@@ -7,6 +7,7 @@ import pytest
 import obspy
 import obspy.geodetics.base as geodetics
 from obspy.taup.ray_paths import get_ray_paths
+from obspy.taup import TauPyModel
 
 
 class TestRayPathCalculations:
@@ -172,3 +173,9 @@ class TestRayPathCalculations:
              0.53004245, 0.52531799]]
         np.testing.assert_allclose(path[:, ::10], path_steps_expected,
                                    rtol=1e-6)
+
+    def test_deep_source(self):
+        # Regression test -- check if deep sources are ok
+        model = TauPyModel("ak135")
+        arrivals = model.get_ray_paths(2000.0, 60.0, ["P"])
+        assert abs(arrivals[0].time - 480.32) < 1e-2


### PR DESCRIPTION
### What does this PR do?

In some circumstances taup fails with a "TauBranch depths not compatible with slowness sampling." error. A simple example which triggers this is:

```
from obspy.taup import TauPyModel
model = TauPyModel("ak135")
arrivals = model.get_ray_paths(2000.0, 60.0, ["P"])
```

I believe the bug lies in the `_fix_other_layers` routine in taup/slowness_model.py. That routine splits a layer, but the indexing assumes only ever a single layer gets split. In some circumstances more than one layer needs to be split, but later layers get inserted incorrectly because the size of `out` has grown and the subsequent indexing needs to be adjusted. This pull request fixes the indexing so the above example now works correctly. 

### Why was it initiated?  Any relevant Issues?

A related issue has been reported in #2682. This may also fix that issue, but I don't have the custom model used to test if that is the case. I think this is also the same issue as #1938. 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
