### PR TITLE
pin sqlalchemy<2

### DIFF
--- a/obspy/clients/filesystem/db.py
+++ b/obspy/clients/filesystem/db.py
@@ -15,6 +15,18 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import PrimaryKeyConstraint
 
 
+# we pinned our dependency to sqlalchemy <2.0 for now, so these warnings are
+# irrelevant. eventually code should be migrated to work with sqlalchemy >=2.0
+# as well
+try:
+    from sqlalchemy.exc import MovedIn20Warning
+except ImportError:
+    pass
+else:
+    import warnings
+    warnings.filterwarnings('ignore', category=MovedIn20Warning)
+
+
 Base = declarative_base()
 
 # Every declarative class should only be instantiated once. Thus we just use a

--- a/obspy/pytest.ini
+++ b/obspy/pytest.ini
@@ -22,6 +22,14 @@ filterwarnings =
     ignore:Auto-removal of grids
 # see issue 3164, can be removed when NRL online tests get removed
     ignore:(?s).*Direct access to online NRL
+# sqlalchemy showing deprecation warnings, seems like big API change with version 2
+# fixed sqlalchemy<2 for now in setup.py
+# also suppressing these warnings directly in clients.filesystem.db because
+# they get raised before test execution during test discovery
+# see https://docs.sqlalchemy.org/en/20/errors.html#error-b8d9
+# see https://docs.sqlalchemy.org/en/20/changelog/migration_20.html
+    ignore:Deprecated API features .* are not compatible with SQLAlchemy 2.0
+    ignore:function is now available as sqlalchemy.orm.declarative_base
 # ignore DeprecationWarnings and PendingDeprecationWarnings triggered by other modules
     ignore::DeprecationWarning:(?!obspy).*
     ignore::PendingDeprecationWarning:(?!obspy).*

--- a/setup.py
+++ b/setup.py
@@ -83,13 +83,16 @@ EXTERNAL_LIBMSEED = False
 # Hard dependencies needed to install/run ObsPy.
 # Backwards compatibility hacks to be removed later:
 #  - matplotlib 3.3 (/3.4?): imaging (see #3242)
+# sqlalchemy pinned to <2.0 for now because of API changes that break
+# clients.filesystem.db. We suppress warnings in that module and also see
+# pytest.ini for some rules to ignore related warnings
 INSTALL_REQUIRES = [
     'numpy>=1.20',
     'scipy>=1.7',
     'matplotlib>=3.3',
     'lxml',
     'setuptools',
-    'sqlalchemy',
+    'sqlalchemy<2',
     'decorator',
     'requests',
 ]


### PR DESCRIPTION
### What does this PR do?

Pin SQLalchemy to version <2 and suppress deprecation warnings in tests

### Why was it initiated?  Any relevant Issues?

Non backwards compatible changes coming in upcoming version 2.0

- https://docs.sqlalchemy.org/en/20/errors.html#error-b8d9
- https://docs.sqlalchemy.org/en/20/changelog/migration_20.html

CC @chad-earthscope 



![Screenshot from 2023-01-20 10-13-22](https://user-images.githubusercontent.com/1842780/213658656-4d46d7f4-78ad-4096-8659-5e66b8624074.png)



### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] ~~While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds~~
- [ ] ~~If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.~~
- [ ] ~~If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.~~
- [ ] All tests still pass.
- [ ] ~~Any new features or fixed regressions are covered via new tests.~~
- [ ] ~~Any new or changed features are fully documented.~~
- [ ] ~~Significant changes have been added to `CHANGELOG.txt` .~~
- [ ] ~~First time contributors have added your name to `CONTRIBUTORS.txt` .~~
- [ ] ~~If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts.~~
- [ ] ~~New modules, add the module to `CODEOWNERS` with your github handle~~
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.
