### PR TITLE
Exposing ray parameter tolerances to get_travel_times in taup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,7 +18,7 @@ Changes:
    * add option "indicate_wave_type" to distinguish S waves in ray paths
      plot by using wiggly lines for shear waves (see #3047)
    * improved accuracy of ray paths by change of root-finding algorithm
-     in SeismicPhase.refine_arrival (see #3064)
+     in SeismicPhase.refine_arrival (see #3064, #3096)
    * improved accuracy of travel time estimates by using theta function
      (see #3068)
    * add support for models without a core or inner core

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -83,7 +83,7 @@ and model. By default it returns arrivals for a number of phases.
     PKIKKIKS phase arrival at 2069.756 seconds
     SKIKKIKS phase arrival at 2277.857 seconds
     PKIKPPKIKP phase arrival at 2353.934 seconds
-    PKPPKP phase arrival at 2356.425 seconds
+    PKPPKP phase arrival at 2356.426 seconds
     PKPPKP phase arrival at 2358.899 seconds
     SKIKSSKIKS phase arrival at 3208.155 seconds
 

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -438,7 +438,9 @@ _DEFAULT_VALUES = {
     "qp": 1000.0,
     "qs": 2000.0,
     # Slowness tolerance
-    "slowness_tolerance": 1e-16
+    "slowness_tolerance": 1e-16,
+    "default_time_ray_param_tol": 1e-1,
+    "default_path_ray_param_tol": 1e-6
 }
 
 

--- a/obspy/taup/__init__.py
+++ b/obspy/taup/__init__.py
@@ -106,7 +106,7 @@ object which can be queried for various attributes.
 
 >>> arr = arrivals[0]
 >>> arr.ray_param, arr.time, arr.incident_angle  # doctest: +ELLIPSIS
-(453.7536..., 485.2100..., 24.3988...)
+(453.7..., 485.210..., 24.39...)
 
 Ray Paths
 ^^^^^^^^^

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1454,9 +1454,12 @@ class SeismicPhase(object):
         if left.purist_dist == search_dist:
             return left
 
-        arrival_time = ((search_dist - left.purist_dist) /
-                        (right.purist_dist - left.purist_dist) *
-                        (right.time - left.time)) + left.time
+        left_theta = left.time + left.ray_param * (
+            search_dist - left.purist_dist)
+        right_theta = right.time + right.ray_param * (
+            search_dist - right.purist_dist)
+        arrival_time = min(left_theta, right_theta)
+
         if math.isnan(arrival_time):
             msg = ('Time is NaN, search=%f leftDist=%f leftTime=%f '
                    'rightDist=%f rightTime=%f')

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -15,6 +15,7 @@ from .helper_classes import (Arrival, SlownessModelError, TauModelError,
                              TimeDist)
 
 from .c_wrappers import clibtau
+from . import _DEFAULT_VALUES
 
 
 _ACTIONS = Enum([
@@ -1098,7 +1099,8 @@ class SeismicPhase(object):
                 times_branches[1][bs] += 1
         return times_branches
 
-    def calc_time(self, degrees, ray_param_tol=1e-1):
+    def calc_time(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]):
         """
         Calculate arrival times for this phase, sorted by time.
         """
@@ -1126,7 +1128,9 @@ class SeismicPhase(object):
                 self._settings["max_recursion"]))
         return arrivals
 
-    def calc_pierce(self, degrees, ray_param_tol=1e-6):
+    def calc_pierce(self, degrees,
+                    ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]
+                    ):
         """
         Calculate pierce points for this phase.
 
@@ -1256,7 +1260,8 @@ class SeismicPhase(object):
         # The arrival is modified in place and must (?) thus be returned.
         return curr_arrival
 
-    def calc_path(self, degrees, ray_param_tol=1e-6):
+    def calc_path(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]):
         """
         Calculate the paths this phase takes through the planet model.
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -673,7 +673,7 @@ class TauPyModel(object):
         :type phase_list: list[str]
         :param receiver_depth_in_km: Receiver depth in km
         :type receiver_depth_in_km: float
-        :param ray_param_tol: absolute tolerance in s used in estimation of
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
             ray parameter.
         :type ray_param_tol: float
 
@@ -713,7 +713,7 @@ class TauPyModel(object):
         :param add_depth: List of additional depths for which to get pierce
             points.
         :type add_depth: list[float]
-        :param ray_param_tol: absolute tolerance in s used in estimation of
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
             ray parameter.
         :type ray_param_tol: float
 
@@ -746,7 +746,7 @@ class TauPyModel(object):
         :type phase_list: list[str]
         :param receiver_depth_in_km: Receiver depth in km
         :type receiver_depth_in_km: float
-        :param ray_param_tol: absolute tolerance in s used in estimation of
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
             ray parameter.
         :type ray_param_tol: float
 

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -764,7 +764,9 @@ class TauPyModel(object):
 
     def get_travel_times_geo(self, source_depth_in_km, source_latitude_in_deg,
                              source_longitude_in_deg, receiver_latitude_in_deg,
-                             receiver_longitude_in_deg, phase_list=("ttall",)):
+                             receiver_longitude_in_deg, phase_list=("ttall",),
+                             ray_param_tol=_DEFAULT_VALUES[
+                                "default_time_ray_param_tol"]):
         """
         Return travel times of every given phase given geographical data.
 
@@ -791,6 +793,9 @@ class TauPyModel(object):
             calculated. If this is empty, all phases in arrivals object
             will be used.
         :type phase_list: list[str]
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
 
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as
@@ -804,7 +809,8 @@ class TauPyModel(object):
                                     self.model.radius_of_planet,
                                     self.planet_flattening)
         arrivals = self.get_travel_times(source_depth_in_km, distance_in_deg,
-                                         phase_list)
+                                         phase_list,
+                                         ray_param_tol=ray_param_tol)
         return arrivals
 
     def get_pierce_points_geo(self, source_depth_in_km, source_latitude_in_deg,
@@ -812,7 +818,9 @@ class TauPyModel(object):
                               receiver_latitude_in_deg,
                               receiver_longitude_in_deg,
                               phase_list=("ttall",),
-                              resample=False, add_depth=[]):
+                              resample=False, add_depth=[],
+                              ray_param_tol=_DEFAULT_VALUES[
+                                "default_path_ray_param_tol"]):
         """
         Return pierce points of every given phase with geographical info.
 
@@ -846,6 +854,9 @@ class TauPyModel(object):
         :param add_depth: List of additional depths for which to get pierce
             points.
         :type add_depth: list[float]
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
 
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as
@@ -860,7 +871,8 @@ class TauPyModel(object):
                                     self.planet_flattening)
 
         arrivals = self.get_pierce_points(source_depth_in_km, distance_in_deg,
-                                          phase_list, add_depth=add_depth)
+                                          phase_list, add_depth=add_depth,
+                                          ray_param_tol=ray_param_tol)
 
         if geodetics.HAS_GEOGRAPHICLIB:
             arrivals = add_geo_to_arrivals(arrivals, source_latitude_in_deg,
@@ -882,7 +894,9 @@ class TauPyModel(object):
     def get_ray_paths_geo(self, source_depth_in_km, source_latitude_in_deg,
                           source_longitude_in_deg, receiver_latitude_in_deg,
                           receiver_longitude_in_deg, phase_list=("ttall",),
-                          resample=False):
+                          resample=False,
+                          ray_param_tol=_DEFAULT_VALUES[
+                              "default_path_ray_param_tol"]):
         """
         Return ray paths of every given phase with geographical info.
 
@@ -909,6 +923,10 @@ class TauPyModel(object):
             calculated. If this is empty, all phases in arrivals object
             will be used.
         :type phase_list: list[str]
+        :param ray_param_tol: Absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
+
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as
             attributes.
@@ -922,7 +940,7 @@ class TauPyModel(object):
                                     self.planet_flattening)
 
         arrivals = self.get_ray_paths(source_depth_in_km, distance_in_deg,
-                                      phase_list)
+                                      phase_list, ray_param_tol=ray_param_tol)
 
         if geodetics.HAS_GEOGRAPHICLIB:
             arrivals = add_geo_to_arrivals(arrivals, source_latitude_in_deg,

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -673,6 +673,9 @@ class TauPyModel(object):
         :type phase_list: list[str]
         :param receiver_depth_in_km: Receiver depth in km
         :type receiver_depth_in_km: float
+        :param ray_param_tol: absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
 
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as
@@ -710,6 +713,9 @@ class TauPyModel(object):
         :param add_depth: List of additional depths for which to get pierce
             points.
         :type add_depth: list[float]
+        :param ray_param_tol: absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
 
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as
@@ -740,6 +746,9 @@ class TauPyModel(object):
         :type phase_list: list[str]
         :param receiver_depth_in_km: Receiver depth in km
         :type receiver_depth_in_km: float
+        :param ray_param_tol: absolute tolerance in s used in estimation of
+            ray parameter.
+        :type ray_param_tol: float
 
         :return: List of ``Arrival`` objects, each of which has the time,
             corresponding phase name, ray parameter, takeoff angle, etc. as

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -12,6 +12,7 @@ from matplotlib.cm import get_cmap
 import matplotlib.text
 import numpy as np
 
+from . import _DEFAULT_VALUES
 from .helper_classes import Arrival
 from .tau_model import TauModel
 from .taup_path import TauPPath
@@ -656,7 +657,9 @@ class TauPyModel(object):
         self.planet_flattening = planet_flattening
 
     def get_travel_times(self, source_depth_in_km, distance_in_degree=None,
-                         phase_list=("ttall",), receiver_depth_in_km=0.0):
+                         phase_list=("ttall",), receiver_depth_in_km=0.0,
+                         ray_param_tol=_DEFAULT_VALUES[
+                             "default_time_ray_param_tol"]):
         """
         Return travel times of every given phase.
 
