### PR TITLE
try to fix CI problem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,7 +178,7 @@ jobs:
       - name: install obspy
         shell: bash -l {0}
         run: |
-          python -m pip install --no-deps -e .[tests]
+          python -m pip install --no-deps .
 
       # try to remove when min dep versions are upped
       - name: remove cartopy for mindepversion MacOS


### PR DESCRIPTION
### What does this PR do?

Changes obspy installation in CI from editable to a regular pip installation.

Also remove the `[tests]` modifier, which does nothing in combination with `--no-deps` anyway and we rely on an environment file for all (testing) dependencies anyway.

### Why was it initiated?  Any relevant Issues?

Some test currently fails because files are being looked up in the install location, which is only holding a link to the source tree though, due to being a pip editable installation.

 - https://github.com/obspy/obspy/actions/runs/3066925112/jobs/4952650308#step:10:268
 - https://tests.obspy.org/127117/#1
 - https://github.com/obspy/obspy/blob/9d10a93d9e862b46b4ce761530ddbb55b414a283/obspy/core/tests/test_waveform_plugins.py#L211-L220

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
