### PR TITLE
polarity analysis: fix calculation of timestamp for sliding windows

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,8 @@ Changes:
      usage (see #3104)
    * Baer picker: fix a bug that could cause crashes on certain versions of
      libffi (see #3183)
+   * polarization analysis: fix calculation of timestamps of the resulting
+     values (see #3211)
  - obspy.taup:
    * add option "indicate_wave_type" to distinguish S waves in ray paths
      plot by using wiggly lines for shear waves (see #3047)

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -514,6 +514,7 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
         tap = cosine_taper(nsamp, p=0.22)
         offset = 0
         while (newstart + (nsamp + nstep) / fs) < etime:
+            timestamp = newstart.timestamp + (float(nsamp) / 2 / fs)
             try:
                 for i, tr in enumerate(stream):
                     dat = tr.data[spoint[i] + offset:
@@ -537,15 +538,15 @@ def polarization_analysis(stream, win_len, win_frac, frqlow, frqhigh, stime,
             if method.lower() == "pm":
                 azimuth, incidence, error_az, error_inc = \
                     particle_motion_odr(data, var_noise)
-                res.append(np.array([newstart.timestamp + float(nstep) / fs,
-                           azimuth, incidence, error_az, error_inc]))
+                res.append(np.array([
+                    timestamp, azimuth, incidence, error_az, error_inc]))
             if method.lower() == "flinn":
                 azimuth, incidence, reclin, plan = flinn(data, var_noise)
-                res.append(np.array([newstart.timestamp + float(nstep) / fs,
-                                    azimuth, incidence, reclin, plan]))
+                res.append(np.array([
+                    timestamp, azimuth, incidence, reclin, plan]))
 
             if verbose:
-                print(newstart, newstart + nsamp / fs, res[-1][1:])
+                print(newstart, newstart + float(nsamp) / fs, res[-1][1:])
             offset += nstep
 
             newstart += float(nstep) / fs

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -123,15 +123,18 @@ class PolarizationTestCase(unittest.TestCase):
         st = _create_test_data()
         t = st[0].stats.starttime
         e = st[0].stats.endtime
+        wlen = 10.0
+        wfrac = 0.1
 
         out = polarization.polarization_analysis(
-            st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
+            st, win_len=wlen, win_frac=wfrac, frqlow=1.0, frqhigh=5.0,
             verbose=False, stime=t, etime=e, method="pm",
             var_noise=0.0)
 
         # all values should be equal for the test data, so check first value
         # and make sure all values are almost equal
-        self.assertEqual(out["timestamp"][0], 1393632001.0)
+        self.assertEqual(out["timestamp"][0], 1393632005.0)
+        self.assertEqual(out["timestamp"][0], t + wlen / 2.0)
         self.assertAlmostEqual(out["azimuth"][0], 26.56505117707799)
         self.assertAlmostEqual(out["incidence"][0], 65.905157447889309)
         self.assertAlmostEqual(out["azimuth_error"][0], 0.000000)
@@ -152,15 +155,18 @@ class PolarizationTestCase(unittest.TestCase):
         st = _create_test_data()
         t = st[0].stats.starttime
         e = st[0].stats.endtime
+        wlen = 10.0
+        wfrac = 0.1
 
         out = polarization.polarization_analysis(
-            st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
+            st, win_len=wlen, win_frac=wfrac, frqlow=1.0, frqhigh=5.0,
             verbose=False, stime=t, etime=e,
             method="flinn", var_noise=0.0)
 
         # all values should be equal for the test data, so check first value
         # and make sure all values are almost equal
-        self.assertEqual(out["timestamp"][0], 1393632001.0)
+        self.assertEqual(out["timestamp"][0], 1393632005.0)
+        self.assertEqual(out["timestamp"][0], t + wlen / 2.0)
         self.assertAlmostEqual(out["azimuth"][0], 26.56505117707799)
         self.assertAlmostEqual(out["incidence"][0], 65.905157447889309)
         self.assertAlmostEqual(out["rectilinearity"][0], 1.000000)


### PR DESCRIPTION
### What does this PR do?

Fixes calculation of timestamps of sliding windows in polarization analysis for methods `pm` and `flinn`. Timestamp was supposed to be calculated as the center of the window, but was instead calculated as window start plus window shifting fraction, i.e. as the start time of the next window.
With window fraction `0.5` the timestamp calculation actually was yielding the expected result, but with lower or higher values yielded values shifted from the expected value by up to half the length of a single time window.

### Why was it initiated?  Any relevant Issues?

Fixes #2811 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
