### PR TITLE
Channel information edit/fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ Changes:
    * response: allow recalculating overall sensitivity even if unit type is not
      one of VEL/ACC/DISP (see #3235)
    * trace: 5x quicker retrieval of seed-id with trace.id / trace.get_id()
+   * inventory: additional formatting tweaks to expanded channel information
+     (see #3261)
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility
  - obspy.io.mseed.spread_time_over_file:

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -83,8 +83,7 @@ Station RJOB (Jochberg, Bavaria, BW-Net)
     Access: None
     Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
     Available Channels:
-     ..EH[ZNE]   200.0 Hz  2007-12-17 to None
-
+        ..EH[ZNE]   200.0 Hz  2007-12-17(351) -
 
 >>> cha = sta[0]
 >>> print(cha)  # doctest: +NORMALIZE_WHITESPACE

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -376,8 +376,8 @@ class Station(BaseNode):
             Access: None
             Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
             Available Channels:
-             ..BHZ        20.0 Hz  2006-12-16 to None
-             ..LHZ         1.0 Hz  2006-12-16 to None
+                ..BHZ        20.0 Hz  2006-12-16(350) -
+                ..LHZ         1.0 Hz  2006-12-16(350) -
 
         The `location` and `channel` selection criteria  may also contain UNIX
         style wildcards (e.g. ``*``, ``?``, ...; see

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -994,18 +994,24 @@ def _unified_content_strings_expanded(contents):
 
     items = []
     for item in contents3:
-        if item[5] != 0:
-            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
-                         " to {end: <.10s}  Depth {ldepth: <.1f} m"
+        start_str = "%.10s(%03d)" % (str(item[3]),
+                                     UTCDateTime(item[3]).julday)
+        if item[4]:
+            end_str = "%.10s(%03d)" % (str(item[4]),
+                                       UTCDateTime(item[4]).julday)
+        else:
+            end_str = "    "  # or "None" ?
+        if item[5]:
+            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.15s}"
+                         " - {end: <15.15s}  Depth {ldepth: <.1f} m"
                          .format(l=item[0], c=item[1], sr=item[2],
-                                 start=str(item[3]), end=str(item[4]),
+                                 start=start_str, end=end_str,
                                  ldepth=item[5]))
         else:
-            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.10s}"
-                         " to {end: <.10s}".format(l=item[0], c=item[1],
-                                                   sr=item[2],
-                                                   start=str(item[3]),
-                                                   end=str(item[4])))
+            items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.15s}"
+                         " - {end: <.15s}"
+                         .format(l=item[0], c=item[1], sr=item[2],
+                                 start=start_str, end=end_str))
 
     return items
 

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -969,8 +969,8 @@ def _unified_content_strings_expanded(contents):
                   item.depth]
                  for item in contents]
 
