### PR TITLE
fix future mpl.cm.get_cmap deprecation

### DIFF
--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -977,9 +977,8 @@ class Inventory(ComparingObject):
         colors = []
 
         if color_per_network and not isinstance(color_per_network, dict):
-            from matplotlib.cm import get_cmap
             codes = set([n.code for n in inv])
-            cmap = get_cmap(name=colormap, lut=len(codes))
+            cmap = plt.get_cmap(name=colormap, lut=len(codes))
             color_per_network = dict([(code, cmap(i))
                                       for i, code in enumerate(sorted(codes))])
 

--- a/obspy/imaging/cm.py
+++ b/obspy/imaging/cm.py
@@ -206,9 +206,9 @@ from pathlib import Path
 from urllib.request import urlopen
 
 import numpy as np
-from matplotlib.cm import get_cmap
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.colors import ListedColormap
+from matplotlib.pyplot import get_cmap
 
 
 def _get_cmap(file_name, lut=None, reverse=False):

--- a/obspy/imaging/source.py
+++ b/obspy/imaging/source.py
@@ -230,7 +230,6 @@ def _plot_radiation_pattern_sphere(
     :param type: 'P' or 'S' (P or S wave).
     """
     import matplotlib.pyplot as plt
-    from matplotlib.cm import get_cmap
     type = type.upper()
     if type not in ("P", "S"):
         msg = ("type must be 'P' or 'S'")
@@ -265,12 +264,12 @@ def _plot_radiation_pattern_sphere(
     if is_p_wave:
         disp = farfield(ned_mt, points, type="P")
         magn = np.sum(disp * points, axis=0)
-        cmap = get_cmap('bwr')
+        cmap = plt.get_cmap('bwr')
         norm = plt.Normalize(-1, 1)
     else:
         disp = farfield(ned_mt, points, type="S")
         magn = np.sqrt(np.sum(disp * disp, axis=0))
-        cmap = get_cmap('Greens')
+        cmap = plt.get_cmap('Greens')
         norm = plt.Normalize(0, 1)
     magn /= np.max(np.abs(magn))
 
@@ -312,7 +311,6 @@ def _plot_radiation_pattern_quiver(ax3d, ned_mt, type):
     :param type: 'P' or 'S' (P or S wave).
     """
     import matplotlib.pyplot as plt
-    from matplotlib.cm import get_cmap
 
     type = type.upper()
     if type not in ("P", "S"):
@@ -329,14 +327,14 @@ def _plot_radiation_pattern_quiver(ax3d, ned_mt, type):
         # normalized magnitude:
         magn = np.sum(disp * points, axis=0)
         magn /= np.max(np.abs(magn))
-        cmap = get_cmap('bwr')
+        cmap = plt.get_cmap('bwr')
     else:
         # get radiation pattern
         disp = farfield(ned_mt, points, type="S")
         # normalized magnitude (positive only):
         magn = np.sqrt(np.sum(disp * disp, axis=0))
         magn /= np.max(np.abs(magn))
-        cmap = get_cmap('Greens')
+        cmap = plt.get_cmap('Greens')
 
     # plot
     # there is a mlab3d bug that quiver vector colors and lengths
@@ -371,9 +369,8 @@ def _plot_beachball(ax2d, rtp_mt):
     :param rtp_mt: moment tensor in RTP convention
     """
     import matplotlib.pyplot as plt
-    from matplotlib.cm import get_cmap
     norm = plt.Normalize(-1., 1.)
-    cmap = get_cmap('bwr')
+    cmap = plt.get_cmap('bwr')
     bball = beach(rtp_mt, xy=(0, 0), width=50, facecolor=cmap(norm(0.7)),
                   bgcolor=cmap(norm(-0.7)))
 

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -26,9 +26,9 @@ from datetime import datetime
 import numpy as np
 import matplotlib.lines as mlines
 import matplotlib.patches as patches
-from matplotlib.cm import get_cmap
 from matplotlib.dates import date2num
 from matplotlib.path import Path
+from matplotlib.pyplot import get_cmap
 from matplotlib.ticker import MaxNLocator, ScalarFormatter
 import scipy.signal as signal
 

--- a/obspy/io/kml/core.py
+++ b/obspy/io/kml/core.py
@@ -11,7 +11,7 @@ Keyhole Markup Language (KML) output support in ObsPy
 from math import log
 
 from lxml.etree import Element, SubElement, tostring
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 
 from obspy import UTCDateTime
 from obspy.core.event import Catalog

--- a/obspy/taup/tau.py
+++ b/obspy/taup/tau.py
@@ -7,7 +7,7 @@ import warnings
 
 import matplotlib as mpl
 import matplotlib.cbook
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 import matplotlib.text
 import numpy as np
 


### PR DESCRIPTION
### What does this PR do?

Fixes a PendingDeprecationWarning. `mpl.cm.get_cmap` will be deprecated in matplotlib 1.7. `mpl.pyplot.get_cmap` will stay.

### Why was it initiated?  Any relevant Issues?

The warnings test case resulted in a lot of errors.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
