### PR TITLE
mseed.util.set_flags_in_fixed_headers: fix block endtime calculation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,9 @@ Changes:
  - obspy.io.gse2:
    * bulletin reading: correctly add Mag2 and amplitudes even if Mag1 is not
      present (see #2420)
+ - obspy.io.mseed:
+   * fix a bug in endtime calculation when writing fixed flags block
+     information (see #3165)
  - obspy.io.stationxml:
    * fix a bug that resulted in losing decimation information of base type
      response stages (see #3159)

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1160,7 +1160,7 @@ def set_flags_in_fixed_headers(filename, flags):
                 # date of the last sample is recstart+samp_rate*(nb_samples-1)
                 # We assume here that a record with samples [0, 1, ..., n]
                 # has a period [ date_0, date_n+1 [  AND NOT [ date_0, date_n ]
-                realendtime = recstart + samp_rate * (nb_samples)
+                realendtime = recstart + nb_samples / samp_rate
 
                 # Convert flags to bytes : activity
                 if 'activity_flags' in flags_value:


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Fixes a bug in calculation of endtime when writing fixed flags to mseed blocks.

### Why was it initiated?  Any relevant Issues?

Fixes #3163 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
