### PR TITLE
Multiclient for making waveform requests to an arbitrary amount of clients based on a config and the requested SEED ID

### DIFF
--- a/obspy/clients/__init__.py
+++ b/obspy/clients/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from obspy.clients.multiclient import MultiClient  # NOQA

--- a/obspy/clients/multiclient.py
+++ b/obspy/clients/multiclient.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+"""
+Client for automatically fetching data through multiple individual clients from
+submodules based on the requested SEED IDs and a given configuration.
+
+:copyright:
+    The ObsPy Development Team (devs@obspy.org)
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+import fnmatch
+import warnings
+from configparser import SafeConfigParser, NoOptionError, NoSectionError
+from pathlib import Path
+
+from obspy.clients.fdsn import Client as FDSNClient
+from obspy.clients.filesystem.sds import Client as SDSClient
+from obspy.clients.seedlink import Client as SeedlinkClient
+
+
+class MultiClient(object):
+    """
+    Client for fetching waveform data from multiple sources
+
+    MultiClient can be used to fetch waveform data in automated workflows from
+    different clients from various submodules based on the SEED ID of the
+    requested waveforms and a configuration that the user has to set up
+    beforehand. In configuration the user can define which SEED ID should be
+    fetched using what client. This can happend in the simplemost case just
+    based on the network code but also more fine grained controlled by the full
+    SEED ID and on in between levels of the SEED ID (station code etc.).
+    The MultiClient can be extended by arbitrary user defined clients as well
+    by adding to ``supported_client_types`` and ``supported_client_kwargs`` as
+    long as the client has a ``get_waveforms()`` method with the same call
+    syntax as obspy clients.
+
+    :param config: Path to a local file with the textual config or file-like
+        object containing the config.
+    :type config: :class:`~pathlib.Path`, str or file-like object
+    :param debug: Can be set to ``True`` to pass down the debug flag to all
+        used clients. This might lead to a lot of printed debug output. The
+        debug flag can also be set just for certain individual clients through
+        the configuration like any other client parameter.
+    """
+    # supported clients, can be extended by the user if needed as long as the
+    # client class has a get_waveforms() method with the usual call syntax
+    supported_client_types = {
+        "fdsn": FDSNClient,
+        "seedlink": SeedlinkClient,
+        "sds": SDSClient,
+        }
+    # explicitely specify what client kwargs we will look for in the config as
+    # we need the information what type (str, int, ..) to use anyway (what
+    # config getter method, to be precise)
+    supported_client_kwargs = {
+        "fdsn": {
+            "base_url": "get", "user": "get", "password": "get",
+            "user_agent": "get", "debug": "getboolean", "timeout": "getfloat"},
+        "seedlink": {
+            "server": "get", "port": "getint", "timeout": "getfloat",
+            "debug": "getboolean"},
+        "sds": {
+            "sds_root": "get", "sds_type": "get", "format": "get",
+            "fileborder_seconds": "getfloat", "fileborder_samples": "getint"},
+        }
+
+    def __init__(self, config, debug=False):
+        self.debug = debug
+        self._clients = {}
+        self._parse_config_lookup_table(config)
+
+    def _parse_config_lookup_table(self, path):
+        """
+        Parse config file
+
+        :type path: :class:`pathlib.Path` or str
+        """
+        config = SafeConfigParser(allow_no_value=True)
+        self._config = config
+        # make all config keys case sensitive
+        config.optionxform = str
+        config.read(str(path))
+        # group lookup dictionary by lookup level, key for the grouping will
+        # simply be the number of '.' found in the key
+        self._lookup = {0: {}, 1: {}, 2: {}, 3: {}}
+        # go through all SEED ID lookup keys
+        for lookup_key, client_key in config.items('lookup'):
+            level = lookup_key.count('.')
+            self._lookup[level][lookup_key] = client_key
+
+    def _get_or_initialize_client(self, client_key):
+        """
+        Lazy client initialization only when given client is actually needed
+        """
+        if client_key in self._clients:
+            return self._clients[client_key]
+        client = self._initialize_client(client_key)
+        return client
+
+    def _initialize_client(self, client_key):
+        """
+        Initialize given client and store it for reuse
+        """
+        config = self._config
+        # check if the server type is recognized
+        client_type = config.get(client_key, "type")
+        if client_type not in self.supported_client_types:
+            msg = (f"Unknown client type '{client_type}' in client definition "
+                   f"section '{client_key}' in config file.")
+            raise NotImplementedError(msg)
+        # parse parameters for client initialization from config
+        kwargs = {}
+        for key, getter in self.supported_client_kwargs[client_type].items():
+            try:
+                kwargs[key] = getattr(config, getter)(client_key, key)
+            except NoOptionError:
+                continue
+        # override debug flag if requested on MultiClient init and if supported
+        # by client type
+        if self.debug and 'debug' in self.supported_client_kwargs[client_type]:
+            kwargs['debug'] = True
+        # initialize client
+        client = self.supported_client_types[client_type](**kwargs)
+        self._clients[client_key] = client
+        return client
+
+    def _lookup_client_key(self, network, station, location, channel):
+        """
+        Lookup and return the client key that should be used to fetch the data
+
+        Raise an Exception if no client is defined via the config for this SEED
+        ID.
+        """
+        if any(wildcard in network + station for wildcard in '?*'):
+            msg = 'No wildcard characters allowed in network or station field'
+            raise ValueError(msg)
+        if any(special_character in network + station + location + channel for
+               special_character in '[]'):
+            msg = "Characters '[' and ']' are not allowed in any field"
+            raise ValueError(msg)
+        lookup = self._lookup
+        nslc = '.'.join((network, station, location, channel))
+        nsl = '.'.join((network, station, location))
+        ns = '.'.join((network, station))
+        n = network
+        msg_multiple_matches = (
+            "Requested SEED ID '{}' matches multiple lookup keys of the same "
+            "level defined in config ('{}'), using first matching lookup key "
+            "'{}'")
+        # try to match starting on full SEED level and succesively falling back
+        # to network level
+        for level, seed_id in zip((3, 2, 1, 0), (nslc, nsl, ns, n)):
+            # check for an exact match
+            if seed_id in lookup[level]:
+                return lookup[level][seed_id]
+            # if there are wildcards on location/channel level, skip to higher
+            # level if no exact match is found
+            if any(wildcard in network + station for wildcard in '?*'):
+                continue
+            # if no direct match, go through and check also allowing for
+            # wildcards
+            matches = []
+            for lookup_key in self._lookup[level].keys():
+                if fnmatch.fnmatch(seed_id, lookup_key):
+                    matches.append(lookup_key)
+            if len(matches) > 1:
+                msg = msg_multiple_matches.format(
+                    nslc, "', '".join(matches), matches[0])
+                warnings.warn(msg)
+            # no match found on this level, go to more general level
+            if not matches:
+                continue
+            return lookup[level][matches[0]]
+        msg = f"Found no matching lookup keys for requested SEED ID: '{nslc}'"
+        raise Exception(msg)
+
+    def get_waveforms(self, network, station, location, channel, starttime,
+                      endtime):
+        """
+        Get waveforms for given SEED ID
+
+        :type network: str
+        :param network: Network code of requested data. Wildcards are not
+            allowed.
+        :type station: str
+        :param station: Station code of requested data. Wildcards are not
+            allowed.
+        :type location: str
+        :param location: Location code of requested data. Wildcards '?' and '*'
+            are allowed (if the specific client that is eventually used for the
+            request supports them). However, if wildcards are used the 
+            requested (wildcarded) SEED ID has to either be matched in exactly
+            the same way in the config file as a lookup key down to location or
+            channel level (e.g. requesting 'Z3.A100A.*.H*' there has to be a
+            lookup key `Z3.A100A.*.H* = ...` in the configuration) or the
+            lookup has to be specified on a higher level (e.g. `Z3.A100A = ...`
+            or `Z3 = ...`)
+        :type channel: str
+        :param channel: Channel code of requested data. Wildcards '?' and '*'
+            are allowed (if the specific client that is eventually used for the
+            request supports them). However, if wildcards are used the
+            requested (wildcarded) SEED ID has to either be matched in exactly
+            the same way in the config file as a lookup key down to location or
+            channel level (e.g. requesting 'Z3.A100A.*.H*' there has to be a
+            lookup key `Z3.A100A.*.H* = ...` in the configuration) or the
+            lookup has to be specified on a higher level (e.g. `Z3.A100A = ...`
+            or `Z3 = ...`)
+        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param starttime: Start time of requested waveforms data.
+        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param endtime: End time of requested waveforms data.
+        :rtype: :class:`~obspy.core.stream.Stream`
+        """
+        client_key = self._lookup_client_key(
+            network, station, location, channel)
+        client = self._get_or_initialize_client(client_key)
+        return client.get_waveforms(network, station, location, channel,
+                                    starttime, endtime)

--- a/obspy/clients/multiclient.py
+++ b/obspy/clients/multiclient.py
@@ -11,8 +11,7 @@ submodules based on the requested SEED IDs and a given configuration.
 """
 import fnmatch
 import warnings
