### PR TITLE
fdsn: fix raising FDSNTooManyRequestsException

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,8 @@ Changes:
      is set to something we do not recognize (see #3138)
    * fix a bug in routing client that made any request made error out when
      "debug=True" was set (see #3214)
+   * fix raising FDSNTooManyRequestsException when server rejects request due
+     to rate limiting, due to a bug instead a TypeError was raised (see #3219)
  - obspy.clients.seishub:
    * submodule removed completely, since it is outdated and not even test
      servers have been running for years (see #2994)

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -1834,7 +1834,7 @@ def raise_on_error(code, data):
         raise NotImplementedError(msg)
     elif code == 429:
         msg = ("Sent too many requests in a given amount of time ('rate "
-               "limiting'). Wait before making a new request.", server_info)
+               "limiting'). Wait before making a new request.")
         raise FDSNTooManyRequestsException(msg, server_info)
     elif code == 500:
         raise FDSNInternalServerException("Service responds: Internal server "


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that prevented the proper exception getting raised when FDSN server rejects request due to rate limiting.

### Why was it initiated?  Any relevant Issues?

fixes #3219 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