@@ -680,14 +683,17 @@ class TauPyModel(object):
         # might be useful, but also difficult: several arrivals can have the
         # same phase.
         tt = TauPTime(self.model, phase_list, source_depth_in_km,
-                      distance_in_degree, receiver_depth_in_km)
+                      distance_in_degree, receiver_depth_in_km,
+                      ray_param_tol=ray_param_tol)
         tt.run()
         return Arrivals(sorted(tt.arrivals, key=lambda x: x.time),
                         model=self.model)
 
     def get_pierce_points(self, source_depth_in_km, distance_in_degree,
                           phase_list=("ttall",), receiver_depth_in_km=0.0,
-                          add_depth=[]):
+                          add_depth=[],
+                          ray_param_tol=_DEFAULT_VALUES[
+                              "default_path_ray_param_tol"]):
         """
         Return pierce points of every given phase.
 
@@ -712,13 +718,15 @@ class TauPyModel(object):
         """
         pp = TauPPierce(self.model, phase_list, source_depth_in_km,
                         distance_in_degree, receiver_depth_in_km,
-                        add_depth)
+                        add_depth, ray_param_tol=ray_param_tol)
         pp.run()
         return Arrivals(sorted(pp.arrivals, key=lambda x: x.time),
                         model=self.model)
 
     def get_ray_paths(self, source_depth_in_km, distance_in_degree=None,
-                      phase_list=("ttall",), receiver_depth_in_km=0.0):
+                      phase_list=("ttall",), receiver_depth_in_km=0.0,
+                      ray_param_tol=_DEFAULT_VALUES[
+                              "default_path_ray_param_tol"]):
         """
         Return ray paths of every given phase.
 
@@ -739,7 +747,8 @@ class TauPyModel(object):
         :rtype: :class:`Arrivals`
         """
         rp = TauPPath(self.model, phase_list, source_depth_in_km,
-                      distance_in_degree, receiver_depth_in_km)
+                      distance_in_degree, receiver_depth_in_km,
+                      ray_param_tol=ray_param_tol)
         rp.run()
         return Arrivals(sorted(rp.arrivals, key=lambda x: x.time),
                         model=self.model)

