### PR TITLE
Seedlink: avoid unnecessary get_info() calls

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,9 @@ maintenance_1.4.x
 =================
 
 Changes:
+ - obspy.clients.seedlink:
+   * avoid unnecessary calls to "get_info()" on waveform requests without
+     wildcards (see #3232)
 
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -130,7 +130,7 @@ class Client(object):
         """
         # need to do an info request?
         if any('*' in x for x in (network, station, location, channel)) \
-                or ('?' in x for x in (network, station)):
+                or any('?' in x for x in (network, station)):
             # need to do an info request on channel level?
             if any('*' in x for x in (location, channel)):
                 info = self.get_info(network=network, station=station,


### PR DESCRIPTION
### What does this PR do?

Avoid calling `get_info()` with every `get_waveforms()` call, even if no wildcards are in the requested SEED ID. 

### Why was it initiated?  Any relevant Issues?

Fixes #3231 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
