### PR TITLE
Mseed: spread time shift out through individual data blockettes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,9 @@ Changes:
    * set origin evaluation status to "rejected" if nonlinloc reports the
      location run as "ABORTED", "IGNORED" or "REJECTED" (see #3230)
    * store "NLLOC" info header line in event and origin comments (see #3230)
+ - obspy.io.mseed.spread_time_over_file:
+   * new routine to spread a time interval progressively across all mseed
+     blockettes in a file
 
 maintenance_1.4.x
 =================

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,13 +8,13 @@ Changes:
    * trace: 5x quicker retrieval of seed-id with trace.id / trace.get_id()
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility
+ - obspy.io.mseed.spread_time_over_file:
+   * new routine to spread a time interval progressively across all mseed
+     blockettes in a file (see #3271)
  - obspy.io.nlloc:
    * set origin evaluation status to "rejected" if nonlinloc reports the
      location run as "ABORTED", "IGNORED" or "REJECTED" (see #3230)
    * store "NLLOC" info header line in event and origin comments (see #3230)
- - obspy.io.mseed.spread_time_over_file:
-   * new routine to spread a time interval progressively across all mseed
-     blockettes in a file
 
 maintenance_1.4.x
 =================

--- a/obspy/io/mseed/__init__.py
+++ b/obspy/io/mseed/__init__.py
@@ -136,6 +136,8 @@ some purposes. Refer to the documentation of each for details.
 +----------------------------------------------------------+--------------------------------------------------------------------------+
 | :func:`~obspy.io.mseed.util.shift_time_of_file`          | Shifts the time of a file preserving all blockettes and flags.           |
 +----------------------------------------------------------+--------------------------------------------------------------------------+
+| :func:`~obspy.io.mseed.util.spread_time_over_file`       | Progressively spreads a time shift over all blockettes in a file.        |
++----------------------------------------------------------+--------------------------------------------------------------------------+
 | :func:`~obspy.io.mseed.util.get_record_information`      | Returns record information about given files and file-like object.       |
 +----------------------------------------------------------+--------------------------------------------------------------------------+
 | :func:`~obspy.io.mseed.util.set_flags_in_fixed_headers`  | Updates a given miniSEED file with some fixed header flags.              |

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -660,12 +660,14 @@ class TestMSEEDUtil():
             # Check individual data blockette offsets
             info = util.get_record_information(filename)
             rl = info["record_length"]
-            for i in range(0,10):
-               # Each blockette should be progressively shifted by 0.1 s
-               i_bef = util.get_record_information(filename,offset=i*rl)
-               i_aft = util.get_record_information(output_filename,offset=i*rl)
-               diff = int((i_aft['starttime'] - i_bef['starttime'])*10 + 0.5)
-               assert diff == i
+            for i in range(0, 10):
+                # Each blockette should be progressively shifted by 0.1 s
+                o = i*rl
+                i_bef = util.get_record_information(filename, offset=o)
+                i_aft = util.get_record_information(output_filename, offset=o)
+                diff = int((i_aft['starttime'] - i_bef['starttime'])*10 + 0.5)
+                assert diff == i
+
 
     def test_time_shifting_special_case(self, testdata):
         """

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -606,7 +606,7 @@ class TestMSEEDUtil():
 
     def test_time_shifting(self, testdata):
         """
-        Tests the shift_time_of_file() function.
+        Tests the shift_time_of_file() and spread_time_over_file() functions.
         """
         with NamedTemporaryFile() as tf:
             output_filename = tf.name
@@ -647,6 +647,25 @@ class TestMSEEDUtil():
             st_after = _read_mseed(output_filename)
             st_before[0].stats.starttime -= 33.3
             assert st_before == st_after
+
+            # Test spread_time_over_file().
+            filename = testdata['BW.BGLD.__.EHE.D.2008.001.first_10_records']
+            # Shift by 0.9 seconds (0.1 s gap between each blockette in file)
+            util.spread_time_over_file(filename, output_filename, 9000)
+            st_before = _read_mseed(filename)
+            st_after = _read_mseed(output_filename)
+            st_before_et = st_before[0].stats.endtime + 0.9
+            st_after_et = st_after[len(st_after)-1].stats.endtime
+            assert st_before_et - st_after_et == 0
+            # Check individual data blockette offsets
+            info = util.get_record_information(filename)
+            rl = info["record_length"]
+            for i in range(0,10):
+               # Each blockette should be progressively shifted by 0.1 s
+               i_bef = util.get_record_information(filename,offset=i*rl)
+               i_aft = util.get_record_information(output_filename,offset=i*rl)
+               diff = int((i_aft['starttime'] - i_bef['starttime'])*10 + 0.5)
+               assert diff == i
 
     def test_time_shifting_special_case(self, testdata):
         """

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -668,7 +668,6 @@ class TestMSEEDUtil():
                 diff = int((i_aft['starttime'] - i_bef['starttime'])*10 + 0.5)
                 assert diff == i
 
-
     def test_time_shifting_special_case(self, testdata):
         """
         Sometimes actually changing the time value is necessary. This works but

--- a/obspy/io/mseed/tests/test_mseed_util.py
+++ b/obspy/io/mseed/tests/test_mseed_util.py
@@ -606,7 +606,7 @@ class TestMSEEDUtil():
 
     def test_time_shifting(self, testdata):
         """
-        Tests the shift_time_of_file() and spread_time_over_file() functions.
+        Tests the shift_time_of_file() function.
         """
         with NamedTemporaryFile() as tf:
             output_filename = tf.name
@@ -648,14 +648,19 @@ class TestMSEEDUtil():
             st_before[0].stats.starttime -= 33.3
             assert st_before == st_after
 
-            # Test spread_time_over_file().
+    def test_time_spreading(self, testdata):
+        """
+        Tests spread_time_over_file() function.
+        """
+        with NamedTemporaryFile() as tf:
+            output_filename = tf.name
             filename = testdata['BW.BGLD.__.EHE.D.2008.001.first_10_records']
             # Shift by 0.9 seconds (0.1 s gap between each blockette in file)
             util.spread_time_over_file(filename, output_filename, 9000)
             st_before = _read_mseed(filename)
             st_after = _read_mseed(output_filename)
             st_before_et = st_before[0].stats.endtime + 0.9
-            st_after_et = st_after[len(st_after)-1].stats.endtime
+            st_after_et = st_after[-1].stats.endtime
             assert st_before_et - st_after_et == 0
             # Check individual data blockette offsets
             info = util.get_record_information(filename)

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1704,17 +1704,17 @@ def spread_time_over_file(input_file, output_file, timeshift):
     :param output_file: The output filename.
     :type timeshift: int
     :param timeshift: The cumulative time shift to be progressively applied in
-        units of 0.0001 s.  Use an integer number.
+        units of 0.0001 s.  Use an integer number, e.g. ``10`` for a total
+        cumulative time shift of one millisecond.
 
-    Wise users will refrain from using this procedure to rewrite original
-    data files.  Using copies of those files will prevent catastrophic
-    corruption/destruction of data if something goes wrong.  Also always check
+    It is strongly recommended to not work directly on the original data to
+    avoid data loss in case anything goes wrong. Also always check
     the resulting output file.
 
     .. rubric:: Technical details
 
     The function will loop over every record and change the "Time correction"
-    field in the fixed section of the MiniSEED header by I*timeshift/(N-1),
+    field in the fixed section of the MiniSEED header by ``I*timeshift/(N-1)``,
     where N is the number of blockettes in the file and I is the blockette
     number (starting with zero).  Thus the start time of the file will be
     unchanged, but the end time will be later or earlier.  Unfortunately

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1676,9 +1676,10 @@ def shift_time_of_file(input_file, output_file, timeshift):
     # Write to the output file.
     data.tofile(output_file)
 
+
 def spread_time_over_file(input_file, output_file, timeshift):
     """
-    Takes a MiniSEED file and a time shift and changes every record to gradually
+    Takes a MiniSEED file and a time shift and changes each record to gradually
     spread the given time shift across all of the blockettes.  The intended use
     is to correct apparent gaps or overlaps less than a sample interval in
     continuous data that could arise due to hardware (clock drift) or
@@ -1713,7 +1714,7 @@ def spread_time_over_file(input_file, output_file, timeshift):
     .. rubric:: Technical details
 
     The function will loop over every record and change the "Time correction"
-    field in the fixed section of the MiniSEED data header by I*timeshift/(N-1),
+    field in the fixed section of the MiniSEED header by I*timeshift/(N-1),
     where N is the number of blockettes in the file and I is the blockette
     number (starting with zero).  Thus the start time of the file will be
     unchanged, but the end time will be later or earlier.  Unfortunately
@@ -1750,7 +1751,7 @@ def spread_time_over_file(input_file, output_file, timeshift):
     shift = timeshift / N
 
     # Loop over every record after the first.
-    for i in range(1,N+1):
+    for i in range(1, N+1):
         remaining_bytes = array_length - i*record_length
         if remaining_bytes < 48:
             if remaining_bytes > 0:
@@ -1782,8 +1783,8 @@ def spread_time_over_file(input_file, output_file, timeshift):
         # requires some more work by changing both, the actual time and the
         # time correction field.
         elif is_time_correction_applied:
-            msg = "The time shift can only be applied by actually changing the "
-            msg += "time. This is experimental. Please make sure the output "
+            msg = "The time shift can only be applied by actually changing the"
+            msg += " time. This is experimental. Please make sure the output "
             msg += "file is correct."
             warnings.warn(msg)
             # The whole process is not particularly fast or optimized but

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1729,6 +1729,10 @@ def spread_time_over_file(input_file, output_file, timeshift):
     record start time which is preferable.
     """
 
+    if timeshift != int(timeshift):
+        msg = "The time shift must be an integer."
+        raise ValueError(msg)
+
     timeshift = int(timeshift)
     # A timeshift of zero makes no sense.
     if timeshift == 0:

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1676,6 +1676,174 @@ def shift_time_of_file(input_file, output_file, timeshift):
     # Write to the output file.
     data.tofile(output_file)
 
+def spread_time_over_file(input_file, output_file, timeshift):
+    """
+    Takes a MiniSEED file and a time shift and changes every record to gradually
+    spread the given time shift across all of the blockettes.  The intended use
+    is to correct apparent gaps or overlaps less than a sample interval in
+    continuous data that could arise due to hardware (clock drift) or
+    software (rounding errors in time calculations during data management).
+
+    The same could be achieved by reading the MiniSEED file with ObsPy,
+    modifying the sample times and writing it again. The problem with this
+    approach is that some record specific flags and special blockettes might
+    not be conserved. This function directly operates on the file and simply
+    changes some header fields, not touching the rest, thus preserving it.
+
+    Will work correctly only if all records have the same record length; this
+    usually should be the case.
+
+    All times are in 0.0001 seconds, that is in 1/10000 seconds. NOT ms but one
+    order of magnitude smaller! This is due to the way time corrections are
+    stored in the MiniSEED format.
+
+    :type input_file: str
+    :param input_file: The input filename.
+    :type output_file: str
+    :param output_file: The output filename.
+    :type timeshift: int
+    :param timeshift: The cumulative time shift to be progressively applied in
+        units of 0.0001 s.  Use an integer number.
+
+    Wise users will refrain from using this procedure to rewrite original
+    data files.  Using copies of those files will prevent catastrophic
+    corruption/destruction of data if something goes wrong.  Also always check
+    the resulting output file.
+
+    .. rubric:: Technical details
+
+    The function will loop over every record and change the "Time correction"
+    field in the fixed section of the MiniSEED data header by I*timeshift/(N-1),
+    where N is the number of blockettes in the file and I is the blockette
+    number (starting with zero).  Thus the start time of the file will be
+    unchanged, but the end time will be later or earlier.  Unfortunately
+    a further flag (bit 1 in the "Activity flags" field) determines whether or
+    not the time correction has already been applied to the record start time.
+    If it has not, all is fine and changing the "Time correction" field is
+    enough.  Otherwise the actual time also needs to be changed.
+
+    One further detail: If bit 1 in the "Activity flags" field is 1 (True) and
+    the "Time correction" field is 0, then the bit will be set to 0 and only
+    the time correction will be changed thus avoiding the need to change the
+    record start time which is preferable.
+    """
+
+    timeshift = int(timeshift)
+    # A timeshift of zero makes no sense.
+    if timeshift == 0:
+        msg = "The timeshift must to be not equal to 0."
+        raise ValueError(msg)
+
+    # Get the necessary information from the file.
+    info = get_record_information(input_file)
+    record_length = info["record_length"]
+
+    byteorder = info["byteorder"]
+    sys_byteorder = "<" if (sys.byteorder == "little") else ">"
+    do_swap = False if (byteorder == sys_byteorder) else True
+
+    # This is in this scenario somewhat easier to use than BytesIO because one
+    # can directly modify the data array.
+    data = np.fromfile(input_file, dtype=np.uint8)
+    array_length = len(data)
+    N = int(array_length / record_length) - 1
+    shift = timeshift / N
+
+    # Loop over every record after the first.
+    for i in range(1,N+1):
+        remaining_bytes = array_length - i*record_length
+        if remaining_bytes < 48:
+            if remaining_bytes > 0:
+                msg = "%i excessive byte(s) in the file. " % remaining_bytes
+                msg += "They will be appended to the output file."
+                warnings.warn(msg)
+            break
+        # Use a slice for the current record.
+        current_record = data[i*record_length: (i+1)*record_length]
+
+        activity_flags = current_record[36]
+        is_time_correction_applied = bool(activity_flags & 2)
+
+        current_time_shift = current_record[40:44]
+        current_time_shift.dtype = np.int32
+        if do_swap:
+            current_time_shift = current_time_shift.byteswap(False)
+        current_time_shift = current_time_shift[0]
+
+        # If the time correction has been applied, but there is no actual
+        # time correction, then simply set the time correction applied
+        # field to false and process normally.
+        # This should rarely be the case.
+        if current_time_shift == 0 and is_time_correction_applied:
+            # This sets bit 2 of the activity flags to 0.
+            current_record[36] = current_record[36] & (~2)
+            is_time_correction_applied = False
+        # This is the case if the time correction has been applied. This
+        # requires some more work by changing both, the actual time and the
+        # time correction field.
+        elif is_time_correction_applied:
+            msg = "The time shift can only be applied by actually changing the "
+            msg += "time. This is experimental. Please make sure the output "
+            msg += "file is correct."
+            warnings.warn(msg)
+            # The whole process is not particularly fast or optimized but
+            # instead intends to avoid errors.
+            # Get the time variables.
+            time = current_record[20:30]
+            year = time[0:2]
+            julday = time[2:4]
+            hour = time[4:5]
+            minute = time[5:6]
+            second = time[6:7]
+            msecs = time[8:10]
+            # Change dtype of multibyte values.
+            year.dtype = np.uint16
+            julday.dtype = np.uint16
+            msecs.dtype = np.uint16
+            if do_swap:
+                year = year.byteswap(False)
+                julday = julday.byteswap(False)
+                msecs = msecs.byteswap(False)
+            dtime = UTCDateTime(year=year[0], julday=julday[0], hour=hour[0],
+                                minute=minute[0], second=second[0],
+                                microsecond=msecs[0] * 100)
+            dtime += (float(i*shift) / 10000)
+            year[0] = dtime.year
+            julday[0] = dtime.julday
+            hour[0] = dtime.hour
+            minute[0] = dtime.minute
+            second[0] = dtime.second
+            msecs[0] = dtime.microsecond / 100
+            # Swap again.
+            if do_swap:
+                year = year.byteswap(False)
+                julday = julday.byteswap(False)
+                msecs = msecs.byteswap(False)
+            # Change dtypes back.
+            year.dtype = np.uint8
+            julday.dtype = np.uint8
+            msecs.dtype = np.uint8
+            # Write to current record.
+            time[0:2] = year[:]
+            time[2:4] = julday[:]
+            time[4] = hour[:]
+            time[5] = minute[:]
+            time[6] = second[:]
+            time[8:10] = msecs[:]
+            current_record[20:30] = time[:]
+
+        # Now modify the time correction flag.
+        current_time_shift += int(i*shift)
+        if current_time_shift != 0:
+            current_time_shift = np.array([current_time_shift], np.int32)
+            if do_swap:
+                current_time_shift = current_time_shift.byteswap(False)
+            current_time_shift.dtype = np.uint8
+            current_record[40:44] = current_time_shift[:]
+
+    # Write to the output file.
+    data.tofile(output_file)
+
 
 def _convert_and_check_encoding_for_writing(encoding):
     """


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

This adds a new routine to utils.io.mseed called spread_time_over_file().  I wrote the routine to fix timing problems with mseed data generated during an old field experiment that had clock drift that caused day-long stretches of continuous data to accumulate an apparent time gap of about 0.5 sample interval by the end of the file.  By taking that gap interval and spreading it progressively over all the blockettes in the file, the continuity of the data can then be guaranteed.

The mseed data itself is not changed; only the headers.  The header modification follows the methods used in utils.io.mseed.shift_time_of_file().

Wrote unit test to test basic functionality.  Also successfully processed 11 Gb of historic data and removed the apparent gaps in it.  

### Why was it initiated?  Any relevant Issues?

Needed a new feature to fix existing data (see description above).

### PR Checklist
/ = not applicable
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [/] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [/] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [/] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the `ready for review` tag when you are ready for the PR to be reviewed.