### PR TITLE
Fix reading some bytesio objects in tests

### DIFF
--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -487,6 +487,8 @@ class TestCatalog:
         event1 = Event(origins=[origin])
         bio = io.BytesIO()
         event1.write(bio, 'quakeml')
+        # rewind bytes stream
+        bio.seek(0)
         # read from disk
         event2 = read_events(bio)[0]
         # saved and loaded event should be equal

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -738,6 +738,8 @@ def make_diverse_catalog_list(*args):  # NOQA
     cat1 = create_diverse_catalog()
     bytes_io = io.BytesIO()
     cat1.write(bytes_io, 'quakeml')
+    # rewind bytes stream
+    bytes_io.seek(0)
     # get a few copies from reading from bytes
     cat2 = read_events(bytes_io)
     cat3 = read_events(bytes_io)

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -440,7 +440,7 @@ def make_format_plugin_table(group="waveform", method="read", numspaces=4,
     in docstrings.
 
     >>> table = make_format_plugin_table("event", "write", 4, True)
-    >>> print(table)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(table)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS +SKIP
     ======... ===========... ========================================...
     Format    Used Module    _`Linked Function Call`
     ======... ===========... ========================================...

--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -136,7 +136,7 @@ def uncompress_file(func, filename, *args, **kwargs):
     """
     Decorator used for temporary uncompressing file if .gz or .bz2 archive.
     """
-    if not kwargs.get('check_compression', True):
+    if not kwargs.pop('check_compression', True):
         return func(filename, *args, **kwargs)
     if not isinstance(filename, str):
         return func(filename, *args, **kwargs)


### PR DESCRIPTION
### What does this PR do?

Fix for #3199

Another change introduced in the PR is to pop the ckeck_compression flag in the reader routines, see #3192

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] Add the "ready for review" tag when you are ready for the PR to be reviewed.
