### PR TITLE
fix some mseed test case setup (setting up bitwise data flags on mseed records used in test)

### DIFF
--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -59,24 +59,24 @@ def _create_mseed_file(filename, record_count, sampling_rate=1.0,
     if seed is not None:
         np.random.seed(seed)
 
-    data = np.fromfile(filename, dtype=np.int8)
+    data = np.fromfile(filename, dtype=np.uint8)
 
     # Modify the flags to get the required statistics.
     for key, value in all_flags.items():
         if key not in flags:
             continue
         _f = value["flags"]
-        _flag_values = np.zeros(record_count - skiprecords, dtype=np.int8)
+        _flag_values = np.zeros(record_count - skiprecords, dtype=np.uint8)
         for _i, name in enumerate(_f):
             if name not in flags[key]:
                 continue
             # Create array with the correct number of flags set.
-            arr = np.zeros(record_count - skiprecords, dtype=np.int8)
+            arr = np.zeros(record_count - skiprecords, dtype=np.uint8)
             arr[:flags[key][name]] = 1 << _i
             np.random.shuffle(arr)
             _flag_values |= arr
         data[value["offset"]:: 256] = np.concatenate([
-            np.zeros(skiprecords, dtype=np.int8), _flag_values])
+            np.zeros(skiprecords, dtype=np.uint8), _flag_values])
 
     # Write again.
     data.tofile(filename)


### PR DESCRIPTION
### What does this PR do?

Fixes a test to avoid a numpy deprecation warning when trying to achieve a binary representation of `1000 0000` by setting a numpy *signed* int8 to the value `128` which can not be represented in that dtype leading to an overflow to `-128` (which looks like ending up as the same binary value, so the test stays the same, just avoids overflow weirdness).

### Why was it initiated?  Any relevant Issues?

CI test runner that raises on unexpected warnings during test runs started complaining about this recently with numpy 1.24

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] ~~While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds~~
- [x] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.~~
- [x] ~~If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.~~
- [x] All tests still pass.
- [x] ~~Any new features or fixed regressions are covered via new tests.~~
- [x] ~~Any new or changed features are fully documented.~~
- [x] ~~Significant changes have been added to `CHANGELOG.txt` .~~
- [x] ~~First time contributors have added your name to `CONTRIBUTORS.txt` .~~
- [x] ~~If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. ~~
- [x] ~~New modules, add the module to `CODEOWNERS` with your github handle~~
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
