### PR TITLE
Fix `beach` pdf output when `Axes` instance is provided to plot into

### DIFF
--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -164,7 +164,7 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     # resize.
     if axes is not None:
         # This is what holds the aspect ratio (but breaks the positioning)
-        col.set_transform(transforms.IdentityTransform())
+        col.set_transform(transforms.Affine2D(np.identity(3)))
         # Next is a dirty hack to fix the positioning:
         # 1. Need to bring the all patches to the origin (0, 0).
         for p in col._paths:

--- a/obspy/imaging/mopad_wrapper.py
+++ b/obspy/imaging/mopad_wrapper.py
@@ -192,7 +192,7 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     # resize.
     if axes is not None:
         # This is what holds the aspect ratio (but breaks the positioning)
-        collection.set_transform(transforms.IdentityTransform())
+        collection.set_transform(transforms.Affine2D(np.identity(3)))
         # Next is a dirty hack to fix the positioning:
         # 1. Need to bring the all patches to the origin (0, 0).
         for p in collection._paths:


### PR DESCRIPTION
### What does this PR do?

This commit is a bug fix, which corrects a bug in the `obspy/imaging/…beachball` functions.

Specifically, when calling the functions `beach(...)` in `obspy/imaging/mopad_wrapper.py` or `obspy/imaging/beachball.py` with the arguments `axes` not equals `None`, there is always an error if save the plotted beachballs into vector files (e.g., .pdf or .eps).

To locate the error/bug, I found that the functions `beach(...)` calls the function `matplotlib.transforms.IdentityTransform()` to create a Transform object. However the created object does not have the method `translate(...)` that is essential for saving plots into vector files.

To fix the bug, it is simple by using the function `matplotlib.transforms.Affine2D(np.identity(3))` instead of `matplotlib.transforms.IdentityTransform()` to create the Transform object. The object created by the former has the method `translate(...)` and hence allows for saving into vector files, while the object created by the latter does not. Excep this difference, the objects created by the two functions have the same behaviours.


### Why was it initiated?  Any relevant Issues?

fixes #2887 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
