### PR TITLE
add test for reading phases from nlloc v7 hyp file

### DIFF
--- a/obspy/io/nlloc/tests/data/nlloc_v7.hyp
+++ b/obspy/io/nlloc/tests/data/nlloc_v7.hyp
@@ -1,0 +1,24 @@
+NLLOC "/dev/shm/NLL/NLL.LuGxVBGQG/.20221031.050241.grid0" "LOCATED" "Location completed."
+PUBLIC_ID None
+SIGNATURE "sekiya   obs:/dev/shm/NLL/NLL.LuGxVBGQG/NLL.LuGxVBGQG.obs   NLLoc:v7.00.13(17Jan2022)   run:17Nov2022 15h49m52"
+COMMENT ""
+GRID  271 296 17  -407.434 -453.957 -1.5  3 3 3 PROB_DENSITY
+SEARCH OCTREE nInitial 40256 nEvaluated 60000 smallestNodeSide 0.744485/0.747466/0.375000 oct_tree_integral 4.782626e+03 scatter_volume 4.689266e+03
+HYPOCENTER  x -94.378 y -81.3451 z -0.5625  OT 28.9603  ix -1 iy -1 iz -1 MAXIMUM_LIKELIHOOD
+GEOGRAPHIC  OT 2022 10 31  05 02 28.960252  Lat -32.726757 Long 116.492222 Depth -0.562500
+QUALITY  Pmax 3.62877e+19 MFmin 4.87596 MFmax 5.28563 RMS 0.817355 Nphs 14 Gap 197.042 Dist 73.3529 Mamp -9.90 0 Mdur -9.90 0
+VPVSRATIO  VpVsRatio 1.77701  Npair 7  Diff 20.88
+STATISTICS  ExpectX -95.435920 Y -82.055796 Z 12.040209  CovXX 110.261 XY 8.30876 XZ 5.92278 YY 24.536 YZ -3.09884 ZZ 110.066 EllAz1  174.359 Dip1  -2.4273 Len1  9.1241 Az2  261.746 Dip2  47.0829 Len2  19.255 Len3  2.025742e+01
+STAT_GEOG  ExpectLat -32.733052 Long 116.480853 Depth 12.040209
+TRANSFORM  AZIMUTHAL_EQUIDIST RefEllipsoid WGS-84  LatOrig -32.000000  LongOrig 117.500000  RotCW 0.000000
+QML_OriginQuality  assocPhCt 14  usedPhCt 14  assocStaCt -1  usedStaCt 7  depthPhCt -1  stdErr 0.817355  azGap 197.042  secAzGap 197.042  gtLevel -  minDist 73.3529 maxDist 274.562 medDist 217.684
+QML_OriginUncertainty  horUnc -1  minHorUnc 7.38902  maxHorUnc 15.9824  azMaxHorUnc 84.5147
+QML_ConfidenceEllipsoid  semiMajorAxisLength 20.2574  semiMinorAxisLength 9.1241  semiIntermediateAxisLength 19.255  majorAxisPlunge 42.8141  majorAxisAzimuth 86.61  majorAxisRotation 322.815
+FOCALMECH  Hyp  -32.726757 116.492222 -0.562500 Mech  0 0 0 mf  0 nObs -1
+PHASE ID    Ins Cmp   On Pha  FM   Date    HrMn   Sec     Err  ErrMag    Coda      Amp       Per       PriorWt  >   TTpred    Res       Weight    StaLoc(X  Y           Z)      SDist    SAzim  RAz  RDip RQual   Tcorr     TTerr
+NWAO         ?    Z    ? P      ? 20221031 0502   41.3602 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00    1.0000 >   12.7040   -0.3041    1.2104  -24.3880 -103.3008   -0.3800   73.3529 107.42  40.0 200.0  0     0.0000    0.6352
+NWAO         ?    ?    ? S      ? 20221031 0502   51.4602 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00    1.0000 >   22.7013   -0.2013    1.1613  -24.3880 -103.3008   -0.3800   73.3529 107.42  40.0 200.0  0     0.0000    1.1351
+KLBR         ?    Z    ? P      ? 20221031 0502   56.8602 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00    1.0000 >   27.3100    0.5900    1.0455   24.1420   45.4457   -0.3200  173.5594  43.07  40.0 200.0  0     0.0000    1.3655
+END_PHASE
+END_NLLOC
+

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -6,6 +6,7 @@ import os
 import re
 import unittest
 import warnings
+from pathlib import Path
 
 from obspy import UTCDateTime, read_events
 from obspy.core.inventory import Inventory, Network, Station, Channel
@@ -37,9 +38,9 @@ class NLLOCTestCase(unittest.TestCase):
     Test suite for obspy.io.nlloc
     """
     def setUp(self):
-        self.path = os.path.dirname(os.path.abspath(inspect.getfile(
-            inspect.currentframe())))
-        self.datapath = os.path.join(self.path, "data")
+        self.path = Path(os.path.dirname(os.path.abspath(inspect.getfile(
+            inspect.currentframe()))))
+        self.datapath = self.path / "data"
 
     def test_write_nlloc_obs(self):
         """
@@ -337,3 +338,13 @@ class NLLOCTestCase(unittest.TestCase):
         pick1, pick2 = cat[0].picks[-1], cat[0].picks[-2]
         self.assertEqual(pick1.time.hour, 0)
         self.assertEqual(pick2.time.second, 0)
+
+    def test_reading_nlloc_v7_hyp_file(self):
+        """
+        Tests that we are getting the positioning of items in phase lines
+        right. Values for arrivals are shifted by one index to the right in hyp
+        files written by newer nonlinloc versions, see #3223
+        """
+        path = str(self.datapath / 'nlloc_v7.hyp')
+        cat = read_nlloc_hyp(path)
+        assert cat[0].origins[0].arrivals[0].azimuth == 40


### PR DESCRIPTION
### What does this PR do?

Fixes issues outlined in #3223 
 - phase lines are different in new nlloc versions, items regarding Arrivals are shifted one index to the right
 - avoid replacing component code with "?", actually just write full channel code unchanged in nlloc "COMP[ONENT]" field

### Why was it initiated?  Any relevant Issues?

fixes #3223 

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the `ready for review` tag when you are ready for the PR to be reviewed.
