### PR TITLE
Rapid travel time plotting in taup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,8 @@ Changes:
      (see #1200, #1423, #2086, #2192, #2390, #3070)
    * add support for a wider range of diffracted phases, like SedPdiffKP
      (see #3085)
+   * allow rapid travel time plotting in plot_travel_times by using
+     precalculated travel times (see #3092)
 
 maintenance_1.3.x
 =================

--- a/misc/docs/source/tutorial/code_snippets/plot_travel_times.py
+++ b/misc/docs/source/tutorial/code_snippets/plot_travel_times.py
@@ -3,4 +3,4 @@ import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots()
 ax = plot_travel_times(source_depth=10, ax=ax, fig=fig,
-                       phase_list=['P', 'PP', 'S'], npoints=200)
+                       phase_list=['P', 'PP', 'S'])

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -211,8 +211,7 @@ size or subplot setup:
 >>> import matplotlib.pyplot as plt
 >>> fig, ax = plt.subplots(figsize=(9, 9))
 >>> ax = plot_travel_times(source_depth=10, phase_list=["P", "S", "PP"],
-...                        ax=ax, fig=fig, verbose=True)
-There was 1 epicentral distance without an arrival
+...                        ax=ax, fig=fig)
 
 .. plot::
     :width: 50%
@@ -222,8 +221,8 @@ There was 1 epicentral distance without an arrival
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots(figsize=(9, 9))
-    ax = plot_travel_times(source_depth=10, ax=ax, phase_list=["P", "S", "PP"],
-                           fig=fig)
+    ax = plot_travel_times(source_depth=10, phase_list=["P", "S", "PP"],
+                           ax=ax, fig=fig)
 
 The ray path plot wrapper function is :func:`~obspy.taup.tau.plot_ray_paths`.
 Again, creating the figure and axes first is optional to have control over e.g.

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -245,7 +245,7 @@ There were rays for all but the following epicentral distances:
     from obspy.taup import plot_ray_paths
     import matplotlib.pyplot as plt
 
-    fig, ax = plt.subplot(subplot_kw=dict(projection='polar'))
+    fig, ax = plt.subplots(subplot_kw=dict(projection='polar'))
     ax = plot_ray_paths(source_depth=100, ax=ax, fig=fig)
 
 More examples of plotting may be found in the :doc:`ObsPy tutorial


### PR DESCRIPTION
### What does this PR do?

This pull request modifies `plot_travel_times` in `obspy.taup` to allow for rapid plotting. It does this by plotting the precalculated times in the `TauModel` rather than recalculating arrivals at specific epicentral distances. 

The old behaviour is:
```
from obspy.taup import plot_travel_times
plot_travel_times(source_depth=10, phase_list=["P", "S", "PP"], npoints=50) 
```
![old](https://user-images.githubusercontent.com/43536815/173565450-203b3245-62fd-4c56-a717-266dbc5ed7ff.png)


The new behaviour is:
```
plot_travel_times(source_depth=10, phase_list=["P", "S", "PP"], npoints=None) 
```
![new](https://user-images.githubusercontent.com/43536815/173565462-f9010ddd-787c-4e95-82d0-9ea42cbffab4.png)

where I have made `npoints=None` the new default, rather than `npoints=50`.

### Why was it initiated?  Any relevant Issues?

I don't think this is related to any existing issues. Recomputing all the travel times at a series of fixed epicentral distances was painfully slow, especially with a lot of phases. I've updated the relevant figures that use this function in the docs. The old behaviour is still available by setting the `npoints` argument to an integer value.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
