### PR TITLE
xfail baer picker tests on one Linux CI runner (see #2984)

### DIFF
--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -4,11 +4,13 @@ The obspy.signal.trigger test suite.
 """
 import gzip
 import os
+import sys
 import unittest
 import warnings
 from ctypes import ArgumentError
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from obspy import Stream, UTCDateTime, read
@@ -80,6 +82,10 @@ class TriggerTestCase(unittest.TestCase):
         self.assertRaises(ArgumentError, clibsignal.recstalta,
                           np.array([1], dtype=np.int32), charfct, ndat, 5, 10)
 
+    @pytest.mark.xfail(
+        os.environ.get('CI') == 'true'
+        and os.environ.get('RUNNER_OS') == 'Linux'
+        and '3.8.13' in sys.version, reason='see #2984')
     def test_pk_baer(self):
         """
         Test pk_baer against implementation for UNESCO short course
@@ -94,6 +100,10 @@ class TriggerTestCase(unittest.TestCase):
         self.assertEqual(nptime, 17545)
         self.assertEqual(pfm, 'IPU0')
 
+    @pytest.mark.xfail(
+        os.environ.get('CI') == 'true'
+        and os.environ.get('RUNNER_OS') == 'Linux'
+        and '3.8.13' in sys.version, reason='see #2984')
     def test_pk_baer_cf(self):
         """
         Test pk_baer against implementation for UNESCO short course


### PR DESCRIPTION
### What does this PR do?

xfail two baer picker tests on one CI runner, just to clean up CI results

### Why was it initiated?  Any relevant Issues?

see #2984 and #3079

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
