### PR TITLE
docs: Fix a few typos

### DIFF
--- a/obspy/io/mseed/src/libmseed/genutils.c
+++ b/obspy/io/mseed/src/libmseed/genutils.c
@@ -1371,7 +1371,7 @@ ms_reduce_rate (double samprate, int16_t *factor1, int16_t *factor2)
   /* Handle case of non-integer less than 16-bit int range */
   else if (samprate <= 32767.0)
   {
-    /* For samples/seconds, determine, potentially approximate, numerator and denomiator */
+    /* For samples/seconds, determine, potentially approximate, numerator and denominator */
     ms_ratapprox (samprate, &num, &den, 32767, 1e-8);
 
     /* Negate the factor2 to denote a division operation */

--- a/obspy/signal/src/evalresp/spline.c
+++ b/obspy/signal/src/evalresp/spline.c
@@ -5051,7 +5051,7 @@ double *penta ( int n, double a1[], double a2[], double a3[], double a4[],
   Discussion:
 
     The matrix A is pentadiagonal.  It is entirely zero, except for
-    the main diagaonal, and the two immediate sub- and super-diagonals.
+    the main diagonal, and the two immediate sub- and super-diagonals.
 
     The entries of Row I are stored as:
 


### PR DESCRIPTION
There are small typos in:
- obspy/io/mseed/src/libmseed/genutils.c
- obspy/signal/src/evalresp/spline.c

Fixes:
- Should read `denominator` rather than `denomiator`.
- Should read `diagonal` rather than `diagaonal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md