### PR TITLE
fix last piece in setup.py that had py3.7

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ master
 
 Changes:
  - obspy.core:
+   * Minimum supported Python version is now 3.8 (see #3081, #3087)
+   * Minimum supported dependency versions are now numpy 1.20, scipy 1.7 and
+     matplotlib 3.3 (see #3081, #3087)
    * Improved expanded channel information in string representation of Station,
      e.g. when displaying station in IPython shell (see #3024)
  - obspy.clients.seishub:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import Extension, find_packages, setup
 
 
 # The minimum python version which can be used to run ObsPy
-MIN_PYTHON_VERSION = (3, 7)
+MIN_PYTHON_VERSION = (3, 8)
 
 # Fail fast if the user is on an unsupported version of python.
 if sys.version_info < MIN_PYTHON_VERSION:


### PR DESCRIPTION
### What does this PR do?

Get rid of last piece mentioning Py3.7 support

### Why was it initiated?  Any relevant Issues?

last patch to #3081 and #3087

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