-    # sorts by sample rate, startdate, and channel code (ZNE321)
-    contents2 = sorted(contents2, key=lambda x: (x[2], x[1], x[3]),
+    # sorts by startdate, sample rate, and channel code (ZNE321)
+    contents2 = sorted(contents2, key=lambda x: (x[1], x[2], x[3]),
                        reverse=True)
 
     uniques = []
@@ -989,7 +989,7 @@ def _unified_content_strings_expanded(contents):
             c[0][1] = mergedch
         contents3.append(c[0])
 
-    contents3 = sorted(contents3, key=lambda x: (x[2], x[3], x[5]),
+    contents3 = sorted(contents3, key=lambda x: (x[3], x[2], x[5]),
                        reverse=True)
 
     items = []

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -1003,7 +1003,7 @@ def _unified_content_strings_expanded(contents):
             end_str = "    "  # or "None" ?
         if item[5]:
             items.append("{l: >5s}.{c: <9s}{sr: 6.1f} Hz  {start: <.15s}"
-                         " - {end: <15.15s}  Depth {ldepth: <.1f} m"
+                         " - {end: <15.15s}  Depth {ldepth: >5.1f} m"
                          .format(l=item[0], c=item[1], sr=item[2],
                                  start=start_str, end=end_str,
                                  ldepth=item[5]))

--- a/obspy/io/kml/tests/data/inventory.kml
+++ b/obspy/io/kml/tests/data/inventory.kml
@@ -68,10 +68,10 @@
 	Access: None 
 	Latitude: 48.1629, Longitude: 11.2752, Elevation: 565.0 m
 	Available Channels:
-		..HH[ZNE]   100.0 Hz  2006-12-16 to None
-		..BH[ZNE]    20.0 Hz  2006-12-16 to None
-		..LH[ZNE]     1.0 Hz  2006-12-16 to None
-		..VH[ZNE]     0.1 Hz  2006-12-16 to None
+    ..HH[ZNE]   100.0 Hz  2006-12-16(350) -
+    ..BH[ZNE]    20.0 Hz  2006-12-16(350) -
+    ..LH[ZNE]     1.0 Hz  2006-12-16(350) -
+    ..VH[ZNE]     0.1 Hz  2006-12-16(350) -
     </description>
         <TimeSpan>
           <begin>2006-12-16T00:00:00.000000Z</begin>
@@ -91,9 +91,9 @@
 	Access: None 
 	Latitude: 49.1440, Longitude: 12.8782, Elevation: 613.0 m
 	Available Channels:
-		..HH[ZNE]   100.0 Hz  2007-02-02 to None
-		..BH[ZNE]    20.0 Hz  2007-02-02 to None
-		..LH[ZNE]     1.0 Hz  2007-02-02 to None
+    ..HH[ZNE]   100.0 Hz  2007-02-02(033) -
+    ..BH[ZNE]    20.0 Hz  2007-02-02(033) -
+    ..LH[ZNE]     1.0 Hz  2007-02-02(033) -
    </description>
         <TimeSpan>
           <begin>2007-02-02T00:00:00.000000Z</begin>
@@ -133,7 +133,7 @@
 	Access: None 
 	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-	..EH[ZNE]   200.0 Hz  2001-05-15 to 2006-12-12
+	..EH[ZNE]   200.0 Hz  2001-05-15(135) - 2006-12-12(346)
   </description>
         <TimeSpan>
           <begin>2001-05-15T00:00:00.000000Z</begin>
@@ -154,7 +154,7 @@
 	Access: None 
 	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-	..EH[ZNE]   200.0 Hz  2006-12-13 to 2007-12-17
+	..EH[ZNE]   200.0 Hz  2006-12-13(347) - 2007-12-17(351)
 	</description>
         <TimeSpan>
           <begin>2006-12-13T00:00:00.000000Z</begin>
@@ -175,7 +175,7 @@
 	Access: None 
 	Latitude: 47.7372, Longitude: 12.7957, Elevation: 860.0 m
 	Available Channels:
-	..EH[ZNE]   200.0 Hz  2007-12-17 to None
+	..EH[ZNE]   200.0 Hz  2007-12-17(351) -
 	</description>
         <TimeSpan>
           <begin>2007-12-17T00:00:00.000000Z</begin>


### PR DESCRIPTION
2nd go at the "expanded channel information" PR with some fixes/edits. Comments or ideas appreciated. Background here https://github.com/obspy/obspy/pull/3024#issuecomment-1376867850

This new version fixes a formatting bug and also adds the 3 digit julian day next to the date, which is helpful for filesystems such as SDS where this is used exclusively. Also removed is the "None" descriptor for channel ends and I swapped "to" with "-"

Below is a tweaked this inventory for AU.NWAO where I added a few fake depths etc to show what it looks like now. The length of the line is consistently / is limited to 74 chars. As before channels are grouped only when they share identical start/stops, and are sorted by sample rate and then start date.  

```
 Station NWAO (Narrogin, Western Australia)
	Station Code: NWAO
	Channel Count: 33/33 (Selected/Total)
	1994-01-01T00:00:00.000000Z - 
	Access: open 
	Latitude: -32.9277, Longitude: 117.2390, Elevation: 265.0 m
	Available Channels:
	    ..BH1        40.0 Hz  2019-01-15(015) -                  Depth   4.2 m
	    ..BH[Z2]     40.0 Hz  2019-01-15(015) -     
	    ..BH[21]     40.0 Hz  2018-12-18(352) - 2019-01-15(015)
	    ..BH1        40.0 Hz  2016-12-08(343) - 2018-12-18(352)  Depth   1.1 m
	    ..BHZ        40.0 Hz  2016-12-08(343) - 2019-01-15(015)
	    ..BH2        40.0 Hz  2016-12-08(343) - 2018-12-18(352)
	    ..BHZ        40.0 Hz  2011-05-05(125) - 2016-12-08(343)  Depth  10.0 m
	    ..BH[NE]     40.0 Hz  2011-05-05(125) - 2016-12-29(364)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2010-03-16(075) - 2011-05-04(124)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2008-11-18(323) - 2008-11-19(324)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2008-10-16(290) - 2008-10-22(296)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2007-01-01(001) - 2007-05-17(137)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2006-03-02(061) - 2007-01-01(001)  Depth  10.0 m
	    ..BH[ZNE]    40.0 Hz  2005-01-31(031) - 2005-05-03(123)  Depth  10.0 m
	  .00.BH[Z21]    20.0 Hz  2001-09-13(256) - 2010-03-15(074)  Depth 105.0 m
	  .00.BHZ        20.0 Hz  1999-02-24(055) - 2001-09-13(256)  Depth 100.0 m
```

** will update the tests if/when

edit: changed sorting from sample rate, start date --> start date, sample rate. there are now thousands of SQLAlchemy 2.0 errors as well