### PR TITLE
gh actions: notify people on certain issue/PR labels

### DIFF
--- a/.github/workflows/label_notifications.yml
+++ b/.github/workflows/label_notifications.yml
@@ -13,5 +13,4 @@ jobs:
         - uses: jenschelkopf/issue-label-notification-action@1.3
           with:
              recipients: |
-                  .taup=@crotwell @johnrudge
-                  .io.nordic=@flixha
+                 bug=@megies

--- a/.github/workflows/label_notifications.yml
+++ b/.github/workflows/label_notifications.yml
@@ -1,0 +1,17 @@
+name: Notify users based on issue labels
+
+on:
+  pull_request:
+      types: [labeled]
+  issues:
+      types: [labeled]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: jenschelkopf/issue-label-notification-action@1.3
+          with:
+             recipients: |
+                  .taup=@crotwell @johnrudge
+                  .io.nordic=@flixha


### PR DESCRIPTION
### What does this PR do?

Sets up a github action that notifies certain people when issues/PRs get certain labels attached to them.

### Why was it initiated?  Any relevant Issues?

I think only very few people look at new obspy issues/PRs that get created, since github notifications can get overwhelming real fast and people tend to hit the "unwatch" emergency switch (or simply never were watching our notifications).
With our project being quite big and there are people only interested in getting notified about certain submodules (e.g. taup) it might be good to have a means to reach certain people with just a few, select "targetted" notifications.

E.g. see recent work on our taup clone, where currently I ping @crotwell to let him know there is something going on that might be relevant upstream. And we have some submodules that mainly got worked on by individual people, and whenever a new issue comes in regarding that, currently somebody has to look up who to ping about it (e.g. me pinging @flixha in #3066).

It seems github has no builtin means to do this, so this is trying out an existing action doing exactly this.

Alternatively, teams could be setup and then pinged (e.g. @obspy/bots) but that seems like it might be a superfluous step.

If we want this gh action, we should think about how to mention it somewhere, probably in the main README.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
