### PR TITLE
Fix links to Python official docs

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/__init__.py
+++ b/obspy/clients/fdsn/mass_downloader/__init__.py
@@ -475,7 +475,7 @@ Logging
 -------
 
 The download helpers utilizes Python's `logging facilities
-<https://docs.python.org/2/library/logging.html>`__. By default it will log to
+<https://docs.python.org/3/library/logging.html>`__. By default it will log to
 stdout at the ``logging.INFO`` level which provides a fair amount of detail. If
 you want to change the log level or setup a different stream handler, just get
 the corresponding logger after you import the download helpers module:

--- a/obspy/core/event/catalog.py
+++ b/obspy/core/event/catalog.py
@@ -167,7 +167,7 @@ class Catalog(object):
 
         :return: Catalog object
         """
-        # see also http://docs.python.org/reference/datamodel.html
+        # see also http://docs.python.org/3/reference/datamodel.html
         return self.__class__(events=self.events[max(0, i):max(0, j):k])
 
     def __iadd__(self, other):

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -554,7 +554,7 @@ class Inventory(ComparingObject):
             The returned object is based on a shallow copy of the original
             object. That means that modifying any mutable child elements will
             also modify the original object
-            (see https://docs.python.org/2/library/copy.html).
+            (see https://docs.python.org/3/library/copy.html).
             Use :meth:`copy()` afterwards to make a new copy of the data in
             memory.
 
@@ -687,7 +687,7 @@ class Inventory(ComparingObject):
             The returned object is based on a shallow copy of the original
             object. That means that modifying any mutable child elements will
             also modify the original object
-            (see https://docs.python.org/2/library/copy.html).
+            (see https://docs.python.org/333/library/copy.html).
             Use :meth:`copy()` afterwards to make a new copy of the data in
             memory.
 

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -687,7 +687,7 @@ class Inventory(ComparingObject):
             The returned object is based on a shallow copy of the original
             object. That means that modifying any mutable child elements will
             also modify the original object
-            (see https://docs.python.org/333/library/copy.html).
+            (see https://docs.python.org/3/library/copy.html).
             Use :meth:`copy()` afterwards to make a new copy of the data in
             memory.
 

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -375,7 +375,7 @@ class Network(BaseNode):
             The returned object is based on a shallow copy of the original
             object. That means that modifying any mutable child elements will
             also modify the original object
-            (see https://docs.python.org/2/library/copy.html).
+            (see https://docs.python.org/3/library/copy.html).
             Use :meth:`copy()` afterwards to make a new copy of the data in
             memory.
 

--- a/obspy/core/inventory/station.py
+++ b/obspy/core/inventory/station.py
@@ -358,7 +358,7 @@ class Station(BaseNode):
             The returned object is based on a shallow copy of the original
             object. That means that modifying any mutable child elements will
             also modify the original object
-            (see https://docs.python.org/2/library/copy.html).
+            (see https://docs.python.org/3/library/copy.html).
             Use :meth:`copy()` afterwards to make a new copy of the data in
             memory.
 

--- a/obspy/io/sac/sactrace.py
+++ b/obspy/io/sac/sactrace.py
@@ -351,7 +351,7 @@ from . import arrayio as _io
 # class or on an instance.  This looks like "if instance is None" on methods.
 #
 # See:
-# https://docs.python.org/3.5/howto/descriptor.html
+# https://docs.python.org/3/howto/descriptor.html
 # https://nbviewer.jupyter.org/urls/gist.github.com/ChrisBeaumont/
 #   5758381/raw/descriptor_writeup.ipynb
 


### PR DESCRIPTION
### What does this PR do?

Fix links to Python official documentation.

### Why was it initiated?  Any relevant Issues?

It makes no sense to link to the old, deprecated Python 2 documentation.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
