### PR TITLE
adjust a test to catch a bug in the code of Stream.select()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@ maintenance_1.4.x
 =================
 
 Changes:
+ - obspy.core:
+   * fix a bug in Stream.select(inventory=...) (see #3282)
  - obspy.clients.fdsn:
    * update URL for raspberryshake FDSN web service (see #3264)
  - obspy.clients.seedlink:

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1851,9 +1851,9 @@ class Stream(object):
             for net in inventory.networks:
                 for sta in net.stations:
                     for chan in sta.channels:
-                        id = '.'.join((net.code, sta.code,
-                                       chan.location_code, chan.code))
-                        trace_ids.append(id)
+                        _id = '.'.join((net.code, sta.code,
+                                        chan.location_code, chan.code))
+                        trace_ids.append(_id)
                         start_dates.append(chan.start_date)
                         end_dates.append(chan.end_date)
             traces = []

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -758,7 +758,7 @@ class TestStream:
                     latitude=0.0, longitude=0.0, elevation=0.0, depth=0.0,
                     start_date=UTCDateTime(1990, 1, 1),
                     end_date=UTCDateTime(1998, 1, 1)),
-            Channel(code='EHZ', location_code='00',
+            Channel(code='EHN', location_code='00',
                     latitude=0.0, longitude=0.0, elevation=0.0, depth=0.0,
                     start_date=UTCDateTime(1999, 1, 1))
         ]


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `Stream.select(inventory=...)` that leads to only one SEED ID getting through, no matter what. Internally the variable `id` also used for filtering was overwritten during the filtering by inventory so that it was set to the last SEED ID checked in the inventory and that being the only SEED IDs let through later on. 

### Why was it initiated?  Any relevant Issues?

fixes #3274 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