-from configparser import SafeConfigParser, NoOptionError, NoSectionError
-from pathlib import Path
+from configparser import SafeConfigParser, NoOptionError
 
 from obspy.clients.fdsn import Client as FDSNClient
 from obspy.clients.filesystem.sds import Client as SDSClient
@@ -24,12 +23,12 @@ class MultiClient(object):
     Client for fetching waveform data from multiple sources
 
     MultiClient can be used to fetch waveform data in automated workflows from
-    different clients from various submodules based on the SEED ID of the
-    requested waveforms and a configuration that the user has to set up
-    beforehand. In configuration the user can define which SEED ID should be
-    fetched using what client. This can happend in the simplemost case just
-    based on the network code but also more fine grained based on network and
-    station code.
+    different clients from various submodules (or user defined clients) based
+    on the SEED ID of the requested waveforms and a configuration that the user
+    has to set up beforehand. In the configuration the user can define which
+    SEED ID should be fetched using what client. This can happend in the
+    simplemost case just based on the network code but also more fine grained
+    based on network and station code.
     The MultiClient can be extended by arbitrary user defined clients by adding
     to ``supported_client_types`` and ``supported_client_kwargs`` as long as
     the client has a ``get_waveforms()`` method with the same call syntax as
@@ -175,7 +174,7 @@ class MultiClient(object):
     def get_waveforms(self, network, station, location, channel, starttime,
                       endtime):
         """
-        Get waveforms for given SEED ID
+        Make a waveform request to an underlying client as defined in config
 
         :type network: str
         :param network: Network code of requested data. Wildcards are not


### PR DESCRIPTION
### What does this PR do?

The motivation for this PR is automated workflows that work with waveform data from a changing set of stations with data being available through a variety of different means.
For data center hosted data, things like EIDA routing client or the IRIS FDSN Federator in many cases are sufficient to pull together data. However, often enough a mix of locally stored data (usually in SDS structures or similar well ordered directory trees) and also non public FDSN services (e.g. provided by non-public SeisComP instances) has to be queried to get all data combined in a certain automated analysis task.

The idea to make this task easy is for the user to specify all details once in a config file and then any obspy based workflow can simply rely on `MultiClient` with the given config file to handle all details of where from and how to fetch the data. In the configuration file an arbitrary amount of clients (currently of type FDSN, seedlink, SDS filesystem, but fully extensible in user code) can be specified, each one with their own set of initialization parameters (varying FDSN URLs, varying SDS directory trees) in combination with lookup information that maps SEED IDs to a certain specific client. The lookup can be based on simply the network code, or on station level (which can be useful e.g. if certain stations are not part of public servers and have to be pulled from file system). 

Still needs some minor tweaking, work on docs and adding some tests.

#### Example config:                                                            
                                                                                
```                                                                             
[lookup]                                                                        
US = fdsn_iris                                                                  
GR = fdsn_bgr                                                                   
GR.WET = sds1                                                                   
                                                                                
[fdsn_iris]                                                                     
type = fdsn                                                                     
base_url = IRIS                                                                 
user_agent = LMU                                                                
timeout = 30                                                                    
                                                                                
[fdsn_bgr]                                                                       
type = fdsn                                                                      
base_url = http://eida.bgr.de                                                    
user_agent = LMU                                                                 
timeout = 20                                                                     
                                                                                
[sds1]                                                                          
type = sds                                                                      
sds_root = /path/to/SDS/archive                                                 
sds_type = D                                                                    
format = MSEED                                                                  
fileborder_seconds = 30                                                         
fileborder_samples = 5000                                                       
```                                                                             
                                                                                
#### Example usage                                                              
                                                                                
```python                                                                       
from obspy import UTCDateTime
from obspy.clients.multiclient import MultiClient

config = "/home/megies/.multiclientrc"

t = UTCDateTime("2023-05-05T05:05:05")

requests = [
    ["US", "KSU1", "*", "BH*", t, t+10],
    ["GR", "FUR", "", "HH?", t, t+10],
    ["GR", "WET", "", "H*", t, t+10],
    ]

client = MultiClient(config)
for args in requests:
    st = client.get_waveforms(*args)
    print(st)
```                                                                             

### Why was it initiated?  Any relevant Issues?

I have done this in one of my workflows for quite a while and recently when working on a new workflow decided to extract the concept and propose to put it into obspy properly to reduce code duplication and duplicated work.


### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
