### PR TITLE
scanner tests: skip test if unable to strip read permission

### DIFF
--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -3,7 +3,6 @@
 The obspy.imaging.scripts.scan / obspy-scan test suite.
 """
 import os
-import platform
 import shutil
 import warnings
 from os.path import abspath, dirname, join, pardir
@@ -54,11 +53,6 @@ class TestScan:
 
             obspy_scan([os.curdir] + ['--output', str(image_path)])
 
-    @pytest.mark.xfail(
-        os.environ.get('RUNNER_OS') == "Windows" or
-        platform.system() == "Windows",
-        reason="changing directory permission to non-readable does not seem "
-               "to work")
     def test_scan_dir_no_permission(self, all_files):
         """
         Run obspy-scan on a directory without read permission.

--- a/obspy/imaging/tests/test_scan.py
+++ b/obspy/imaging/tests/test_scan.py
@@ -3,6 +3,7 @@
 The obspy.imaging.scripts.scan / obspy-scan test suite.
 """
 import os
+import platform
 import shutil
 import warnings
 from os.path import abspath, dirname, join, pardir
@@ -54,7 +55,8 @@ class TestScan:
             obspy_scan([os.curdir] + ['--output', str(image_path)])
 
     @pytest.mark.xfail(
-        os.environ.get('RUNNER_OS') == "Windows",
+        os.environ.get('RUNNER_OS') == "Windows" or
+        platform.system() == "Windows",
         reason="changing directory permission to non-readable does not seem "
                "to work")
     def test_scan_dir_no_permission(self, all_files):
@@ -71,6 +73,23 @@ class TestScan:
             shutil.copy(all_files[0], no_permission_dir)
             # take away read permissions
             no_permission_dir.chmod(0o000)
+            # still sometimes even on Linux CI runners it seems that stripping
+            # read permission does not work and the scanner is able to process
+            # it, thus ending up with a higher counter than if properly making
+            # the directory not readable
+            try:
+                os.listdir(no_permission_dir)
+            # this is what we want, not being able to read the directory, thus
+            # the scanner only processing one item
+            except PermissionError:
+                pass
+            # this is unexpected, we weren't able to strip read permissions,
+            # and then in consequence this test is meaningless and we mark it
+            # as a skipped test
+            else:
+                pytest.skip(
+                    "unable to remove read permission from a test file for "
+                    "testing purposes")
             scanner.parse(str(no_permission_dir))
             # should not have been able to read test file but also not raised
             # an error


### PR DESCRIPTION
..on directory for testing purposes

### What does this PR do?

Skip a test on the fly if we are unable to strip read permissions on a file for testing purposes

### Why was it initiated?  Any relevant Issues?

CI test fails, https://tests.obspy.org/128232/#1

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
