### PR TITLE
fdsn routing: fix a bug when "debug=True" was set

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@ Changes:
      constraints (see #3140)
    * do not use autodiscovery of file format in get_stations, unless "format"
      is set to something we do not recognize (see #3138)
+   * fix a bug in routing client that made any request made error out when
+     "debug=True" was set (see #3214)
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)

--- a/obspy/clients/base.py
+++ b/obspy/clients/base.py
@@ -212,7 +212,12 @@ class HTTPClient(RemoteBaseClient, metaclass=ABCMeta):
             # Construct the same URL requests would construct.
             from requests import PreparedRequest  # noqa
             p = PreparedRequest()
-            p.prepare(method="GET", **_request_args)
+            # request doesnt use timeout parameter, it's used when actually
+            # sending the request, but the request is never sent in this debug
+            # block anyway, it's just for printing info on what would be sent
+            p.prepare(
+                method="GET",
+                **{k: v for k, v in _request_args.items() if k != "timeout"})
             print("Downloading %s ..." % p.url)
             if data is not None:
                 print("Sending along the following payload:")


### PR DESCRIPTION
### What does this PR do?

Fix a minor bug that made FDSN routing clients error out when `debug=True` was set on initialization.

### Why was it initiated?  Any relevant Issues?

Fixes #3213 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the `ready for review` tag when you are ready for the PR to be reviewed.
