### PR TITLE
XSEED Parser: better error message when trying to read a file that does not exist

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,9 @@ Changes:
    * store "NLLOC" info header line in event and origin comments (see #3230)
  - obspy.io.seg2:
    * Less strict date/time parsing (#3283).
+ - obspy.io.xseed:
+   * Improve error message when trying to read a local path to a file that does
+     not exist with XSEED Parser (see #2686)
  - obspy.signal:
    * all butterworth filters: correct zero-phase filtering of 2-d arrays and
      filtering along non-default axis of 2-d arrays (see #3291)

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -172,9 +172,11 @@ class Parser(object):
             warnings.warn("Clearing parser before every subsequent read()")
             self.__init__()
         # try to transform everything into BytesIO object
+        potential_filename_provided = None
         if isinstance(data, (str, Path)):
             if isinstance(data, Path):
                 data = str(data)
+            potential_filename_provided = data
             if re.search(r"://", data) is not None:
                 url = data
                 data = io.BytesIO()
@@ -232,7 +234,11 @@ class Parser(object):
                 raise
             self._format = 'XSEED'
         else:
-            raise IOError("First byte of data must be in [0-9<]")
+            msg = "First byte of data must be in [0-9<]"
+            if potential_filename_provided is not None \
+                    and not os.path.exists(potential_filename_provided):
+                msg += '. If a filename was provided, the file does not exist.'
+            raise IOError(msg)
 
     def get_xseed(self, version=DEFAULT_XSEED_VERSION, split_stations=False):
         """


### PR DESCRIPTION



<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Shows a better error message when trying to read a local file with XSEED Parser but that path is not existing actually (e.g. mistyped filename etc).

The logic is quite convoluted and lots of different inputs are allowed of type str/bytes, so at the time the error gets raised it isn't immediately obvious if the input actually was a filename or not, so this is kind of a middle way to improve the message. 

```python
In [1]: from obspy.io.xseed import Parser
   ...: 
   ...: dlseedpath = '/home/code/my_dlseedfile.dlseed'
   ...: 
   ...: parser = Parser(dlseedpath)
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
Input In [1], in <cell line: 5>()
      1 from obspy.io.xseed import Parser
      3 dlseedpath = '/home/code/my_dlseedfile.dlseed'
----> 5 parser = Parser(dlseedpath)

File ~/git/obspy/obspy/io/xseed/parser.py:119, in Parser.__init__(self, data, debug, strict, compact)
    117 # if a file name is given, read it directly to the parser object
    118 if data:
--> 119     self.read(data)

File ~/miniconda3/envs/master/lib/python3.10/site-packages/decorator.py:232, in decorate.<locals>.fun(*args, **kw)
    230 if not kwsyntax:
    231     args, kw = fix(args, kw, sig)
--> 232 return caller(func, *(extras + args), **kw)

File ~/git/obspy/obspy/core/util/decorator.py:298, in map_example_filename.<locals>._map_example_filename(func, *args, **kwargs)
    296                 except IOError:
    297                     pass
--> 298 return func(*args, **kwargs)

File ~/git/obspy/obspy/io/xseed/parser.py:241, in Parser.read(self, data)
    238 if potential_filename_provided is not None \
    239         and not os.path.exists(potential_filename_provided):
    240     msg += '. If a filename was provided, the file does not exist.'
--> 241 raise IOError(msg)

OSError: First byte of data must be in [0-9<]. If a filename was provided, the file does not exist.

```

### Why was it initiated?  Any relevant Issues?

fixes #2686 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
