### PR TITLE
Further minor accuracy improvement to taup refine_arrival

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,8 @@ Changes:
      plot by using wiggly lines for shear waves (see #3047)
    * improved accuracy of ray paths by change of root-finding algorithm
      in SeismicPhase.refine_arrival (see #3064)
+   * improved accuracy of travel time estimates by using theta function
+     (see #3068)
 
 maintenance_1.3.x
 =================

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1317,6 +1317,7 @@ class SeismicPhase(object):
         new_ray_param = brentq(residual, left_ray_param, right_ray_param,
                                xtol=tolerance, maxiter=recursion_limit,
                                disp=False)
+        new_ray_param = np.float64(new_ray_param)
 
         # the arrival brentq calculated at its last iteration
         last = new_arrivals[-1]

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1314,11 +1314,21 @@ class SeismicPhase(object):
                 dist = shoot.purist_dist
             return dist_radian - dist
 
-        brentq(residual, left_ray_param, right_ray_param,
-               xtol=tolerance, maxiter=recursion_limit,
-               disp=False)
-        # return the arrival brentq calculated at its last iteration
-        return new_arrivals[-1]
+        new_ray_param = brentq(residual, left_ray_param, right_ray_param,
+                               xtol=tolerance, maxiter=recursion_limit,
+                               disp=False)
+
+        # the arrival brentq calculated at its last iteration
+        last = new_arrivals[-1]
+
+        # Use stationarity of the theta function to get better estimate of time
+        # Buland and Chapman (1983), equations (16) and (20)
+        theta = last.time + last.ray_param * (dist_radian - last.purist_dist)
+
+        return Arrival(self, degrees, theta,
+                       dist_radian, new_ray_param,
+                       ray_index, self.name, self.purist_name,
+                       self.source_depth, self.receiver_depth)
 
     def shoot_ray(self, degrees, ray_param):
         if (any(phase in self.name


### PR DESCRIPTION
### What does this PR do?

This pull request is a very minor tweak to the improvements made to the taup `SeismicPhase.refine_arrival` method in #3064. It exploits the fact that a more accurate estimate of the travel time can be obtained by exploiting the stationarity of the theta function, as described in equations (16) and (20) of Buland and Chapman (1983). 

A simple code to demonstrate the improvement in accuracy is:
```
import obspy
from obspy.taup import TauPyModel
obspy.taup.seismic_phase.REFINE_DIST_RADIAN_TOL = 0.1
model = TauPyModel("prem")
arrivals = model.get_travel_times(0.0, 60.0, ["P"])
print(arrivals)
```
On master, without the adjustment to `REFINE_DIST_RADIAN_TOL` above, the travel time is estimated as 607.153 seconds. When the poor tolerance `REFINE_DIST_RADIAN_TOL=0.1` is chosen above, a less accurate estimate of 607.164 seconds is printed. However, on the branch of this pull request, the above code still estimates 607.153 seconds even with the wide tolerance, thanks to the use of the theta function in estimating travel time. There are no significant differences in run time from this use of the theta function.

### Why was it initiated?  Any relevant Issues?

See #3064 for the discussion of previous issues.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
