### PR TITLE
fdsn: fix eida routing get_waveforms_bulk()

### DIFF
--- a/obspy/clients/fdsn/routing/eidaws_routing_client.py
+++ b/obspy/clients/fdsn/routing/eidaws_routing_client.py
@@ -14,7 +14,7 @@ from ..client import get_bulk_string
 from ..header import FDSNNoDataException
 from .routing_client import (
     BaseRoutingClient, _assert_attach_response_not_in_kwargs,
-    _assert_filename_not_in_kwargs)
+    _assert_filename_not_in_kwargs, _assert_format_not_in_kwargs)
 
 
 class EIDAWSRoutingClient(BaseRoutingClient):
@@ -96,8 +96,7 @@ class EIDAWSRoutingClient(BaseRoutingClient):
         new_bulk = []
         for t, _b in bulk_per_time_interval.items():
             # channel level and text to keep it fast.
-            inv = self.get_stations_bulk(_b, format="text",
-                                         level="channel", **kwargs)
+            inv = self.get_stations_bulk(_b, level="channel", **kwargs)
             for c in sorted(set(inv.get_contents()["channels"])):
                 new_bulk.append(c.split("."))
                 new_bulk[-1].extend(t)
@@ -148,6 +147,7 @@ class EIDAWSRoutingClient(BaseRoutingClient):
         """
         return super(EIDAWSRoutingClient, self).get_stations(**kwargs)
 
+    @_assert_format_not_in_kwargs
     @_assert_filename_not_in_kwargs
     def get_stations_bulk(self, bulk, **kwargs):
         """
@@ -159,8 +159,8 @@ class EIDAWSRoutingClient(BaseRoutingClient):
         station service if the service supports them (otherwise they are
         silently ignored for that particular fdsnws endpoint).
 
-        The ``filename`` parameter of the single provider FDSN client is not
-        supported for practical reasons.
+        The ``filename`` and ``format`` parameters of the single provider FDSN
+        client are not supported for practical reasons.
 
         This can route on a number of different parameters, please see the
         web site of the `EIDAWS Routing Service

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -72,6 +72,13 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
 
 
 @decorator.decorator
+def _assert_format_not_in_kwargs(f, *args, **kwargs):
+    if "format" in kwargs:
+        raise ValueError("The `format` argument is not supported")
+    return f(*args, **kwargs)
+
+
+@decorator.decorator
 def _assert_filename_not_in_kwargs(f, *args, **kwargs):
     if "filename" in kwargs:
         raise ValueError("The `filename` argument is not supported")


### PR DESCRIPTION

### What does this PR do?

fix eida routing get_waveforms_bulk()

see test fail in https://tests.obspy.org/130191, warnings section has the relevant info showing the xml parser choking up on something that isn't xml.

Internally was making a call to `get_stations_bulk()` of the routing client with `format='text'` but that routing client routine internally uses a special format `post` specific to the routing web service. For some reason having `format='text'` in there made some server response get read as StationXML when it wasn't.. weird.

This also makes `get_stations_bulk()` of the routing client reject `format` kwarg, since this doesn't make sense anyway as internally it uses `post` format special to EIDA routing web service.

### Why was it initiated?  Any relevant Issues?

This problem surfaced as a side effect of #3212 so it's not in a released version and no changelog needed.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
