### PR TITLE
Fix beach pdf output when Axes instance is provided to plot into

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,10 @@ Changes:
  - obspy.clients.seedlink:
    * avoid unnecessary calls to "get_info()" on waveform requests without
      wildcards (see #3232)
+ - obspy.imaging:
+   * fix a bug that raised an error when plotting beachball patches with
+     routine "beach" with providing an existing axes instance (for proper
+     scaling) and saving to vector graphics as pdf/eps (see #2887)
 
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,10 @@
 #
 # Deliberately including folders without owners specified
 
-/obspy/.github     @trichter @d-chambers
+/obspy/.github      @trichter @d-chambers @megies
+/obspy/pytest.ini   @trichter @d-chambers @megies
+/obspy/conftest.py  @trichter @d-chambers @megies
+
 /obspy/core        @megies @trichter @d-chambers
 /obspy/geodetics
 /obspy/imaging

--- a/obspy/conftest.py
+++ b/obspy/conftest.py
@@ -65,6 +65,9 @@ def image_path(request, save_image_directory):
 
     These will be saved to obspy_test_images if --keep-images is selected.
     Using this fixture will also mark a test with "image".
+    Default filetype will be "png". Custom filetype for a test can be set by
+    marking the test with "image_path_suffix" marker and providing the filetype
+    (e.g. "pdf") as first argument of the marker.
     """
     parent_obj = getattr(request.node.parent, 'obj', None)
     node_name = request.node.name
@@ -74,7 +77,15 @@ def image_path(request, save_image_directory):
         else:
             parent_name = str(parent_obj.__class__.__name__)
         node_name = parent_name + '_' + node_name
-    new_path = save_image_directory / (node_name + '.png')
+    # determine what suffix to use for plot
+    # https://docs.pytest.org/en/7.1.x/how-to/
+    #     fixtures.html#using-markers-to-pass-data-to-fixtures
+    suffix_marker = request.node.get_closest_marker("image_path_suffix")
+    if suffix_marker is None:
+        suffix = 'png'
+    else:
+        suffix = suffix_marker.args[0]
+    new_path = save_image_directory / (node_name + f'.{suffix}')
     yield new_path
     # finally close all figs created by this test
     from matplotlib.pyplot import close

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -171,7 +171,11 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
         # 2. Then use the offset property of the collection to position the
         #    patches
         col.set_offsets(xy)
-        col._transOffset = axes.transData
+        try:
+            col.set_offset_transform(axes.transData)
+        except AttributeError:
+            # compatibility for matplotlib 3.3 (and maybe 3.4 too?)
+            col._transOffset = axes.transData
 
     col.set_edgecolor(edgecolor)
     col.set_alpha(alpha)

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -163,7 +163,7 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     # resize.
     if axes is not None:
         # This is what holds the aspect ratio (but breaks the positioning)
-        col.set_transform(transforms.IdentityTransform())
+        col.set_transform(transforms.Affine2D(np.identity(3)))
         # Next is a dirty hack to fix the positioning:
         # 1. Need to bring the all patches to the origin (0, 0).
         for p in col._paths:

--- a/obspy/imaging/mopad_wrapper.py
+++ b/obspy/imaging/mopad_wrapper.py
@@ -192,7 +192,7 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
     # resize.
     if axes is not None:
         # This is what holds the aspect ratio (but breaks the positioning)
-        collection.set_transform(transforms.IdentityTransform())
+        collection.set_transform(transforms.Affine2D(np.identity(3)))
         # Next is a dirty hack to fix the positioning:
         # 1. Need to bring the all patches to the origin (0, 0).
         for p in collection._paths:

--- a/obspy/imaging/mopad_wrapper.py
+++ b/obspy/imaging/mopad_wrapper.py
@@ -200,7 +200,11 @@ def beach(fm, linewidth=2, facecolor='b', bgcolor='w', edgecolor='k',
         # 2. Then use the offset property of the collection to position the
         # patches
         collection.set_offsets(xy)
-        collection._transOffset = axes.transData
+        try:
+            collection.set_offset_transform(axes.transData)
+        except AttributeError:
+            # compatibility for matplotlib 3.3 (and maybe 3.4 too?)
+            collection._transOffset = axes.transData
     collection.set_edgecolors(edgecolor)
     collection.set_alpha(alpha)
     collection.set_linewidth(linewidth)

--- a/obspy/imaging/tests/test_beachball.py
+++ b/obspy/imaging/tests/test_beachball.py
@@ -6,6 +6,7 @@ import os
 import warnings
 
 import matplotlib.pyplot as plt
+import pytest
 
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.core.util.testing import WarningsCapture
@@ -310,3 +311,21 @@ class TestBeachballPlot:
         w = [_i for _i in w
              if "falling back to the mopad wrapper" in _i.lower()]
         assert w
+
+    @pytest.mark.image_path_suffix('pdf')
+    def test_beach_with_axes_to_pdf(self, image_path):
+        """
+        Regression test for #2887
+
+        Tests using `beach` with passing in an `Axes` object and saving to pdf
+        """
+        fig = plt.figure(figsize=(6, 4))
+        ax = fig.add_subplot(111, aspect='equal')
+
+        bb = beach((0, 45, 90), facecolor='k', width=120, axes=ax, xy=(0, 0))
+        ax.add_collection(bb)
+        ax.set_xlim(-2, 4)
+        ax.set_ylim(-1, 2)
+        ax.grid()
+
+        fig.savefig(image_path)

--- a/obspy/pytest.ini
+++ b/obspy/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+# -ra shows one liners for skipped tests with reason of skip
 addopts =
     --doctest-modules
     --json-report-file=none
@@ -6,6 +7,7 @@ addopts =
     --tb=native
     --continue-on-collection-errors
     --strict-markers
+    -ra
 markers =
     network: Test requires network resources (internet)
     image: Test produces a matplotlib image

--- a/obspy/pytest.ini
+++ b/obspy/pytest.ini
@@ -5,9 +5,11 @@ addopts =
     --json-report-indent=2
     --tb=native
     --continue-on-collection-errors
+    --strict-markers
 markers =
     network: Test requires network resources (internet)
     image: Test produces a matplotlib image
+    image_path_suffix: Used internally to set what filetype a test plot should be made with
 filterwarnings =
     ignore:Matplotlib is currently using agg
     ignore:Downloading::cartopy

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ EXTERNAL_EVALRESP = False
 EXTERNAL_LIBMSEED = False
 
 # Hard dependencies needed to install/run ObsPy.
+# Backwards compatibility hacks to be removed later:
+#  - matplotlib 3.3 (/3.4?): imaging (see #3242)
 INSTALL_REQUIRES = [
     'numpy>=1.20',
     'scipy>=1.7',


### PR DESCRIPTION

### What does this PR do?

This commit is a bug fix, which corrects a bug in the obspy/imaging/…beachball functions.

Specifically, when calling the functions beach(...) in obspy/imaging/mopad_wrapper.py or obspy/imaging/beachball.py with the arguments axes not equals None, there is always an error if save the plotted beachballs into vector files (e.g., .pdf or .eps).

To locate the error/bug, I found that the functions beach(...) calls the function matplotlib.transforms.IdentityTransform() to create a Transform object. However the created object does not have the method translate(...) that is essential for saving plots into vector files.

To fix the bug, it is simple by using the function matplotlib.transforms.Affine2D(np.identity(3)) instead of matplotlib.transforms.IdentityTransform() to create the Transform object. The object created by the former has the method translate(...) and hence allows for saving into vector files, while the object created by the latter does not. Excep this difference, the objects created by the two functions have the same behaviours.

### Why was it initiated?  Any relevant Issues?

fixes #2887 and supersedes #3241 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
