### PR TITLE
testing: remove artifacts from when unittest was main testing framework

### DIFF
--- a/obspy/clients/fdsn/tests/test_base_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_base_routing_client.py
@@ -228,11 +228,3 @@ class BaseRoutingClientTestCase(unittest.TestCase):
             "Failed to download data of type 'station' from "
             "'https://example.com' due to:"))
         self.assertIn("ValueError: random", msg)
-
-
-def suite():  # pragma: no cover
-    return unittest.makeSuite(BaseRoutingClientTestCase, 'test')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1725,11 +1725,3 @@ class ClientTestCase(unittest.TestCase):
             client = Client(
                 'GFZ', eida_token=os.path.join(self.datapath,
                                                'event_helpstring.txt'))
-
-
-def suite():
-    return unittest.makeSuite(ClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_eidaws_routing_client.py
@@ -376,11 +376,3 @@ AA B2 -- DD 2017-01-01T00:00:00 2017-01-02T00:10:00
                 network='OE', station='UNNA', channel='HHZ', location='*',
                 starttime=t1, endtime=t2)
         self.assertIn('No data', e.exception.args[0])
-
-
-def suite():  # pragma: no cover
-    return unittest.makeSuite(EIDAWSRoutingClientTestCase, 'test')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -355,11 +355,3 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         # because times stamps and also order might change slightly.
         # But the get_contents() method should be safe enough.
         self.assertEqual(inv.get_contents(), inv2.get_contents())
-
-
-def suite():  # pragma: no cover
-    return unittest.makeSuite(FederatorRoutingClientTestCase, 'test')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2809,20 +2809,3 @@ class DownloadHelperTestCase(unittest.TestCase):
             d = MassDownloader()
             d.download(domain=dom, restrictions=restrictions,
                        mseed_storage="mseed", stationxml_storage="stationxml")
