### PR TITLE
5x speed-up for trace.id / trace.get_id()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes:
  - obspy.core:
    * response: allow recalculating overall sensitivity even if unit type is not
      one of VEL/ACC/DISP (see #3235)
+   * trace: 4x quicker retrieval of seed-id with trace.id / trace.get_id()
  - obspy.io.nlloc:
    * set origin evaluation status to "rejected" if nonlinloc reports the
      location run as "ABORTED", "IGNORED" or "REJECTED" (see #3230)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ Changes:
  - obspy.core:
    * response: allow recalculating overall sensitivity even if unit type is not
      one of VEL/ACC/DISP (see #3235)
-   * trace: 4x quicker retrieval of seed-id with trace.id / trace.get_id()
+   * trace: 5x quicker retrieval of seed-id with trace.id / trace.get_id()
  - obspy.io.nlloc:
    * set origin evaluation status to "rejected" if nonlinloc reports the
      location run as "ABORTED", "IGNORED" or "REJECTED" (see #3230)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -872,8 +872,8 @@ class Trace(object):
         >>> print(tr.id)
         BW.MANZ..EHZ
         """
-        return (self.stats.network + '.' + self.stats.station + '.' +
-                self.stats.location + '.' + self.stats.channel)
+        return '.'.join((self.stats.network, self.stats.station,
+                         self.stats.location, self.stats.channel))
 
     id = property(get_id)
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -872,8 +872,8 @@ class Trace(object):
         >>> print(tr.id)
         BW.MANZ..EHZ
         """
-        out = "%(network)s.%(station)s.%(location)s.%(channel)s"
-        return out % (self.stats)
+        return (self.stats.network + '.' + self.stats.station + '.' +
+                self.stats.location + '.' + self.stats.channel)
 
     id = property(get_id)
 


### PR DESCRIPTION
### What does this PR do?
This PR makes retrieving the seed-id of a trace 4 times quicker than previously.

While it wasn't particularly slow, when looping through many traces the change can still be noticeable and is very simple. The previous syntax was nicely succinct, but relatively slow compared to alternatives.

### Why was it initiated?  Any relevant Issues?
I noted that I could speed up [`trace.get_id`](https://github.com/obspy/obspy/blob/49b8b411ff10593ce9583f90d6fbbb582dc07fc9/obspy/core/trace.py#L875-L876) with this tiny change. See code below for a quick comparison for the run times (in python 3.11):

```python
from obspy import read
st = read()
tr = st[0]

# original code: 1200 ns
%timeit out = "%(network)s.%(station)s.%(location)s.%(channel)s"; out % (tr.stats) 
# Alt 1: 350 ns 
%timeit "{}.{}.{}.{}".format( tr.stats.network, tr.stats.station, tr.stats.location, tr.stats.channel)
# Alt 2: 274 ns
%timeit (tr.stats.network + '.' + tr.stats.station + '.' + tr.stats.location + '.' + tr.stats.channel)
# Alt 3: 222 ns
%timeit '.'.join((tr.stats.network, tr.stats.station, tr.stats.location, tr.stats.channel))
```

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
~- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds~
~- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.~
~- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.~
- [X] All tests still pass.
~- [ ] Any new features or fixed regressions are covered via new tests.~
~- [ ] Any new or changed features are fully documented.~
- [X] Significant changes have been added to `CHANGELOG.txt` .
~- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .~
~- [ ] If the changes affect any plotting functions you have checked that the plots~
      ~from all the CI builds look correct. Add the "upload_plots" tag so that plotting~
      ~outputs are attached as artifacts.~
~- [ ] New modules, add the module to `CODEOWNERS` with your github handle~
- [ ] Add the `ready for review` tag when you are ready for the PR to be reviewed.
