### PR TITLE
Ignore DeprecationWarnings and PendingDeprecationWarnings triggered by other modules

### DIFF
--- a/obspy/pytest.ini
+++ b/obspy/pytest.ini
@@ -20,5 +20,8 @@ filterwarnings =
     ignore:Lines of type I have not been implemented yet
 # https://github.com/matplotlib/matplotlib/issues/21723
     ignore:Auto-removal of grids
-# see issue 3164, can be rmoved when NRL online tests get removed
+# see issue 3164, can be removed when NRL online tests get removed
     ignore:(?s).*Direct access to online NRL
+# ignore DeprecationWarnings and PendingDeprecationWarnings triggered by other modules
+    ignore::DeprecationWarning:(?!obspy).*
+    ignore::PendingDeprecationWarning:(?!obspy).*


### PR DESCRIPTION
### What does this PR do?

See title. It adds two filters to pytest.ini

### Why was it initiated?  Any relevant Issues?

Deprecation warnings triggered in external modules have to be fixed upstream. E.g. this deprecation in shapely has to be fixed in cartopy and it should not be shown in our test results:
https://tests.obspy.org/132205/#1

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