-
-
-def suite():
-    testsuite = unittest.TestSuite()
-    testsuite.addTest(unittest.makeSuite(DomainTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(DownloadHelpersUtilTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(TimeIntervalTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(ChannelTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(StationTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(DownloadHelperTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(ClientDownloadHelperTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(RestrictionsTestCase, 'test'))
-    return testsuite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/fdsn/tests/test_wadl_parser.py
+++ b/obspy/clients/fdsn/tests/test_wadl_parser.py
@@ -500,11 +500,3 @@ class WADLParserTestCase(unittest.TestCase):
                     'starttime', 'station']
         self.assertEqual(sorted(params.keys()), expected)
         self.assertEqual(len(w), 0)
-
-
-def suite():
-    return unittest.makeSuite(WADLParserTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/filesystem/tests/test_sds.py
+++ b/obspy/clients/filesystem/tests/test_sds.py
@@ -285,11 +285,3 @@ class SDSTestCase(unittest.TestCase):
             self.assertEqual([], got_nslc)
             got_nslc = client.get_all_nslc(datetime=t - 2 * 24 * 3600)
             self.assertEqual([], got_nslc)
-
-
-def suite():
-    return unittest.makeSuite(SDSTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/filesystem/tests/test_tsindex.py
+++ b/obspy/clients/filesystem/tests/test_tsindex.py
@@ -8,7 +8,6 @@ import os
 import re
 import requests
 import tempfile
-import unittest
 import uuid
 from unittest import mock, TestCase
 
@@ -962,16 +961,3 @@ class TSIndexDatabaseHandlerTestCase(TestCase):
         for idx, r in enumerate(query_results):
             result = r[:6]  # ignore updt date
             self.assertEqual(result, expected_ts_summary_data[idx])
-
-
-def suite():
-    testsuite = unittest.TestSuite()
-    testsuite.addTest(unittest.makeSuite(ClientTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(IndexerTestCase, 'test'))
-    testsuite.addTest(unittest.makeSuite(TSIndexDatabaseHandlerTestCase,
-                                         'test'))
-    return testsuite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -273,11 +273,3 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(st1[0].stats.endtime, st2[0].stats.endtime)
         self.assertEqual(st1[0].data[0], 24)
         self.assertAlmostEqual(st2[0].data[0], -2.8373747e-06)
-
-
-def suite():
-    return unittest.makeSuite(ClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/neic/tests/test_client.py
+++ b/obspy/clients/neic/tests/test_client.py
@@ -108,11 +108,3 @@ class ClientTestCase(unittest.TestCase):
         for pattern in patterns:
             st2 = client.get_waveforms_nscl(pattern, t, duration)
             self.assertEqual(st, st2)
-
-
-def suite():
-    return unittest.makeSuite(ClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -108,11 +108,3 @@ class ClientTestCase(unittest.TestCase):
                 break
         else:
             raise
-
-
-def suite():
-    return unittest.makeSuite(ClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_seedlinkconnection.py
+++ b/obspy/clients/seedlink/tests/test_seedlinkconnection.py
@@ -42,11 +42,3 @@ class SeedLinkConnectionTestCase(unittest.TestCase):
             msg = 'Calling add_stream with selectors_str=None raised ' + \
                   'AttributeError'
             self.fail(msg)
-
-
-def suite():
-    return unittest.makeSuite(SeedLinkConnectionTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_slclient.py
+++ b/obspy/clients/seedlink/tests/test_slclient.py
@@ -59,11 +59,3 @@ class SLClientTestCase(unittest.TestCase):
         sl_client.verbose = 2
         sl_client.initialize()
         sl_client.run()
-
-
-def suite():
-    return unittest.makeSuite(SLClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_slnetstation.py
+++ b/obspy/clients/seedlink/tests/test_slnetstation.py
@@ -26,11 +26,3 @@ class SLNetStationTestCase(unittest.TestCase):
         self.assertNotEqual(id(station1.selectors), id(station2.selectors))
         self.assertEqual(station1.get_selectors(), ['FOO'])
         self.assertEqual(station2.get_selectors(), [])
-
-
-def suite():
-    return unittest.makeSuite(SLNetStationTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_slpacket.py
+++ b/obspy/clients/seedlink/tests/test_slpacket.py
@@ -48,11 +48,3 @@ class SLPacketTestCase(unittest.TestCase):
         xml = b'<?xml version="1.0" encoding="utf-8"?>'
         self.assertTrue(payload.startswith(xml))
         self.assertEqual(len(payload), 456)
-
-
-def suite():
-    return unittest.makeSuite(SLPacketTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/seedlink/tests/test_slstate.py
+++ b/obspy/clients/seedlink/tests/test_slstate.py
@@ -23,11 +23,3 @@ class SLStateTestCase(unittest.TestCase):
 
         self.assertNotEqual(id(slstate1.databuf), id(slstate2.databuf))
         self.assertNotEqual(id(slstate1.packed_buf), id(slstate2.packed_buf))
-
-
-def suite():
-    return unittest.makeSuite(SLStateTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -475,11 +475,3 @@ class ClientTestCase(unittest.TestCase):
                 model="ak135f_5s", bulk=[], data=b"1234\n5678")
 
         self.assertEqual(payload[0], b"1234\n5678")
-
-
-def suite():
-    return unittest.makeSuite(ClientTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/ah/tests/test_core.py
+++ b/obspy/io/ah/tests/test_core.py
@@ -317,11 +317,3 @@ class CoreTestCase(unittest.TestCase):
                 -236., -242., -252., -262.]))
             np.testing.assert_array_almost_equal(tr.data[-4:], np.array([
                 101., 106., 107., 104.]))
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/arclink/tests/test_inventory_xml.py
+++ b/obspy/io/arclink/tests/test_inventory_xml.py
@@ -155,11 +155,3 @@ class ArclinkInventoryTestCase(unittest.TestCase):
                             self.assertAlmostEqual(arc_cs[1], sta_cs[1])
                         else:
                             self.assertEqual(arc_cs, sta_cs)
-
-
-def suite():
-    return unittest.makeSuite(ArclinkInventoryTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/ascii/tests/test_ascii.py
+++ b/obspy/io/ascii/tests/test_ascii.py
@@ -698,11 +698,3 @@ class ASCIITestCase(unittest.TestCase):
 
         for actual, expected in zip(actual_lines, expected_lines):
             self.assertEqual(actual.strip(), expected.strip())
-
-
-def suite():
-    return unittest.makeSuite(ASCIITestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/cmtsolution/tests/test_core.py
+++ b/obspy/io/cmtsolution/tests/test_core.py
@@ -239,11 +239,3 @@ class CmtsolutionTestCase(unittest.TestCase):
 
         self.assertEqual(cat[2].origins[1].latitude, -13.68)
         self.assertEqual(cat[2].origins[1].longitude, -111.93)
-
-
-def suite():
-    return unittest.makeSuite(CmtsolutionTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/cnv/tests/test_core.py
+++ b/obspy/io/cnv/tests/test_core.py
@@ -74,11 +74,3 @@ class CNVTestCase(unittest.TestCase):
                 assert "with unmapped phase hint: S" in str(w[-1].message)
 
         self.assertEqual(expected.splitlines(), got.splitlines())
-
-
-def suite():
-    return unittest.makeSuite(CNVTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/css/tests/test_core.py
+++ b/obspy/io/css/tests/test_core.py
@@ -145,11 +145,3 @@ class CoreTestCase(unittest.TestCase):
         """
         # 1
         self.assertRaises(FileNotFoundError, _read_css, self.filename_css_3)
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/css/tests/test_station.py
+++ b/obspy/io/css/tests/test_station.py
@@ -68,11 +68,3 @@ class CSSStationTestCase(unittest.TestCase):
         ]
 
         self._run_test(inv, fname)
-
-
-def suite():
-    return unittest.makeSuite(CSSStationTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/dmx/tests/test_core.py
+++ b/obspy/io/dmx/tests/test_core.py
@@ -88,11 +88,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(st[1].data.sum(), 3003120.0)
         np.testing.assert_array_equal(
             st[1].data[:5], [537., 721., 844., 924., 977.])
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/focmec/tests/test_core.py
+++ b/obspy/io/focmec/tests/test_core.py
@@ -217,11 +217,3 @@ class FOCMECTestCase(unittest.TestCase):
             self.assertEqual(focmec.azimuthal_gap, 236.7)
             self.assertEqual(focmec.station_polarity_count, 23)
             self.assertEqual(focmec.misfit, 0.0)
-
-
-def suite():
-    return unittest.makeSuite(FOCMECTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gcf/tests/test_core.py
+++ b/obspy/io/gcf/tests/test_core.py
@@ -157,11 +157,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertAlmostEqual(st[0].stats.sampling_rate, 500.0)
         self.assertEqual(st[0].stats.channel, 'HNN')
         self.assertEqual(st[0].stats.station, '6018')
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gse2/tests/test_bulletin.py
+++ b/obspy/io/gse2/tests/test_bulletin.py
@@ -748,11 +748,3 @@ class BulletinTestCase(unittest.TestCase):
     def test_incomplete_file(self):
         filename = os.path.join(self.path, 'gse_2.0_incomplete.txt')
         self.assertRaises(GSE2BulletinSyntaxError, _read_gse2, filename)
-
-
-def suite():
-    return unittest.makeSuite(BulletinTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gse2/tests/test_core.py
+++ b/obspy/io/gse2/tests/test_core.py
@@ -361,11 +361,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(str(tr.stats.starttime),
                          '1990-04-07T00:07:33.000000Z')
         self.assertEqual(tr.data[0:10].tolist(), testdata)
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gse2/tests/test_libgse1.py
+++ b/obspy/io/gse2/tests/test_libgse1.py
@@ -40,11 +40,3 @@ class LibGSE1TestCase(unittest.TestCase):
         libgse1.read(fh, verify_chksum=True)  # correct
         self.assertRaises(ChksumError, libgse1.read, fh, verify_chksum=True)
         fh.close()
-
-
-def suite():
-    return unittest.makeSuite(LibGSE1TestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gse2/tests/test_libgse2.py
+++ b/obspy/io/gse2/tests/test_libgse2.py
@@ -254,11 +254,3 @@ class LibGSE2TestCase(unittest.TestCase):
                 warnings.simplefilter('ignore', UserWarning)
                 got = compile_sta2(header)
             self.assertEqual(got.decode(), line2)
-
-
-def suite():
-    return unittest.makeSuite(LibGSE2TestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/gse2/tests/test_paz.py
+++ b/obspy/io/gse2/tests/test_paz.py
@@ -63,11 +63,3 @@ class PAZTestCase(unittest.TestCase):
         self.assertAlmostEqual(30.08709, z[2].imag)
         self.assertAlmostEqual(0.5, k)
         f.close()
-
-
-def suite():
-    return unittest.makeSuite(PAZTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/hypodd/tests/test_pha.py
+++ b/obspy/io/hypodd/tests/test_pha.py
@@ -148,11 +148,3 @@ class PHATestCase(unittest.TestCase):
             cat2 = read_events(tempfile)
         self.assertEqual(len(cat2), 1)
         self.assertEqual(len(cat2[0].picks), 1)
-
-
-def suite():
-    return unittest.makeSuite(PHATestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/iaspei/tests/test_core.py
+++ b/obspy/io/iaspei/tests/test_core.py
@@ -162,11 +162,3 @@ class IASPEITestCase(unittest.TestCase):
             with io.BytesIO(fh.read()) as buf:
                 buf.seek(0, 0)
                 self.assertFalse(_is_ims10_bulletin(buf))
-
-
-def suite():  # pragma: no cover
-    return unittest.makeSuite(IASPEITestCase, 'test')
-
-
-if __name__ == '__main__':  # pragma: no cover
-    unittest.main(defaultTest='suite')

--- a/obspy/io/json/tests/test_json.py
+++ b/obspy/io/json/tests/test_json.py
@@ -72,11 +72,3 @@ class JSONTestCase(unittest.TestCase):
 
     def tearDown(self):
         del self.event
-
-
-def suite():
-    return unittest.makeSuite(JSONTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -381,11 +381,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(len(data), 5750)
         self.assertTrue(np.allclose(valuesdeb, data[:len(valuesdeb)]))
         self.assertTrue(np.allclose(valuesend, data[-len(valuesend):]))
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/kml/tests/test_kml.py
+++ b/obspy/io/kml/tests/test_kml.py
@@ -48,11 +48,3 @@ class KMLTestCase(unittest.TestCase):
             expected = fh.read()
         # compare the two
         compare_xml_strings(expected, got)
-
-
-def suite():
-    return unittest.makeSuite(KMLTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -1609,11 +1609,3 @@ class MSEEDReadingAndWritingTestCase(unittest.TestCase):
         del tr2.stats["_format"]
         del tr2.stats["mseed"]
         self.assertEqual(tr, tr2)
-
-
-def suite():
-    return unittest.makeSuite(MSEEDReadingAndWritingTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -1247,11 +1247,3 @@ class MSEEDSpecialIssueTestCase(unittest.TestCase):
             "Failed to decode location code as ASCII."))
         self.assertEqual(len(st), 1)
         self.assertEqual(st[0].id, '.GECKO.A.CNZ')
-
-
-def suite():
-    return unittest.makeSuite(MSEEDSpecialIssueTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -1333,11 +1333,3 @@ class MSEEDUtilTestCase(unittest.TestCase):
             _read_mseed(buf)
         self.assertEqual(
             str(e.exception), "No MiniSEED data record found in file.")
-
-
-def suite():
-    return unittest.makeSuite(MSEEDUtilTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/mseed/tests/test_recordanalyzer.py
+++ b/obspy/io/mseed/tests/test_recordanalyzer.py
@@ -404,11 +404,3 @@ CALCULATED VALUES
 
 ''' % (filename,)  # noqa
         self.assertEqual(expected, out.stdout.replace("\t", "    "))  # noq
-
-
-def suite():
-    return unittest.makeSuite(RecordAnalyserTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/ndk/tests/test_ndk.py
+++ b/obspy/io/ndk/tests/test_ndk.py
@@ -381,11 +381,3 @@ class NDKTestCase(unittest.TestCase):
         date, time = "2009/07/20", "10:44:60.0"
         self.assertEqual(_parse_date_time(date, time),
                          UTCDateTime(2009, 7, 20, 10, 45))
-
-
-def suite():
-    return unittest.makeSuite(NDKTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/nied/tests/test_fnetmt_reading.py
+++ b/obspy/io/nied/tests/test_fnetmt_reading.py
@@ -68,11 +68,3 @@ class FNETMTCatalogReadingTestCase(unittest.TestCase):
             filename = os.path.join(self.path, _i)
             is_fnetmt = _is_fnetmt_catalog(filename)
             self.assertFalse(is_fnetmt)
-
-
-def suite():
-    return unittest.makeSuite(FNETMTCatalogReadingTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/nied/tests/test_knet_reading.py
+++ b/obspy/io/nied/tests/test_knet_reading.py
@@ -97,11 +97,3 @@ class KnetReadingTestCase(unittest.TestCase):
             filename = os.path.join(self.path, _i)
             is_knet = _is_knet_ascii(filename)
             self.assertFalse(is_knet)
-
-
-def suite():
-    return unittest.makeSuite(KnetReadingTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -337,11 +337,3 @@ class NLLOCTestCase(unittest.TestCase):
         pick1, pick2 = cat[0].picks[-1], cat[0].picks[-2]
         self.assertEqual(pick1.time.hour, 0)
         self.assertEqual(pick2.time.second, 0)
-
-
-def suite():
-    return unittest.makeSuite(NLLOCTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/nlloc/tests/test_util.py
+++ b/obspy/io/nlloc/tests/test_util.py
@@ -61,11 +61,3 @@ class NLLOCTestCase(unittest.TestCase):
         expected = np.load(filename)
         for field in expected.dtype.fields:
             np.testing.assert_allclose(got[field], expected[field], rtol=1e-5)
-
-
-def suite():
-    return unittest.makeSuite(NLLOCTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/pdas/tests/test_core.py
+++ b/obspy/io/pdas/tests/test_core.py
@@ -54,11 +54,3 @@ class PDASTestCase(unittest.TestCase):
         Tests the _read_pdas function.
         """
         self.assertTrue(_is_pdas(self.testfile))
-
-
-def suite():
-    return unittest.makeSuite(PDASTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/pde/tests/test_mchedr.py
+++ b/obspy/io/pde/tests/test_mchedr.py
@@ -325,11 +325,3 @@ Gumma, Ibaraki, Kanagawa, Miyagi, Saitama, Tochigi and Tokyo.')
             warnings.simplefilter('always')
             catalog = read_events(filename)
             self.assertTrue(len(catalog), 1)
-
-
-def suite():
-    return unittest.makeSuite(MchedrTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/quakeml/tests/test_quakeml.py
+++ b/obspy/io/quakeml/tests/test_quakeml.py
@@ -1197,11 +1197,3 @@ class QuakeMLTestCase(unittest.TestCase):
         self.assertEqual(extra, cat2.extra)
         self.assertIn(('custom1', custom1), cat2.extra.items())
         self.assertIn(('custom2', custom2), cat2.extra.items())
-
-
-def suite():
-    return unittest.makeSuite(QuakeMLTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/reftek/tests/test_core.py
+++ b/obspy/io/reftek/tests/test_core.py
@@ -617,11 +617,3 @@ class ReftekTestCase(unittest.TestCase):
         self.assertEqual(len(st[2]), 2090)
         for tr, (_, expected) in zip(st, sorted(npz.items())):
             np.testing.assert_array_equal(expected, tr.data)
-
-
-def suite():
-    return unittest.makeSuite(ReftekTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/rg16/tests/test_read_rg16.py
+++ b/obspy/io/rg16/tests/test_read_rg16.py
@@ -559,14 +559,3 @@ class TestReadRG16Headers(unittest.TestCase):
         with open(HEADER_BLOCK_SAME_RU_CODE, 'rb') as fi:
             num_records = rc._cmp_nbr_records(fi)
         self.assertEqual(num_records, 2180 * 3)
-
-
-def suite():
-    test_suite = unittest.TestSuite()
-    test_suite.addTest(unittest.makeSuite(TestReadRG16, 'test'))
-    test_suite.addTest(unittest.makeSuite(TestReadRG16Headers, 'test'))
-    return test_suite
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/obspy/io/rg16/tests/test_util.py
+++ b/obspy/io/rg16/tests/test_util.py
@@ -50,11 +50,3 @@ class TestRG16Util(unittest.TestCase):
         ieee = b'\x40\x48\xf5\xc3'
         out = _read(BytesIO(ieee), 0, 4, 'IEEE')
         self.assertAlmostEqual(out, 3.14, delta=1e-6)
-
-
-def suite():
-    return unittest.makeSuite(TestRG16Util, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/obspy/io/sac/tests/test_core.py
+++ b/obspy/io/sac/tests/test_core.py
@@ -925,11 +925,3 @@ class CoreTestCase(unittest.TestCase):
         """
         tr0 = read(self.file_encode, encoding='cp1252')[0]
         self.assertEqual(tr0.stats.get('channel'), 'ÇÏÿÿÇÏÿÿ')
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/sac/tests/test_sacpz.py
+++ b/obspy/io/sac/tests/test_sacpz.py
@@ -188,11 +188,3 @@ class SACPZTestCase(unittest.TestCase):
         # plt.semilogx(f,phase1)
         # plt.semilogx(f,phase2,'k--')
         # plt.show()
-
-
-def suite():
-    return unittest.makeSuite(SACPZTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -454,11 +454,3 @@ class SACTraceTestCase(unittest.TestCase):
         self.assertEqual(result[0x1b8:(0x1b8+8)], b'TEST    ')
         # kcmpnm is at offset 0x258 in the file
         self.assertEqual(result[0x258:(0x258+8)], b'Z       ')
-
-
-def suite():
-    return unittest.makeSuite(SACTraceTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/scardec/tests/test_core.py
+++ b/obspy/io/scardec/tests/test_core.py
@@ -178,11 +178,3 @@ class ScardecTestCase(unittest.TestCase):
             self.assertTrue(_is_scardec(filename))
         for filename in bad_files:
             self.assertFalse(_is_scardec(filename))
-
-
-def suite():
-    return unittest.makeSuite(ScardecTestCase, "test")
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/obspy/io/seg2/tests/test_seg2.py
+++ b/obspy/io/seg2/tests/test_seg2.py
@@ -135,11 +135,3 @@ class SEG2TestCase(unittest.TestCase):
         # test seg2 specific header values
         # (trace headers include SEG2 file header)
         self.assertEqual(st[0].stats.seg2, TRACE3_HEADER)
-
-
-def suite():
-    return unittest.makeSuite(SEG2TestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/segy/tests/test_core.py
+++ b/obspy/io/segy/tests/test_core.py
@@ -689,11 +689,3 @@ class SEGYCoreTestCase(unittest.TestCase):
             "Can not write traces with more than 32767 samples (trace at "
             "index 0):\n... | 1970-01-01T00:00:00.000000Z - "
             "1970-01-01T00:05:27.670000Z | 100.0 Hz, 32768 samples")
-
-
-def suite():
-    return unittest.makeSuite(SEGYCoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -795,11 +795,3 @@ def rms(x, y):
     https://github.com/krischer/mtspec
     """
     return np.sqrt(((x - y) ** 2).mean() / (x ** 2).mean())
-
-
-def suite():
-    return unittest.makeSuite(SEGYTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/segy/tests/test_su.py
+++ b/obspy/io/segy/tests/test_su.py
@@ -134,11 +134,3 @@ class SUTestCase(unittest.TestCase):
         del ist[0].stats.su.data_encoding
 
         self.assertEqual(st.traces, ist)
-
-
-def suite():
-    return unittest.makeSuite(SUTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/seisan/tests/test_core.py
+++ b/obspy/io/seisan/tests/test_core.py
@@ -209,11 +209,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(st1[0].data, st2[0].data))
         self.assertTrue(np.allclose(st1[1].data, st2[1].data))
         self.assertTrue(np.allclose(st1[2].data, st2[2].data))
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/seiscomp/tests/test_core.py
+++ b/obspy/io/seiscomp/tests/test_core.py
@@ -47,11 +47,3 @@ class CoreTestCase(unittest.TestCase):
         expected_error = ("0.99 is not a supported version. Use one of these "
                           "versions: [0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12].")
         self.assertEqual(e.exception.args[0], expected_error)
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/seiscomp/tests/test_event.py
+++ b/obspy/io/seiscomp/tests/test_event.py
@@ -439,11 +439,3 @@ class EventTestCase(unittest.TestCase):
         with NamedTemporaryFile() as tf:
             catalog.write(tf, format='SC3ML', validate=True)
             self.assertTrue(filecmp.cmp(filename, tf.name))
-
-
-def suite():
-    return unittest.makeSuite(EventTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -304,11 +304,3 @@ class SC3MLTestCase(unittest.TestCase):
         poles = response.response_stages[1].poles
         self.assertEqual(zeros, [])
         self.assertEqual(poles, [])
-
-
-def suite():
-    return unittest.makeSuite(SC3MLTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/sh/tests/test_core.py
+++ b/obspy/io/sh/tests/test_core.py
@@ -318,11 +318,3 @@ class CoreTestCase(unittest.TestCase):
             # remove binary file too (dynamically created)
             os.remove(os.path.splitext(tempfile)[0] + '.QBN')
         self.assertEqual(header2, header1)
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/sh/tests/test_evt.py
+++ b/obspy/io/sh/tests/test_evt.py
@@ -100,11 +100,3 @@ class EvtTestCase(unittest.TestCase):
         self.assertIn('BLA.WET.11.DHZ', waveform_ids)
         self.assertIn('BLB.UBR.00.BHZ', waveform_ids)
         self.assertIn('BLA.WERD.11.DHZ', waveform_ids)
-
-
-def suite():
-    return unittest.makeSuite(EvtTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/shapefile/tests/test_core.py
+++ b/obspy/io/shapefile/tests/test_core.py
@@ -426,11 +426,3 @@ class ShapefileTestCase(unittest.TestCase):
                     expected_records=expected_inventory_records)
                 self.assertEqual(shp.shapeType, shapefile.POINT)
                 _close_shapefile_reader(shp)
-
-
-def suite():
-    return unittest.makeSuite(ShapefileTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/stationtxt/tests/test_station_text_parsing.py
+++ b/obspy/io/stationtxt/tests/test_station_text_parsing.py
@@ -885,11 +885,3 @@ class StationTextTestCase(unittest.TestCase):
             written_content = b"".join(written_text_file.split(b" "))
             for line in written_content:
                 self.assertIn(line, expected_content)
-
-
-def suite():
-    return unittest.makeSuite(StationTextTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -1334,11 +1334,3 @@ class StationXMLTestCase(unittest.TestCase):
         assert stage.decimation_factor == 2
         assert stage.decimation_input_sample_rate == 1024000.0
         assert stage.decimation_offset == 1
-
-
-def suite():
-    return unittest.makeSuite(StationXMLTestCase, "test")
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/wav/tests/test_core.py
+++ b/obspy/io/wav/tests/test_core.py
@@ -119,11 +119,3 @@ class CoreTestCase(unittest.TestCase):
             np.testing.assert_array_equal(tr31.data[:13], testdata // 2)
             os.remove(testfile0)
             os.remove(testfile1)
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/win/tests/test_core.py
+++ b/obspy/io/win/tests/test_core.py
@@ -58,11 +58,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(len(st[0]), 6000)
         self.assertAlmostEqual(st[0].stats.sampling_rate, 100.0)
         self.assertEqual(st[0].stats.channel, 'a100')
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_blockettes.py
+++ b/obspy/io/xseed/tests/test_blockettes.py
@@ -320,11 +320,3 @@ class BlocketteTestCase(unittest.TestCase):
         self.assertFalse(a != b)
         self.assertFalse(a == c)
         self.assertFalse(a == d)
-
-
-def suite():
-    return unittest.makeSuite(BlocketteTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_core.py
+++ b/obspy/io/xseed/tests/test_core.py
@@ -819,11 +819,3 @@ class CoreTestCase(unittest.TestCase):
             i_r = r.get_evalresp_response_for_frequencies(
                 frequencies=frequencies, output=unit)
             np.testing.assert_equal(e_r, i_r, "%s - %s" % (filename, unit))
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_fields.py
+++ b/obspy/io/xseed/tests/test_fields.py
@@ -177,11 +177,3 @@ class FieldsTestCase(unittest.TestCase):
             orig = b'ABC' + character.encode("utf-8") + b'DEF~'
             result = field.read(io.BytesIO(orig))
             self.assertEqual(result, 'ABC' + character + 'DEF')
-
-
-def suite():
-    return unittest.makeSuite(FieldsTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_parser.py
+++ b/obspy/io/xseed/tests/test_parser.py
@@ -849,11 +849,3 @@ class ParserTestCase(unittest.TestCase):
         evresp = evalresp_for_frequencies(0.01, [0.0, 1.0, 10.0], filename,
                                           obspy.UTCDateTime(2015, 1, 2))
         np.testing.assert_allclose(obs_r, evresp)
-
-
-def suite():
-    return unittest.makeSuite(ParserTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_scripts.py
+++ b/obspy/io/xseed/tests/test_scripts.py
@@ -132,11 +132,3 @@ Parsing file %s
             parser1 = Parser(expected)
             parser2 = Parser(actual)
             self.assertEqual(parser1.get_seed(), parser2.get_seed())
-
-
-def suite():
-    return unittest.makeSuite(ScriptTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/xseed/tests/test_utils.py
+++ b/obspy/io/xseed/tests/test_utils.py
@@ -76,11 +76,3 @@ class UtilsTestCase(unittest.TestCase):
             self.assertEqual(
                 got, expected,
                 "_is_resp() returns %s for file %s" % (got, filename))
-
-
-def suite():
-    return unittest.makeSuite(UtilsTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/y/tests/test_core.py
+++ b/obspy/io/y/tests/test_core.py
@@ -60,11 +60,3 @@ class CoreTestCase(unittest.TestCase):
         self.assertEqual(tr.stats.channel, 'E')
         self.assertEqual(tr.stats.location, 'SP')
         self.assertEqual(tr.stats.network, '')
-
-
-def suite():
-    return unittest.makeSuite(CoreTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/io/zmap/tests/test_zmap.py
+++ b/obspy/io/zmap/tests/test_zmap.py
@@ -312,11 +312,3 @@ class ZMAPTestCase(unittest.TestCase):
         full_zmap.update(zmap_dict)
         string = '\t'.join(full_zmap[f] for f in self.zmap_fields)
         return string
-
-
-def suite():
-    return unittest.makeSuite(ZMAPTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/realtime/tests/test_rttrace.py
+++ b/obspy/realtime/tests/test_rttrace.py
@@ -198,11 +198,3 @@ class RtTraceTestCase(unittest.TestCase):
         rt_trace = RtTrace()
         rt_trace.register_rt_process('tauc', width=20, notexistingoption=True)
         self.assertRaises(TypeError, rt_trace.append, trace)
-
-
-def suite():
-    return unittest.makeSuite(RtTraceTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/realtime/tests/test_signal.py
+++ b/obspy/realtime/tests/test_signal.py
@@ -291,11 +291,3 @@ class RealTimeSignalTestCase(unittest.TestCase):
         self.rt_trace.label = "RT Trace"
         st += self.rt_trace
         st.plot(automerge=False, color='blue', equal_scale=False)
-
-
-def suite():
-    return unittest.makeSuite(RealTimeSignalTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/scripts/tests/test_print.py
+++ b/obspy/scripts/tests/test_print.py
@@ -32,11 +32,3 @@ XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 
 XX.TEST..BHZ | 2008-01-15T00:00:00.025000Z - 2008-01-15T00:00:15.875000Z | 40.0 Hz, 635 samples
 '''  # noqa
         self.assertEqual(expected, out.stdout)
-
-
-def suite():
-    return unittest.makeSuite(PrintTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_array_analysis.py
+++ b/obspy/signal/tests/test_array_analysis.py
@@ -186,11 +186,3 @@ class ArrayTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(la[:, 0].sum(), 0., decimal=8)
         np.testing.assert_almost_equal(la[:, 1].sum(), 0., decimal=8)
         np.testing.assert_almost_equal(la[:, 2].sum(), 0., decimal=8)
-
-
-def suite():
-    return unittest.makeSuite(ArrayTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_calibration.py
+++ b/obspy/signal/tests/test_calibration.py
@@ -135,11 +135,3 @@ class CalibrationTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(freq, freq2, decimal=4)
         np.testing.assert_array_almost_equal(amp, amp2, decimal=4)
         np.testing.assert_array_almost_equal(phase, phase2, decimal=4)
-
-
-def suite():
-    return unittest.makeSuite(CalibrationTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_cpxtrace.py
+++ b/obspy/signal/tests/test_cpxtrace.py
@@ -135,11 +135,3 @@ class CpxTraceTestCase(unittest.TestCase):
         rms = np.sqrt(np.sum((sigma[1] - self.res[:, 10]) ** 2) /
                       np.sum(self.res[:, 10] ** 2))
         self.assertEqual(rms < 1.0e-5, True)
-
-
-def suite():
-    return unittest.makeSuite(CpxTraceTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_differentiate_and_integrate.py
+++ b/obspy/signal/tests/test_differentiate_and_integrate.py
@@ -57,11 +57,3 @@ class IntegrateTestCase(unittest.TestCase):
             np.testing.assert_allclose(
                 integrate_spline(np.zeros(10), dx=0.5, k=k),
                 np.zeros(10))
-
-
-def suite():
-    return unittest.makeSuite(IntegrateTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_filter.py
+++ b/obspy/signal/tests/test_filter.py
@@ -276,11 +276,3 @@ class FilterTestCase(unittest.TestCase):
                 for got in (got1, got2, got3):
                     np.testing.assert_allclose(got, expected, rtol=1e-3,
                                                atol=0.9)
-
-
-def suite():
-    return unittest.makeSuite(FilterTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -172,11 +172,3 @@ class FreqTraceTestCase(unittest.TestCase):
         self.assertEqual(m_dis, 1.0)
         self.assertAlmostEqual(m_vel, 0.0174524064373, 6)
         self.assertAlmostEqual(m_acc, 0.00872487417563, 6)
-
-
-def suite():
-    return unittest.makeSuite(FreqTraceTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_hoctavbands.py
+++ b/obspy/signal/tests/test_hoctavbands.py
@@ -115,11 +115,3 @@ class HoctavbandsTestCase(unittest.TestCase):
         rms = np.sqrt(np.sum((hob[:, 7] - self.res[:, 27]) ** 2) /
                       np.sum(self.res[:, 27] ** 2))
         self.assertEqual(rms < 1.0e-5, True)
-
-
-def suite():
-    return unittest.makeSuite(HoctavbandsTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_invsim.py
+++ b/obspy/signal/tests/test_invsim.py
@@ -524,11 +524,3 @@ class InvSimTestCase(unittest.TestCase):
         yi_ref = [0.94899576, 0.97572004, 0.9927136, 0.99978309, 0.99686554,
                   0.98398301, 0.96128491]
         self.assertTrue(np.allclose(yi, yi_ref, rtol=1e-7, atol=0))
-
-
-def suite():
-    return unittest.makeSuite(InvSimTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_konnoohmachi.py
+++ b/obspy/signal/tests/test_konnoohmachi.py
@@ -144,11 +144,3 @@ class KonnoOhmachiTestCase(unittest.TestCase):
         self.assertFalse(np.all(smoothed_4 == smoothed_5))
         # Input dtype should be output dtype.
         self.assertEqual(smoothed_4.dtype, np.float64)
-
-
-def suite():
-    return unittest.makeSuite(KonnoOhmachiTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -197,11 +197,3 @@ class PolarizationTestCase(unittest.TestCase):
                                         rtol=1e-4))
         self.assertTrue(np.allclose(out["timestamp"] - out["timestamp"][0],
                                     np.arange(0, 97.85, 0.05), rtol=1e-5))
-
-
-def suite():
-    return unittest.makeSuite(PolarizationTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_quality_control.py
+++ b/obspy/signal/tests/test_quality_control.py
@@ -878,11 +878,3 @@ class QualityControlTestCase(unittest.TestCase):
             md = MSEEDMetadata(files=[tf.name], add_flags=True)
             md.validate_qc_metrics(md.meta)
             md.get_json_meta(validate=True)
-
-
-def suite():
-    return unittest.makeSuite(QualityControlTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_regression.py
+++ b/obspy/signal/tests/test_regression.py
@@ -62,11 +62,3 @@ class RegressionTestCase(unittest.TestCase):
         result = linear_regression(self.x, self.y, intercept_origin=True)
         np.testing.assert_equal(len(result), 2)
         np.testing.assert_allclose(result, ref_result)
-
-
-def suite():
-    return unittest.makeSuite(RegressionTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -495,11 +495,3 @@ class RotateTestCase(unittest.TestCase):
 
         self.assertEqual(success_count, 12)
         self.assertEqual(failure_count, 12)
-
-
-def suite():
-    return unittest.makeSuite(RotateTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_sonic.py
+++ b/obspy/signal/tests/test_sonic.py
@@ -231,11 +231,3 @@ class SonicTestCase(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(transff, transffth, decimal=6)
         np.testing.assert_array_almost_equal(transffll, transffth, decimal=6)
-
-
-def suite():
-    return unittest.makeSuite(SonicTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_stream.py
+++ b/obspy/signal/tests/test_stream.py
@@ -176,11 +176,3 @@ class StreamTestCase(unittest.TestCase):
         for i, tr in enumerate(st):
             st_bkp[i].decimate(10, strict_length=False)
             self.assertEqual(tr, st_bkp[i])
-
-
-def suite():
-    return unittest.makeSuite(StreamTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_trace.py
+++ b/obspy/signal/tests/test_trace.py
@@ -168,11 +168,3 @@ class TraceTestCase(unittest.TestCase):
         self.assertAlmostEqual(0.0811378285461, fp, places=7)
         tr2.decimate(4, no_filter=True)
         np.testing.assert_array_equal(tr.data, tr2.data)
-
-
-def suite():
-    return unittest.makeSuite(TraceTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -602,11 +602,3 @@ class TriggerTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(c1, c2, rtol=1e-10))
         ref = np.array([0.38012302, 0.37704431, 0.47674533, 0.67992292])
         self.assertTrue(np.allclose(ref, c2[99:103]))
-
-
-def suite():
-    return unittest.makeSuite(TriggerTestCase, 'test')
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')


### PR DESCRIPTION
### What does this PR do?

Remove some unneeded stubs from back when unittest was our main testing framework

### Why was it initiated?  Any relevant Issues?

Cleanup code base 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
