### PR TITLE
Fix massdownloader channel priority missing data

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -49,6 +49,15 @@ class _SlotsEqualityComparisionObject(object):
                     for _i in self.__slots__])
 
 
+def _sta_int_key(station, interval):
+    """
+    Returns a tuple that can be used as a key in dictionaries to identify a
+    unique combination of Station+Interval
+    """
+    return (station.network, station.station, interval.start.ns,
+            interval.end.ns)
+
+
 class Station(_SlotsEqualityComparisionObject):
     """
     Object representing a seismic station within the download helper classes.
@@ -393,12 +402,16 @@ class Channel(_SlotsEqualityComparisionObject):
     Object representing a Channel. Each time interval should end up in one
     MiniSEED file.
     """
-    __slots__ = ["location", "channel", "intervals"]
+    __slots__ = ["location", "channel", "intervals", "channel_priority",
+                 "location_priority"]
 
-    def __init__(self, location, channel, intervals):
+    def __init__(self, location, channel, intervals, channel_priority=0,
+                 location_priority=0):
         self.location = location
         self.channel = channel
         self.intervals = intervals
+        self.channel_priority = channel_priority
+        self.location_priority = location_priority
 
     @property
     def needs_station_file(self):
@@ -927,9 +940,14 @@ class ClientDownloadHelper(object):
         """
         downloaded_bytes = 0
         discarded_bytes = 0
+        highest_channel_priorities = {}
         for sta in self.stations.values():
             for cha in sta.channels:
                 for interval in cha.intervals:
+                    sta_int_key = _sta_int_key(sta, interval)
+                    current_cha_prio_high = \
+                        highest_channel_priorities.setdefault(
+                            sta_int_key, np.inf)
                     # The status of the interval should not have changed if
                     # it did not require downloading in the first place.
                     if interval.status != STATUS.NEEDS_DOWNLOADING:
@@ -1000,8 +1018,36 @@ class ClientDownloadHelper(object):
                             interval.status = STATUS.DOWNLOAD_REJECTED
                             continue
 
+                    self.logger.info(f'{cha.channel} {cha.channel_priority}')
+                    if cha.channel_priority < current_cha_prio_high:
+                        highest_channel_priorities[sta_int_key] = \
+                            cha.channel_priority
                     downloaded_bytes += size
                     interval.status = STATUS.DOWNLOADED
+
+        # last step: from all the valid/good data we kept, determine for each
+        # station+interval combination group channels by priority and only keep
+        # data with highest priority
+        for sta in self.stations.values():
+            for cha in sta.channels:
+                for interval in cha.intervals:
+                    # we only look at actually downloaded and approved data
+                    if interval.status != STATUS.DOWNLOADED:
+                        continue
+                    sta_int_key = _sta_int_key(sta, interval)
+                    # greater than here actually means a lower priority
+                    priority = cha.channel_priority
+                    if priority > highest_channel_priorities[sta_int_key]:
+                        self.logger.info(
+                            f"File {interval.filename} is not needed since a "
+                            f"higher priority channel was downloaded as well. "
+                            f"File will be deleted.")
+                        size = os.path.getsize(interval.filename)
+                        utils.safe_delete(interval.filename)
+                        discarded_bytes += size
+                        downloaded_bytes -= size
+                        interval.status = STATUS.DOWNLOAD_REJECTED
+
         return downloaded_bytes, discarded_bytes
 
     def _parse_miniseed_filenames(self, filenames, restrictions):

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -327,13 +327,11 @@ def filter_channel_priority(channels, key, priorities=None):
     if priorities is None:
         return channels
     filtered_channels = []
-    for pattern in priorities:
-        if filtered_channels:
-            break
-        for channel in channels:
+    for channel in channels:
+        for i, pattern in enumerate(priorities):
             if fnmatch.fnmatch(getattr(channel, key), pattern):
                 filtered_channels.append(channel)
-                continue
+                break
     return filtered_channels
 
 

--- a/obspy/clients/fdsn/mass_downloader/utils.py
+++ b/obspy/clients/fdsn/mass_downloader/utils.py
@@ -328,8 +328,10 @@ def filter_channel_priority(channels, key, priorities=None):
         return channels
     filtered_channels = []
     for channel in channels:
+        setattr(channel, f'{key}_priority', np.inf)
         for i, pattern in enumerate(priorities):
             if fnmatch.fnmatch(getattr(channel, key), pattern):
+                setattr(channel, f'{key}_priority', i)
                 filtered_channels.append(channel)
                 break
     return filtered_channels


### PR DESCRIPTION
### What does this PR do?

fdsn massdownloader: make channel_priority robust to advertized but missing data 
 
currently (at least when only "weak" availability data is available), any channels that are in principle available according to metadata overrule all other channels that come later in the channel_priority listing, e.g. if the the first item in channel_priority successfully matches a channel, all other channels are ignored, even if the former selected channel actually yields "No data available at server" while some other channels actually do have data but are later in the channel_priority (see #2794)  
 
Currently the only way to fix this is to first try and download *all* channels' data that match any of the given channel_priority wildards, and then at the very end it is evaluated if some higher priority data was downloaded and lower priority data get deleted again.  
 
This certainly is not ideal, since it might blow up the amount of data downloaded and subsequently discarded, but it is likely the lesser evil compared to losing whole stations from the final download result  


### Why was it initiated?  Any relevant Issues?

*Please fill in (link relevant issues with "see #123456", mark issues that get resolved with "fixes #12345")*

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