--- a/obspy/taup/taup_path.py
+++ b/obspy/taup/taup_path.py
@@ -3,22 +3,27 @@
 Ray path calculations.
 """
 from .taup_pierce import TauPPierce
+from . import _DEFAULT_VALUES
 
 
 class TauPPath(TauPPierce):
     """
     Calculate the ray paths for each phase, using TauPPierce and TauPTime.
     """
-    def calculate(self, degrees):
+    def calculate(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]):
         """
         Call all the necessary calculations to obtain the ray paths.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         self.recalc_phases()
         self.arrivals = []
-        self.calculate_path(degrees)
+        self.calculate_path(degrees, ray_param_tol)
 
-    def calculate_path(self, degrees):
+    def calculate_path(self, degrees,
+                       ray_param_tol=_DEFAULT_VALUES[
+                           "default_path_ray_param_tol"]
+                       ):
         """
         Calculates the ray paths for phases at the given distance by
         calling the calculate_path method of the SeismicPhase class. The
@@ -26,4 +31,4 @@ class TauPPath(TauPPierce):
         """
         self.degrees = degrees
         for phase in self.phases:
-            self.arrivals += phase.calc_path(degrees)
+            self.arrivals += phase.calc_path(degrees, ray_param_tol)

--- a/obspy/taup/taup_path.py
+++ b/obspy/taup/taup_path.py
@@ -3,27 +3,22 @@
 Ray path calculations.
 """
 from .taup_pierce import TauPPierce
-from . import _DEFAULT_VALUES
 
 
 class TauPPath(TauPPierce):
     """
     Calculate the ray paths for each phase, using TauPPierce and TauPTime.
     """
-    def calculate(self, degrees,
-                  ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]):
+    def calculate(self, degrees):
         """
         Call all the necessary calculations to obtain the ray paths.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         self.recalc_phases()
         self.arrivals = []
