### PR TITLE
CI: try to fix docs build

### DIFF
--- a/.github/docs_conda_env.yml
+++ b/.github/docs_conda_env.yml
@@ -6,7 +6,11 @@ dependencies:
   # obspy
   - decorator
   - lxml
-  - matplotlib
+  # sphinx currently is failing trying to import "deprecated" from
+  # matplotlib.cbook, seems it was deprecated in mpl 3.4 and removed in 3.6,
+  # see
+  # https://github.com/matplotlib/matplotlib/blob/v3.5.0/lib/matplotlib/cbook/__init__.py#L37
+  - matplotlib < 3.6
   - numpy
   - scipy
   - requests  


### PR DESCRIPTION


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fix CI docs build workflow

### Why was it initiated?  Any relevant Issues?

CI failing to build docs, currently. The sphinx version we use tries to import something that was removed in matplotlib 3.6 apparently

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
