### PR TITLE
scan: skip directories that lack permission

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,8 @@ Changes:
      #3117)
  - obspy.clients.fdsn:
    * add URL mapping 'EIDA' for http://eida-federator.ethz.ch (see #3050)
+ - obspy.imaging:
+   * Scanner/obspy-scan: skip directories without read permission (see #3115)
  - obspy.io.gse2:
    * bulletin reading: correctly add Mag2 and amplitudes even if Mag1 is not
      present (see #2420)

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -160,7 +160,13 @@ def recursive_parse(data_dict, samp_int_dict, path, counter, format=None,
         counter = parse_file_to_dict(data_dict, samp_int_dict, path, counter,
                                      format, verbose, quiet=quiet)
     elif os.path.isdir(path):
-        for file in (os.path.join(path, file) for file in os.listdir(path)):
+        try:
+            dirlist = os.listdir(path)
+        except PermissionError:
+            if verbose or not quiet:
+                print(f"Can not read directory {path} ('Permission denied')")
+            return counter
+        for file in (os.path.join(path, file) for file in dirlist):
             counter = recursive_parse(data_dict, samp_int_dict, file, counter,
                                       format, verbose, quiet, ignore_links)
     else:

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -53,6 +53,10 @@ class TestScan:
 
             obspy_scan([os.curdir] + ['--output', str(image_path)])
 
+    @pytest.mark.xfail(
+        os.environ.get('RUNNER_OS') == "Windows",
+        reason="changing directory permission to non-readable does not seem "
+               "to work")
     def test_scan_dir_no_permission(self, all_files):
         """
         Run obspy-scan on a directory without read permission.

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -4,8 +4,9 @@ The obspy.imaging.scripts.scan / obspy-scan test suite.
 """
 import os
 import shutil
-from os.path import abspath, dirname, join, pardir
 import warnings
+from os.path import abspath, dirname, join, pardir
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
@@ -51,6 +52,34 @@ class TestScan:
                 shutil.copy(filename, os.curdir)
 
             obspy_scan([os.curdir] + ['--output', str(image_path)])
+
+    def test_scan_dir_no_permission(self, all_files):
+        """
+        Run obspy-scan on a directory without read permission.
+        Should just skip it and not raise an exception. see #3115
+        """
+        # Copy files to a temp folder to avoid wildcard scans.
+        scanner = Scanner()
+        with TemporaryWorkingDirectory():
+            no_permission_dir = Path('no_permission_dir')
+            no_permission_dir.mkdir()
+            # copy one test file in
+            shutil.copy(all_files[0], no_permission_dir)
+            # take away read permissions
+            no_permission_dir.chmod(0o000)
+            scanner.parse(str(no_permission_dir))
+            # should not have been able to read test file but also not raised
+            # an error
+            assert scanner.counter == 1
+            assert not scanner.data
+            # now allow read permission and read again
+            no_permission_dir.chmod(0o777)
+            scanner.parse(str(no_permission_dir))
+            assert scanner.counter == 2
+            assert '.LMOW..BHE' in scanner.data
+            for child in no_permission_dir.iterdir():
+                child.unlink()
+            no_permission_dir.rmdir()
 
     def test_scan_function_and_scanner_class(self, all_files, image_path):
         """


### PR DESCRIPTION
### What does this PR do?

Skips directories when recursively scanning with `obspy-scan ...` command line tool (or the underlying low level routines) if they lack read permission. We already skip files without permission but not directories. A warning while be shown if verbose flag is used.

still needs:
 - [x] test
 - [x] changelog

### Why was it initiated?  Any relevant Issues?

Problem reported in gitter chat of a scan erroring out hitting an unreadable special directory (some recycling bin special dir on a windows system)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