-        self.calculate_path(degrees, ray_param_tol)
+        self.calculate_path(degrees)
 
-    def calculate_path(self, degrees,
-                       ray_param_tol=_DEFAULT_VALUES[
-                           "default_path_ray_param_tol"]
-                       ):
+    def calculate_path(self, degrees):
         """
         Calculates the ray paths for phases at the given distance by
         calling the calculate_path method of the SeismicPhase class. The
@@ -31,4 +26,4 @@ class TauPPath(TauPPierce):
         """
         self.degrees = degrees
         for phase in self.phases:
-            self.arrivals += phase.calc_path(degrees, ray_param_tol)
+            self.arrivals += phase.calc_path(degrees, self.ray_param_tol)

--- a/obspy/taup/taup_pierce.py
+++ b/obspy/taup/taup_pierce.py
@@ -3,6 +3,7 @@
 Pierce point calculations.
 """
 from .taup_time import TauPTime
+from . import _DEFAULT_VALUES
 
 
 class TauPPierce(TauPTime):
@@ -59,20 +60,25 @@ class TauPPierce(TauPTime):
             TauPTime.depth_correct(self, depth, receiver_depth)
             self.model = orig_tau_model
 
-    def calculate(self, degrees):
+    def calculate(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]
+                  ):
         """
         Call all the necessary calculations to obtain the pierce points.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         self.recalc_phases()
         self.arrivals = []
-        self.calculate_pierce(degrees)
+        self.calculate_pierce(degrees, ray_param_tol)
 
-    def calculate_pierce(self, degrees):
+    def calculate_pierce(self, degrees,
+                         ray_param_tol=_DEFAULT_VALUES[
+                            "default_path_ray_param_tol"]
+                         ):
         """
         Calculates the pierce points for phases at the given distance by
         calling the calculate_pierce method of the SeismicPhase class.
         The results are then in self.arrivals.
         """
         for phase in self.phases:
