### PR TITLE
Add support for inner core diffracted phases in taup with Kdiff

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,7 +24,7 @@ Changes:
    * add support for models without a core or inner core
      (see #1200, #1423, #2086, #2192, #2390, #3070)
    * add support for a wider range of diffracted phases, like SedPdiffKP
-     (see #3085)
+     (see #3085) and PKdiffP (see #3095)
    * allow rapid travel time plotting in plot_travel_times by using
      precalculated travel times (see #3092)
    * return pierce points for any depth (see #1742, #3072)

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -308,6 +308,8 @@ depth to an interface involved in an interaction.
       interfaces
     * ``diff`` appended to ``P`` or ``S`` - diffracted wave along the core
       mantle boundary
+    * ``diff`` appended to ``K`` - diffracted wave along the inner-core
+      outer-core boundary
     * ``kmps`` appended to a velocity - horizontal phase velocity (see 10
       below)
     * ``ed`` appended to ``P`` or ``S`` - an exclusively downgoing path, for a

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -307,8 +307,7 @@ depth to an interface involved in an interaction.
     * ``v`` - topside reflection, used primarily for crustal and mantle
       interfaces
     * ``diff`` appended to ``P`` or ``S`` - diffracted wave along the core
-      mantle boundary
-    * ``diff`` appended to ``K`` - diffracted wave along the inner-core
+      mantle boundary; appended to ``K`` - diffracted wave along the inner-core
       outer-core boundary
     * ``kmps`` appended to a velocity - horizontal phase velocity (see 10
       below)

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -324,7 +324,7 @@ class SeismicPhase(object):
                     if current_leg[0] != next_leg[0]:
                         # like Sed Pdiff conversion
                         is_p_wave = not is_p_wave
-                elif next_leg == "K":
+                elif next_leg[0] == "K":
                     end_action = _ACTIONS["transdown"]
                     self.add_to_branch(tau_model, self.current_branch,
                                        tau_model.cmb_branch - 1, is_p_wave,
@@ -388,14 +388,14 @@ class SeismicPhase(object):
                     self.add_to_branch(
                         tau_model, self.current_branch, tau_model.moho_branch,
                         is_p_wave, end_action)
-                elif next_leg[0] in ("P", "S") or next_leg in ("K", "END"):
+                elif next_leg[0] in ("P", "S", "K") or next_leg == "END":
                     if next_leg == 'END':
                         discon_branch = upgoing_rec_branch
-                    elif next_leg == 'K':
+                    elif next_leg[0] == 'K':
                         discon_branch = tau_model.cmb_branch
                     else:
                         discon_branch = 0
-                    if current_leg == 'k' and next_leg != 'K':
+                    if current_leg == 'k' and next_leg[0] != 'K':
                         end_action = _ACTIONS["transup"]
                     else:
                         end_action = _ACTIONS["reflect_underside"]
@@ -450,7 +450,7 @@ class SeismicPhase(object):
                 elif next_leg[0] == "^":
                     discon_branch = closest_branch_to_depth(tau_model,
                                                             next_leg[1:])
-                    if prev_leg == "K":
+                    if prev_leg[0] == "K":
                         end_action = _ACTIONS["reflect_underside"]
                         self.add_to_branch(tau_model, self.current_branch,
                                            discon_branch, is_p_wave,
@@ -563,7 +563,7 @@ class SeismicPhase(object):
                         if (self.current_branch < tau_model.cmb_branch - 1 or
                             (self.current_branch == tau_model.cmb_branch - 1
                              and end_action != _ACTIONS["diffract"])
-                                and prev_leg != "K"):
+                                and prev_leg[0] != "K"):
                             end_action = _ACTIONS["diffract"]
                             self.add_to_branch(
                                 tau_model, self.current_branch,
@@ -683,7 +683,7 @@ class SeismicPhase(object):
                     self.add_to_branch(
                         tau_model, self.current_branch, tau_model.cmb_branch,
                         is_p_wave, end_action)
-                elif next_leg in ("K", "Kdiff"):
+                elif next_leg[0] == "K":
                     if prev_leg in ("P", "S", "K", "Pdiff", "Sdiff", "Kdiff"):
                         end_action = _ACTIONS["turn"]
                         self.add_to_branch(
@@ -766,7 +766,7 @@ class SeismicPhase(object):
                     self.add_to_branch(
                         tau_model, self.current_branch, tau_model.iocb_branch,
                         is_p_wave, end_action)
-                elif next_leg == "K":
+                elif next_leg[0] == "K":
                     end_action = _ACTIONS["transup"]
                     self.add_to_branch(
                         tau_model, self.current_branch, tau_model.iocb_branch,

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -1002,20 +1002,17 @@ def plot_travel_times(source_depth, phase_list=("ttbasic",), min_degrees=0,
             ph = SeismicPhase(phase, depth_corrected_model)
             dist_deg = (180.0/np.pi)*ph.dist
             time_min = ph.time/60
+            c = COLORS[i % len(COLORS)]
             if len(dist_deg) > 0:
                 if plot_all:
                     # wrap-around plotting
                     while dist_deg[0] > 360.0:
                         dist_deg = dist_deg - 360.0
-                    ax.plot(dist_deg, time_min, label=phase,
-                            color=COLORS[i % len(COLORS)])
-                    ax.plot(dist_deg - 360.0, time_min, label=None,
-                            color=COLORS[i % len(COLORS)])
-                    ax.plot(360.0 - dist_deg, time_min, label=None,
-                            color=COLORS[i % len(COLORS)])
+                    ax.plot(dist_deg, time_min, label=phase, color=c)
+                    ax.plot(dist_deg - 360.0, time_min, label=None, color=c)
+                    ax.plot(360.0 - dist_deg, time_min, label=None, color=c)
                 else:
-                    ax.plot(dist_deg, time_min, label=phase,
-                            color=COLORS[i % len(COLORS)])
+                    ax.plot(dist_deg, time_min, label=phase, color=c)
 
         if legend:
             ax.legend(loc=2, numpoints=1)

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -1000,13 +1000,22 @@ def plot_travel_times(source_depth, phase_list=("ttbasic",), min_degrees=0,
         phase_names = sorted(parse_phase_list(phase_list))
         for i, phase in enumerate(phase_names):
             ph = SeismicPhase(phase, depth_corrected_model)
-            dist_deg = (180.0/np.pi)*ph.dist % 360.0
+            dist_deg = (180.0/np.pi)*ph.dist
             time_min = ph.time/60
-            ax.plot(dist_deg, time_min, label=phase,
-                    color=COLORS[i % len(COLORS)])
-            if plot_all:
-                ax.plot(360.0 - dist_deg, time_min, label=None,
-                        color=COLORS[i % len(COLORS)])
+            if len(dist_deg) > 0:
+                if plot_all:
+                    # wrap-around plotting
+                    while dist_deg[0] > 360.0:
+                        dist_deg = dist_deg - 360.0
+                    ax.plot(dist_deg, time_min, label=phase,
+                            color=COLORS[i % len(COLORS)])
+                    ax.plot(dist_deg - 360.0, time_min, label=None,
+                            color=COLORS[i % len(COLORS)])
+                    ax.plot(360.0 - dist_deg, time_min, label=None,
+                            color=COLORS[i % len(COLORS)])
+                else:
+                    ax.plot(dist_deg, time_min, label=phase,
+                            color=COLORS[i % len(COLORS)])
 
         if legend:
             ax.legend(loc=2, numpoints=1)

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -1000,14 +1000,13 @@ def plot_travel_times(source_depth, phase_list=("ttbasic",), min_degrees=0,
         phase_names = sorted(parse_phase_list(phase_list))
         for i, phase in enumerate(phase_names):
             ph = SeismicPhase(phase, depth_corrected_model)
-            dist_deg = (180.0/np.pi)*ph.dist
-            if plot_all:
-                dist_deg = dist_deg % 360.0
-                mask = dist_deg > 180
-                dist_deg[mask] = 360.0 - dist_deg[mask]
+            dist_deg = (180.0/np.pi)*ph.dist % 360.0
             time_min = ph.time/60
             ax.plot(dist_deg, time_min, label=phase,
                     color=COLORS[i % len(COLORS)])
+            if plot_all:
+                ax.plot(360.0 - dist_deg, time_min, label=None,
+                        color=COLORS[i % len(COLORS)])
 
         if legend:
             ax.legend(loc=2, numpoints=1)

--- a/obspy/taup/tests/test_seismic_phase.py
+++ b/obspy/taup/tests/test_seismic_phase.py
@@ -85,9 +85,9 @@ class TestTauPySeismicPhase:
         """
         model = TauPyModel('iasp91')
         phs = ["SedPdiffKP", "PdiffPdiff", "PedPdiffKKP",
-               "PdiffKKPdiff", "PPdiff"]
-        dists = [155.0, 210.0, 310.0, 300.0, 220.0]
-        times = [1464.97, 1697.88, 2052.42, 2008.03, 1742.27]
+               "PdiffKKPdiff", "PPdiff", "SKdiffP"]
+        dists = [155.0, 210.0, 310.0, 300.0, 220.0, 200.0]
+        times = [1464.97, 1697.88, 2052.42, 2008.03, 1742.27, 1431.53]
 
         for ph, dist, time in zip(phs, dists, times):
             phase = SeismicPhase(ph, model.model)


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for inner core diffracted phases in `obspy.taup` with the notation `Kdiff`. An example is:
```
from obspy.taup import TauPyModel
model = TauPyModel("ak135")
arrivals = model.get_ray_paths(0.0, 160, ["PKdiffP"])
print(arrivals)
arrivals.plot_rays()
```
![Figure_1](https://user-images.githubusercontent.com/43536815/174563409-7d85927d-16fc-48c8-bbd0-acc8ae42880a.png)
```
2 arrivals
        PKdiffP phase arrival at 1213.904 seconds
        PKdiffP phase arrival at 1296.514 seconds
```
A very small tweak is also made to the `plot_travel_times` function updated in #3092. It better plots the wrap-around phases at 180 and 360 degrees by plotting with separate lines. Compare the far right of the new plot  
![plot_travel_times](https://user-images.githubusercontent.com/43536815/174563865-534acccc-c653-4817-96ee-e3b3bf3d2ada.png)
with the old one of #3092.

### Why was it initiated?  Any relevant Issues?

Support for inner core diffracted phases has been requested for the java version of taup, see https://github.com/crotwell/TauP/issues/3 . This PR supports the PKP_Cdiff phase requested in that issue, but not the PKP_Bdiff phase. @crotwell -- can you take a look and see if you want to add `Kdiff` to the java version too?

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
