### PR TITLE
Enhance CI workflow triggers

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,20 +1,21 @@
 name: wheels
 on:
+  pull_request:
   push:
     branches:
       - master
-      - 'test_wheels*'
     tags:
       - '*'
   release:
     types: [published]
 
 concurrency:
-  group: wheels-${{ github.event_name }}-${{ github.ref_name }}
+  group: wheels-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   build_wheels:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test_wheels')
     name: build (${{ matrix.os }}, ${{ matrix.build }})
     runs-on: ${{ matrix.os }}
     env:
@@ -63,6 +64,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_sdist:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test_wheels')
     name: build sdist
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -14,9 +14,9 @@ env:
   condition: ${{ (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs' }}
 
 # cancel previous runs, but only in PRs, do not cancel previous runs if this run will be skipped
- concurrency:
-    group: docs-${{ github.event.pull_request.number || github.run_id }}-${{ !env.condition || github.run_id }}
-    cancel-in-progress: true
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.run_id }}-${{ !env.condition || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -1,6 +1,7 @@
 name: "docs"
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - master
@@ -9,15 +10,18 @@ on:
   release:
     types: [published]
 
+env:
+  condition: ${{ (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs' }}
 
-# Cancel previous runs, but only in PRs
-concurrency:
-  group: docs-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+# cancel previous runs, but only in PRs, do not cancel previous runs if this run will be skipped
+ concurrency:
+    group: docs-${{ github.event.pull_request.number || github.run_id }}-${{ !env.condition || github.run_id }}
+    cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build_docs')
+    # only run if on master branch OR if PR is updated and build_docs label present OR if build_docs_label is added
+    if: github.event_name != 'pull_request' || env.condition
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -10,18 +10,15 @@ on:
   release:
     types: [published]
 
-env:
-  condition: ${{ (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs' }}
-
 # cancel previous runs, but only in PRs, do not cancel previous runs if this run will be skipped
 concurrency:
-  group: docs-${{ github.event.pull_request.number || github.run_id }}-${{ !env.condition || github.run_id }}
+  group: docs-${{ github.event.pull_request.number || github.run_id }}-${{ !((github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs') || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build:
     # only run if on master branch OR if PR is updated and build_docs label present OR if build_docs_label is added
-    if: github.event_name != 'pull_request' || env.condition
+    if: github.event_name != 'pull_request' || ((github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -1,7 +1,6 @@
 name: "docs"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - master


### PR DESCRIPTION
### What does this PR do?

I tried to improve the workflow triggers. The goal was to trigger the corresponding workflows when specific labels are added using the "labeled" pull_request event. This was impractical, because workflows were triggered for all new applied labels. Later, jobs can be canceled for inappropriate labels, but then the checks tab will only show these skipped jobs.
Therefore, I removed this feature again for the docs_building workflow.

Secondly, I added a trigger for the wheel building; these are now triggered in PRs with the test_wheels label instead of using specific branch names.

~This PR is branched from #3205.~

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the "build_docs" tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the "test_network" tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] Add the "ready for review" tag when you are ready for the PR to be reviewed.