-            self.arrivals += phase.calc_pierce(degrees)
+            self.arrivals += phase.calc_pierce(degrees, ray_param_tol)

--- a/obspy/taup/taup_pierce.py
+++ b/obspy/taup/taup_pierce.py
@@ -12,10 +12,11 @@ class TauPPierce(TauPTime):
     relating to the different arrivals.
     """
     def __init__(self, model, phase_list, depth, degrees, receiver_depth=0.0,
-                 add_depth=[]):
+                 add_depth=[],
+                 ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]):
         super(TauPPierce, self).__init__(
             model=model, phase_list=phase_list, depth=depth, degrees=degrees,
-            receiver_depth=receiver_depth)
+            receiver_depth=receiver_depth, ray_param_tol=ray_param_tol)
         self.only_turn_points = False
         self.only_rev_points = False
         self.only_under_points = False
@@ -60,25 +61,20 @@ class TauPPierce(TauPTime):
             TauPTime.depth_correct(self, depth, receiver_depth)
             self.model = orig_tau_model
 
-    def calculate(self, degrees,
-                  ray_param_tol=_DEFAULT_VALUES["default_path_ray_param_tol"]
-                  ):
+    def calculate(self, degrees):
         """
         Call all the necessary calculations to obtain the pierce points.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         self.recalc_phases()
         self.arrivals = []
-        self.calculate_pierce(degrees, ray_param_tol)
+        self.calculate_pierce(degrees)
 
-    def calculate_pierce(self, degrees,
-                         ray_param_tol=_DEFAULT_VALUES[
-                            "default_path_ray_param_tol"]
-                         ):
+    def calculate_pierce(self, degrees):
         """
         Calculates the pierce points for phases at the given distance by
         calling the calculate_pierce method of the SeismicPhase class.
         The results are then in self.arrivals.
         """
         for phase in self.phases:
-            self.arrivals += phase.calc_pierce(degrees, ray_param_tol)
+            self.arrivals += phase.calc_pierce(degrees, self.ray_param_tol)

--- a/obspy/taup/taup_time.py
+++ b/obspy/taup/taup_time.py
@@ -5,6 +5,7 @@ Travel time calculations.
 from .helper_classes import TauModelError
 from .seismic_phase import SeismicPhase
 from .utils import parse_phase_list
+from . import _DEFAULT_VALUES
 
 
 class TauPTime(object):
@@ -82,16 +83,19 @@ class TauPTime(object):
                           str(temp_phase_name))
             self.phases = new_phases
 
-    def calculate(self, degrees):
+    def calculate(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]
+                  ):
         """
         Calculate the arrival times.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         # Called before, but depth_correct might have changed the phases.
         self.recalc_phases()
-        self.calc_time(degrees)
+        self.calc_time(degrees, ray_param_tol)
 
-    def calc_time(self, degrees):
+    def calc_time(self, degrees,
+                  ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]):
         """
         Calls the calc_time method of SeismicPhase to calculate arrival
         times for every phase, each sorted by time.
@@ -99,7 +103,7 @@ class TauPTime(object):
         self.degrees = degrees
         self.arrivals = []
         for phase in self.phases:
-            self.arrivals += phase.calc_time(degrees)
+            self.arrivals += phase.calc_time(degrees, ray_param_tol)
         # Sort them.
         self.arrivals = sorted(self.arrivals,
                                key=lambda arrivals: arrivals.time)

