### PR TITLE
deprecate online NRL access

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,8 @@ Changes:
      client, resulting in raspberry shake matches being excluded from results
      (see #3127)
  - obspy.clients.nrl:
+   * deprecate online NRL client as it will stop working in Spring 2023 when
+     old NRLv1 gets taken offline (see #3164)
    * enable reading from a downloaded full copy of the NRLv2 at
      http://ds.iris.edu/ds/nrl/ (see #3058)
    * Fix a bug in recaculation of overall instrument sensitivity after

--- a/obspy/clients/nrl/__init__.py
+++ b/obspy/clients/nrl/__init__.py
@@ -16,6 +16,15 @@ To cite use of the NRL, please see [Templeton2017]_.
 Basic Usage
 -----------
 
+.. warning::
+    Connecting to NRL hosted online is deprecated. The new NRLv2 will stop
+    providing navigational information in machine readable form in favor of the
+    html navigation, so the existing client for online use will stop working
+    when the original NRLv1 is taken offline (announced for Spring 2023).
+    Please consider using a full downloaded copy of the NRL (v1 or v2,
+    `instructions on NRL homepage <https://ds.iris.edu/ds/nrl/>`_) providing a
+    local path, e.g. ``nrl = NRL('./downloads/NRL')``.
+
 The first step is to initialize a NRL client object. A client object can be
 initialized either with the base URL of a NRL hosted on a web server or with a
 local directory path to a downloaded and unpacked NRL zip file. The default is

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -24,6 +24,7 @@ import requests
 import obspy
 from obspy.core.compatibility import get_text_from_response
 from obspy.core.inventory.util import _textwrap
+from obspy.core.util.decorator import deprecated
 
 
 # Simple cache for remote NRL access. The total data amount will always be
@@ -331,9 +332,27 @@ class LocalNRL(NRL):
 
 class RemoteNRL(NRL):
     """
+    DEPRECATED
+
     Subclass of NRL for accessing remote copy of NRL.
+
+    Direct access to online NRL is deprecated as it will stop working when the
+    original NRLv1 gets taken offline (Spring 2023), please consider working
+    locally with a downloaded full copy of the old NRLv1 or new NRLv2 following
+    instructions on the
+    `NRL landing page <https://ds.iris.edu/ds/nrl/>`_.
     """
+    @deprecated()
     def __init__(self, root='https://ds.iris.edu/NRL'):
+        """
+        DEPRECATED
+
+        Direct access to online NRL is deprecated as it will stop working when
+        the original NRLv1 gets taken offline (Spring 2023), please consider
+        working locally with a downloaded full copy of the old NRLv1 or new
+        NRLv2 following instructions on the
+        `NRL landing page <https://ds.iris.edu/ds/nrl/>`_.
+        """
         self.root = root
         super(self.__class__, self).__init__()
 

--- a/obspy/clients/nrl/client.py
+++ b/obspy/clients/nrl/client.py
@@ -39,6 +39,10 @@ class NRL(object):
     https://ds.iris.edu/NRL/
 
     Created with a URL for remote access or filesystem accessing a local copy.
+
+    .. warning::
+        Remote access to online NRL is deprecated as it will stop working in
+        Spring 2023 due to server side changes.
     """
     _index = 'index.txt'
 


### PR DESCRIPTION

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Deprecate usage of NRL to access the online NRL.
This will stop working when NRLv1 gets taken offline, since new NRLv2 is not serving navigational txt files online and navigational info instead is provided in fancy html pages which aren't trivial / would be a pain to parse, but however they are still there when downloading a full NRLv2 copy, so downloading NRL and working locally will be the only choice unless somebody wants to implement a client for the new NRL web service.

### Why was it initiated?  Any relevant Issues?

Closes #3160 and closes #3122

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
