### PR TITLE
Added exception for unpacking error of AH file reading

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -200,6 +200,7 @@ Changes:
    * fix a bug while checking for valid URI syntax when setting identifiers on
      inventory type objects (see #2905)
    * fix a bug unpacking strings while reading event comments of AH files
+     (see #3107)
  - obspy.clients.arclink:
    * submodule removed completely, since ArcLink was officially deprecated and
      deactivated on all big datacenters years ago (see #2994)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -199,6 +199,7 @@ Changes:
      frequency ranges outside of the valid response information (see #2988)
    * fix a bug while checking for valid URI syntax when setting identifiers on
      inventory type objects (see #2905)
+   * fix a bug unpacking strings while reading event comments of AH files
  - obspy.clients.arclink:
    * submodule removed completely, since ArcLink was officially deprecated and
      deactivated on all big datacenters years ago (see #2994)

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -116,7 +116,7 @@ def _unpack_string(data):
     string = data.unpack_string()
     try:
         string = string.split(b'\x00', 1)
-    except Exception:
+    except UnicodeDecodeError:
         string = string.split()
     string = string[0].strip().decode("utf-8")
     return string

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -114,8 +114,8 @@ def _get_ah_version(filename):
 
 def _unpack_string(data):
     try:
-        string = data.unpack_string().split(b'\x00',
-                                            1)[0].strip().decode("utf-8")
+        string = data.unpack_string().split(
+            b'\x00', 1)[0].strip().decode("utf-8")
     except Exception:
         string = data.unpack_string().split()[0].strip().decode("utf-8")
     return string

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -15,6 +15,8 @@ a number of values followed by the time series data.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
+import warnings
+
 import numpy as np
 
 from obspy import Stream, Trace, UTCDateTime
@@ -113,13 +115,14 @@ def _get_ah_version(filename):
 
 
 def _unpack_string(data):
-    string = data.unpack_string()
+    data = data.unpack_string().split(b'\x00', 1)[0].strip()
     try:
-        string = string.split(b'\x00', 1)
+        data = data.decode("utf-8")
     except UnicodeDecodeError:
-        string = string.split()
-    string = string[0].strip().decode("utf-8")
-    return string
+        msg = f'can not decode {data} as UTF-8, decoding with replacing errors'
+        warnings.warn(msg)
+        data = data.decode("utf-8", errors="replace")
+    return data
 
 
 def _read_ah1(filename):

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -113,7 +113,12 @@ def _get_ah_version(filename):
 
 
 def _unpack_string(data):
-    return data.unpack_string().split(b'\x00', 1)[0].strip().decode("utf-8")
+    try:
+        string = data.unpack_string().split(b'\x00',
+                                            1)[0].strip().decode("utf-8")
+    except Exception:
+        string = data.unpack_string().split()[0].strip().decode("utf-8")
+    return string
 
 
 def _read_ah1(filename):

--- a/obspy/io/ah/core.py
+++ b/obspy/io/ah/core.py
@@ -113,11 +113,12 @@ def _get_ah_version(filename):
 
 
 def _unpack_string(data):
+    string = data.unpack_string()
     try:
-        string = data.unpack_string().split(
-            b'\x00', 1)[0].strip().decode("utf-8")
+        string = string.split(b'\x00', 1)
     except Exception:
-        string = data.unpack_string().split()[0].strip().decode("utf-8")
+        string = string.split()
+    string = string[0].strip().decode("utf-8")
     return string
 
 


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes an issue with `_unpack_string` method for AH file format. I encountered that already some time ago but only fixed it locally

### Why was it initiated?  Any relevant Issues?

No relevant issues yet.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
