### PR TITLE
response: do not report unknown units as type "displacement" to evalresp

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,11 @@ Changes:
    * Minimum supported Python version is now 3.8 (see #3081, #3087)
    * Minimum supported dependency versions are now numpy 1.20, scipy 1.7 and
      matplotlib 3.3 (see #3081, #3087)
+   * response: avoid reporting all unkown units (e.g. "RAD/S") to evalresp as
+     displacement ("DIS") which with default value for "output" ("VEL") leads
+     to evalresp adding a differentiation during response calculation. Instead
+     report undefined unit, which makes evalresp use response as is and
+     essentially ignoring "output" parameter (see #2945)
    * Improved expanded channel information in string representation of Station,
      e.g. when displaying station in IPython shell (see #3024)
    * limit length of list which records processing info (see #2882)

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1195,12 +1195,15 @@ class Response(ComparingObject):
                 "MBAR": ew.ENUM_UNITS["PRESSURE"]}
             if key not in units_mapping:
                 if key is not None:
-                    msg = ("The unit '%s' is not known to ObsPy. It will be "
-                           "assumed to be displacement for the calculations. "
-                           "This mostly does the right thing but please "
-                           "proceed with caution.") % key
+                    msg = (f"The unit '{key}' is not known to ObsPy. It will "
+                           f"be passed in to evalresp as 'undefined'. This "
+                           f"should result in evalresp using the response as "
+                           f"is, without adding any integration or "
+                           f"differentiation and the 'output' parameter "
+                           f"(here: '{output}') not having any effect. Please "
+                           f"double check output data.")
                     warnings.warn(msg)
-                value = ew.ENUM_UNITS["DIS"]
+                value = ew.ENUM_UNITS["UNDEF_UNITS"]
             else:
                 value = units_mapping[key]
 

--- a/obspy/core/tests/data/response_radian_per_second.xml
+++ b/obspy/core/tests/data/response_radian_per_second.xml
@@ -1,0 +1,101 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0">
+  <Source></Source>
+  <Sender></Sender>
+  <Module></Module>
+  <ModuleURI></ModuleURI>
+  <Created>2000-01-01T00:00:00.000000Z</Created>
+  <Network code="XX">
+    <Description></Description>
+    <SelectedNumberStations>1</SelectedNumberStations>
+    <Station code="XX" startDate="2000-01-01T00:00:00.000000Z">
+      <Description></Description>
+      <Latitude unit="DEGREES">1.0</Latitude>
+      <Longitude unit="DEGREES">1.0</Longitude>
+      <Elevation unit="METERS">1.0</Elevation>
+      <Site>
+        <Name></Name>
+      </Site>
+      <CreationDate>2000-01-01T00:00:00.000000Z</CreationDate>
+      <TotalNumberChannels>1</TotalNumberChannels>
+      <SelectedNumberChannels>1</SelectedNumberChannels>
+      <Channel code="HJ1" locationCode="" startDate="2000-01-01T00:00:00.000000Z">
+        <Latitude unit="DEGREES">1.0</Latitude>
+        <Longitude unit="DEGREES">1.0</Longitude>
+        <Elevation unit="METERS">1.0</Elevation>
+        <Depth unit="METERS">0.0</Depth>
+        <Azimuth unit="DEGREES">90.0</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <SampleRate>200.0</SampleRate>
+        <Sensor>
+          <Type>FOG rotational sensor</Type>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>1000000000.0</Value>
+            <Frequency>0.02</Frequency>
+            <InputUnits>
+              <Name>RAD/S</Name>
+              <Description>Radians per Second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>Digital Counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>RAD/S</Name>
+                <Description>Radians per Second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>1.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">1.0</NormalizationFrequency>
+              <Zero number="0">
+                <Real minusError="1.0" plusError="1.0">1.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real minusError="1.0" plusError="1.0">1.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.02</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>Volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>Digital Counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">200.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1000000000.0</Value>
+              <Frequency>0.0</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>


### PR DESCRIPTION
### What does this PR do?

Do not report unknown / unrecognized units / units not representable in evalresp to evalresp as type "displacement", as this leads to e.g. input units of radian/second on a rotational sensor with using the unchanged default of `output="VEL"` to have a differentiation added on top of the response stated in metadata, which makes no sense.
If unknown units come into play, just report to evalresp as "undefined" which seems to consistently just use the response from metadata as is, essentially ignoring "output" parameter.

Seems unproblematic and I think it makes total sense. No existing tests had to be adjusted, since I'm assuming they all are in the realm of DIS/VEL/ACC.

### Why was it initiated?  Any relevant Issues?

Fixes #2945 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
