### PR TITLE
Taup fix for models with no discontinuities

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,9 @@ Changes:
  - obspy.io.gcf:
    * Fixed an issue in algorithm to split and encode last few data into GCF 
      blocks (see #3252)
+ - obspy.taup:
+   * bugfix to allow calculations for a model with no discontinuities
+     (see #3070)
 
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,7 +19,7 @@ Changes:
      blocks (see #3252)
  - obspy.taup:
    * bugfix to allow calculations for a model with no discontinuities
-     (see #3070)
+     (see #3070, #3244)
 
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================

--- a/obspy/taup/taup_create.py
+++ b/obspy/taup/taup_create.py
@@ -124,7 +124,7 @@ class TauPCreate(object):
                 os.makedirs(dirname)
             self.tau_model.serialize(self.output_filename)
             if self.debug:
-                print("Done Saving " + self.output_filename)
+                print("Done Saving " + str(self.output_filename))
         except IOError as e:
             print("Tried to write!\n Caught IOError. Do you have write "
                   "permission in this directory?", e)

--- a/obspy/taup/tests/test_tau.py
+++ b/obspy/taup/tests/test_tau.py
@@ -1034,14 +1034,12 @@ class TestTauPyModel:
     def test_regional_models(self, testdata):
         """
         Tests small regional models as this used to not work.
-
-        Note: It looks like too much work to get a 1-layer model working.
-        The problem is first in finding the moho, and second in coarsely-
-        sampling slowness. Also, why bother.
         """
-        model_names = ["2_layer_model", "5_layer_model",
+        model_names = ["1_layer_model", "2_layer_model", "5_layer_model",
                        "2_layer_no_discontinuity_model"]
         expected_results = [
+            [("p", 18.143), ("sP", 22.054), ("s", 31.509), ("PP", 4107.380),
+             ("SP", 5619.257), ("PS", 5621.396), ("SS", 7133.265)],
             [("p", 18.143), ("P", 19.202), ("Pn", 19.202), ("P", 19.884),
              ("sP", 22.054), ("pP", 23.023), ("pP", 23.038), ("sP", 25.656),
              ("sP", 25.759), ("s", 31.509), ("S", 33.395), ("Sn", 33.395),

--- a/obspy/taup/velocity_model.py
+++ b/obspy/taup/velocity_model.py
@@ -629,6 +629,13 @@ class VelocityModel(object):
             above['bot_p_velocity'] != below['top_p_velocity'],
             above['bot_s_velocity'] != below['top_s_velocity'])
 
+        if len(mask) == 0:
+            # Special case where have no discontinuities
+            self.moho_depth = temp_moho_depth
+            self.cmb_depth = temp_cmb_depth
+            self.iocb_depth = temp_iocb_depth
+            return
+
         # Find discontinuity closest to current Moho
         moho_diff = np.abs(self.moho_depth - above['bot_depth'])
         moho_diff[~mask] = moho_min


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue described by @dylanmikesell and @kaspervanwijk in the comments of #3070, namely the failure to build a tau model when there are no discontinuities present. With this PR, the one layer model example now works:

```
from obspy.taup import TauPyModel
from obspy.taup.taup_create import build_taup_model
build_taup_model('1_layer_model.tvel')
model = TauPyModel("1_layer_model")
arrivals = model.get_ray_paths(distance_in_degree=160.0, source_depth_in_km=0.0)
print(arrivals)
```

```
Building obspy.taup model for '1_layer_model.tvel' ...
filename = 1_layer_model.tvel
Done reading velocity model.
Radius of model  is 6371.0
Using parameters provided in TauP_config.ini (or defaults if not) to call SlownessModel...
Parameters are:
taup.create.min_delta_p = 0.1 sec / radian
taup.create.max_delta_p = 11.0 sec / radian
taup.create.max_depth_interval = 115.0 kilometers
taup.create.max_range_interval = 0.04363323129985824 degrees
taup.create.max_interp_error = 0.05 seconds
taup.create.allow_inner_core_s = True
Slow model  224 P layers,382 S layers
Done calculating Tau branches.
Done Saving /home/john/Documents/students/stuart/obspy/obspy/taup/data/1_layer_model.npz
Method run is done, but not necessarily successful.
10 arrivals
	P phase arrival at 2023.939 seconds
	PP phase arrival at 2642.064 seconds
	PP phase arrival at 3148.690 seconds
	S phase arrival at 3514.964 seconds
	PS phase arrival at 3796.746 seconds
	SP phase arrival at 3796.746 seconds
	PS phase arrival at 4417.046 seconds
	SP phase arrival at 4417.046 seconds
	SS phase arrival at 4588.459 seconds
	SS phase arrival at 5468.313 seconds
```
These arrivals agree with the java version.

### Why was it initiated?  Any relevant Issues?

See #3070.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
