### PR TITLE
seg2: fix reading string header field with empty value

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,9 @@ Changes:
  - obspy.io.mseed:
    * fix a bug in endtime calculation when writing fixed flags block
      information (see #3165)
+ - obspy.io.seg2:
+   * fix reading files that have a string header field with an empty value (see
+     #3174, #3178)
  - obspy.io.stationxml:
    * fix a bug that resulted in losing decimation information of base type
      response stages (see #3159)

--- a/obspy/io/seg2/seg2.py
+++ b/obspy/io/seg2/seg2.py
@@ -323,7 +323,7 @@ class SEG2(object):
             try:
                 value = string[1]
             except IndexError:
-                value = ''
+                value = b''
             if key == 'NOTE':
                 value = [cleanup_and_decode_string(line)
                          for line in value.split(self.line_terminator)


### PR DESCRIPTION
### What does this PR do?

Fixes reading SEG2 files that have string header fields with an empty value

### Why was it initiated?  Any relevant Issues?

fixes #3174 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
