### PR TITLE
Checks for bad phases in taup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,9 @@ Changes:
    * return pierce points for any depth (see #1742, #3072)
    * bug fix for rays which cannot turn due to low velocity at bottom
      of layer (see #3080)
+   * add some checks for bad phases, so "ScScS" is not allowed
+     (see #2774, #3082)
+
 
 maintenance_1.3.x
 =================

--- a/obspy/taup/tests/test_seismic_phase.py
+++ b/obspy/taup/tests/test_seismic_phase.py
@@ -106,7 +106,7 @@ class TestTauPySeismicPhase:
         Simple check to see if illegal phase names are caught.
         """
         legal_phase_names = ["ScS", "ScSScS"]
-        illegal_phase_names = ["ScScS"]
+        illegal_phase_names = ["ScScS", "PKIKPKIKP", "PKIKIKP"]
 
         for name in legal_phase_names:
             SeismicPhase(name, tau_model)

--- a/obspy/taup/tests/test_seismic_phase.py
+++ b/obspy/taup/tests/test_seismic_phase.py
@@ -13,7 +13,7 @@ from obspy.taup import TauPyModel
 from obspy.taup.tau_model import TauModel
 from obspy.taup.seismic_phase import SeismicPhase
 from obspy.taup.taup_create import build_taup_model
-
+from obspy.taup.helper_classes import TauModelError
 
 # Most generic way to get the data folder path.
 DATA = os.path.join(os.path.dirname(os.path.abspath(
@@ -100,3 +100,17 @@ class TestTauPySeismicPhase:
             assert abs(arrival.time - time) < tol
             assert abs(arrival.pierce["time"][-1] - time) < tol
             assert abs(arrival.path["time"][-1] - time) < tol
+
+    def test_phase_names(self, tau_model):
+        """
+        Simple check to see if illegal phase names are caught.
+        """
+        legal_phase_names = ["ScS", "ScSScS"]
+        illegal_phase_names = ["ScScS"]
+
+        for name in legal_phase_names:
+            SeismicPhase(name, tau_model)
+
+        for name in illegal_phase_names:
+            with pytest.raises(TauModelError):
+                SeismicPhase(name, tau_model)


### PR DESCRIPTION
### What does this PR do?

This a port of a bug fix in the java version of taup that checks for bad phases. 

https://github.com/crotwell/TauP/commit/b534c8ed4bd05c2d4608e81feee35825d56dfa35

### Why was it initiated?  Any relevant Issues?

This fixes #2774 which noted an impossible phase ScScS. The new behaviour is
```
from obspy.taup import TauPyModel
scs_times = TauPyModel( model="ak135" ).get_travel_times( 0, 0, phase_list=["ScS","ScScS","ScSScS"] )
print(scs_times)
```
```
Error with this phase, skipping it: ScScS
2 arrivals
	ScS phase arrival at 935.771 seconds
	ScSScS phase arrival at 1871.542 seconds
```

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
