### PR TITLE
docs: note on water level with non flat response

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,9 @@ Changes:
      intersection of equator and prime meridian (see #3067)
    * Fix a bug in recaculation of overall instrument sensitivity (see #3099)
    * Fix colored IPython output on Windows (see #3148, #3171)
+   * Add a warning in `Trace.remove_response()` docs, regarding using water
+     level mechanism with instrument response non-flat with the requested
+     output units (see #3172, #3136)
  - obspy.clients.fdsn:
    * Fix a bug in `get_stations_bulk` regarding parameter "includerestricted"
      (see #3158)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2692,6 +2692,16 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         (specifying the four corner frequencies of the frequency taper as a
         tuple in `pre_filt`).
 
+        .. warning::
+            The water level approach can lead to unexpected results that
+            strongly suppress valid/wanted parts of the spectrum if the
+            requested output unit is not the native quantity of the instrument,
+            i.e. the instrument response is not flat for that quantity (e.g.
+            requesting output ``"VEL"`` for an accelerometer). For details see
+            https://github.com/obspy/obspy/issues/3136.
+            In this case it might be better to set ``water_level=None`` and use
+            ``pre_filt`` option instead.
+
         .. note::
 
             Any additional kwargs will be passed on to

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2705,7 +2705,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         .. note::
 
             Any additional kwargs will be passed on to
-            :meth:`obspy.core.inventory.response.Response.get_evalresp_response`,
+            :meth:`Response.get_evalresp_response()
+            <obspy.core.inventory.response.Response.get_evalresp_response>`,
             see documentation of that method for further customization (e.g.
             start/stop stage and hiding overall sensitivity mismatch warning).
 
@@ -2716,8 +2717,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             :meth:`~obspy.core.trace.Trace.simulate` with the identical
             response provided as
             a (dataless) SEED or RESP file and when using the same
-            `water_level` and `pre_filt` (and options `sacsim=True` and
-            `pitsasim=False` which influence very minor details in detrending
+            ``water_level`` and ``pre_filt`` (and options ``sacsim=True`` and
+            ``pitsasim=False`` which influence very minor details in detrending
             and tapering).
 
         .. rubric:: Example


### PR DESCRIPTION
### What does this PR do?

Adds a warning to `Trace.remove_response()` docs, recommending to not use water level mechanism if output units don't match native units of the instrument, e.g. accelerometer taken to ground velocity.

On top of this we could implement a warning message, checking requested `units` option and the response stage 1 input units of the instrument.. but that might not cover all cases either, and not sure if needed, and can be done in another PR if anybody feels thats needed.

### Why was it initiated?  Any relevant Issues?

Fixes #3136 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
