### PR TITLE
Fix gcf block bug, second attempt

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,15 @@ Changes:
      routine "beach" with providing an existing axes instance (for proper
      scaling) and saving to vector graphics as pdf/eps (see #2887)
 
+ - obspy.io.gcf:
+   * Fixed an issue in algorithm to split and encode last few data into GCF 
+      blocks. Problem were that number of data samples in a GCF block is
+      computed from product of number of four-byte records in data block and
+      compression code (which can be 1, 2, or 4) hence number of samples must
+      be an integer multiple of the compression code meaning that compression
+      used in last data block may have to be other than highest possible based
+      on the data solely. 
+
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,15 +14,9 @@ Changes:
    * fix a bug that raised an error when plotting beachball patches with
      routine "beach" with providing an existing axes instance (for proper
      scaling) and saving to vector graphics as pdf/eps (see #2887)
-
  - obspy.io.gcf:
    * Fixed an issue in algorithm to split and encode last few data into GCF 
-      blocks. Problem were that number of data samples in a GCF block is
-      computed from product of number of four-byte records in data block and
-      compression code (which can be 1, 2, or 4) hence number of samples must
-      be an integer multiple of the compression code meaning that compression
-      used in last data block may have to be other than highest possible based
-      on the data solely. 
+     blocks (see #3252)
 
 1.4.0 (doi: 10.5281/zenodo.6645832)
 ===================================

--- a/obspy/io/gcf/src/gcf_io.c
+++ b/obspy/io/gcf/src/gcf_io.c
@@ -44,6 +44,8 @@
 //    2022-03-10  Removed use of time.h by changing use of time_t to derrived arithmetic type gtime
 //                 moved inclusion of unistd.h and to header file
 //    2022-03-15  Added sampling rate 800 Hz as an allowed sampling rate
+//    2022-12-20  Added check in write_gcf that number of samples in last block is compatible with
+//                 compression, else split into two blocks
 //    
 //  TODO:
 //  
@@ -316,7 +318,6 @@ void merge_GcfFile(GcfFile *obj, int mode, double tol) {
       Ord = (int *)malloc(obj->n_seg*sizeof(int));
       NewOrd = (int *)malloc(obj->n_seg*sizeof(int)); 
       ord = (double *)malloc(obj->n_seg*sizeof(double));
-      
       
       // chunks to use when reallocating 
       chunk = MAX_DATA_BLOCK*10;
@@ -1235,8 +1236,13 @@ int write_gcf(const char *f, GcfFile *obj) {
                   d1++;     // last data point
                   // find the compression level
                   d32 = obj->seg[i].data[d1]-obj->seg[i].data[d0];
-                  if (d32 < -32768 || d32 > 32767) {
+                  if (d32 < -32768 || d32 > 32767 || obj->seg[i].n_data - d1 <= 250) {
                      // need 4 byte for each difference, maximum number of data points are 250
+                     //  if number of data points left are <= 250 just use 4 bytes for each difference
+                     //  this will not alter the size of the file but guarantees that we can write all
+                     //  samples, e.g. if there are only 3 samples left this can not be represented 
+                     //  if compression code is 2 or 4 as number of samples is evaluated as number of
+                     //  four-byte records.
                      c = 4;
                      d1 = d0+249;  // 249 here to prevent compression to get swaped to 2 later
                   } else {                        
@@ -1263,6 +1269,19 @@ int write_gcf(const char *f, GcfFile *obj) {
                               c = cprev; 
                               break;
                            }
+                        }
+                     }
+                     // check if all data is covered, if so check that number of data points in block 
+                     //  is compatible with compression 
+                     if (d1+1 >= obj->seg[i].n_data && c != 4) {
+                        n = d1-d0+1;
+                        if (c == 1) {
+                           // number of data points must be an integer multiple of 4
+                           d1 -= n-(n/4)*4;
+                        }
+                        if (c == 2) {
+                           // number of data points must be an integer multiple of 2
+                           d1 -= n-(n/2)*2;
                         }
                      }
                   }

--- a/obspy/io/gcf/src/gcf_io.h
+++ b/obspy/io/gcf/src/gcf_io.h
@@ -306,8 +306,8 @@ int parse_gcf_block(unsigned char buffer[1024], GcfSeg *seg, int mode, int endia
  *                or where decoding data failed will not be merged.
  *                
  *  RETURN:
- *   function returns 0 if all went well, -1 if file could not be opened, 1 if file is
- *   not data file, Note, even if 0 is returned file may still contain errors in individual
+ *   function returns 0 if all went well, -1 if file could not be opened, > 0 if file is
+ *   not a data file, Note, even if 0 is returned file may still contain errors in individual
  *   segments.
  */
 int read_gcf(const char *f, GcfFile *obj, int mode);

--- a/obspy/io/gcf/tests/test_core.py
+++ b/obspy/io/gcf/tests/test_core.py
@@ -301,3 +301,33 @@ class TestCore():
 
                 # compare
                 assert out_stream == in_stream
+
+    def test_split_last_block(self):
+        """
+        test writing a file where number of data would fit into a
+        single block but number of data will not be properly
+        set due to high compression level
+        """
+        head = {'starttime': UTCDateTime("2020-10-01 00:00:00"),
+                'sampling_rate': 100,
+                'station': 'XXXX',
+                'channel': 'HHZ',
+                'gcf': AttribDict({
+                    'system_id': 'XXXXZ0',
+                    'stream_id': 'XXXXZ0',
+                    'sys_type': 0,
+                    't_leap': False,
+                    'gain': -1,
+                    'digi': 0,
+                    'ttl': 0,
+                    'blk': 0,
+                    'FIC': 0,
+                    'RIC': 718,
+                    'stat': 0})}
+        data = np.array([i for i in range(719)])
+        tr = Trace(data=data, header=head)
+        with NamedTemporaryFile() as tf:
+            filename = tf.name
+            _write_gcf(tr, filename)
+            st = _read_gcf(filename)
+        assert tr == st[0]

--- a/obspy/io/gcf/tests/test_core.py
+++ b/obspy/io/gcf/tests/test_core.py
@@ -324,7 +324,7 @@ class TestCore():
                     'FIC': 0,
                     'RIC': 718,
                     'stat': 0})}
-        data = np.array([i for i in range(719)])
+        data = np.arange(719)
         tr = Trace(data=data, header=head)
         with NamedTemporaryFile() as tf:
             filename = tf.name


### PR DESCRIPTION
### What does this PR do?
Fixes a BUG in the algorithm to split and encode last few data points into GCF blocks

### Why was it initiated?  Any relevant Issues?
Issue were brought up in post "MiniSEED to GCF" in discourse.obspy.org forum (https://discourse.obspy.org/t/miniseed-to-gcf/1598)

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