--- a/obspy/taup/taup_time.py
+++ b/obspy/taup/taup_time.py
@@ -13,7 +13,9 @@ class TauPTime(object):
     Calculate travel times for different branches using linear interpolation
     between known slowness samples.
     """
-    def __init__(self, model, phase_list, depth, degrees, receiver_depth=0.0):
+    def __init__(self, model, phase_list, depth, degrees, receiver_depth=0.0,
+                 ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]
+                 ):
         self.source_depth = depth
         self.receiver_depth = receiver_depth
         self.degrees = degrees
@@ -25,6 +27,7 @@ class TauPTime(object):
         # A standard and a depth corrected model. Both are needed.
         self.model = model
         self.depth_corrected_model = self.model
+        self.ray_param_tol = ray_param_tol
 
     def run(self):
         """
@@ -83,19 +86,16 @@ class TauPTime(object):
                           str(temp_phase_name))
             self.phases = new_phases
 
-    def calculate(self, degrees,
-                  ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]
-                  ):
+    def calculate(self, degrees):
         """
         Calculate the arrival times.
         """
         self.depth_correct(self.source_depth, self.receiver_depth)
         # Called before, but depth_correct might have changed the phases.
         self.recalc_phases()
-        self.calc_time(degrees, ray_param_tol)
+        self.calc_time(degrees)
 
