### PR TITLE
move pytest import into skip network decorator

### DIFF
--- a/obspy/core/util/decorator.py
+++ b/obspy/core/util/decorator.py
@@ -18,7 +18,6 @@ import warnings
 import zipfile
 
 import numpy as np
-import pytest
 from decorator import decorator
 
 from obspy.core.util import get_example_file
@@ -114,6 +113,8 @@ def skip_on_network_error(func, *args, **kwargs):
     Decorator to mark test routines that fail with certain network
     errors (e.g. timeouts) as "skipped" rather than "Error".
     """
+    import pytest  # NOQA
+
     try:
         return func(*args, **kwargs)
     ###################################################


### PR DESCRIPTION
### What does this PR do?

The doc build action currently fails (eg [here](https://github.com/obspy/obspy/actions/runs/4325286632/jobs/7551241516)) because `obspy.core.utils.decorator` imports pytest and pytest isn't listed as a dependency in the `INSTALL_REQUIRES` section of setup.py. 

Since there may be other issues with users trying to use the decorators module without having pytest installed, I think the best course of action is simply move the pytest import into the function that uses it.

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [X] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [X] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [X] All tests still pass.
- [X] Any new features or fixed regressions are covered via new tests.
- [X] Any new or changed features are fully documented.
- [X] Significant changes have been added to `CHANGELOG.txt` .
- [X] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [X] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [X] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the `ready for review` tag when you are ready for the PR to be reviewed.
