### PR TITLE
limit length of list which records processing info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes:
  - obspy.core:
    * Improved expanded channel information in string representation of Station,
      e.g. when displaying station in IPython shell (see #3024)
+   * limit length of list which records processing info (see #2882)
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2721,3 +2721,14 @@ class TestTrace:
 
         assert tr.stats.sampling_rate == 30
         assert tr.data.shape[0] == 1
+
+    def test_long_processing_list(self):
+        """
+        issue 2882
+        """
+        tr = read()[0]
+        with pytest.warns(UserWarning, match='.*maximal length') as record:
+            for _ in range(110):
+                tr.trim(0.01)
+        assert len(tr.stats.processing) == 100
+        assert len(record) == 1

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -2727,8 +2727,12 @@ class TestTrace:
         issue 2882
         """
         tr = read()[0]
-        with pytest.warns(UserWarning, match='.*maximal length') as record:
-            for _ in range(110):
+        for n in (100, 5, 10):
+            if n != 100:
+                tr._max_processing_info = n
+            with pytest.warns(UserWarning, match='.*maximal length') as record:
+                tr.stats.processing = [''] * (n-1)
                 tr.trim(0.01)
-        assert len(tr.stats.processing) == 100
-        assert len(record) == 1
+                tr.trim(0.01)
+            assert len(tr.stats.processing) == n
+            assert len(record) == 1

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -326,6 +326,7 @@ class Trace(object):
         See also: :meth:`Trace.__str__`.
     """
     _always_contiguous = True
+    _max_processing_info = 100
 
     def __init__(self, data=np.array([]), header=None):
         # make sure Trace gets initialized with suitable ndarray as self.data
@@ -2298,12 +2299,11 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         trace's :class:`~obspy.core.trace.Stats` object.
         """
         proc = self.stats.setdefault('processing', [])
-        if len(proc) == 99:
-            warnings.warn(
-                'List of processing information in Trace.stats.processing '
-                'reached maximal length of 100 entries.'
-                )
-        if len(proc) < 100:
+        if len(proc) == self._max_processing_info-1:
+            msg = ('List of processing information in Trace.stats.processing '
+                   'reached maximal length of {} entries.')
+            warnings.warn(msg.format(self._max_processing_info))
+        if len(proc) < self._max_processing_info:
             proc.append(info)
 
     @_add_processing_info

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2298,7 +2298,13 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         trace's :class:`~obspy.core.trace.Stats` object.
         """
         proc = self.stats.setdefault('processing', [])
-        proc.append(info)
+        if len(proc) == 99:
+            warnings.warn(
+                'List of processing information in Trace.stats.processing '
+                'reached maximal length of 100 entries.'
+                )
+        if len(proc) < 100:
+            proc.append(info)
 
     @_add_processing_info
     def split(self):


### PR DESCRIPTION
### What does this PR do?

Limit length of list, which records processing info, to 100 entries. Also emits a warning when reaching this limit.

### Why was it initiated?  Any relevant Issues?

Fix for #2882

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
