### PR TITLE
gps2dist_azimuth: Replace deprecated "np.alltrue" by "np.all"

### DIFF
--- a/obspy/geodetics/base.py
+++ b/obspy/geodetics/base.py
@@ -256,7 +256,7 @@ def gps2dist_azimuth(lat1, lon1, lat2, lon2, a=WGS84_A, f=WGS84_F):
     else:
         try:
             values = calc_vincenty_inverse(lat1, lon1, lat2, lon2, a, f)
-            if np.alltrue(np.isnan(values)):
+            if np.all(np.isnan(values)):
                 raise StopIteration
             return values
         except StopIteration:


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Replaces ``np.alltrue`` in function gps2dist_azimuth by ``np.all``. 

### Why was it initiated?  Any relevant Issues?

According to the [NumPy 1.25.0 Release Notes](https://numpy.org/devdocs/release/1.25.0-notes.html) ``np.alltrue`` is deprecated. Use ``np.all`` instead.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.