### PR TITLE
fix map plots with custom user options

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,8 @@ Changes:
    * Improved expanded channel information in string representation of Station,
      e.g. when displaying station in IPython shell (see #3024)
    * limit length of list which records processing info (see #2882)
+   * map plots: fix initial map setup, properly pass through user specified
+     options, like "projection" etc (see #3191)
  - obspy.clients.fdsn:
    * update URL for NCEDC to https (see #3203)
    * add all valid parameters to get_stations_bulk, e.g. geographical
@@ -29,6 +31,8 @@ Changes:
      than 100 Hz (see #3093)
    * spectrogram: better exception type and messages when input signal is too
      short (see #3093)
+   * map plots: fix initial map setup, properly pass through user specified
+     options, like "projection" etc (see #3191)
  - obspy.signal:
    * coincidence trigger: improve speed of template matching and less memory
      usage (see #3104)

--- a/obspy/imaging/maps.py
+++ b/obspy/imaging/maps.py
@@ -269,12 +269,13 @@ def plot_cartopy(lons, lats, size, color, labels=None, projection='global',
 
     if ax is None:
         fig, map_ax, cm_ax, show_colorbar = _basic_setup(
-            lons=lons, lats=lats, size=size, color=color, labels=None,
-            projection='global', resolution='110m', continent_fill_color='0.8',
-            water_fill_color='1.0', colormap=None, colorbar=None, marker="o",
-            title=None, colorbar_ticklabel_format=None,
-            proj_kwargs=None)
-
+            lons=lons, lats=lats, size=size, color=color, labels=labels,
+            projection=projection, resolution=resolution,
+            continent_fill_color=continent_fill_color,
+            water_fill_color=water_fill_color, colormap=colormap,
+            colorbar=colorbar, marker=marker, title=title,
+            colorbar_ticklabel_format=colorbar_ticklabel_format,
+            proj_kwargs=proj_kwargs)
     else:
         if isinstance(ax, matplotlib.figure.Figure):
             fig = ax


### PR DESCRIPTION
### What does this PR do?

Fixes map plots with user specified options like custom "projection" kwarg. These weren't properly passed through to the new helper method for initial cartopy plot setup, so default values were always winning.

### Why was it initiated?  Any relevant Issues?

fixes #3191 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
