### PR TITLE
Fix reading StationXML with base type ResponseStage that has decimation info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ Changes:
    * bulletin reading: correctly add Mag2 and amplitudes even if Mag1 is not
      present (see #2420)
  - obspy.io.stationxml:
+   * fix a bug that resulted in losing decimation information of base type
+     response stages (see #3159)
    * enable reading StationXML 1.2 and write new files with schema version
      1.2 (see #3153)
  - obspy.io.wav:

--- a/obspy/io/stationxml/core.py
+++ b/obspy/io/stationxml/core.py
@@ -526,7 +526,12 @@ def _read_response_stage(stage_elem, _ns):
                 stage_sequence_number=stage_sequence_number,
                 stage_gain=stage_gain,
                 stage_gain_frequency=stage_gain_frequency,
-                resource_id=resource_id, input_units=None, output_units=None)
+                resource_id=resource_id, input_units=None, output_units=None,
+                decimation_input_sample_rate=decimation_input_sample_rate,
+                decimation_factor=decimation_factor,
+                decimation_offset=decimation_offset,
+                decimation_delay=decimation_delay,
+                decimation_correction=decimation_correction)
         # Raise if none of the previous ones has been found.
         msg = "Could not find a valid Response Stage Type."
         raise ValueError(msg)

--- a/obspy/io/stationxml/tests/data/F1_423_small.xml
+++ b/obspy/io/stationxml/tests/data/F1_423_small.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:iris="http://www.fdsn.org/xml/station/1/iris">
+ <Source>IRIS-DMC</Source>
+ <Sender>IRIS-DMC</Sender>
+ <Module>IRIS WEB SERVICE: fdsnws-station | version: 1.1.33</Module>
+ <ModuleURI>http://service.iris.edu/fdsnws/station/1/query?net=QI&amp;sta=VPASS&amp;cha=BDF&amp;starttime=2018-08-06T00:00:01&amp;level=response&amp;format=xml&amp;includecomments=true&amp;nodata=404</ModuleURI>
+ <Created>2018-08-06T20:17:16</Created>
+ <Network code="QI" startDate="2018-08-06T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open">
+  <Description>[IRIS DMC] Station XML Validator Passing Test File</Description>
+  <TotalNumberStations>1</TotalNumberStations>
+  <SelectedNumberStations>1</SelectedNumberStations>
+  <Station code="TPASS" startDate="2018-08-06T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open" iris:alternateNetworkCodes="_FDSN,.UNRESTRICTED">
+   <Latitude>47.66157</Latitude>
+   <Longitude>-122.31332</Longitude>
+   <Elevation>225.879999</Elevation>
+   <Site>
+    <Name>Synthetic Test File, IRIS DMC, USA, 218 2018, Tim Ronan</Name>
+   </Site>
+   <CreationDate>2018-08-06T00:00:00</CreationDate>
+   <TotalNumberChannels>1</TotalNumberChannels>
+   <SelectedNumberChannels>1</SelectedNumberChannels>
+   <Channel code="BDF" endDate="2500-12-31T23:59:59" locationCode="00" restrictedStatus="open" startDate="2018-08-06T00:00:00">
+    <Latitude>47.66157</Latitude>
+    <Longitude>-122.31332</Longitude>
+    <Elevation>225.879999</Elevation>
+    <Depth>0</Depth>
+    <Azimuth>359</Azimuth>
+    <Dip>0</Dip>
+    <Type>CONTINUOUS</Type>
+    <Type>GEOPHYSICAL</Type>
+    <SampleRate>2E01</SampleRate>
+    <ClockDrift>0E00</ClockDrift>
+    <CalibrationUnits>
+     <Name>V</Name>
+     <Description>Volts</Description>
+    </CalibrationUnits>
+    <Sensor>
+     <Description>GEM (Infrasound), 0.2-50 Hz, 0.4 V/Pa-null</Description>
+    </Sensor>
+    <Response>
+     <InstrumentSensitivity>
+      <Value>2.44648E5</Value>
+      <Frequency>1E0</Frequency>
+      <InputUnits>
+       <Name>PA</Name>
+       <Description>No Abbreviation Referenced</Description>
+      </InputUnits>
+      <OutputUnits>
+       <Name>COUNTS</Name>
+       <Description>Digital Counts</Description>
+      </OutputUnits>
+     </InstrumentSensitivity>
+     <Stage number="1">
+      <Decimation>
+       <InputSampleRate>512000.0</InputSampleRate>
+       <Factor>1</Factor>
+       <Offset>0.1</Offset>
+       <Delay>0.2</Delay>
+       <Correction>1.3</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>0.4</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="2">
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="3">
+      <Coefficients>
+       <InputUnits>
+        <Name>V</Name>
+        <Description>Volts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">1.00000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>512000.0</InputSampleRate>
+       <Factor>1</Factor>
+       <Offset>0</Offset>
+       <Delay>0.0</Delay>
+       <Correction>0.0</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>611621.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+
+    </Response>
+   </Channel>
+  </Station>
+ </Network>
+</FDSNStationXML>

--- a/obspy/io/stationxml/tests/data/F1_423_small.xml
+++ b/obspy/io/stationxml/tests/data/F1_423_small.xml
@@ -53,11 +53,11 @@
      </InstrumentSensitivity>
      <Stage number="1">
       <Decimation>
-       <InputSampleRate>512000.0</InputSampleRate>
-       <Factor>1</Factor>
-       <Offset>0.1</Offset>
-       <Delay>0.2</Delay>
-       <Correction>1.3</Correction>
+       <InputSampleRate>1024000.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>1</Offset>
+       <Delay>0.5</Delay>
+       <Correction>0.4</Correction>
       </Decimation>
       <StageGain>
        <Value>0.4</Value>

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -1329,11 +1329,11 @@ class StationXMLTestCase(unittest.TestCase):
         path = os.path.join(self.data_dir, 'F1_423_small.xml')
         inv = _read_stationxml(path)
         stage = inv[0][0][0].response.response_stages[0]
-        assert stage.decimation_correction == 1.3
-        assert stage.decimation_delay == 0.2
-        assert stage.decimation_factor == 1
-        assert stage.decimation_input_sample_rate == 512000.0
-        assert stage.decimation_offset == 0.1
+        assert stage.decimation_correction == 0.4
+        assert stage.decimation_delay == 0.5
+        assert stage.decimation_factor == 2
+        assert stage.decimation_input_sample_rate == 1024000.0
+        assert stage.decimation_offset == 1
 
 
 def suite():

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -1321,6 +1321,20 @@ class StationXMLTestCase(unittest.TestCase):
         self.assertEqual(len(inv_stationxml_network), 1)
         self.assertEqual(len(inv_stationxml_network[0]), 0)
 
+    def test_read_basic_responsestage_with_decimation(self):
+        """
+        Make sure basic ResponseStage elements that have decimation information
+        do not lose that information.
+        """
+        path = os.path.join(self.data_dir, 'F1_423_small.xml')
+        inv = _read_stationxml(path)
+        stage = inv[0][0][0].response.response_stages[0]
+        assert stage.decimation_correction == 1.3
+        assert stage.decimation_delay == 0.2
+        assert stage.decimation_factor == 1
+        assert stage.decimation_input_sample_rate == 512000.0
+        assert stage.decimation_offset == 0.1
+
 
 def suite():
     return unittest.makeSuite(StationXMLTestCase, "test")


### PR DESCRIPTION
### What does this PR do?

Fixes reading StationXML with base type ResponseStage that includes decimation information.

### Why was it initiated?  Any relevant Issues?

Fixes #3118 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
