### PR TITLE
be nice to plugins based on zip format

### DIFF
--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -164,8 +164,14 @@ def uncompress_file(func, filename, *args, **kwargs):
             pass
     elif zipfile.is_zipfile(filename):
         try:
-            zip = zipfile.ZipFile(filename)
-            obj_list = [zip.read(name) for name in zip.namelist()]
+            with zipfile.ZipFile(filename) as zip:
+                if b'obspy_no_uncompress' in zip.comment:
+                    # be nice to plugins based on zip format
+                    # do not uncompress the file if tag is present
+                    # see issue #3192
+                    obj_list = None
+                else:
+                    obj_list = [zip.read(name) for name in zip.namelist()]
         except Exception:
             pass
     elif filename.endswith('.bz2'):


### PR DESCRIPTION
### What does this PR do?

As discussed in #3192 this PR implements a check whether zip files should be uncompressed automatically. To use this feature/magic, plugins have to write a comment to the zip file including `b'obspy_no_uncompress'`.

### Why was it initiated?  Any relevant Issues?

Closes #3192

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
