### PR TITLE
get_stations_bulk params / turn off get_stations autodiscovery

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ Changes:
    * limit length of list which records processing info (see #2882)
  - obspy.clients.fdsn:
    * update URL for NCEDC to https (see #3203)
+   * add all valid parameters to get_stations_bulk (see #3140)
+   * do not use autodiscovery of file format in get_stations (see #3138)
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1062,12 +1062,12 @@ class Client(object):
             self._attach_dataselect_url_to_stream(st)
             return st
 
-    def get_stations_bulk(self, bulk, minlatitude=None, maxlatitude=None,
+    def get_stations_bulk(self, bulk, level=None, includerestricted=None,
+                          includeavailability=None, filename=None,
+                          minlatitude=None, maxlatitude=None,
                           minlongitude=None, maxlongitude=None, latitude=None,
                           longitude=None, minradius=None, maxradius=None,
-                          level=None, includerestricted=None,
-                          includeavailability=None, updatedafter=None,
-                          matchtimeseries=None, filename=None, format=None,
+                          updatedafter=None, matchtimeseries=None, format=None,
                           **kwargs):
         """
         Query the station service of the client. Bulk request.

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -752,7 +752,12 @@ class Client(object):
             data_stream.close()
         else:
             # This works with XML and StationXML data.
-            inventory = read_inventory(data_stream)
+            if format is None or format == 'xml':
+                inventory = read_inventory(data_stream, format='STATIONXML')
+            elif format == 'text':
+                inventory = read_inventory(data_stream, format='STATIONTEXT')
+            else:
+                inventory = read_inventory(data_stream)
             data_stream.close()
             return inventory
 
@@ -1057,9 +1062,14 @@ class Client(object):
             self._attach_dataselect_url_to_stream(st)
             return st
 
-    def get_stations_bulk(self, bulk, level=None, includerestricted=None,
-                          includeavailability=None, filename=None, **kwargs):
-        r"""
+    def get_stations_bulk(self, bulk, minlatitude=None, maxlatitude=None,
+                          minlongitude=None, maxlongitude=None, latitude=None,
+                          longitude=None, minradius=None, maxradius=None,
+                          level=None, includerestricted=None,
+                          includeavailability=None, updatedafter=None,
+                          matchtimeseries=None, filename=None, format=None,
+                          **kwargs):
+        """
         Query the station service of the client. Bulk request.
 
         Send a bulk request for stations to the server. `bulk` can either be
@@ -1156,6 +1166,31 @@ class Client(object):
         :type bulk: str, file or list[list]
         :param bulk: Information about the requested data. See above for
             details.
+        :type minlatitude: float
+        :param minlatitude: Limit to stations with a latitude larger than the
+            specified minimum.
+        :type maxlatitude: float
+        :param maxlatitude: Limit to stations with a latitude smaller than the
+            specified maximum.
+        :type minlongitude: float
+        :param minlongitude: Limit to stations with a longitude larger than the
+            specified minimum.
+        :type maxlongitude: float
+        :param maxlongitude: Limit to stations with a longitude smaller than
+            the specified maximum.
+        :type latitude: float
+        :param latitude: Specify the latitude to be used for a radius search.
+        :type longitude: float
+        :param longitude: Specify the longitude to be used for a radius
+            search.
+        :type minradius: float
+        :param minradius: Limit results to stations within the specified
+            minimum number of degrees from the geographic point defined by the
+            latitude and longitude parameters.
+        :type maxradius: float
+        :param maxradius: Limit results to stations within the specified
+            maximum number of degrees from the geographic point defined by the
+            latitude and longitude parameters.
         :type level: str
         :param level: Specify the level of detail for the results ("network",
             "station", "channel", "response"), e.g. specify "response" to get
@@ -1166,10 +1201,20 @@ class Client(object):
         :type includeavailability: bool
         :param includeavailability: Specify if results should include
             information about time series data availability.
+        :type updatedafter: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param updatedafter: Limit to metadata updated after specified date;
+            updates are data center specific.
+        :type matchtimeseries: bool
+        :param matchtimeseries: Only include data for which matching time
+            series data is available.
         :type filename: str or file
         :param filename: If given, the downloaded data will be saved there
             instead of being parsed to an ObsPy object. Thus it will contain
             the raw data from the webservices.
+        :type format: str
+        :param format: The format in which to request station information.
+            ``"xml"`` (StationXML) or ``"text"`` (FDSN station text format).
+            XML has more information but text is much faster.
 
         Any additional keyword arguments will be passed to the webservice as
         additional arguments. If you pass one of the default parameters and the
@@ -1182,9 +1227,20 @@ class Client(object):
             raise ValueError(msg)
 
         arguments = OrderedDict(
+            minlatitude=minlatitude,
+            maxlatitude=maxlatitude,
+            minlongitude=minlongitude,
+            maxlongitude=maxlongitude,
+            latitude=latitude,
+            longitude=longitude,
+            minradius=minradius,
+            maxradius=maxradius,
             level=level,
             includerestricted=includerestricted,
-            includeavailability=includeavailability
+            includeavailability=includeavailability,
+            updatedafter=updatedafter,
+            matchtimeseries=matchtimeseries,
+            format=format
         )
         bulk = get_bulk_string(bulk, arguments)
 
@@ -1199,7 +1255,12 @@ class Client(object):
             return
         else:
             # Works with text and StationXML data.
-            inv = obspy.read_inventory(data_stream)
+            if format is None or format == 'xml':
+                inv = read_inventory(data_stream, format='STATIONXML')
+            elif format == 'text':
+                inv = read_inventory(data_stream, format='STATIONTEXT')
+            else:
+                inv = read_inventory(data_stream)
             data_stream.close()
             return inv
 


### PR DESCRIPTION
this is the same PR as #3173 which I was unable to sync with master without starting over (?)

it currently has the get_stations_bulk parameters defined as below, which are jumbled but non-breaking, as discussed  

```
    def get_stations_bulk(self, bulk, level=None, includerestricted=None,
                          includeavailability=None, filename=None,
                          minlatitude=None, maxlatitude=None,
                          minlongitude=None, maxlongitude=None, latitude=None,
                          longitude=None, minradius=None, maxradius=None,
                          updatedafter=None, matchtimeseries=None, format=None,
                          **kwargs):
```

forgive the delays!

fixes #3140 
supersedes #3173 