### PR TITLE
Avoid plotting across shadow zones in plot_travel_times

### DIFF
--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1655,6 +1655,30 @@ class SeismicPhase(object):
     def get_earliest_arrival(cls, rel_phases, degrees):
         raise NotImplementedError("baaa")
 
+    def _shadow_zone_splits(self):
+        """
+        A list of slices that split  on any shadow zones.
+        """
+        if self.head_or_diffract_seq:
+            return [slice(0, None)]
+        else:
+            return _repeated_value_splits(self.ray_param)
+
+
+def _repeated_value_splits(x):
+    """
+    A list of slices that split a 1D numpy array where values repeat.
+    """
+    split_indices = []
+    idxs = np.where(x[1:] - x[:-1] == 0)[0] + 1
+    left_index = 0
+    for i in idxs:
+        split_indices.append(slice(left_index, i))
+        left_index = i
+    split_indices.append(slice(left_index, None))
+
+    return split_indices
+
 
 def closest_branch_to_depth(tau_model, depth_string):
     """

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1672,7 +1672,7 @@ def _repeated_value_splits(x):
     A list of slices that split a 1D numpy array where values repeat.
     """
     split_indices = []
-    idxs = np.where(x[1:] - x[:-1] == 0)[0] + 1
+    idxs = np.where(np.diff(x) == 0)[0] + 1
     left_index = 0
     for i in idxs:
         split_indices.append(slice(left_index, i))

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1657,11 +1657,13 @@ class SeismicPhase(object):
 
     def _shadow_zone_splits(self):
         """
-        A list of slices that split  on any shadow zones.
+        A list of slices that split on any shadow zones.
         """
         if self.head_or_diffract_seq:
+            # don't split any diffracted waves
             return [slice(0, None)]
         else:
+            # shadow zones are where ray parameter repeats
             return _repeated_value_splits(self.ray_param)
 
 


### PR DESCRIPTION
### What does this PR do?

This is a small tweak to the rapid travel time plotting in #3092. That function plotted each phase as one continous line, which is an issue if there is a shadow zone. This PR breaks the curve at all shadow zones.

An example, using `DWThot.npz` from issue #1639
```
from obspy.taup import TauPyModel, plot_travel_times
model = TauPyModel("DWThot.npz")
plot_travel_times(0.0, model=model, phase_list=["P", "S"])
```
Old behaviour:
![old](https://user-images.githubusercontent.com/43536815/176027581-338f11b1-0849-4d50-b7f7-90bd1449c529.png)
New behaviour:
![new](https://user-images.githubusercontent.com/43536815/176027606-69119822-8536-44b8-8851-d3e4d2926d73.png)
With this PR the shadow zone for S is plotted correctly.

This also fixes a small issue with `Arrivals.plot_rays()`. When `indicate_wave_type=True` and `legend=True` there could be duplicate legend labels. This PR removes the duplicates.

### Why was it initiated?  Any relevant Issues?

Builds on #3092.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
