### PR TITLE
read/write support for csv, eventtxt and csz

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ Changes:
      (see #3261)
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility (see #3269)
+ - obspy.io:
+   * add read and write support for CSV, EVENTTXT and CSZ formats (see #3285)
  - obspy.io.mseed.spread_time_over_file:
    * new routine to spread a time interval progressively across all mseed
      blockettes in a file (see #3271)
@@ -33,7 +35,7 @@ Changes:
      routine "beach" with providing an existing axes instance (for proper
      scaling) and saving to vector graphics as pdf/eps (see #2887)
  - obspy.io.gcf:
-   * Fixed an issue in algorithm to split and encode last few data into GCF 
+   * Fixed an issue in algorithm to split and encode last few data into GCF
      blocks (see #3252)
  - obspy.taup:
    * bugfix to allow calculations for a model with no discontinuities

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@
 /obspy/io/cmtsolution
 /obspy/io/cnv
 /obspy/io/css
+/obspy/io/csv            @trichter
 /obspy/io/dmx            @ThomasLecocq
 /obspy/io/focmec         @megies
 /obspy/io/gcf            @paitor

--- a/misc/docs/source/packages/index.rst
+++ b/misc/docs/source/packages/index.rst
@@ -132,6 +132,7 @@ categories.*
 
     obspy.io.cmtsolution
     obspy.io.cnv
+    obspy.io.csv
     obspy.io.focmec
     obspy.io.gse2
     obspy.io.hypodd

--- a/misc/docs/source/packages/obspy.io.csv.rst
+++ b/misc/docs/source/packages/obspy.io.csv.rst
@@ -1,0 +1,14 @@
+.. currentmodule:: obspy.io.csv
+.. automodule:: obspy.io.csv
+
+    .. comment to end block
+
+    Modules
+    -------
+    .. autosummary::
+       :toctree: autogen
+       :nosignatures:
+
+       core
+
+    .. comment to end block

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -32,7 +32,8 @@ from obspy.core.util.misc import to_int_or_zero, buffered_load_entry_point
 # defining ObsPy modules currently used by runtests and the path function
 DEFAULT_MODULES = ['clients.filesystem', 'core', 'geodetics', 'imaging',
                    'io.ah', 'io.alsep', 'io.arclink', 'io.ascii',
-                   'io.cmtsolution', 'io.cnv', 'io.css', 'io.dmx', 'io.focmec',
+                   'io.cmtsolution', 'io.cnv', 'io.css', 'io.csv', 'io.dmx',
+                   'io.focmec',
                    'io.hypodd', 'io.iaspei', 'io.gcf', 'io.gse2', 'io.json',
                    'io.kinemetrics', 'io.kml', 'io.mseed', 'io.ndk', 'io.nied',
                    'io.nlloc', 'io.nordic', 'io.pdas', 'io.pde', 'io.quakeml',

--- a/obspy/io/csv/__init__.py
+++ b/obspy/io/csv/__init__.py
@@ -128,4 +128,4 @@ Code example creating event plots::
     plt.show()
 """
 
-from obspy.io.csv.core import events2array, load_csv, load_eventtxt
+from obspy.io.csv.core import _events2array, load_csv, load_eventtxt

--- a/obspy/io/csv/__init__.py
+++ b/obspy/io/csv/__init__.py
@@ -1,0 +1,131 @@
+"""
+obspy.io.csv - CSV, CSZ and EVENTTXT read/write support for earthquake catalogs
+===============================================================================
+
+
+Usage CSV
+---------
+
+CSV format can be used to store a catalog with basic origin properties.
+Picks cannot be stored.
+
+>>> from obspy import read_events
+>>> events = read_events()  # load example events
+>>> print(events)
+3 Event(s) in Catalog:
+2012-04-04T14:21:42.300000Z | +41.818,  +79.689 | 4.4  mb | manual
+2012-04-04T14:18:37.000000Z | +39.342,  +41.044 | 4.3  ML | manual
+2012-04-04T14:08:46.000000Z | +38.017,  +37.736 | 3.0  ML | manual
+>>> events.write('catalog.csv', 'CSV')  # declare 'CSV' as format
+>>> print(read_events('catalog.csv'))  # doctest: +NORMALIZE_WHITESPACE
+3 Event(s) in Catalog:
+2012-04-04T14:21:42.300000Z | +41.818,  +79.689 | 4.4  mb
+2012-04-04T14:18:37.000000Z | +39.342,  +41.044 | 4.3  ML
+2012-04-04T14:08:46.000000Z | +38.017,  +37.736 | 3.0  ML
+>>> with open('catalog.csv') as f: print(f.read())
+id,time,lat,lon,dep,magtype,mag
+20120404_0000041,2012-04-04T14:21:42.30000,41.818000,79.689000,1.000,mb,4.40
+20120404_0000038,2012-04-04T14:18:37.00000,39.342000,41.044000,14.400,ML,4.30
+20120404_0000039,2012-04-04T14:08:46.00000,38.017000,37.736000,7.000,ML,3.00
+<BLANKLINE>
+
+It is possible to load arbitrary csv files. Define the field names in the code
+or use the first line in the file to define the field names.
+The following field names have to be used to read the origin time:
+`time` (UTC time string) or `year, mon, day, hour, minu, sec`.
+The following additional field names have to be used:
+`lat, lon, dep, mag`. `magtype`, `id` and some other fields are optional.
+For external csv files, the format `'CSV'` has to be explicitly specified.
+
+>>> from obspy.core.util import get_example_file
+>>> with open(get_example_file('external.csv')) as f: print(f.read())
+Year, Month, Day, Hour, Minute, Seconds, code, Lat, Lon, Depth, Magnitude, ID
+2023, 05, 06, 19, 55, 01.3, LI, 10.1942, 124.8300, 50.47, 0.2, 2023abcde
+<BLANKLINE>
+>>> names = 'year mon day hour minu sec _ lat lon dep mag id'
+>>> events = read_events('/path/to/external.csv', 'CSV', skipheader=1, names=names)
+>>> print(events)  # doctest: +NORMALIZE_WHITESPACE
+1 Event(s) in Catalog:
+2023-05-06T19:55:01.300000Z | +10.194, +124.830 | 0.2
+
+
+Usage EVENTTXT
+--------------
+
+The EVENTTXT format is a flavour of CSV, reading and writing is directly
+supported.
+
+>>> from obspy import read_events
+>>> print(read_events('https://service.iris.edu/fdsnws/event/1/query?minmagnitude=8.5&format=text&endtime=2020-01-01'))  # doctest: +NORMALIZE_WHITESPACE
+7 Event(s) in Catalog:
+2012-04-11T08:38:37.000000Z |  +2.238,  +93.014 | 8.6  MW
+2011-03-11T05:46:23.000000Z | +38.296, +142.498 | 9.1  MW
+2010-02-27T06:34:13.000000Z | -36.148,  -72.933 | 8.8  MW
+2007-09-12T11:10:26.000000Z |  -4.464, +101.396 | 8.5  MW
+2005-03-28T16:09:35.000000Z |  +2.096,  +97.113 | 8.6  MW
+2004-12-26T00:58:52.000000Z |  +3.413,  +95.901 | 9.0  MW
+1960-05-22T19:11:14.000000Z | -38.170,  -72.570 | 8.5
+
+
+
+Usage CSZ
+---------
+
+CSZ format can be used to store a catalog with picks in a set of csv files
+zipped into a single file.
+It works similar to NumPy's npz format.
+Compression may be used with `compression` and `compresslevel` parameters
+(see `zipfile doc <https://docs.python.org/library/zipfile.html#zipfile.ZipFile>`_).
+
+>>> events = read_events('/path/to/example.pha')
+>>> print(events)
+2 Event(s) in Catalog:
+2025-05-14T14:35:35.510000Z | +40.225,  +10.450 | 3.5  None
+2025-05-14T15:43:05.280000Z | +40.223,  +10.450 | 1.8  None
+>>> print(len(events[0].picks))
+2
+>>> events.write('catalog.csz', 'CSZ')
+>>> events2 = read_events('catalog.csz')
+>>> print(events2)  # doctest: +NORMALIZE_WHITESPACE
+2 Event(s) in Catalog:
+2025-05-14T14:35:35.510000Z | +40.225,  +10.450 | 3.5
+2025-05-14T15:43:05.280000Z | +40.223,  +10.450 | 1.8
+>>> print(len(events2[0].picks))
+2
+
+Load CSV/CSZ/EVENTTXT file into numpy array
+-------------------------------------------
+
+For plotting, e.t.c, it is useful to represent the event paramters with a numpy
+array.
+The `load_csv` function can be used to load a CSV or CSZ file as numpy array.
+The `load_eventtxt` function ca be used to load an EVENTTXT file as numpy array.
+
+>>> from obspy.io.csv import load_csv
+>>> t = load_csv('catalog.csv')
+>>> print(t)  # doctest: +NORMALIZE_WHITESPACE
+[ ('20120404_0000041', '2012-04-04T14:21:42.300',  41.818,  79.689,   1. , 'mb',  4.4)
+  ('20120404_0000038', '2012-04-04T14:18:37.000',  39.342,  41.044,  14.4, 'ML',  4.3)
+  ('20120404_0000039', '2012-04-04T14:08:46.000',  38.017,  37.736,   7. , 'ML',  3. )]
+ >>> print(t['mag'])
+ [ 4.4  4.3  3. ]
+
+Convert ObsPy catalog into numpy array
+--------------------------------------
+
+The `events2array` function  can be used to convert an ObsPy catalog to numpy array.
+Code example creating event plots::
+
+    import matplotlib.pyplot as plt
+    from obspy import read_events
+    from obspy.io.csv import events2array
+    events = read_events()
+    t = events2array(events)
+    plt.subplot(121)
+    plt.scatter(t['lon'], t['lat'], 4*t['mag']**2)
+    plt.subplot(122)
+    plt.scatter(t['time'], t['mag'], 4*t['mag']**2)
+    plt.show()
+"""
+
+from obspy.io.csv.core import events2array, load_csv, load_eventtxt

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -1,4 +1,3 @@
-## Copyright 2022 Tom Eulenfeld, MIT license
 """
 CSV and CSZ read/write support for ObsPy earthquake catalogs
 
@@ -50,10 +49,10 @@ FIELDS = {
     'eventtxt': (
         '{id},{time!s:.25},{lat:.6f},{lon:.6f},{dep:.3f},{author},,{contrib},,'
         '{magtype},{mag:.2f},{magauthor},{region}').split(',')
-    }
+}
 PFIELDS = {
     'basic': '{seedid} {phase} {time:.5f} {weight:.3f}'
-    }
+}
 CSZ_COMMENT = f'CSZ format v{__version__} obspy_no_uncompress'.encode('utf-8')
 # for load_csv
 DTYPE = {
@@ -64,7 +63,7 @@ DTYPE = {
     'mag': float,
     'magtype': 'U10',
     'id': 'U50'
-    }
+}
 
 # catalog and contribid are not used
 EVENTTXT_NAMES = (  # for reading
@@ -79,14 +78,14 @@ EVENTTXT_HEADER = (  # for writing
 def _is_csv(fname, **kwargs):
     try:
         return _read_csv(fname, format_check=True)
-    except:
+    except Exception:
         return False
 
 
 def _is_eventtxt(fname, **kwargs):
     try:
         return _read_eventtxt(fname, format_check=True)
-    except:
+    except Exception:
         return False
 
 
@@ -97,7 +96,7 @@ def _is_csz(fname, **kwargs):
             assert (zipf.comment.startswith(b'CSZ') and
                     zipf.comment.endswith(b'obspy_no_uncompress'))
         return True
-    except:
+    except Exception:
         return False
 
 
@@ -160,7 +159,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
         catalog = read_events('external.csv', 'CSV', skipheader=1, names=names)
     """
     if default is None:
-        default= DEFAULT
+        default = DEFAULT
     events = []
     with _open(fname) as f:
         for _ in range(skipheader):
@@ -195,7 +194,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                 longitude=row['lon'],
                 depth=dep,
                 creation_info=info
-                )
+            )
             try:
                 # add zero to eliminate negative zeros in magnitudes
                 mag = float(row['mag']) + 0
@@ -227,7 +226,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                 origins=[origin],
                 resource_id=id_,
                 event_descriptions=descs
-                )
+            )
             events.append(event)
             if format_check:
                 return True
@@ -306,7 +305,7 @@ def _write_csv(events, fname, fields='basic', depth_in_km=True, delimiter=',',
             d = {'time': origin.time,
                  'lat': origin.latitude,
                  'lon': origin.longitude,
-                 'dep' if depth_in_km else 'depm' : dep,
+                 'dep' if depth_in_km else 'depm': dep,
                  'mag': mag,
                  'magtype': magtype,
                  'id': evid,
@@ -340,9 +339,9 @@ def load_csv(fname, skipheader=0, only=None, names=None,
             names = f.readline().strip().split(',')
         names = _names_sequence(names)
         dtype = [(n, DTYPE[n]) for n in names if n in DTYPE and
-                        (only is None or n in only)]
+                 (only is None or n in only)]
         usecols = [i for i, n in enumerate(names) if n in DTYPE and
-                        (only is None or n in only)]
+                   (only is None or n in only)]
         kw.setdefault('usecols', usecols)
         kw.setdefault('dtype', dtype)
         return np.genfromtxt(f, delimiter=delimiter, **kw)
@@ -410,7 +409,7 @@ def _write_picks(event, fname, fields_picks='basic', delimiter=','):
     weights = {str(arrival.pick_id): arrival.time_weight
                for arrival in origin.arrivals if arrival.time_weight}
     phases = {str(arrival.pick_id): arrival.phase
-               for arrival in origin.arrivals if arrival.phase}
+              for arrival in origin.arrivals if arrival.phase}
     with _open(fname, 'w') as f:
         f.write(delimiter.join(fieldnames) + '\n')
         for pick in event.picks:

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -33,11 +33,8 @@ import zipfile
 
 
 import numpy as np
-from obspy import UTCDateTime as UTC
+from obspy import UTCDateTime as UTC, __version__
 from obspy.core import event as evmod
-
-
-__version__ = '0.8.1-dev'
 
 # for reading
 DEFAULT = {'magtype': ''}
@@ -53,7 +50,7 @@ FIELDS = {
 PFIELDS = {
     'basic': '{seedid} {phase} {time:.5f} {weight:.3f}'
 }
-CSZ_COMMENT = f'CSZ format v{__version__} obspy_no_uncompress'.encode('utf-8')
+CSZ_COMMENT = f'CSZ format ObsPy v{__version__} obspy_no_uncompress'.encode('utf-8')
 # for load_csv
 DTYPE = {
     'time': 'datetime64[ms]',

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -415,6 +415,8 @@ def _write_picks(event, fname, fields_picks='basic', delimiter=','):
             pick_id = str(pick.resource_id)
             try:
                 seedid = pick.waveform_id.id
+                if seedid is None:
+                    raise AttributeError
             except AttributeError:
                 warn(f'No waveform id found for pick {pick_id}')
                 seedid = ''

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -51,7 +51,8 @@ FIELDS = {
 PFIELDS = {
     'basic': '{seedid} {phase} {time:.5f} {weight:.3f}'
 }
-CSZ_COMMENT = f'CSZ format ObsPy v{__version__} obspy_no_uncompress'.encode('utf-8')
+CSZ_COMMENT = f'CSZ format ObsPy v{__version__} obspy_no_uncompress'.encode(
+    'utf-8')
 # for load_csv
 DTYPE = {
     'time': 'datetime64[ms]',
@@ -152,7 +153,8 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
 
     >>> from obspy import read_events
     >>> names = 'year mon day hour minu sec _ lat lon dep mag id'
-    >>> events = read_events('/path/to/external.csv', 'CSV', skipheader=1, names=names)
+    >>> events = read_events(
+    ...     '/path/to/external.csv', 'CSV', skipheader=1, names=names)
     >>> print(events)  # doctest: +NORMALIZE_WHITESPACE
     1 Event(s) in Catalog:
     2023-05-06T19:55:01.300000Z | +10.194, +124.830 | 0.2

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -27,6 +27,7 @@ import csv
 from contextlib import contextmanager
 import io
 import math
+import pathlib
 from string import Formatter
 from warnings import warn
 import zipfile
@@ -109,8 +110,8 @@ def _origin(event):
 
 @contextmanager
 def _open(filein, *args, **kwargs):
-    """Accept both files or file names"""
-    if isinstance(filein, str):  # filename
+    """Accept files or file names or pathlib objects"""
+    if isinstance(filein, (str, pathlib.PurePath)):  # filename
         with open(filein, *args, **kwargs) as f:
             yield f
     else:  # file-like object

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -1,0 +1,485 @@
+## Copyright 2022 Tom Eulenfeld, MIT license
+"""
+CSV and CSZ read/write support for ObsPy earthquake catalogs
+
+You can use the following field names to read an external CSV file
+time or year, mon, day, hour, minu, sec
+lat, lon, dep, mag, magtype, id
+(see also global FIELDS variable and help of read_csv)
+
+Note: This plugin can be easily extended to write and read more event
+information.
+If you are interested, please send a PR to the github repository.
+  1. Add 'extended' or similar key to FIELDS dict, e.g. as a start use
+      'extended': (
+          '{time!s:.25} {lat:.6f} {lat_err:.6f} {lon:.6f} {lon_err:.6f} '
+          '{dep:.3f} {dep_err:.3f} {mag:.2f} {mag_err:.2f} {magtype} {id}'
+          )
+     You can also test by just passing the string to `fields` option.
+  2. Implement writing functionality in write_csv by adding the new properties
+     to the dict d. Missing values have to be handled.
+  3. Implement reading functionality for the new properties in read_csv.
+  4. Write some tests testing all new properties. Check that an event with
+     all new properties defined or missing can be written and read again.
+Similar can be done for the picks using PFIELDS, _write_picks, _read_picks
+"""
+
+import csv
+from contextlib import contextmanager
+import io
+import math
+from string import Formatter
+from warnings import warn
+import zipfile
+
+
+import numpy as np
+from obspy import UTCDateTime as UTC
+from obspy.core import event as evmod
+
+
+__version__ = '0.8.1-dev'
+
+# for reading
+DEFAULT = {'magtype': ''}
+# for writing
+FIELDS = {
+    'basic': (
+        '{id} {time!s:.25} {lat:.6f} {lon:.6f} {dep:.3f} '
+        '{magtype} {mag:.2f}'),
+    'eventtxt': (
+        '{id},{time!s:.25},{lat:.6f},{lon:.6f},{dep:.3f},{author},,{contrib},,'
+        '{magtype},{mag:.2f},{magauthor},{region}').split(',')
+    }
+PFIELDS = {
+    'basic': '{seedid} {phase} {time:.5f} {weight:.3f}'
+    }
+CSZ_COMMENT = f'CSZ format v{__version__} obspy_no_uncompress'.encode('utf-8')
+# for load_csv
+DTYPE = {
+    'time': 'datetime64[ms]',
+    'lat': float,
+    'lon': float,
+    'dep': float,
+    'mag': float,
+    'magtype': 'U10',
+    'id': 'U50'
+    }
+
+# catalog and contribid are not used
+EVENTTXT_NAMES = (  # for reading
+    'id time lat lon dep author catalog contrib contribid '
+    'magtype mag magauthor region')
+EVENTTXT_HEADER = (  # for writing
+    '#EventID | Time | Latitude | Longitude | Depth/km | Author | Catalog | '
+    'Contributor | ContributorID | MagType | Magnitude | MagAuthor | '
+    'EventLocationName')
+
+
+def _is_csv(fname, **kwargs):
+    try:
+        return _read_csv(fname, format_check=True)
+    except:
+        return False
+
+
+def _is_eventtxt(fname, **kwargs):
+    try:
+        return _read_eventtxt(fname, format_check=True)
+    except:
+        return False
+
+
+def _is_csz(fname, **kwargs):
+    try:
+        assert zipfile.is_zipfile(fname)
+        with zipfile.ZipFile(fname) as zipf:
+            assert (zipf.comment.startswith(b'CSZ') and
+                    zipf.comment.endswith(b'obspy_no_uncompress'))
+        return True
+    except:
+        return False
+
+
+def _evid(event):
+    return str(event.resource_id).split('/')[-1]
+
+
+def _origin(event):
+    return event.preferred_origin() or event.origins[0]
+
+
+@contextmanager
+def _open(filein, *args, **kwargs):
+    """Accept both files or file names"""
+    if isinstance(filein, str):  # filename
+        with open(filein, *args, **kwargs) as f:
+            yield f
+    else:  # file-like object
+        yield filein
+
+
+def _names_sequence(names):
+    if isinstance(names, dict):
+        names = [names.get(i, '_') for i in range(max(names.keys())+1)]
+    elif ' ' in names:
+        names = names.split()
+    return names
+
+
+def _string(row, key):
+    if key in row and row[key].strip() != '':
+        return row[key].strip()
+
+
+def _read_csv(fname, skipheader=0, default=None, names=None,
+              check_compression=None, format_check=False,
+              **kwargs):
+    """
+    Read a CSV file and return ObsPy Catalog
+
+    :param skipheader: skip first rows of file
+    :param depth_in_kim: depth is given in kilometer (default: True) or
+        meter (False)
+    :param default: dictionary with default values, at the moment only
+         magtype is supported,
+         i.e. to set magtypes use `default={'magtype': 'Ml'}`
+    :param names: determined automatically from header line of file,
+        otherwise can be specified as string, sequence or dict
+    :param check_compression: not used by read_csv
+    :param format_check: Read only the first event
+    :param **kargs: all other kwargs are passed to csv.DictReader,
+        important additional arguments are fieldnames, dialect, delimiter, etc
+
+    You can read csv files created by this module or external csv files.
+    Example reading an external csv file:
+
+        from obspy import read_events
+        names = ('year mon day hour minu sec _ '
+                 'lat lon dep _ _ mag _ _ _ _ _ _ id')
+        catalog = read_events('external.csv', 'CSV', skipheader=1, names=names)
+    """
+    if default is None:
+        default= DEFAULT
+    events = []
+    with _open(fname) as f:
+        for _ in range(skipheader):
+            f.readline()
+        if names is not None:
+            kwargs.setdefault('fieldnames', _names_sequence(names))
+        reader = csv.DictReader(f, **kwargs)
+        for row in reader:
+            if 'time' in row:
+                time = UTC(row['time'])
+            else:
+                time = UTC(
+                    '{year}-{mon}-{day} {hour}:{minu}:{sec}'.format(**row))
+            try:
+                if 'depm' in row:
+                    dep = float(row['depm'])
+                else:
+                    dep = float(row['dep']) * 1000
+                if math.isnan(dep):
+                    raise
+            except:
+                dep = None
+            author = _string(row, 'author')
+            contrib = _string(row, 'contrib')
+            if author is not None or contrib is not None:
+                info = evmod.CreationInfo(author=author, agency_id=contrib)
+            else:
+                info = None
+            origin = evmod.Origin(
+                time=time,
+                latitude=row['lat'],
+                longitude=row['lon'],
+                depth=dep,
+                creation_info=info
+                )
+            try:
+                # add zero to eliminate negative zeros in magnitudes
+                mag = float(row['mag']) + 0
+                if math.isnan(mag):
+                    raise
+            except:
+                magnitudes = []
+            else:
+                try:
+                    magtype = row['magtype']
+                    if magtype.lower() in ('', 'none', 'null', 'nan'):
+                        raise
+                except:
+                    magtype = default.get('magtype')
+                magauthor = _string(row, 'magauthor')
+                info = (evmod.CreationInfo(author=magauthor) if magauthor
+                        else None)
+                magnitudes = [evmod.Magnitude(
+                    mag=mag, magnitude_type=magtype, creation_info=info)]
+            try:
+                id_ = evmod.ResourceIdentifier(row['id'].strip())
+            except:
+                id_ = None
+            region = _string(row, 'region')
+            descs = ([evmod.EventDescription(region, 'region name')]
+                     if region else [])
+            event = evmod.Event(
+                magnitudes=magnitudes,
+                origins=[origin],
+                resource_id=id_,
+                event_descriptions=descs
+                )
+            events.append(event)
+            if format_check:
+                return True
+    if format_check:
+        # empty file will return an empty catalog,
+        # but it is not detected as CSV file
+        return False
+    return evmod.Catalog(events=events)
+
+
+def _write_csv(events, fname, fields='basic', depth_in_km=True, delimiter=',',
+               header=None):
+    """
+    Write ObsPy catalog to CSV file
+
+    :param events: catalog or list of events
+    :param fname: file name
+    :param depth_in_km: write depth in units of kilometer (default: True) or
+        meter
+    :param delimiter: defaults to `','`, if the delimiter is changed, ObsPy's
+        read_events function will not automatically identify the file as
+        CSV file
+    """
+    fields = FIELDS.get(fields, fields)
+    if ' ' in fields:
+        fields = fields.split()
+    fmtstr = delimiter.join(fields)
+    if not depth_in_km and 'depm' not in fmtstr:
+        fmtstr = fmtstr.replace('dep', 'depm')
+    if header is None:
+        fieldnames = [
+            fn for _, fn, _, _ in Formatter().parse(fmtstr) if fn is not None]
+        header = delimiter.join(fieldnames)
+    with _open(fname, 'w') as f:
+        f.write(header + '\n')
+        for event in events:
+            evid = str(event.resource_id).split('/')[-1]
+            try:
+                origin = _origin(event)
+            except:
+                warn(f'No origin found -> do not write event {evid}')
+                continue
+            try:
+                author = origin.creation_info.author
+            except AttributeError:
+                author = ''
+            try:
+                contrib = origin.creation_info.agency_id
+            except AttributeError:
+                contrib = ''
+            try:
+                magnitude = event.preferred_magnitude() or event.magnitudes[0]
+            except:
+                warn(f'No magnitude found for event {evid}')
+                mag = float('nan')
+                magtype = ''
+                magauthor = ''
+            else:
+                mag = magnitude.mag
+                magtype = magnitude.magnitude_type or ''
+                try:
+                    magauthor = magnitude.creation_info.author
+                except:
+                    magauthor = ''
+            try:
+                dep = origin.depth / (1000 if depth_in_km else 1)
+            except:
+                warn(f'No depth set for event {evid}')
+                dep = float('nan')
+            for description in event.event_descriptions:
+                if str(description.type) == 'region name':
+                    region = description.text
+                    break
+            else:
+                region = ''
+            d = {'time': origin.time,
+                 'lat': origin.latitude,
+                 'lon': origin.longitude,
+                 'dep' if depth_in_km else 'depm' : dep,
+                 'mag': mag,
+                 'magtype': magtype,
+                 'id': evid,
+                 'author': author,
+                 'contrib': contrib,
+                 'magauthor': magauthor,
+                 'region': region,
+                 }
+            f.write(fmtstr.format(**d).replace('nan', '') + '\n')
+
+
+def load_csv(fname, skipheader=0, only=None, names=None,
+             delimiter=',', **kw):
+    """
+    Load CSV or CSZ file into numpy array
+
+    :param only: sequence, read only columns speified by name
+    :param skipheader, names: see `read_csv`
+    :param **kw: Other kwargs are passed to `np.loadtxt`
+
+    """
+    if isinstance(fname, str) and zipfile.is_zipfile(fname):
+        with zipfile.ZipFile(fname) as zipf:
+            with io.TextIOWrapper(
+                    zipf.open('events.csv'), encoding='utf-8') as f:
+                return load_csv(f)
+    with _open(fname) as f:
+        for _ in range(skipheader):
+            f.readline()
+        if names is None:
+            names = f.readline().strip().split(',')
+        names = _names_sequence(names)
+        dtype = [(n, DTYPE[n]) for n in names if n in DTYPE and
+                        (only is None or n in only)]
+        usecols = [i for i, n in enumerate(names) if n in DTYPE and
+                        (only is None or n in only)]
+        kw.setdefault('usecols', usecols)
+        kw.setdefault('dtype', dtype)
+        return np.genfromtxt(f, delimiter=delimiter, **kw)
+
+
+def events2array(events, **kw):
+    """
+    Convert ObsPy catalog to numpy array
+
+    All kwargs are passed to `load_csv`, e.g. use `only=('lat', 'lon', 'mag')`
+    to get an array with lat, lon, mag parameters.
+    """
+    with io.StringIO() as f:
+        _write_csv(events, f)
+        f.seek(0)
+        return load_csv(f, **kw)
+
+
+def _read_eventtxt(fname, default=None, format_check=False):
+    return _read_csv(fname,
+                     skipheader=1, names=EVENTTXT_NAMES, delimiter='|',
+                     default=default, format_check=format_check)
+
+
+def _write_eventtxt(events, fname):
+    return _write_csv(events, fname, fields='eventtxt', header=EVENTTXT_HEADER,
+                      delimiter='|')
+
+
+def load_eventtxt(fname, **kw):
+    kw.setdefault('delimiter', '|')
+    kw.setdefault('skipheader', 1)
+    return load_csv(fname, names=EVENTTXT_NAMES, **kw)
+
+
+def _read_picks(event, fname):
+    otime = _origin(event).time
+    picks = []
+    arrivals = []
+    with _open(fname) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            phase = row['phase']
+            seedid = row['seedid']
+            wid = (evmod.WaveformStreamID(seed_string=seedid) if seedid
+                   else None)
+            pick = evmod.Pick(waveform_id=wid, phase_hint=phase,
+                              time=otime + float(row['time']))
+            arrival = evmod.Arrival(phase=phase, pick_id=pick.resource_id,
+                                    time_weight=float(row['weight']))
+            picks.append(pick)
+            arrivals.append(arrival)
+    event.picks = picks
+    event.origins[0].arrivals = arrivals
+
+
+def _write_picks(event, fname, fields_picks='basic', delimiter=','):
+    fields = PFIELDS.get(fields_picks, fields_picks)
+    if ' ' in fields:
+        fields = fields.split()
+    fmtstr = delimiter.join(fields)
+    fieldnames = [
+        fn for _, fn, _, _ in Formatter().parse(fmtstr) if fn is not None]
+    origin = _origin(event)
+    weights = {str(arrival.pick_id): arrival.time_weight
+               for arrival in origin.arrivals if arrival.time_weight}
+    phases = {str(arrival.pick_id): arrival.phase
+               for arrival in origin.arrivals if arrival.phase}
+    with _open(fname, 'w') as f:
+        f.write(delimiter.join(fieldnames) + '\n')
+        for pick in event.picks:
+            pick_id = str(pick.resource_id)
+            try:
+                seedid = pick.waveform_id.id
+            except:
+                warn(f'No waveform id found for pick {pick_id}')
+                seedid = ''
+            d = {'time': pick.time - origin.time,
+                 'seedid': seedid,
+                 'phase': phases.get(pick_id, pick.phase_hint),
+                 'weight': weights.get(pick_id, 1.)}
+            f.write(fmtstr.format(**d) + '\n')
+
+
+def _read_csz(fname, default=None, check_compression=None):
+    """
+    Read a CSZ file and return ObsPy Catalog with picks
+
+    :param default: dictionary with default values, at the moment only
+         magtype is supported,
+         i.e. to set magtypes use `default={'magtype': 'Ml'}`
+    :param check_compression: Has to be set to False, when using
+        ObsPy's read_events() function, otherwise ObsPy will automatically
+        unpack the zip file and reading it with obspycsv will not work.
+        The option is not used by read_csz.
+    """
+    with zipfile.ZipFile(fname) as zipf:
+        with io.TextIOWrapper(zipf.open('events.csv'), encoding='utf-8') as f:
+            events = _read_csv(f, default=default)
+        for event in events:
+            evid = _evid(event)
+            fname = f'picks_{evid}.csv'
+            if fname not in zipf.namelist():
+                continue
+            with io.TextIOWrapper(zipf.open(fname), encoding='utf-8') as f:
+                _read_picks(event, f)
+    return events
+
+
+def _write_csz(events, fname, fields='basic', fields_picks='basic', **kwargs):
+    """
+    Write ObsPy catalog to CSZ file
+
+    :param events: catalog or list of events
+    :param fname: file name
+    :param **kwargs: compression and compression level can be specified see
+    https://docs.python.org/library/zipfile.html#zipfile.ZipFile
+    ```
+    events.write('CSZ', compression=True, compresslevel=9)
+    ```
+    """
+    # allow True as value for compression
+    if kwargs.get('compression') is True:
+        kwargs['compression'] = zipfile.ZIP_DEFLATED
+    with zipfile.ZipFile(fname, mode='w', **kwargs) as zipf:
+        zipf.comment = CSZ_COMMENT
+        with io.StringIO() as f:
+            _write_csv(events, f, fields=fields)
+            zipf.writestr('events.csv', f.getvalue())
+        for event in events:
+            if len(event.picks) == 0:
+                continue
+            evid = str(event.resource_id).split('/')[-1]
+            try:
+                _origin(event)
+            except:
+                continue
+            with io.StringIO() as f:
+                _write_picks(event, f, fields_picks=fields_picks)
+                zipf.writestr(f'picks_{evid}.csv', f.getvalue())

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -88,10 +88,12 @@ def _is_eventtxt(fname, **kwargs):
 
 def _is_csz(fname, **kwargs):
     try:
-        assert zipfile.is_zipfile(fname)
+        if not zipfile.is_zipfile(fname):
+            return False
         with zipfile.ZipFile(fname) as zipf:
-            assert (zipf.comment.startswith(b'CSZ') and
-                    zipf.comment.endswith(b'obspy_no_uncompress'))
+            if not (zipf.comment.startswith(b'CSZ') and
+                    zipf.comment.endswith(b'obspy_no_uncompress')):
+                return False
         return True
     except Exception:
         return False

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -348,7 +348,7 @@ def load_csv(fname, skipheader=0, only=None, names=None,
         return np.genfromtxt(f, delimiter=delimiter, **kw)
 
 
-def events2array(events, **kw):
+def _events2array(events, **kw):
     """
     Convert ObsPy catalog to numpy array
 

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -150,10 +150,12 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
     You can read csv files created by this module or external csv files.
     Example reading an external csv file:
 
-        from obspy import read_events
-        names = ('year mon day hour minu sec _ '
-                 'lat lon dep _ _ mag _ _ _ _ _ _ id')
-        catalog = read_events('external.csv', 'CSV', skipheader=1, names=names)
+    >>> from obspy import read_events
+    >>> names = 'year mon day hour minu sec _ lat lon dep mag id'
+    >>> events = read_events('/path/to/external.csv', 'CSV', skipheader=1, names=names)
+    >>> print(events)  # doctest: +NORMALIZE_WHITESPACE
+    1 Event(s) in Catalog:
+    2023-05-06T19:55:01.300000Z | +10.194, +124.830 | 0.2
     """
     if default is None:
         default = DEFAULT

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -6,7 +6,7 @@ time or year, mon, day, hour, minu, sec
 lat, lon, dep, mag, magtype, id
 (see also global FIELDS variable and help of read_csv)
 
-Note: This plugin can be easily extended to write and read more event
+Note: This module can be easily extended to write and read more event
 information.
 If you are interested, please send a PR to the github repository.
   1. Add 'extended' or similar key to FIELDS dict, e.g. as a start use

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -180,7 +180,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                     dep = float(row['dep']) * 1000
                 if math.isnan(dep):
                     raise
-            except:
+            except Exception:
                 dep = None
             author = _string(row, 'author')
             contrib = _string(row, 'contrib')
@@ -200,14 +200,14 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                 mag = float(row['mag']) + 0
                 if math.isnan(mag):
                     raise
-            except:
+            except Exception:
                 magnitudes = []
             else:
                 try:
                     magtype = row['magtype']
                     if magtype.lower() in ('', 'none', 'null', 'nan'):
                         raise
-                except:
+                except Exception:
                     magtype = default.get('magtype')
                 magauthor = _string(row, 'magauthor')
                 info = (evmod.CreationInfo(author=magauthor) if magauthor
@@ -216,7 +216,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                     mag=mag, magnitude_type=magtype, creation_info=info)]
             try:
                 id_ = evmod.ResourceIdentifier(row['id'].strip())
-            except:
+            except Exception:
                 id_ = None
             region = _string(row, 'region')
             descs = ([evmod.EventDescription(region, 'region name')]
@@ -266,7 +266,7 @@ def _write_csv(events, fname, fields='basic', depth_in_km=True, delimiter=',',
             evid = str(event.resource_id).split('/')[-1]
             try:
                 origin = _origin(event)
-            except:
+            except Exception:
                 warn(f'No origin found -> do not write event {evid}')
                 continue
             try:
@@ -279,7 +279,7 @@ def _write_csv(events, fname, fields='basic', depth_in_km=True, delimiter=',',
                 contrib = ''
             try:
                 magnitude = event.preferred_magnitude() or event.magnitudes[0]
-            except:
+            except Exception:
                 warn(f'No magnitude found for event {evid}')
                 mag = float('nan')
                 magtype = ''
@@ -289,11 +289,11 @@ def _write_csv(events, fname, fields='basic', depth_in_km=True, delimiter=',',
                 magtype = magnitude.magnitude_type or ''
                 try:
                     magauthor = magnitude.creation_info.author
-                except:
+                except AttributeError:
                     magauthor = ''
             try:
                 dep = origin.depth / (1000 if depth_in_km else 1)
-            except:
+            except Exception:
                 warn(f'No depth set for event {evid}')
                 dep = float('nan')
             for description in event.event_descriptions:
@@ -416,7 +416,7 @@ def _write_picks(event, fname, fields_picks='basic', delimiter=','):
             pick_id = str(pick.resource_id)
             try:
                 seedid = pick.waveform_id.id
-            except:
+            except AttributeError:
                 warn(f'No waveform id found for pick {pick_id}')
                 seedid = ''
             d = {'time': pick.time - origin.time,
@@ -477,7 +477,7 @@ def _write_csz(events, fname, fields='basic', fields_picks='basic', **kwargs):
             evid = str(event.resource_id).split('/')[-1]
             try:
                 _origin(event)
-            except:
+            except Exception:
                 continue
             with io.StringIO() as f:
                 _write_picks(event, f, fields_picks=fields_picks)

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -132,20 +132,17 @@ def _string(row, key):
 
 
 def _read_csv(fname, skipheader=0, default=None, names=None,
-              check_compression=None, format_check=False,
-              **kwargs):
+              format_check=False, **kwargs):
     """
     Read a CSV file and return ObsPy Catalog
 
+    :param fname: file name
     :param skipheader: skip first rows of file
-    :param depth_in_kim: depth is given in kilometer (default: True) or
-        meter (False)
     :param default: dictionary with default values, at the moment only
          magtype is supported,
          i.e. to set magtypes use `default={'magtype': 'Ml'}`
     :param names: determined automatically from header line of file,
         otherwise can be specified as string, sequence or dict
-    :param check_compression: not used by read_csv
     :param format_check: Read only the first event
     :param **kargs: all other kwargs are passed to csv.DictReader,
         important additional arguments are fieldnames, dialect, delimiter, etc
@@ -430,17 +427,13 @@ def _write_picks(event, fname, fields_picks='basic', delimiter=','):
             f.write(fmtstr.format(**d) + '\n')
 
 
-def _read_csz(fname, default=None, check_compression=None):
+def _read_csz(fname, default=None):
     """
     Read a CSZ file and return ObsPy Catalog with picks
 
     :param default: dictionary with default values, at the moment only
          magtype is supported,
          i.e. to set magtypes use `default={'magtype': 'Ml'}`
-    :param check_compression: Has to be set to False, when using
-        ObsPy's read_events() function, otherwise ObsPy will automatically
-        unpack the zip file and reading it with obspycsv will not work.
-        The option is not used by read_csz.
     """
     with zipfile.ZipFile(fname) as zipf:
         with io.TextIOWrapper(zipf.open('events.csv'), encoding='utf-8') as f:

--- a/obspy/io/csv/tests/__init__.py
+++ b/obspy/io/csv/tests/__init__.py
@@ -1,0 +1,1 @@
+MODULE_NAME = "obspy.io.csv"

--- a/obspy/io/csv/tests/data/events.txt
+++ b/obspy/io/csv/tests/data/events.txt
@@ -1,0 +1,3 @@
+#EventID | Time | Latitude | Longitude | Depth/km | Author | Catalog | Contributor | ContributorID | MagType | Magnitude | MagAuthor | EventLocationName
+3337497|2012-04-11T08:38:37.00000|2.237600|93.014400|26.300|ISC||ISC||MW|8.60|GCMT|SUMATRA
+2413|1960-05-22T19:11:14.00000|-38.170000|-72.570000|0.000||||||8.50||

--- a/obspy/io/csv/tests/data/external.csv
+++ b/obspy/io/csv/tests/data/external.csv
@@ -1,0 +1,2 @@
+Year, Month, Day, Hour, Minute, Seconds, code, Lat, Lon, Depth, Magnitude, ID
+2023, 05, 06, 19, 55, 01.3, LI, 10.1942, 124.8300, 50.47, 0.2, 2023abcde

--- a/obspy/io/csv/tests/data/incomplete.csv
+++ b/obspy/io/csv/tests/data/incomplete.csv
@@ -1,0 +1,3 @@
+time,lat,lon,dep,mag,magtype,id
+2012-04-04,42,42,nan,null,,id1
+2012-04-04,42,42,,10,Munreal,id1

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -1,0 +1,216 @@
+# Copyright 2022 Tom Eulenfeld, MIT license
+import io
+import os.path
+from tempfile import gettempdir
+
+import numpy as np
+import obspy
+from obspy import read_events
+from obspy.core.util import NamedTemporaryFile
+import obspycsv
+from packaging import version
+import pytest
+from obspy.core.util import get_example_file
+
+
+
+def test_csv():
+    events = read_events()
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        events.write(ft.name, 'CSV')
+        events2 = read_events(ft.name)
+    assert len(events2) == len(events)
+    assert events2[0].origins[0].time == events[0].origins[0].time
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        events.write(ft.name, 'CSV', depth_in_km=True)
+        events2 = read_events(ft.name)
+    assert len(events2) == len(events)
+    assert events2[0].origins[0].time == events[0].origins[0].time
+
+
+def test_csv_reading_external_catalog():
+    names = 'year mon day hour minu sec _ lat lon dep mag id'
+    incomplete_names = 'year mon day hour minu sec _ lat lon dep'
+    fname = '/path/to/external.csv'
+    assert not obspycsv._is_csv(fname)
+    events = read_events(fname, 'CSV', skipheader=1, names=names)
+    events2 = read_events(fname, 'CSV', skipheader=1, names=incomplete_names)
+    assert len(events) == 1
+    assert str(events[0].origins[0].time) == '2023-05-06T19:55:01.300000Z'
+    assert len(events[0].magnitudes) == 1
+    assert len(events2) == 1
+    assert str(events2[0].origins[0].time) == '2023-05-06T19:55:01.300000Z'
+    assert len(events2[0].magnitudes) == 0
+
+
+def test_csv_incomplete_catalog():
+    events = read_events()
+    del events[0].magnitudes[0].magnitude_type
+    events[1].magnitudes = []
+    events[1].preferred_magnitude_id = None
+    events[1].origins[0].depth = None
+    events[2].origins = []
+    events[2].preferred_origin_id = None
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        with pytest.warns(Warning):
+            events.write(ft.name, 'CSV')
+        events2 = read_events(ft.name, 'CSV')
+    assert len(events2) == 2
+    assert events2[0].origins[0].time == events[0].origins[0].time
+    assert events2[1].origins[0].depth is None
+    assert events2[1].origins[0].time == events[1].origins[0].time
+
+    fname = get_example_file('incomplete.csv')
+    assert obspycsv._is_csv(fname)
+    events = read_events(fname)
+    assert len(events) == 2
+    assert events[0].origins[0].depth is None
+    assert len(events[0].magnitudes) == 0
+    assert events[1].origins[0].depth is None
+    assert len(events[1].magnitudes) == 1
+    assert events[1].magnitudes[0].mag == 10.0
+
+
+def test_csv_custom_fmt():
+    events = read_events()
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        fname = ft.name
+        events.write(fname, 'CSV', fields='{lat:.5f} {lon:.5f}')
+        assert not obspycsv._is_csv(fname)
+        data = np.genfromtxt(fname, names=True, delimiter=',')
+        assert len(data) == 3
+        assert len(data[0]) == 2
+
+
+def test_csv_empty():
+    assert not obspycsv._is_csv(b'')
+    empty_cat = obspycsv.read_csv(b'')
+    assert len(empty_cat) == 0
+
+
+def test_csz(check_compression=False):
+    events = read_events('/path/to/example.pha')
+    tempdir = gettempdir()
+    fname = os.path.join(tempdir, 'obbspycsv_testfile.csz')
+    with NamedTemporaryFile(suffix='.csz') as ft:
+        fname = ft.name
+        def _test_write_read(events, **kw):
+            events.write(fname, 'CSZ', **kw)
+            assert obspycsv._is_csz(fname)
+            events2 = read_events(fname, check_compression=check_compression)
+            assert len(events2) == len(events)
+            for ev1, ev2 in zip(events, events2):
+                assert len(ev2.origins[0].arrivals) == \
+                                  len(ev1.origins[0].arrivals)
+                assert len(ev2.picks) == \
+                                 len(ev1.picks)
+        _test_write_read(events)
+        _test_write_read(events, compression=False)
+        try:
+            import zlib
+        except ImportError:
+            pass
+        else:
+            _test_write_read(events, compression=True, compresslevel=6)
+        # test with missing origin and waveformid
+        events[1].origins = []
+        events[0].picks[0].waveform_id = None
+        with pytest.warns(Warning):
+            events.write(fname, 'CSZ')
+        assert obspycsv._is_csz(fname)
+        events2 = read_events(fname, check_compression=check_compression)
+        assert len(events2) == 1
+        assert (len(events2[0].origins[0].arrivals) ==
+                len(events[0].origins[0].arrivals))
+        assert len(events2[0].picks) == len(events[0].picks)
+
+
+def test_csz_without_picks(check_compression=False):
+    events = read_events()
+    with NamedTemporaryFile(suffix='.csz') as ft:
+        fname = ft.name
+        events.write(fname, 'CSZ')
+        assert obspycsv._is_csz(fname)
+        events2 = read_events(fname, check_compression=check_compression)
+        assert events2[0]._format == 'CSZ'
+        assert len(events2) == len(events)
+
+
+@pytest.mark.skipif(version.parse(obspy.__version__) < version.parse('1.4'),
+                    reason='only supported for ObsPy>=1.4')
+def test_csz_without_check_compression_parameters():
+    test_csz(check_compression=True)
+    test_csz_without_picks(check_compression=True)
+
+
+def test_load_csv():
+    events = read_events()
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        events.write(ft.name, 'CSV')
+        t = obspycsv.load_csv(ft.name)
+    assert t['mag'][0] == 4.4
+    with NamedTemporaryFile(suffix='.csz') as ft:
+        events.write(ft.name, 'CSZ')
+        t = obspycsv.load_csv(ft.name)
+    assert t['mag'][0] == 4.4
+    t = obspycsv.events2array(events)
+    assert t['mag'][0] == 4.4
+
+
+def test_load_csv_incomplete_catalog():
+    events = read_events()
+    del events[0].magnitudes[0].magnitude_type
+    events[1].magnitudes = []
+    events[1].preferred_magnitude_id = None
+    events[2].origins = []
+    events[2].preferred_origin_id = None
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        with pytest.warns(Warning):
+            events.write(ft.name, 'CSV')
+        t = obspycsv.load_csv(ft.name)
+    assert len(t) == 2
+    assert np.isnan(t['mag'][1])
+
+
+def test_load_csv_some_cols():
+    events = read_events()
+    with NamedTemporaryFile(suffix='.csv') as ft:
+        fields = '{lat:.6f} {lon:.6f} {mag:.2f}'
+        events.write(ft.name, 'CSV', fields=fields)
+        t = obspycsv.load_csv(ft.name)
+        t2 = obspycsv.load_csv(ft.name, only=['mag'])
+        t3 = obspycsv.load_csv(ft.name, skipheader=1, names={2: 'mag'})
+    assert t['mag'][0] == 4.4
+    assert t2['mag'][0] == 4.4
+    assert t3['mag'][0] == 4.4
+    assert 'mag' in t2.dtype.names
+    assert 'lat' not in t2.dtype.names
+    assert 'mag' in t3.dtype.names
+    assert 'lat' not in t3.dtype.names
+
+
+def test_events2array():
+    events = read_events()
+    t = obspycsv.events2array(events)
+    assert t['mag'][0] == 4.4
+
+
+def test_eventtxt():
+    fname = get_example_file('events.txt')
+    assert obspycsv._is_eventtxt(fname)
+    events = read_events(fname)
+    arr = obspycsv.load_eventtxt(fname)
+    assert len(events) == 2
+    assert str(events[0].origins[0].time) == '2012-04-11T08:38:37.000000Z'
+    assert events[0].origins[0].creation_info.author == 'ISC'
+    assert events[0].magnitudes[0].creation_info.author == 'GCMT'
+    assert events[0].event_descriptions[0].text == 'SUMATRA'
+    assert len(events[0].magnitudes) == 1
+    assert events[1].origins[0].creation_info == None
+    assert events[1].magnitudes[0].creation_info == None
+    assert list(arr['mag']) == [8.6, 8.5]
+    with open(fname) as f:
+        eventtxt = f.read()
+    with io.StringIO() as f:
+        events.write(f, 'EVENTTXT')
+        assert f.getvalue() == eventtxt

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -106,7 +106,7 @@ def test_csz(check_compression=False):
         _test_write_read(events)
         _test_write_read(events, compression=False)
         try:
-            import zlib  # flake8: noqa
+            import zlib  # noqa: F401
         except ImportError:
             pass
         else:

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -205,8 +205,8 @@ def test_eventtxt():
     assert events[0].magnitudes[0].creation_info.author == 'GCMT'
     assert events[0].event_descriptions[0].text == 'SUMATRA'
     assert len(events[0].magnitudes) == 1
-    assert events[1].origins[0].creation_info == None
-    assert events[1].magnitudes[0].creation_info == None
+    assert events[1].origins[0].creation_info is None
+    assert events[1].magnitudes[0].creation_info is None
     assert list(arr['mag']) == [8.6, 8.5]
     with open(fname) as f:
         eventtxt = f.read()

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -3,11 +3,9 @@ import os.path
 from tempfile import gettempdir
 
 import numpy as np
-import obspy
 from obspy import read_events
 from obspy.core.util import NamedTemporaryFile
 import obspy.io.csv.core as iocsv
-from packaging import version
 import pytest
 from obspy.core.util import get_example_file
 
@@ -135,8 +133,6 @@ def test_csz_without_picks(check_compression=False):
         assert len(events2) == len(events)
 
 
-@pytest.mark.skipif(version.parse(obspy.__version__) < version.parse('1.4'),
-                    reason='only supported for ObsPy>=1.4')
 def test_csz_without_check_compression_parameters():
     test_csz(check_compression=True)
     test_csz_without_picks(check_compression=True)

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -149,7 +149,7 @@ def test_load_csv():
         events.write(ft.name, 'CSZ')
         t = iocsv.load_csv(ft.name)
     assert t['mag'][0] == 4.4
-    t = iocsv.events2array(events)
+    t = iocsv._events2array(events)
     assert t['mag'][0] == 4.4
 
 
@@ -187,7 +187,7 @@ def test_load_csv_some_cols():
 
 def test_events2array():
     events = read_events()
-    t = iocsv.events2array(events)
+    t = iocsv._events2array(events)
     assert t['mag'][0] == 4.4
 
 

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -1,4 +1,3 @@
-# Copyright 2022 Tom Eulenfeld, MIT license
 import io
 import os.path
 from tempfile import gettempdir
@@ -11,7 +10,6 @@ import obspycsv
 from packaging import version
 import pytest
 from obspy.core.util import get_example_file
-
 
 
 def test_csv():
@@ -94,6 +92,7 @@ def test_csz(check_compression=False):
     fname = os.path.join(tempdir, 'obbspycsv_testfile.csz')
     with NamedTemporaryFile(suffix='.csz') as ft:
         fname = ft.name
+
         def _test_write_read(events, **kw):
             events.write(fname, 'CSZ', **kw)
             assert obspycsv._is_csz(fname)
@@ -101,9 +100,9 @@ def test_csz(check_compression=False):
             assert len(events2) == len(events)
             for ev1, ev2 in zip(events, events2):
                 assert len(ev2.origins[0].arrivals) == \
-                                  len(ev1.origins[0].arrivals)
+                    len(ev1.origins[0].arrivals)
                 assert len(ev2.picks) == \
-                                 len(ev1.picks)
+                    len(ev1.picks)
         _test_write_read(events)
         _test_write_read(events, compression=False)
         try:

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -6,7 +6,7 @@ import numpy as np
 import obspy
 from obspy import read_events
 from obspy.core.util import NamedTemporaryFile
-import obspycsv
+import obspy.io.csv.core as iocsv
 from packaging import version
 import pytest
 from obspy.core.util import get_example_file
@@ -30,7 +30,7 @@ def test_csv_reading_external_catalog():
     names = 'year mon day hour minu sec _ lat lon dep mag id'
     incomplete_names = 'year mon day hour minu sec _ lat lon dep'
     fname = '/path/to/external.csv'
-    assert not obspycsv._is_csv(fname)
+    assert not iocsv._is_csv(fname)
     events = read_events(fname, 'CSV', skipheader=1, names=names)
     events2 = read_events(fname, 'CSV', skipheader=1, names=incomplete_names)
     assert len(events) == 1
@@ -59,7 +59,7 @@ def test_csv_incomplete_catalog():
     assert events2[1].origins[0].time == events[1].origins[0].time
 
     fname = get_example_file('incomplete.csv')
-    assert obspycsv._is_csv(fname)
+    assert iocsv._is_csv(fname)
     events = read_events(fname)
     assert len(events) == 2
     assert events[0].origins[0].depth is None
@@ -74,15 +74,15 @@ def test_csv_custom_fmt():
     with NamedTemporaryFile(suffix='.csv') as ft:
         fname = ft.name
         events.write(fname, 'CSV', fields='{lat:.5f} {lon:.5f}')
-        assert not obspycsv._is_csv(fname)
+        assert not iocsv._is_csv(fname)
         data = np.genfromtxt(fname, names=True, delimiter=',')
         assert len(data) == 3
         assert len(data[0]) == 2
 
 
 def test_csv_empty():
-    assert not obspycsv._is_csv(b'')
-    empty_cat = obspycsv.read_csv(b'')
+    assert not iocsv._is_csv(b'')
+    empty_cat = iocsv._read_csv(b'')
     assert len(empty_cat) == 0
 
 
@@ -95,7 +95,7 @@ def test_csz(check_compression=False):
 
         def _test_write_read(events, **kw):
             events.write(fname, 'CSZ', **kw)
-            assert obspycsv._is_csz(fname)
+            assert iocsv._is_csz(fname)
             events2 = read_events(fname, check_compression=check_compression)
             assert len(events2) == len(events)
             for ev1, ev2 in zip(events, events2):
@@ -116,7 +116,7 @@ def test_csz(check_compression=False):
         events[0].picks[0].waveform_id = None
         with pytest.warns(Warning):
             events.write(fname, 'CSZ')
-        assert obspycsv._is_csz(fname)
+        assert iocsv._is_csz(fname)
         events2 = read_events(fname, check_compression=check_compression)
         assert len(events2) == 1
         assert (len(events2[0].origins[0].arrivals) ==
@@ -129,7 +129,7 @@ def test_csz_without_picks(check_compression=False):
     with NamedTemporaryFile(suffix='.csz') as ft:
         fname = ft.name
         events.write(fname, 'CSZ')
-        assert obspycsv._is_csz(fname)
+        assert iocsv._is_csz(fname)
         events2 = read_events(fname, check_compression=check_compression)
         assert events2[0]._format == 'CSZ'
         assert len(events2) == len(events)
@@ -146,13 +146,13 @@ def test_load_csv():
     events = read_events()
     with NamedTemporaryFile(suffix='.csv') as ft:
         events.write(ft.name, 'CSV')
-        t = obspycsv.load_csv(ft.name)
+        t = iocsv.load_csv(ft.name)
     assert t['mag'][0] == 4.4
     with NamedTemporaryFile(suffix='.csz') as ft:
         events.write(ft.name, 'CSZ')
-        t = obspycsv.load_csv(ft.name)
+        t = iocsv.load_csv(ft.name)
     assert t['mag'][0] == 4.4
-    t = obspycsv.events2array(events)
+    t = iocsv.events2array(events)
     assert t['mag'][0] == 4.4
 
 
@@ -166,7 +166,7 @@ def test_load_csv_incomplete_catalog():
     with NamedTemporaryFile(suffix='.csv') as ft:
         with pytest.warns(Warning):
             events.write(ft.name, 'CSV')
-        t = obspycsv.load_csv(ft.name)
+        t = iocsv.load_csv(ft.name)
     assert len(t) == 2
     assert np.isnan(t['mag'][1])
 
@@ -176,9 +176,9 @@ def test_load_csv_some_cols():
     with NamedTemporaryFile(suffix='.csv') as ft:
         fields = '{lat:.6f} {lon:.6f} {mag:.2f}'
         events.write(ft.name, 'CSV', fields=fields)
-        t = obspycsv.load_csv(ft.name)
-        t2 = obspycsv.load_csv(ft.name, only=['mag'])
-        t3 = obspycsv.load_csv(ft.name, skipheader=1, names={2: 'mag'})
+        t = iocsv.load_csv(ft.name)
+        t2 = iocsv.load_csv(ft.name, only=['mag'])
+        t3 = iocsv.load_csv(ft.name, skipheader=1, names={2: 'mag'})
     assert t['mag'][0] == 4.4
     assert t2['mag'][0] == 4.4
     assert t3['mag'][0] == 4.4
@@ -190,15 +190,15 @@ def test_load_csv_some_cols():
 
 def test_events2array():
     events = read_events()
-    t = obspycsv.events2array(events)
+    t = iocsv.events2array(events)
     assert t['mag'][0] == 4.4
 
 
 def test_eventtxt():
     fname = get_example_file('events.txt')
-    assert obspycsv._is_eventtxt(fname)
+    assert iocsv._is_eventtxt(fname)
     events = read_events(fname)
-    arr = obspycsv.load_eventtxt(fname)
+    arr = iocsv.load_eventtxt(fname)
     assert len(events) == 2
     assert str(events[0].origins[0].time) == '2012-04-11T08:38:37.000000Z'
     assert events[0].origins[0].creation_info.author == 'ISC'

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -120,6 +120,7 @@ def test_csz(check_compression=False):
         assert (len(events2[0].origins[0].arrivals) ==
                 len(events[0].origins[0].arrivals))
         assert len(events2[0].picks) == len(events[0].picks)
+        assert events2[0].picks[0].waveform_id is None
 
 
 def test_csz_without_picks(check_compression=False):

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -106,7 +106,7 @@ def test_csz(check_compression=False):
         _test_write_read(events)
         _test_write_read(events, compression=False)
         try:
-            import zlib
+            import zlib  # flake8: noqa
         except ImportError:
             pass
         else:

--- a/obspy/io/csv/tests/test_csv.py
+++ b/obspy/io/csv/tests/test_csv.py
@@ -50,7 +50,7 @@ def test_csv_incomplete_catalog():
     events[2].origins = []
     events[2].preferred_origin_id = None
     with NamedTemporaryFile(suffix='.csv') as ft:
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match='.*event 2012'):
             events.write(ft.name, 'CSV')
         events2 = read_events(ft.name, 'CSV')
     assert len(events2) == 2
@@ -114,7 +114,7 @@ def test_csz(check_compression=False):
         # test with missing origin and waveformid
         events[1].origins = []
         events[0].picks[0].waveform_id = None
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match='No.*found'):
             events.write(fname, 'CSZ')
         assert iocsv._is_csz(fname)
         events2 = read_events(fname, check_compression=check_compression)
@@ -164,7 +164,7 @@ def test_load_csv_incomplete_catalog():
     events[2].origins = []
     events[2].preferred_origin_id = None
     with NamedTemporaryFile(suffix='.csv') as ft:
-        with pytest.warns(Warning):
+        with pytest.warns(Warning, match='No.*found.*for event'):
             events.write(ft.name, 'CSV')
         t = iocsv.load_csv(ft.name)
     assert len(t) == 2

--- a/setup.py
+++ b/setup.py
@@ -334,7 +334,10 @@ ENTRY_POINTS = {
         'IMS10BULLETIN = obspy.io.iaspei.core',
         'EVT = obspy.io.sh.evt',
         'FOCMEC = obspy.io.focmec.core',
-        'HYPODDPHA = obspy.io.hypodd.pha'
+        'HYPODDPHA = obspy.io.hypodd.pha',
+        'CSV = obspy.io.csv.core',
+        'CSZ = obspy.io.csv.core',
+        'EVENTTXT = obspy.io.csv.core',
         ],
     'obspy.plugin.event.QUAKEML': [
         'isFormat = obspy.io.quakeml.core:_is_quakeml',
@@ -417,6 +420,21 @@ ENTRY_POINTS = {
         'isFormat = obspy.io.hypodd.pha:_is_pha',
         'readFormat = obspy.io.hypodd.pha:_read_pha',
         'writeFormat = obspy.io.hypodd.pha:_write_pha',
+        ],
+    'obspy.plugin.event.CSV': [
+        'isFormat = obspy.io.csv.core:_is_csv',
+        'readFormat = obspy.io.csv.core:_read_csv',
+        'writeFormat = obspy.io.csv.core:_write_csv',
+        ],
+    'obspy.plugin.event.CSZ': [
+        'isFormat = obspy.io.csv.core:_is_csz',
+        'readFormat = obspy.io.csv.core:_read_csz',
+        'writeFormat = obspy.io.csv.core:_write_csz',
+        ],
+    'obspy.plugin.event.EVENTTXT': [
+        'isFormat = obspy.io.csv.core:_is_eventtxt',
+        'readFormat = obspy.io.csv.core:_read_eventtxt',
+        'writeFormat = obspy.io.csv.core:_write_eventtxt',
         ],
     'obspy.plugin.inventory': [
         'STATIONXML = obspy.io.stationxml.core',


### PR DESCRIPTION
### What does this PR do?

Id adds read and write support for csv, eventtxt and csz. csz is a custom format and basically a collection of csv files bundled in a zip file (similar to numpys npz format) for io of a catalog with picks.

### Why was it initiated?  Any relevant Issues?

Fixes  #1467

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
