### PR TITLE
Spectrogram fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,12 @@ Changes:
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)
+ - obspy.imaging:
+   * spectrogram: change the computation for default window length if not
+     specified to give useful values for sampling rates much higher or lower
+     than 100 Hz (see #3093)
+   * spectrogram: better exception type and messages when input signal is too
+     short (see #3093)
  - obspy.taup:
    * add option "indicate_wave_type" to distinguish S waves in ray paths
      plot by using wiggly lines for shear waves (see #3047)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1495,7 +1495,7 @@ class TestTrace:
         """
         Tests spectrogram method if matplotlib is installed
         """
-        tr = Trace(data=np.arange(25))
+        tr = Trace(data=np.arange(250))
         tr.stats.sampling_rate = 20
         tr.spectrogram(show=False)
 

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -63,8 +63,8 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
         to 1. High overlaps take a long time to compute.
     :type wlen: int or float
     :param wlen: Window length for fft in seconds. If this parameter is too
-        small, the calculation will take forever. If None, it defaults to
-        (samp_rate/100.0).
+        small, the calculation will take forever. If None, it defaults to a
+        window length matching 128 samples.
     :type log: bool
     :param log: Logarithmic frequency axis if True, linear frequency axis
         otherwise.

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -107,11 +107,10 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
         wlen = 128 / samp_rate
 
     npts = len(data)
+
     # nfft needs to be an integer, otherwise a deprecation will be raised
     # XXX add condition for too many windows => calculation takes for ever
     nfft = int(_nearest_pow_2(wlen * samp_rate))
-    if nfft > npts:
-        nfft = int(_nearest_pow_2(npts / 8.0))
 
     if mult is not None:
         mult = int(_nearest_pow_2(mult))

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -112,6 +112,12 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
     # XXX add condition for too many windows => calculation takes for ever
     nfft = int(_nearest_pow_2(wlen * samp_rate))
 
+    if npts < nfft:
+        msg = (f'Input signal too short ({npts} samples, window length '
+               f'{wlen} seconds, nfft {nfft} samples, sampling rate '
+               f'{samp_rate} Hz)')
+        raise ValueError(msg)
+
     if mult is not None:
         mult = int(_nearest_pow_2(mult))
         mult = mult * nfft
@@ -126,6 +132,13 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
     # XXX mlab.specgram uses fft, would be better and faster use rfft
     specgram, freq, time = mlab.specgram(data, Fs=samp_rate, NFFT=nfft,
                                          pad_to=mult, noverlap=nlap)
+
+    if len(time) < 2:
+        msg = (f'Input signal too short ({npts} samples, window length '
+               f'{wlen} seconds, nfft {nfft} samples, {nlap} samples window '
+               f'overlap, sampling rate {samp_rate} Hz)')
+        raise ValueError(msg)
+
     # db scale and remove zero/offset for amplitude
     if dbscale:
         specgram = 10 * np.log10(specgram[1:, :])

--- a/obspy/imaging/spectrogram.py
+++ b/obspy/imaging/spectrogram.py
@@ -104,7 +104,7 @@ def spectrogram(data, samp_rate, per_lap=0.9, wlen=None, log=False,
 
     # set wlen from samp_rate if not specified otherwise
     if not wlen:
-        wlen = samp_rate / 100.
+        wlen = 128 / samp_rate
 
     npts = len(data)
     # nfft needs to be an integer, otherwise a deprecation will be raised

--- a/obspy/imaging/tests/test_spectrogram.py
+++ b/obspy/imaging/tests/test_spectrogram.py
@@ -6,6 +6,8 @@ import os
 import warnings
 
 import numpy as np
+import matplotlib.pyplot as plt
+import pytest
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.imaging import spectrogram
@@ -43,3 +45,47 @@ class TestSpectrogram:
         spectrogram.spectrogram(st[0].data, log=False, outfile=image_path_2,
                                 samp_rate=st[0].stats.sampling_rate,
                                 show=False)
+
+    def test_spectrogram_defaults(self):
+        """
+        Make sure input at varying sampling rates and data lengths does not
+        suffer from defaults (wlen etc) being calculated to nonsensical values
+        resulting in errors raised from the underlying mlab spectrogram
+
+        wlen (in s) used to be calculated as (samp_rate / 100) which makes no
+        sense, it results in very large window sizes for high sampling rates
+        and in window lengths that dont even include a two samples for low
+        sampling rates like 1 Hz.
+        """
+        # input of 30 minutes sampled at 1 Hz should definitely be able to have
+        # a sensible default for window length, but it used to fail
+        data = np.ones(1800)
+        spectrogram.spectrogram(data, samp_rate=1, show=False)
+        plt.close('all')
+
+    def test_spectrogram_nice_error_messages(self):
+        """
+        Make sure to have some nice messages on weird input
+        """
+        # Only 20 samples at 1 Hz and our default tries to window 128 samples,
+        # so we dont even have enough data for a single window. This used to
+        # fail inside mlab specgram with ugly error message about the input
+        data = np.ones(20)
+        msg = ('Input signal too short (20 samples, window length 6.4 '
+               'seconds, nfft 128 samples, sampling rate 20.0 Hz)')
+        with pytest.raises(ValueError) as e:
+            spectrogram.spectrogram(data, samp_rate=20.0, show=False)
+        assert str(e.value) == msg
+        # Only 130 samples at 1 Hz and our default tries to window 128 samples,
+        # so we dont have enough data for two windows. In principle we could
+        # still plot that but our code currently relies on having at least two
+        # windows for plotting. It does not seem worthwhile to change the code
+        # to do so, so just show a nice error
+        data = np.ones(130)
+        msg = ('Input signal too short (130 samples, window length 6.4 '
+               'seconds, nfft 128 samples, 115 samples window overlap, '
+               'sampling rate 20.0 Hz)')
+        with pytest.raises(ValueError) as e:
+            spectrogram.spectrogram(data, samp_rate=20.0, show=False)
+        assert str(e.value) == msg
+        plt.close('all')


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix some problems in `spectrogram`

 - calculation for default window length from input data if not specified was nonsensical and resulted in wlen not even including two samples at low sampling rates of e.g. 1 Hz which resulted in weird error messages from mlab specgram popping up
 - show nice error messages if signal is so short that it would create less than two windows for the spectrogram
 - get rid of some nfft calculation magic, dividing nfft by 8 if nfft was higher than npts of signal. just let a proper message show that signal is too short for the calculated nfft
 
Since this is changing behavior, I decided to base this on master, even though you could look at it as being a bug.

### Why was it initiated?  Any relevant Issues?

@heinerigel reporting weird error messages when trying to plot a spectrogram of a signal with 1 Hz sampling rate ;-)

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
