### PR TITLE
nlloc hyp reading: set "rejected" when nonlinloc reports bad location run and store info in comments

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,10 @@ Changes:
  - obspy.core:
    * response: allow recalculating overall sensitivity even if unit type is not
      one of VEL/ACC/DISP (see #3235)
+ - obspy.io.nlloc:
+   * set origin evaluation status to "rejected" if nonlinloc reports the
+     location run as "ABORTED", "IGNORED" or "REJECTED" (see #3230)
+   * store "NLLOC" info header line in event and origin comments (see #3230)
 
 maintenance_1.4.x
 =================

--- a/obspy/io/nlloc/__init__.py
+++ b/obspy/io/nlloc/__init__.py
@@ -35,7 +35,7 @@ Event:	2006-07-15T17:21:20.195670Z | +51.658,   +7.737
                                    version='NLLoc:v6.02.07')
  preferred_origin_id: ResourceIdentifier(id="smi:local/...")
                 ---------
-            comments: 1 Elements
+            comments: 2 Elements
                picks: 5 Elements
              origins: 1 Elements
 
@@ -54,7 +54,7 @@ Origin
                                    creation_time=UTCDateTime(2013, 6, 21, ...),
                                    version='NLLoc:v6.02.07')
                 ---------
-            comments: 1 Elements
+            comments: 2 Elements
             arrivals: 5 Elements
 
 
@@ -113,7 +113,7 @@ Origin
      creation_info: CreationInfo(creation_time=UTCDateTime(2014, 10, 17,
 16, 30, 8), version='NLLoc:v6.00.0')
     ---------
-          comments: 1 Elements
+          comments: 2 Elements
           arrivals: 8 Elements
 """
 if __name__ == '__main__':

--- a/obspy/io/nlloc/__init__.py
+++ b/obspy/io/nlloc/__init__.py
@@ -115,6 +115,17 @@ Origin
     ---------
           comments: 2 Elements
           arrivals: 8 Elements
+
+If NonLinLoc reports the location run as "ABORTED", "IGNORED" or "REJECTED",
+the evaluation status of the origin will be set to "rejected" (which otherwise
+is unset, i.e. ``None``). Further information might be found in the "NLLOC"
+info header line of the hyp file that gets stored in event and origin comments:
+
+>>> cat = read_events("/path/to/nlloc_rejected.hyp", format="NLLOC_HYP")
+>>> print(cat[0].origins[0].evaluation_status)
+rejected
+>>> print(cat[0].comments[1].text)  # doctest: +ELLIPSIS
+NLLOC ... "REJECTED" ... max prob location on grid boundary 10, rejecting ...
 """
 if __name__ == '__main__':
     import doctest

--- a/obspy/io/nlloc/core.py
+++ b/obspy/io/nlloc/core.py
@@ -241,6 +241,8 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks,
     hor_unc, min_hor_unc, max_hor_unc, hor_unc_azim = \
         map(float, line.split()[1:9:2])
 
+    nlloc_info_line = 'NLLOC ' + lines['NLLOC']
+
     # assign origin info
     event = Event()
     o = Origin()
@@ -251,7 +253,10 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks,
     ou = o.origin_uncertainty
     oq = o.quality
     o.comments.append(Comment(text=stats_info_string, force_resource_id=False))
+    o.comments.append(Comment(text=nlloc_info_line, force_resource_id=False))
     event.comments.append(Comment(text=comment, force_resource_id=False))
+    event.comments.append(Comment(text=nlloc_info_line,
+                                  force_resource_id=False))
 
     # SIGNATURE field's first item is LOCSIG, which is supposed to be
     # 'Identification of an individual, institiution or other entity'
@@ -264,6 +269,13 @@ def _read_single_hypocenter(lines, coordinate_converter, original_picks,
     o.creation_info = CreationInfo(creation_time=creation_time,
                                    version=version,
                                    author=signature)
+
+    # nlloc writes location status in "NLLOC" line
+    # char location status LOCATED, ABORTED, IGNORED, REJECTED
+    # set evaluation status to "rejected" if it is anything but LOCATED
+    nlloc_location_status = lines['NLLOC'].split()[1].strip('\'"')
+    if nlloc_location_status in ('ABORTED', 'IGNORED', 'REJECTED'):
+        o.evaluation_status = 'rejected'
 
     # negative values can appear on diagonal of covariance matrix due to a
     # precision problem in NLLoc implementation when location coordinates are

--- a/obspy/io/nlloc/tests/data/nlloc_custom.qml
+++ b/obspy/io/nlloc/tests/data/nlloc_custom.qml
@@ -10,6 +10,9 @@
       <comment>
         <text>NonLinLoc OctTree Location</text>
       </comment>
+      <comment>
+        <text>NLLOC "./nlloc.20100527.165625.grid0" "LOCATED" "Location completed."</text>
+      </comment>
       <creationInfo>
         <author>Megies LMU Munich</author>
         <creationTime>2014-10-17T16:30:08.000000Z</creationTime>
@@ -50,6 +53,9 @@
         <comment>
             <text>Note: Depth/Latitude/Longitude errors are calculated from covariance matrix as 1D marginal (Lon/Lat errors as great circle degrees) while OriginUncertainty min/max horizontal errors are calculated from 2D error ellipsoid and are therefore seemingly higher compared to 1D errors. Error estimates can be reconstructed from the following original NonLinLoc error statistics line:
 STATISTICS ExpectX 4473.68 Y 5323.29 Z 4.59501  CovXX 0.0282621 XY -0.0053866 XZ 0.0043871 YY 0.0191034 YZ 0.00503624 ZZ 0.036713 EllAz1  206.782 Dip1  16.4026 Len1  0.227982 Az2  300.149 Dip2  11.2855 Len2  0.327468 Len3  3.709256e-01</text>
+        </comment>
+        <comment>
+          <text>NLLOC "./nlloc.20100527.165625.grid0" "LOCATED" "Location completed."</text>
         </comment>
         <creationInfo>
           <author>Megies LMU Munich</author>

--- a/obspy/io/nlloc/tests/data/nlloc_rejected.hyp
+++ b/obspy/io/nlloc/tests/data/nlloc_rejected.hyp
@@ -1,0 +1,23 @@
+NLLOC "./locs/20211214_2020-12-09_manual_loc/20211214_2020-12-09_manual.20201209.163708.grid0" "REJECTED" "WARNING: max prob location on grid boundary 10, rejecting location."
+SIGNATURE "   obs:./picks/taupo_2020-12-09_manual_PickFiles/Picks_2020m000124.dat   NLLoc:v7.00.00(27Oct2017)  run:14Dec2021 22h40m22"
+COMMENT ""
+GRID  240 240 80  0 0 -4  0.5 0.5 0.5 PROB_DENSITY
+SEARCH OCTREE nInitial 25000 nEvaluated 49928 smallestNodeSide 0.074688/0.074688/0.125000 oct_tree_integral 3.450765e+01 scatter_volume 3.450765e+01
+HYPOCENTER  x 0.0373438 y 2.42734 z 35.3125  OT 3.0582  ix -1 iy -1 iz -1 MAXIMUM_LIKELIHOOD
+GEOGRAPHIC  OT 2020 12 09  16 37 3.058205  Lat -39.278154 Long 175.300434 Depth 35.312500
+QUALITY  Pmax 3.39278e+150 MFmin 29.4569 MFmax 29.5213 RMS 0.645344 Nphs 53 Gap 263.731 Dist 4.14012 Mamp -9.90 0 Mdur -9.90 0
+VPVSRATIO  VpVsRatio 1.7759  Npair 24  Diff 7.8165
+STATISTICS  ExpectX 0.987252 Y 4.05843 Z 32.9989  CovXX 0.914195 XY -0.152226 XZ 0.25015 YY 6.22208 YZ -2.06938 ZZ 5.98514 EllAz1  89.3552 Dip1  -2.55491 Len1  1.78372 Az2  2.05253 Dip2  46.5237 Len2  3.77301 Len3  5.375995e+00
+STAT_GEOG  ExpectLat -39.263474 Long 175.311476 Depth 32.998901
+TRANSFORM  SIMPLE LatOrig -39.300000  LongOrig 175.300000  RotCW 0.000000
+QML_OriginQuality  assocPhCt 55  usedPhCt 53  assocStaCt -1  usedStaCt 29  depthPhCt -1  stdErr 0.645344  azGap 263.731  secAzGap 263.731  gtLevel -  minDist 4.14012 maxDist 107.432 medDist 38.7315
+QML_OriginUncertainty  horUnc -1  minHorUnc 1.44659  maxHorUnc 3.78429  azMaxHorUnc 178.359
+QML_ConfidenceEllipsoid  semiMajorAxisLength 5.376  semiMinorAxisLength 1.78372  semiIntermediateAxisLength 3.77301  majorAxisPlunge 43.3623  majorAxisAzimuth 176.94  majorAxisRotation 227.074
+FOCALMECH  Hyp  -39.278154 175.300434 35.312500 Mech  0 0 0 mf  0 nObs 0
+PHASE ID Ins Cmp On Pha  FM Date     HrMn   Sec     Err  ErrMag    Coda      Amp       Per  >   TTpred    Res       Weight    StaLoc(X  Y         Z)        SDist    SAzim  RAz  RDip RQual    Tcorr
+TLZ    ?    Z    ? P      ? 20201209 1637   19.3339 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00 >   17.6946   -1.4189    0.8293   20.7446  107.8444   -0.6600  107.4316  11.11  40.0 200.0  0     0.0000
+TLZ    ?    N    ? S      ? 20201209 1637   32.6579 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00 >   32.3436   -2.7439    0.2918   20.7446  107.8444   -0.6600  107.4316  11.11  40.0 200.0  0     0.0000
+MAVZ   ?    Z    ? P      d 20201209 1637   10.7803 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00 >    0.0000    0.0000    0.0000 -100000000000000000000.0000 -100000000000000000000.0000 -100000000000000000000.0000    0.0000   0.00 359.0  -1.0  0     0.0000
+MAVZ   ?    ?    ? S      ? 20201209 1637   17.3001 GAU -1.00e+00 -1.00e+00 -1.00e+00 -1.00e+00 >    0.0000    0.0000    0.0000 -100000000000000000000.0000 -100000000000000000000.0000 -100000000000000000000.0000    0.0000   0.00 359.0  -1.0  0     0.0000
+END_PHASE
+END_NLLOC

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -348,3 +348,22 @@ class NLLOCTestCase(unittest.TestCase):
         path = str(self.datapath / 'nlloc_v7.hyp')
         cat = read_nlloc_hyp(path)
         assert cat[0].origins[0].arrivals[0].azimuth == 107.42
+        # compare test_rejected_origin test case
+        assert cat[0].origins[0].evaluation_status is None
+
+    def test_rejected_origin(self):
+        """
+        Tests that we are marking rejected event/origin as such.
+        Also tests that NLLOC header line is written into comment.
+        (testing that evaluation status is left empty on "LOCATED" reported by
+        nonlinloc is tested in other test case.
+        """
+        path = str(self.datapath / 'nlloc_rejected.hyp')
+        cat = read_nlloc_hyp(path)
+        expected_comment = (
+            'NLLOC "./locs/20211214_2020-12-09_manual_loc/20211214_2020-12-09_'
+            'manual.20201209.163708.grid0" "REJECTED" "WARNING: max prob '
+            'location on grid boundary 10, rejecting location."')
+        assert cat[0].origins[0].evaluation_status == "rejected"
+        assert cat[0].origins[0].comments[1].text == expected_comment
+        assert cat[0].comments[1].text == expected_comment


### PR DESCRIPTION
### What does this PR do?

Some additions to reading nonlinloc hyp files:
 - set `origin.evaluation_status` to `"rejected"` when nonlinloc reports the location run as "ABORTED", "IGNORED" or "REJECTED"
 - put the "NLLOC" info line (that has the above info in it) as a comment on both the `event` and `origin` objects

The last part of #2986 (rejected arrivals) is not handled any further since QuakeML has no appropriate field like "evaluation status" on arrivals and since these Arrivals are set to weight `0.0` by nonlinloc (in addition to bogus values in most arrival info fields), so there is a way to find out for the user if an Arrival was rejected or not

### Why was it initiated?  Any relevant Issues?

Fixes #2986 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
