### PR TITLE
Speedup template matching in coincidence trigger

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,18 +5,21 @@ Changes:
  - obspy.core:
    * Improved expanded channel information in string representation of Station,
      e.g. when displaying station in IPython shell (see #3024)
- - obspy.db:
-   * submodule removed completely, since mostly being used in discontinued
-     seishub server (see #2994)
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)
+ - obspy.db:
+   * submodule removed completely, since mostly being used in discontinued
+     seishub server (see #2994)
  - obspy.imaging:
    * spectrogram: change the computation for default window length if not
      specified to give useful values for sampling rates much higher or lower
      than 100 Hz (see #3093)
    * spectrogram: better exception type and messages when input signal is too
      short (see #3093)
+ - obspy.signal:
+   * coincidence trigger: improve speed of template matching and less memory
+     usage (see #3104)
  - obspy.taup:
    * add option "indicate_wave_type" to distinguish S waves in ray paths
      plot by using wiggly lines for shear waves (see #3047)

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -689,23 +689,23 @@ def coincidence_trigger(trigger_type, thr_on, thr_off, stream,
     :rtype: list
     :returns: List of event triggers sorted chronologically.
     """
-    st = stream.copy()
     # if no trace ids are specified use all traces ids found in stream
     if trace_ids is None:
-        trace_ids = [tr.id for tr in st]
+        trace_ids = [tr.id for tr in stream]
     # we always work with a dictionary with trace ids and their weights later
     if isinstance(trace_ids, list) or isinstance(trace_ids, tuple):
         trace_ids = dict.fromkeys(trace_ids, 1)
     # set up similarity thresholds as a dictionary if necessary
     if not isinstance(similarity_threshold, dict):
-        similarity_threshold = dict.fromkeys([tr.stats.station for tr in st],
-                                             similarity_threshold)
+        similarity_threshold = dict.fromkeys(
+            [tr.stats.station for tr in stream], similarity_threshold)
 
     # the single station triggering
     triggers = []
     # prepare kwargs for trigger_onset
     kwargs = {'max_len_delete': delete_long_trigger}
-    for tr in st:
+    for tr in stream:
+        tr = tr.copy()
         if tr.id not in trace_ids:
             msg = "At least one trace's ID was not found in the " + \
                   "trace ID list and was disregarded (%s)" % tr.id


### PR DESCRIPTION
### What does this PR do?

Speeds up template matching in coincidence trigger event detection routine. Maximum similarity with given templates is now calculated once for every single station trigger before starting the coincidence part of the code.

### Why was it initiated?  Any relevant Issues?

Template matching was done multiple times on overlapping single station triggers during the coincidence building, due to how it was done on the fly in that part of the code.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