-    def calc_time(self, degrees,
-                  ray_param_tol=_DEFAULT_VALUES["default_time_ray_param_tol"]):
+    def calc_time(self, degrees):
         """
         Calls the calc_time method of SeismicPhase to calculate arrival
         times for every phase, each sorted by time.
@@ -103,7 +103,7 @@ class TauPTime(object):
         self.degrees = degrees
         self.arrivals = []
         for phase in self.phases:
-            self.arrivals += phase.calc_time(degrees, ray_param_tol)
+            self.arrivals += phase.calc_time(degrees, self.ray_param_tol)
         # Sort them.
         self.arrivals = sorted(self.arrivals,
                                key=lambda arrivals: arrivals.time)

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -90,13 +90,13 @@ class TestTauPyModel:
         assert arr.name == expected_arr["name"]
         assert abs(arr.time - expected_arr["time"]) < 2e-2
         diff = arr.ray_param_sec_degree - expected_arr["ray_param_sec_degree"]
-        assert round(abs(diff), 2) == 0
+        assert abs(diff) < 2e-2
         diff = arr.takeoff_angle - expected_arr["takeoff_angle"]
-        assert round(abs(diff), 1) == 0
+        assert abs(diff) < 2e-1
         diff = arr.incident_angle - expected_arr["incident_angle"]
-        assert round(abs(diff), 1) == 0
+        assert abs(diff) < 2e-1
         diff = arr.purist_distance - expected_arr["purist_distance"]
-        assert round(abs(diff), 2) == 0
+        assert abs(diff) < 2e-2
         assert arr.purist_name == expected_arr["purist_name"]
 
     def test_p_iasp91_manual(self):
@@ -111,11 +111,11 @@ class TestTauPyModel:
         p_arrival = arrivals[0]
 
         assert p_arrival.name == "P"
-        assert round(abs(p_arrival.time-412.43), 2) == 0
-        assert round(abs(p_arrival.ray_param_sec_degree-8.613), 3) == 0
-        assert round(abs(p_arrival.takeoff_angle-26.74), 2) == 0
-        assert round(abs(p_arrival.incident_angle-26.70), 2) == 0
-        assert round(abs(p_arrival.purist_distance-35.00), 2) == 0
+        assert abs(p_arrival.time-412.43) < 2e-2
+        assert abs(p_arrival.ray_param_sec_degree-8.613) < 2e-3
+        assert abs(p_arrival.takeoff_angle-26.74) < 2e-2
+        assert abs(p_arrival.incident_angle-26.70) < 2e-2
+        assert abs(p_arrival.purist_distance-35.00) < 2e-2
         assert p_arrival.purist_name == "P"
 
     @pytest.mark.skipif(not geodetics.HAS_GEOGRAPHICLIB,
@@ -137,11 +137,11 @@ class TestTauPyModel:
         p_arrival = arrivals[0]
 
         assert p_arrival.name == "P"
-        assert round(abs(p_arrival.time-412.43), 2) == 0
-        assert round(abs(p_arrival.ray_param_sec_degree-8.613), 3) == 0
-        assert round(abs(p_arrival.takeoff_angle-26.74), 2) == 0
-        assert round(abs(p_arrival.incident_angle-26.70), 2) == 0
-        assert round(abs(p_arrival.purist_distance-35.00), 2) == 0
+        assert abs(p_arrival.time-412.43) < 2e-2
+        assert abs(p_arrival.ray_param_sec_degree-8.613) < 2e-3
+        assert abs(p_arrival.takeoff_angle-26.74) < 2e-2
+        assert abs(p_arrival.incident_angle-26.70) < 2e-2
+        assert abs(p_arrival.purist_distance-35.00) < 2e-2
         assert p_arrival.purist_name == "P"
 
     def test_p_iasp91_geo_fallback_manual(self):
@@ -165,11 +165,11 @@ class TestTauPyModel:
         p_arrival = arrivals[0]
 
         assert p_arrival.name == "P"
-        assert round(abs(p_arrival.time-412.43), 2) == 0
-        assert round(abs(p_arrival.ray_param_sec_degree-8.613), 3) == 0
-        assert round(abs(p_arrival.takeoff_angle-26.74), 2) == 0
-        assert round(abs(p_arrival.incident_angle-26.70), 2) == 0
-        assert round(abs(p_arrival.purist_distance-35.00), 2) == 0
+        assert abs(p_arrival.time-412.43) < 2e-2
+        assert abs(p_arrival.ray_param_sec_degree-8.613) < 2e-3
+        assert abs(p_arrival.takeoff_angle-26.74) < 2e-2
+        assert abs(p_arrival.incident_angle-26.70) < 2e-2
+        assert abs(p_arrival.purist_distance-35.00) < 2e-2
         assert p_arrival.purist_name == "P"
 
     def test_p_iasp91(self, caches):

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -88,7 +88,7 @@ class TestTauPyModel:
         assert arr.distance == expected_arr["distance"]
         assert arr.source_depth == expected_arr["depth"]
         assert arr.name == expected_arr["name"]
-        assert round(abs(arr.time - expected_arr["time"]), 2) == 0
+        assert abs(arr.time - expected_arr["time"]) < 2e-2
         diff = arr.ray_param_sec_degree - expected_arr["ray_param_sec_degree"]
         assert round(abs(diff), 2) == 0
         diff = arr.takeoff_angle - expected_arr["takeoff_angle"]


### PR DESCRIPTION
### What does this PR do?

This PR builds on #3064 and #3068 and allows one to set the tolerance used for the estimating the ray parameter in the top-level functions `TauPyModel.get_ray_paths`, `TauPyModel.get_pierce_points`, and `TauPyModel.get_travel_times`. It also sets some default values for these tolerances in `_DEFAULT_VALUES["default_time_ray_param_tol"]` and `_DEFAULT_VALUES["default_path_ray_param_tol"]`. If all one is interested in is a travel time rather than the ray path, then one can use a fairly coarse ray parameter tolerance, so the `"default_time_ray_param_tol"` has been set at a rather larger value than `"default_path_ray_param_tol"`.

Examples:
```
from obspy.taup import TauPyModel
model = TauPyModel("prem")
arrivals = model.get_travel_times(0.0, 60.0, ["P"], ray_param_tol=1e1)
print(arrivals)
```
```
1 arrivals
	P phase arrival at 607.161 seconds
```
```
arrivals = model.get_travel_times(0.0, 60.0, ["P"], ray_param_tol=1e-1)
print(arrivals)
```
```
1 arrivals
	P phase arrival at 607.153 seconds
```

### Why was it initiated?  Any relevant Issues?

The need for documenting and exposing the tolerance goes back to issue #1296. The tolerance is now at least mentioned in the docstring of the top-level methods, and much easier for users to play with. There is now no longer a `obspy.taup.seismic_phase.REFINE_DIST_RADIAN_TOL` value that can be set.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
