### PR TITLE
Fix Stream.slice/trim return traces with different npts

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changes:
    * Trace.resample: Changed default for `window` to "hann" following a name
      change in scipy, "hanning" is not recognized anymore in newest scipy
      (see #3117)
+   * Fix different data length for trim/slice methods (see #2608)
    * Fix missing legend and plot artifacts in Inventory map plots at
      intersection of equator and prime meridian (see #3067)
  - obspy.clients.fdsn:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes:
      change in scipy, "hanning" is not recognized anymore in newest scipy
      (see #3117)
    * Fix different data length for trim/slice methods (see #2608)
+   * Add keep_empty_traces option to Stream.trim (see #2608)
    * Fix missing legend and plot artifacts in Inventory map plots at
      intersection of equator and prime meridian (see #3067)
  - obspy.clients.fdsn:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1515,6 +1515,8 @@ class Stream(object):
         BW.RJOB..EHN | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         BW.RJOB..EHE | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         """
+        if not self:
+            return self
         # select start/end time fitting to a sample point of the first trace
         if nearest_sample:
             tr = self.traces[0]
@@ -1531,7 +1533,7 @@ class Stream(object):
                     endtime = tr.stats.endtime + delta * tr.stats.delta
             except TypeError:
                 msg = ('starttime and endtime must be UTCDateTime objects '
-                       'or None for this call to Stream.trim()')
+                       'or None for this call to Stream.slice()')
                 raise TypeError(msg)
         for trace in self.traces:
             trace.trim(starttime, endtime, pad=pad,
@@ -1651,6 +1653,26 @@ class Stream(object):
         BW.RJOB..EHN | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         BW.RJOB..EHE | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         """
+        if not self:
+            return copy.copy(self)
+        # select start/end time fitting to a sample point of the first trace
+        if nearest_sample:
+            tr = self.traces[0]
+            try:
+                if starttime is not None:
+                    delta = compatibility.round_away(
+                        (starttime - tr.stats.starttime) *
+                        tr.stats.sampling_rate)
+                    starttime = tr.stats.starttime + delta * tr.stats.delta
+                if endtime is not None:
+                    delta = compatibility.round_away(
+                        (endtime - tr.stats.endtime) * tr.stats.sampling_rate)
+                    # delta is negative!
+                    endtime = tr.stats.endtime + delta * tr.stats.delta
+            except TypeError:
+                msg = ('starttime and endtime must be UTCDateTime objects '
+                       'or None for this call to Stream.trim()')
+                raise TypeError(msg)
         tmp = copy.copy(self)
         tmp.traces = []
         new = tmp.copy()

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1533,7 +1533,7 @@ class Stream(object):
                     endtime = tr.stats.endtime + delta * tr.stats.delta
             except TypeError:
                 msg = ('starttime and endtime must be UTCDateTime objects '
-                       'or None for this call to Stream.slice()')
+                       'or None for this call to Stream.trim()')
                 raise TypeError(msg)
         for trace in self.traces:
             trace.trim(starttime, endtime, pad=pad,
@@ -1671,7 +1671,7 @@ class Stream(object):
                     endtime = tr.stats.endtime + delta * tr.stats.delta
             except TypeError:
                 msg = ('starttime and endtime must be UTCDateTime objects '
-                       'or None for this call to Stream.trim()')
+                       'or None for this call to Stream.slice()')
                 raise TypeError(msg)
         tmp = copy.copy(self)
         tmp.traces = []

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1456,7 +1456,7 @@ class Stream(object):
         write_format(self, filename, **kwargs)
 
     def trim(self, starttime=None, endtime=None, pad=False,
-             nearest_sample=True, fill_value=None):
+             keep_empty_traces=False, nearest_sample=True, fill_value=None):
         """
         Cut all traces of this Stream object to given start and end time.
 
@@ -1468,6 +1468,9 @@ class Stream(object):
         :param pad: Gives the possibility to trim at time points outside the
             time frame of the original trace, filling the trace with the
             given ``fill_value``. Defaults to ``False``.
+        :type keep_empty_traces: bool, optional
+        :param keep_empty_traces: Empty traces will be kept if set to ``True``.
+            Defaults to ``False``.
         :type nearest_sample: bool, optional
         :param nearest_sample: If set to ``True``, the closest sample is
             selected, if set to ``False``, the inner (next sample for a
@@ -1512,8 +1515,6 @@ class Stream(object):
         BW.RJOB..EHN | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         BW.RJOB..EHE | 2009-08-24T00:20:20.000000Z ... | 100.0 Hz, 501 samples
         """
-        if not self:
-            return
         # select start/end time fitting to a sample point of the first trace
         if nearest_sample:
             tr = self.traces[0]
@@ -1535,8 +1536,9 @@ class Stream(object):
         for trace in self.traces:
             trace.trim(starttime, endtime, pad=pad,
                        nearest_sample=nearest_sample, fill_value=fill_value)
-        # remove empty traces after trimming
-        self.traces = [_i for _i in self.traces if _i.stats.npts]
+        if not keep_empty_traces:
+            # remove empty traces after trimming
+            self.traces = [_i for _i in self.traces if _i.stats.npts]
         return self
 
     def _ltrim(self, starttime, pad=False, nearest_sample=True):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -486,10 +486,11 @@ class TestStream:
         """
         # It defaults to True.
         st = read()
+        utc1 = st[0].stats.starttime + 0.1
+        utc2 = st[0].stats.endtime - 0.1
         with mock.patch("obspy.core.trace.Trace.slice") as patch:
             patch.return_value = st[0]
-            st.slice(1, 2)
-
+            st.slice(utc1, utc2)
         assert patch.call_count == 3
         for arg in patch.call_args_list:
             assert arg[1]["nearest_sample"]
@@ -497,8 +498,7 @@ class TestStream:
         # Force True.
         with mock.patch("obspy.core.trace.Trace.slice") as patch:
             patch.return_value = st[0]
-            st.slice(1, 2, nearest_sample=True)
-
+            st.slice(utc1, utc2, nearest_sample=True)
         assert patch.call_count == 3
         for arg in patch.call_args_list:
             assert arg[1]["nearest_sample"]
@@ -507,7 +507,6 @@ class TestStream:
         with mock.patch("obspy.core.trace.Trace.slice") as patch:
             patch.return_value = st[0]
             st.slice(1, 2, nearest_sample=False)
-
         assert patch.call_count == 3
         for arg in patch.call_args_list:
             assert not arg[1]["nearest_sample"]

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2820,3 +2820,16 @@ class TestStream:
         npts = np.sum(same_sign)
         assert np.sum(np.abs(st4[0].data[same_sign]) <=
                       np.abs(st2[0].data[same_sign])) == npts
+
+    def test_stream_trim_slice_same_length(self):
+        """
+        See issue #2608
+
+        End time 00:20:04.045 is in the middle of two samples
+        00:20:04.04 versus 00:20:04.05
+        """
+        st = read()
+        utc = st[0].stats.starttime + 1.045
+        n1 = len(st.slice(None, utc)[0])
+        n2 = len(st.trim(None, utc)[0])
+        assert n1 == n2


### PR DESCRIPTION
### What does this PR do?

Stream.trim/slice return traces with the same number of data points now, even for edge cases.
Added keep_empty_traces parameter to Stream.trim to stay consistent with Stream.slice.

### Why was it initiated?  Any relevant Issues?

See issue #2608

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
