### PR TITLE
Add missing argument to ppick type declaration

### DIFF
--- a/obspy/signal/headers.py
+++ b/obspy/signal/headers.py
@@ -61,7 +61,7 @@ clibsignal.ppick.argtypes = [
     np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
                            flags='C_CONTIGUOUS'),
     C.c_int, C.POINTER(C.c_int), C.c_char_p, C.c_float, C.c_int, C.c_int,
-    C.c_float, C.c_float, C.c_int, C.c_int]
+    C.c_float, C.c_float, C.c_int, C.c_int, C.POINTER(C.c_float)]
 clibsignal.ppick.restype = C.c_int
 
 clibsignal.ar_picker.argtypes = [

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -4,13 +4,11 @@ The obspy.signal.trigger test suite.
 """
 import gzip
 import os
-import sys
 import unittest
 import warnings
 from ctypes import ArgumentError
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from obspy import Stream, UTCDateTime, read
@@ -82,10 +80,6 @@ class TriggerTestCase(unittest.TestCase):
         self.assertRaises(ArgumentError, clibsignal.recstalta,
                           np.array([1], dtype=np.int32), charfct, ndat, 5, 10)
 
-    @pytest.mark.xfail(
-        os.environ.get('CI') == 'true'
-        and os.environ.get('RUNNER_OS') == 'Linux'
-        and '3.8.13' in sys.version, reason='see #2984')
     def test_pk_baer(self):
         """
         Test pk_baer against implementation for UNESCO short course
@@ -100,10 +94,6 @@ class TriggerTestCase(unittest.TestCase):
         self.assertEqual(nptime, 17545)
         self.assertEqual(pfm, 'IPU0')
 
-    @pytest.mark.xfail(
-        os.environ.get('CI') == 'true'
-        and os.environ.get('RUNNER_OS') == 'Linux'
-        and '3.8.13' in sys.version, reason='see #2984')
     def test_pk_baer_cf(self):
         """
         Test pk_baer against implementation for UNESCO short course


### PR DESCRIPTION
### What does this PR do?

The missing argument causes an error in `fi_prep_cif_var`.

### Why was it initiated?  Any relevant Issues?

Fixes #2984

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [n/a] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [n/a] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [n/a] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [n/a] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.