### PR TITLE
Fix directory lookup in waveform plugin tests

### DIFF
--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -5,11 +5,13 @@ import threading
 import time
 import warnings
 from copy import deepcopy
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
 import pytest
 
+import obspy
 from obspy import Trace, read
 from obspy.io.mseed.core import _write_mseed
 from obspy.core.utcdatetime import UTCDateTime
@@ -208,8 +210,13 @@ class TestWaveformPlugins:
         # Get all the test directories.
         paths = {}
         all_paths = []
+        # dont rely on f.dist.location to lookup install path, as this seems to
+        # recently not be able to follow a pip editable install correctly. this
+        # seems safe unless custom installed plugins come into play, but we can
+        # not test these here properly anyway
+        install_dir = Path(obspy.__file__).parent.parent
         for f in formats:
-            path = os.path.join(f.dist.location,
+            path = os.path.join(install_dir,
                                 *f.module_name.split('.')[:-1])
             path = os.path.join(path, 'tests', 'data')
             all_paths.append(path)


### PR DESCRIPTION
### What does this PR do?

plugin tests: avoid looking up wrong directories in a pip editable install seems setuptools changed at some point and is pointing towards the shimmy directory of the editable install now rather to where the actual content is located / the link is pointing to

### Why was it initiated?  Any relevant Issues?

see #3142 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
