### PR TITLE
Fix some tests writing in source tree

### DIFF
--- a/obspy/clients/filesystem/tests/test_tsindex.py
+++ b/obspy/clients/filesystem/tests/test_tsindex.py
@@ -11,10 +11,10 @@ import tempfile
 import uuid
 from unittest import mock, TestCase
 
+from obspy import read, UTCDateTime
+from obspy.core.util.misc import TemporaryWorkingDirectory
 from obspy.clients.filesystem.tsindex import Client, Indexer, \
     TSIndexDatabaseHandler
-from obspy import read
-from obspy import UTCDateTime
 
 
 def get_test_data_filepath():
@@ -642,42 +642,42 @@ class IndexerTestCase(TestCase):
                                filename_pattern="*.mseed")
 
     def test_download_leap_seconds_file(self):
-        filepath = get_test_data_filepath()
-        database = os.path.join(filepath, 'timeseries.sqlite')
-        indexer = Indexer(filepath,
-                          database=database)
-        # mock actually downloading the file since this requires a internet
-        # connection
-        indexer._download = mock.MagicMock(return_value=requests.Response())
-        # create a empty leap-seconds.list file
-        test_file = os.path.join(
-                            os.path.dirname(database), "leap-seconds.list")
-        file_path = indexer.download_leap_seconds_file(test_file)
-        # assert that the file was put in the same location as the
-        # sqlite db
-        self.assertTrue(os.path.isfile(file_path))
-        self.assertEqual(file_path, test_file)
-        os.remove(test_file)
+        with TemporaryWorkingDirectory() as tempdir:
+            database = os.path.join(tempdir, 'timeseries.sqlite')
+            indexer = Indexer(tempdir,
+                              database=database)
+            # mock actually downloading the file since this requires a internet
+            # connection
+            indexer._download = mock.MagicMock(
+                return_value=requests.Response())
+            # create a empty leap-seconds.list file
+            test_file = os.path.join(
+                                os.path.dirname(database), "leap-seconds.list")
+            file_path = indexer.download_leap_seconds_file(test_file)
+            # assert that the file was put in the same location as the
+            # sqlite db
+            self.assertTrue(os.path.isfile(file_path))
+            self.assertEqual(file_path, test_file)
 
     def test_download_leap_seconds_file_no_path_given(self):
-        filepath = get_test_data_filepath()
-        database = os.path.join(filepath, 'timeseries.sqlite')
-        indexer = Indexer(filepath,
-                          database=database)
-        # mock actually downloading the file since this requires a internet
-        # connection
-        indexer._download = mock.MagicMock(return_value=requests.Response())
-        file_path = indexer.download_leap_seconds_file()
+        with TemporaryWorkingDirectory() as tempdir:
+            database = os.path.join(tempdir, 'timeseries.sqlite')
+            indexer = Indexer(tempdir,
+                              database=database)
+            # mock actually downloading the file since this requires a internet
+            # connection
+            indexer._download = mock.MagicMock(
+                return_value=requests.Response())
+            file_path = indexer.download_leap_seconds_file()
 
-        self.assertEqual(
-            os.path.normpath(file_path),
-            os.path.normpath(os.path.join(os.path.dirname(database),
-                                          "leap-seconds.list")))
+            self.assertEqual(
+                os.path.normpath(file_path),
+                os.path.normpath(os.path.join(os.path.dirname(database),
+                                              "leap-seconds.list")))
 
-        # assert that the file was put in the same location as the
-        # sqlite db
-        self.assertTrue(os.path.isfile(file_path))
-        os.remove(file_path)
+            # assert that the file was put in the same location as the
+            # sqlite db
+            self.assertTrue(os.path.isfile(file_path))
 
     def test__get_leap_seconds_file(self):
         filepath = get_test_data_filepath()
@@ -699,12 +699,16 @@ class IndexerTestCase(TestCase):
 
         # test search
         # create a empty leap-seconds.list file
-        test_file = os.path.normpath(os.path.join(
-                            os.path.dirname(database), "leap-seconds.list"))
-        open(test_file, 'a').close()
-        file_path = os.path.normpath(indexer._get_leap_seconds_file("SEARCH"))
-        self.assertEqual(file_path, test_file)
-        os.remove(test_file)
+        with TemporaryWorkingDirectory() as tempdir:
+            database = os.path.join(tempdir, 'timeseries.sqlite')
+            indexer = Indexer(tempdir,
+                              database=database)
+            test_file = os.path.normpath(os.path.join(
+                os.path.dirname(database), "leap-seconds.list"))
+            open(test_file, 'a').close()
+            file_path = os.path.normpath(
+                indexer._get_leap_seconds_file("SEARCH"))
+            self.assertEqual(file_path, test_file)
 
     def test_build_file_list(self):
         filepath = get_test_data_filepath()

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -386,7 +386,7 @@ def TemporaryWorkingDirectory():  # noqa --> this name is IMHO ok for a CM
     old_dir = os.getcwd()
     os.chdir(tempdir)
     try:
-        yield
+        yield tempdir
     finally:
         os.chdir(old_dir)
         try:


### PR DESCRIPTION
### What does this PR do?

Make some tests not write to source tree during tests. Also makes our temp directory testing context manager yield the path of the temp dir

### Why was it initiated?  Any relevant Issues?

Tests fail in some settings, e.g. when installing obspy with pip as root into a system python, running the tests as regular user

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
