### PR TITLE
Stream.rotate: enable rotating multiple groups of traces simultaneously

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,8 @@ Changes:
      output units (see #3172, #3136)
    * Fix reusing Catalog/Inventory map plots, i.e. doing multiple cartopy plots
      with these objects into the same axes (see #3018)
+   * Fix Stream.rotate with multiple-station or multiple-event Streams (see
+     #2623, 3155)
  - obspy.clients.fdsn:
    * Fix a bug in `get_stations_bulk` regarding parameter "includerestricted"
      (see #3158)

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2775,6 +2775,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                           **kwargs)
                 new_traces.extend(st.traces)
             self.traces = new_traces
+            self.sort()
             return self
 
         # if working on a single SEED ID group just do the requested rotation
@@ -2783,7 +2784,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 msg = ("With method '->ZNE' station metadata has to be "
                        "provided as 'inventory' parameter.")
                 raise ValueError(msg)
-            return self._rotate_to_zne(inventory, **kwargs)
+            self._rotate_to_zne(inventory, **kwargs)
+            self.sort()
+            return self
         elif method == "NE->RT":
             func = "rotate_ne_rt"
         elif method == "RT->NE":
@@ -2872,6 +2875,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 for comp in (i_1, i_2, i_3):
                     comp.stats.back_azimuth = back_azimuth
                     comp.stats.inclination = inclination
+        # sort stream, so that order of traces will stay the same, even if
+        # internals of implementation change
+        self.sort()
         return self
 
     def copy(self):

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2775,7 +2775,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                           **kwargs)
                 new_traces.extend(st.traces)
             self.traces = new_traces
-            self.sort()
             return self
 
         # if working on a single SEED ID group just do the requested rotation
@@ -2784,9 +2783,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 msg = ("With method '->ZNE' station metadata has to be "
                        "provided as 'inventory' parameter.")
                 raise ValueError(msg)
-            self._rotate_to_zne(inventory, **kwargs)
-            self.sort()
-            return self
+            return self._rotate_to_zne(inventory, **kwargs)
         elif method == "NE->RT":
             func = "rotate_ne_rt"
         elif method == "RT->NE":
@@ -2875,9 +2872,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 for comp in (i_1, i_2, i_3):
                     comp.stats.back_azimuth = back_azimuth
                     comp.stats.inclination = inclination
-        # sort stream, so that order of traces will stay the same, even if
-        # internals of implementation change
-        self.sort()
         return self
 
     def copy(self):

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2801,19 +2801,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # Split to get the components. No need for further checks for the
         # method as invalid methods will be caught by previous conditional.
         input_components, output_components = method.split("->")
-        # Figure out inclination and back-azimuth.
-        if back_azimuth is None:
-            try:
-                back_azimuth = self[0].stats.back_azimuth
-            except Exception:
-                msg = "No back-azimuth specified."
-                raise TypeError(msg)
-        if len(input_components) == 3 and inclination is None:
-            try:
-                inclination = self[0].stats.inclination
-            except Exception:
-                msg = "No inclination specified."
-                raise TypeError(msg)
         # Do one of the two-component rotations.
         if len(input_components) == 2:
             input_1 = self.select(component=input_components[0])
@@ -2827,7 +2814,15 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     msg = "All components need to have the same time span."
                     raise ValueError(msg)
             for i_1, i_2 in zip(input_1, input_2):
-                output_1, output_2 = func(i_1.data, i_2.data, back_azimuth)
+                # Figure out back-azimuth.
+                baz = back_azimuth
+                if baz is None:
+                    try:
+                        baz = i_1.stats.back_azimuth
+                    except Exception:
+                        msg = "No back-azimuth specified."
+                        raise TypeError(msg)
+                output_1, output_2 = func(i_1.data, i_2.data, baz)
                 i_1.data = output_1
                 i_2.data = output_2
                 # Rename the components.
@@ -2837,7 +2832,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     output_components[1]
                 # Add the azimuth and inclination to the stats object.
                 for comp in (i_1, i_2):
-                    comp.stats.back_azimuth = back_azimuth
+                    comp.stats.back_azimuth = baz
         # Do one of the three-component rotations.
         else:
             input_1 = self.select(component=input_components[0])
@@ -2856,8 +2851,23 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     msg = "All components need to have the same time span."
                     raise ValueError(msg)
             for i_1, i_2, i_3 in zip(input_1, input_2, input_3):
+                # Figure out inclination and back-azimuth.
+                baz = back_azimuth
+                inc = inclination
+                if baz is None:
+                    try:
+                        baz = i_1.stats.back_azimuth
+                    except Exception:
+                        msg = "No back-azimuth specified."
+                        raise TypeError(msg)
+                if inc is None:
+                    try:
+                        inc = i_1.stats.inclination
+                    except Exception:
+                        msg = "No inclination specified."
+                        raise TypeError(msg)
                 output_1, output_2, output_3 = func(
-                    i_1.data, i_2.data, i_3.data, back_azimuth, inclination)
+                    i_1.data, i_2.data, i_3.data, baz, inc)
                 i_1.data = output_1
                 i_2.data = output_2
                 i_3.data = output_3
@@ -2870,8 +2880,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                     output_components[2]
                 # Add the azimuth and inclination to the stats object.
                 for comp in (i_1, i_2, i_3):
-                    comp.stats.back_azimuth = back_azimuth
-                    comp.stats.inclination = inclination
+                    comp.stats.back_azimuth = baz
+                    comp.stats.inclination = inc
         return self
 
     def copy(self):

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2751,7 +2751,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         """
         # check if we have a mix of multiple SEED ID groups that need to be
         # handled separately
-        seed_id_groups = set()
+        seed_id_groups = {}
         for tr in self:
             net, sta, loc, cha = tr.id.split(".")
             if not len(cha):
@@ -2759,7 +2759,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                 raise ValueError(msg)
             comp = cha[-1]
             cha_prefix = cha[:-1]
-            seed_id_groups.add((net, sta, loc, cha_prefix))
+            seed_id_groups[(net, sta, loc, cha_prefix)] = None
         # recursively rotate each set of matching SEED IDs if needed
         if len(seed_id_groups) > 1:
             new_traces = []

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2032,12 +2032,15 @@ class TestStream:
         # again, with angles given in stats and just 2 components
         st = st2.copy()
         st = st[1:3] + st[4:]
-        st[0].stats.back_azimuth = 190
-        st[2].stats.back_azimuth = 200
+        for tr in st[:2]:
+            tr.stats.back_azimuth = 190
+        for tr in st[2:]:
+            tr.stats.back_azimuth = 200
         st.rotate(method='NE->RT')
         st.rotate(method='RT->NE')
         assert np.allclose(st[0].data, st2[1].data)
         assert np.allclose(st[1].data, st2[2].data)
+        assert st[2].stats.back_azimuth == 200
         # rotate to LQT and back with 6 traces
         st = st2.copy()
         st.rotate(method='ZNE->LQT', back_azimuth=100, inclination=30)
@@ -2057,12 +2060,15 @@ class TestStream:
         with pytest.raises(ValueError):
             st.rotate(method='UNKNOWN')
         # rotating without back_azimuth raises TypeError
-        st = Stream()
+        st = read()
+        for tr in st:
+            del tr.stats.back_azimuth
+            del tr.stats.inclination
         with pytest.raises(TypeError):
-            st.rotate(method='RT->NE')
+            st[1:].rotate(method='NE->RT')
         # rotating without inclination raises TypeError for LQT-> or ZNE->
         with pytest.raises(TypeError):
-            st.rotate(method='LQT->ZNE', back_azimuth=30)
+            st.rotate(method='ZNE->LQT', back_azimuth=30)
         # having traces with different timespans or sampling rates will fail
         st = read()
         st[1].stats.sampling_rate = 2.0

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2011,22 +2011,18 @@ class TestStream:
         st = read()
         st += st.copy()
         st[3:].normalize()
-        for tr in st[3:]:
-            tr.stats.location = '01'
-        # sort input, because after round trip output will be sorted too
-        st.sort()
         st2 = st.copy()
         # rotate to RT and back with 6 traces
         st.rotate(method='NE->RT', back_azimuth=30)
         assert (st[0].stats.channel[-1] + st[1].stats.channel[-1] +
-                st[2].stats.channel[-1]) == 'RTZ'
+                st[2].stats.channel[-1]) == 'ZRT'
         assert (st[3].stats.channel[-1] + st[4].stats.channel[-1] +
-                st[5].stats.channel[-1]) == 'RTZ'
+                st[5].stats.channel[-1]) == 'ZRT'
         st.rotate(method='RT->NE', back_azimuth=30)
         assert (st[0].stats.channel[-1] + st[1].stats.channel[-1] +
-                st[2].stats.channel[-1]) == 'ENZ'
+                st[2].stats.channel[-1]) == 'ZNE'
         assert (st[3].stats.channel[-1] + st[4].stats.channel[-1] +
-                st[5].stats.channel[-1]) == 'ENZ'
+                st[5].stats.channel[-1]) == 'ZNE'
         assert np.allclose(st[0].data, st2[0].data)
         assert np.allclose(st[1].data, st2[1].data)
         assert np.allclose(st[2].data, st2[2].data)
@@ -2052,7 +2048,7 @@ class TestStream:
                 st[2].stats.channel[-1]) == 'LQT'
         st.rotate(method='LQT->ZNE', back_azimuth=100, inclination=30)
         assert st[0].stats.channel[-1] + st[1].stats.channel[-1] + \
-               st[2].stats.channel[-1] == 'ENZ'
+               st[2].stats.channel[-1] == 'ZNE'
         assert np.allclose(st[0].data, st2[0].data)
         assert np.allclose(st[1].data, st2[1].data)
         assert np.allclose(st[2].data, st2[2].data)
@@ -2686,9 +2682,6 @@ class TestStream:
         st_expected = read('/path/to/ffbx_rotated.slist', format='SLIST')
         st_unrotated = read("/path/to/ffbx_unrotated_gaps.mseed",
                             format="MSEED")
-        # rotation now sorts the stream at the end, so adjust here to keep
-        # tests working that check traces on expected order in stream
-        st_expected.sort()
         for tr in st_expected:
             # ignore format specific keys and processing which also holds
             # version number

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2036,6 +2036,7 @@ class TestStream:
             tr.stats.back_azimuth = 190
         for tr in st[2:]:
             tr.stats.back_azimuth = 200
+            tr.stats.starttime = tr.stats.starttime + 1000
         st.rotate(method='NE->RT')
         st.rotate(method='RT->NE')
         assert np.allclose(st[0].data, st2[1].data)
@@ -2065,7 +2066,7 @@ class TestStream:
             del tr.stats.back_azimuth
             del tr.stats.inclination
         with pytest.raises(TypeError):
-            st[1:].rotate(method='NE->RT')
+            st.rotate(method='NE->RT')
         # rotating without inclination raises TypeError for LQT-> or ZNE->
         with pytest.raises(TypeError):
             st.rotate(method='ZNE->LQT', back_azimuth=30)

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2694,6 +2694,8 @@ class TestStream:
             # do some checks on results
             assert len(st) == 30
             # compare data
+            st.sort()
+            st_expected.sort()
             for tr_got, tr_expected in zip(st, st_expected):
                 np.testing.assert_allclose(tr_got.data, tr_expected.data,
                                            rtol=1e-7)

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2011,6 +2011,8 @@ class TestStream:
         st = read()
         st += st.copy()
         st[3:].normalize()
+        for tr in st[3:]:
+            tr.stats.location = '01'
         st2 = st.copy()
         # rotate to RT and back with 6 traces
         st.rotate(method='NE->RT', back_azimuth=30)

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2013,18 +2013,20 @@ class TestStream:
         st[3:].normalize()
         for tr in st[3:]:
             tr.stats.location = '01'
+        # sort input, because after round trip output will be sorted too
+        st.sort()
         st2 = st.copy()
         # rotate to RT and back with 6 traces
         st.rotate(method='NE->RT', back_azimuth=30)
         assert (st[0].stats.channel[-1] + st[1].stats.channel[-1] +
-                st[2].stats.channel[-1]) == 'ZRT'
+                st[2].stats.channel[-1]) == 'RTZ'
         assert (st[3].stats.channel[-1] + st[4].stats.channel[-1] +
-                st[5].stats.channel[-1]) == 'ZRT'
+                st[5].stats.channel[-1]) == 'RTZ'
         st.rotate(method='RT->NE', back_azimuth=30)
         assert (st[0].stats.channel[-1] + st[1].stats.channel[-1] +
-                st[2].stats.channel[-1]) == 'ZNE'
+                st[2].stats.channel[-1]) == 'ENZ'
         assert (st[3].stats.channel[-1] + st[4].stats.channel[-1] +
-                st[5].stats.channel[-1]) == 'ZNE'
+                st[5].stats.channel[-1]) == 'ENZ'
         assert np.allclose(st[0].data, st2[0].data)
         assert np.allclose(st[1].data, st2[1].data)
         assert np.allclose(st[2].data, st2[2].data)
@@ -2050,7 +2052,7 @@ class TestStream:
                 st[2].stats.channel[-1]) == 'LQT'
         st.rotate(method='LQT->ZNE', back_azimuth=100, inclination=30)
         assert st[0].stats.channel[-1] + st[1].stats.channel[-1] + \
-               st[2].stats.channel[-1] == 'ZNE'
+               st[2].stats.channel[-1] == 'ENZ'
         assert np.allclose(st[0].data, st2[0].data)
         assert np.allclose(st[1].data, st2[1].data)
         assert np.allclose(st[2].data, st2[2].data)
@@ -2684,6 +2686,9 @@ class TestStream:
         st_expected = read('/path/to/ffbx_rotated.slist', format='SLIST')
         st_unrotated = read("/path/to/ffbx_unrotated_gaps.mseed",
                             format="MSEED")
+        # rotation now sorts the stream at the end, so adjust here to keep
+        # tests working that check traces on expected order in stream
+        st_expected.sort()
         for tr in st_expected:
             # ignore format specific keys and processing which also holds
             # version number


### PR DESCRIPTION

### What does this PR do?

Fix Stream.rotate() with multiple-station Streams

### Why was it initiated?  Any relevant Issues?

Fixes #2623 with an alternative approach to #3124 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
