### PR TITLE
ci: remove libffi workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,12 +180,6 @@ jobs:
         run: |
           python -m pip install --no-deps -e .[tests]
 
-      # reinstall libffi to avoid python 3,8 failures in pk_baer, see (#2758)
-      - name: fix libffi
-        shell: bash -l {0}
-        if: runner.os == 'Linux' && contains(matrix.python-version, '3.8')
-        run: conda install libffi=3.3.*
-
       # try to remove when min dep versions are upped
       - name: remove cartopy for mindepversion MacOS
         shell: bash -l {0}


### PR DESCRIPTION
### What does this PR do?

Remove a work-around in tests.yml, added in #2758

### Why was it initiated?  Any relevant Issues?

The work-around is not working anymore for recent conda. Let's see if tests are passing without it.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
