### PR TITLE
Fix recalculate sensitivity

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changes:
      (see #3117)
    * Fix missing legend and plot artifacts in Inventory map plots at
      intersection of equator and prime meridian (see #3067)
+   * Fix a bug in recaculation of overall instrument sensitivity (see #3099)
  - obspy.clients.fdsn:
    * add URL mapping 'EIDA' for http://eida-federator.ethz.ch (see #3050)
    * Fix issue where "https://" URLs were not matched by the IRIS federator
@@ -17,6 +18,9 @@ Changes:
  - obspy.clients.nrl:
    * enable reading from a downloaded full copy of the NRLv2 at
      http://ds.iris.edu/ds/nrl/ (see #3058)
+   * Fix a bug in recaculation of overall instrument sensitivity after
+     assembling response from separate sensor and datalogger response parts
+     (see #3099)
  - obspy.imaging:
    * Scanner/obspy-scan: skip directories without read permission (see #3115)
  - obspy.io.gse2:

--- a/obspy/clients/nrl/tests/test_nrl.py
+++ b/obspy/clients/nrl/tests/test_nrl.py
@@ -51,6 +51,14 @@ class NRLTestCase(unittest.TestCase):
             datalogger_keys=self.local_dl_key,
             sensor_keys=self.local_sensor_key)
 
+        # Make sure that NRL.get_response() has overall instrument sensitivity
+        # correctly recalculated after combining sensor and datalogger
+        # information, see #3099.
+        # Before fixing this bug the result was 945089653.7285056 which is a
+        # relative deviation of 0.00104
+        assert resp.instrument_sensitivity.value == pytest.approx(
+            944098418.0614196, abs=0, rel=1e-4)
+
         # All of them should be Response objects.
         self.assertIsInstance(resp, Response)
         self.assertIsInstance(dl_resp, Response)

--- a/obspy/clients/nrl/tests/test_nrl.py
+++ b/obspy/clients/nrl/tests/test_nrl.py
@@ -10,12 +10,23 @@ from obspy.core.inventory import (Response, PolesZerosResponseStage,
 from obspy.clients.nrl.client import NRL, LocalNRL, RemoteNRL
 
 
-pytestmark = pytest.mark.network
-
-
-class NRLTestCase(unittest.TestCase):
+@pytest.mark.network
+class NRLRemoteTestCase(unittest.TestCase):
     """
-    NRL test suite.
+    Minimal NRL test suite connecting to online NRL
+
+    """
+    def setUp(self):
+        # This is also the default URL.
+        self.nrl_online = NRL(root='http://ds.iris.edu/NRL')
+
+    def test_nrl_type(self):
+        self.assertIsInstance(self.nrl_online, RemoteNRL)
+
+
+class NRLLocalTestCase(unittest.TestCase):
+    """
+    NRL test suite using stripped down local NRL without network usage.
 
     """
     def setUp(self):
@@ -28,16 +39,8 @@ class NRLTestCase(unittest.TestCase):
         self.local_dl_key = ['REF TEK', 'RT 130 & 130-SMA', '1', '1']
         self.local_sensor_key = ['Guralp', 'CMG-3T', '120s - 50Hz', '1500']
 
-        # This is also the default URL.
-        self.nrl_online = NRL(root='http://ds.iris.edu/NRL')
-
-        self.list_of_nrls = [self.nrl_local, self.nrl_online]
-
-    def test_nrl_types(self):
-        for nrl in self.list_of_nrls:
-            self.assertIsInstance(nrl, NRL)
+    def test_nrl_type(self):
         self.assertIsInstance(self.nrl_local, LocalNRL)
-        self.assertIsInstance(self.nrl_online, RemoteNRL)
 
     def test_get_response(self):
         # Get only the sensor response.
@@ -122,11 +125,3 @@ Select the sensor manufacturer (20 items):
             err.exception.args[0],
             "Provided path '/some/really/random/path' seems to be a local "
             "file path but the directory does not exist.")
-
-
-def suite():  # pragma: no cover
-    return unittest.makeSuite(NRLTestCase, 'test')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main(defaultTest='suite')

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1077,6 +1077,7 @@ class Response(ComparingObject):
             # XXX is this safe enough, or should we lookup the stage sequence
             # XXX number explicitly?
             frequency = self.response_stages[0].normalization_frequency
+        self.instrument_sensitivity.frequency = float(frequency)
         response_at_frequency = self._call_eval_resp_for_frequencies(
             frequencies=[frequency], output=output,
             hide_sensitivity_mismatch_warning=True)[0][0]


### PR DESCRIPTION
### What does this PR do?

Fixes the bug described in #3099 which leads to the first call of `Response.recalculate_sensitivity()` not giving correct results in likely many cases and only consecutive calls giving the expected results.

Also, properly un-mark "network" most tests, all but one test can be run without network on local test data.

### Why was it initiated?  Any relevant Issues?

See #3099 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
