### PR TITLE
silence some matplotlib warnings

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -8,7 +8,9 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
-  - scipy
+  # see #3330 and SciTools/cartopy#2199
+  # unpin again later on when this is fixed
+  - scipy < 1.11
   - requests
   - setuptools
   # see #3258

--- a/.github/test_mindep_conda_env.yml
+++ b/.github/test_mindep_conda_env.yml
@@ -8,7 +8,9 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
-  - scipy
+  # see #3330 and SciTools/cartopy#2199
+  # unpin again later on when this is fixed
+  - scipy < 1.11
   - requests
   - setuptools
   # see #3258

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -837,7 +837,7 @@ class MomentTensor:
         if np.linalg.norm(enodes) < 1e-10:
             enodes = exs
         enodess = rotmat @ enodes
-        cos_alpha = float((ez.T @ ezs))
+        cos_alpha = float((ez.T @ ezs)[0][0])
         if cos_alpha > 1.:
             cos_alpha = 1.
         if cos_alpha < -1.:

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -434,7 +434,11 @@ class Scanner(object):
             width = min(width, height * 4)
             fig.set_figwidth(width)
             plt.subplots_adjust(top=1, bottom=0, left=0, right=1)
-            plt.tight_layout()
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", "The figure layout has changed to tight",
+                    UserWarning)
+                plt.tight_layout()
 
             fig.savefig(outfile)
             plt.close(fig)

--- a/obspy/imaging/scripts/scan.py
+++ b/obspy/imaging/scripts/scan.py
@@ -422,7 +422,6 @@ class Scanner(object):
             height = len(labels) * 0.5
             height = max(4, height)
             fig.set_figheight(height)
-            plt.tight_layout()
 
             if not starttime or not endtime:
                 days = ax.get_xlim()

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -34,7 +34,6 @@ import scipy.signal as signal
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.core.util import create_empty_data_chunk
-from obspy.core.util.base import MATPLOTLIB_VERSION
 from obspy.geodetics import FlinnEngdahl, kilometer2degrees, locations2degrees
 from obspy.imaging.util import (_set_xaxis_obspy_dates, _id_key, _timestring)
 
@@ -1455,10 +1454,7 @@ class WaveformPlotting(object):
     def _remove_zoomlevel_warning_text(self):
         ax = self.fig.axes[0]
         if self._minmax_warning_text in ax.texts:
-            if MATPLOTLIB_VERSION < [3, 6]:
-                ax.texts.remove(self._minmax_warning_text)
-            else:
-                self._minmax_warning_text.remove()
+            self._minmax_warning_text.remove()
         self._minmax_warning_text = None
 
     def _draw_overlap_axvspans(self, st, ax):

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1659,9 +1659,9 @@ def shift_time_of_file(input_file, output_file, timeshift):
             # Write to current record.
             time[0:2] = year[:]
             time[2:4] = julday[:]
-            time[4] = hour[:]
-            time[5] = minute[:]
-            time[6] = second[:]
+            time[4] = hour[0]
+            time[5] = minute[0]
+            time[6] = second[0]
             time[8:10] = msecs[:]
             current_record[20:30] = time[:]
 

--- a/obspy/signal/tf_misfit.py
+++ b/obspy/signal/tf_misfit.py
@@ -1081,7 +1081,7 @@ def plot_tf_misfits(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         img_tfem.set_clim(-clim, clim)
 
         # add text box for EM + PM
-        textstr = 'EM = %.2f\nPM = %.2f' % (_em[itr], _pm[itr])
+        textstr = 'EM = %.2f\nPM = %.2f' % (_em[itr][0], _pm[itr][0])
         props = dict(boxstyle='round', facecolor='white')
         ax_sig.text(-0.3, 0.5, textstr, transform=ax_sig.transAxes,
                     verticalalignment='center', horizontalalignment='left',
@@ -1341,7 +1341,7 @@ def plot_tf_gofs(st1, st2, dt=0.01, t0=0., fmin=1., fmax=10., nf=100, w0=6,
         img_tfeg.set_clim(0., clim)
 
         # add text box for EG + PG
-        textstr = 'EG = %2.2f\nPG = %2.2f' % (_eg[itr], _pg[itr])
+        textstr = 'EG = %2.2f\nPG = %2.2f' % (_eg[itr][0], _pg[itr][0])
         props = dict(boxstyle='round', facecolor='white')
         ax_sig.text(-0.3, 0.5, textstr, transform=ax_sig.transAxes,
                     verticalalignment='center', horizontalalignment='left',

--- a/obspy/taup/seismic_phase.py
+++ b/obspy/taup/seismic_phase.py
@@ -1616,7 +1616,7 @@ class SeismicPhase(object):
             raise RuntimeError(msg) from e
 
         takeoff_angle = np.degrees(math.asin(np.clip(
-            takeoff_velocity * ray_param /
+            takeoff_velocity.item() * ray_param /
             (self.tau_model.radius_of_planet - self.source_depth), -1.0, 1.0)))
         if not self.down_going[0]:
             # upgoing, so angle is in 90-180 range
@@ -1643,7 +1643,7 @@ class SeismicPhase(object):
             raise RuntimeError(msg) from e
 
         incident_angle = np.degrees(math.asin(np.clip(
-            incident_velocity * ray_param /
+            incident_velocity.item() * ray_param /
             (self.tau_model.radius_of_planet - self.receiver_depth),
             -1.0, 1.0)))
         if self.down_going[-1]:

--- a/obspy/taup/slowness_model.py
+++ b/obspy/taup/slowness_model.py
@@ -15,6 +15,7 @@ from .slowness_layer import (bullen_depth_for,
                              evaluate_at_bullen)
 from .velocity_layer import (VelocityLayer, evaluate_velocity_at_bottom,
                              evaluate_velocity_at_top)
+from .utils import _flat
 
 
 def _fix_critical_depths(critical_depths, layer_num, is_p_wave):
@@ -1815,7 +1816,7 @@ class SlownessModel(object):
                     dtype=SlownessLayer)
                 bot_layer = (p, top_layer['bot_depth'],
                              s_layer['bot_p'], s_layer['bot_depth'])
-                out[other_layer_num+number_added] = bot_layer
+                out[other_layer_num+number_added] = _flat(bot_layer)
                 out = np.insert(out, other_layer_num+number_added, top_layer)
                 # Fix critical layers since we have added a slowness layer.
                 _fix_critical_depths(critical_depths,

--- a/obspy/taup/tau_branch.py
+++ b/obspy/taup/tau_branch.py
@@ -240,10 +240,10 @@ class TauBranch(object):
             bot_branch.tau[:index_s] = (self.tau[:index_s] -
                                         top_branch.tau[:index_s])
 
-            bot_branch.time[index_s] = time_dist_s['time']
-            bot_branch.dist[index_s] = time_dist_s['dist']
-            bot_branch.tau[index_s] = (time_dist_s['time'] -
-                                       s_ray_param * time_dist_s['dist'])
+            bot_branch.time[index_s] = time_dist_s['time'].item()
+            bot_branch.dist[index_s] = time_dist_s['dist'].item()
+            bot_branch.tau[index_s] = (
+                time_dist_s['time'] - s_ray_param * time_dist_s['dist']).item()
 
             bot_branch.time[index_s + 1:] = (self.time[index_s:] -
                                              top_branch.time[index_s + 1:])
@@ -260,10 +260,10 @@ class TauBranch(object):
             bot_branch.tau[:index_p] = (self.tau[:index_p] -
                                         top_branch.tau[:index_p])
 
-            bot_branch.time[index_p] = time_dist_p['time']
-            bot_branch.dist[index_p] = time_dist_p['dist']
-            bot_branch.tau[index_p] = (time_dist_p['time'] -
-                                       p_ray_param * time_dist_p['dist'])
+            bot_branch.time[index_p] = time_dist_p['time'].item()
+            bot_branch.dist[index_p] = time_dist_p['dist'].item()
+            bot_branch.tau[index_p] = (
+                time_dist_p['time'] - p_ray_param * time_dist_p['dist']).item()
 
             bot_branch.time[index_p + 1:] = (self.time[index_p:] -
                                              top_branch.time[index_p + 1:])
@@ -281,10 +281,10 @@ class TauBranch(object):
             bot_branch.tau[:index_s] = (self.tau[:index_s] -
                                         top_branch.tau[:index_s])
 
-            bot_branch.time[index_s] = time_dist_s['time']
-            bot_branch.dist[index_s] = time_dist_s['dist']
-            bot_branch.tau[index_s] = (time_dist_s['time'] -
-                                       s_ray_param * time_dist_s['dist'])
+            bot_branch.time[index_s] = time_dist_s['time'].item()
+            bot_branch.dist[index_s] = time_dist_s['dist'].item()
+            bot_branch.tau[index_s] = (
+                time_dist_s['time'] - s_ray_param * time_dist_s['dist']).item()
 
             bot_branch.time[index_s + 1:index_p] = (
                 self.time[index_s:index_p - 1] -
@@ -296,10 +296,10 @@ class TauBranch(object):
                 self.tau[index_s:index_p - 1] -
                 top_branch.tau[index_s + 1:index_p])
 
-            bot_branch.time[index_p] = time_dist_p['time']
-            bot_branch.dist[index_p] = time_dist_p['dist']
-            bot_branch.tau[index_p] = (time_dist_p['time'] -
-                                       p_ray_param * time_dist_p['dist'])
+            bot_branch.time[index_p] = time_dist_p['time'].item()
+            bot_branch.dist[index_p] = time_dist_p['dist'].item()
+            bot_branch.tau[index_p] = (
+                time_dist_p['time'] - p_ray_param * time_dist_p['dist']).item()
 
             bot_branch.time[index_p + 1:] = (self.time[index_p - 1:] -
                                              top_branch.time[index_p + 1:])
@@ -386,9 +386,10 @@ class TauBranch(object):
                         ray_param,
                         s_mod.radius_of_planet)
                     the_path[path_index]['p'] = ray_param
-                    the_path[path_index]['time'] = time
-                    the_path[path_index]['dist'] = dist
-                    the_path[path_index]['depth'] = turn_s_layer['bot_depth']
+                    the_path[path_index]['time'] = time.item()
+                    the_path[path_index]['dist'] = dist.item()
+                    the_path[path_index]['depth'] = \
+                        turn_s_layer['bot_depth'].item()
                     path_index += 1
 
         # Upgoing branches:
@@ -414,10 +415,11 @@ class TauBranch(object):
                     turn_s_layer,
                     ray_param,
                     s_mod.radius_of_planet)
-                the_path[path_index]['p'] = ray_param
-                the_path[path_index]['time'] = time
-                the_path[path_index]['dist'] = dist
-                the_path[path_index]['depth'] = turn_s_layer['top_depth']
+                the_path[path_index]['p'] = ray_param.item()
+                the_path[path_index]['time'] = time.item()
+                the_path[path_index]['dist'] = dist.item()
+                the_path[path_index]['depth'] = \
+                    turn_s_layer['top_depth'].item()
                 path_index += 1
                 mask[first_unmasked] = True
 

--- a/obspy/taup/utils.py
+++ b/obspy/taup/utils.py
@@ -179,3 +179,22 @@ def _classify_path(path, model):
     if abs(error_p) < abs(error_s):
         return "p"
     return "s"
+
+
+def _flat(list_or_tuple):
+    """
+    Return a flat version of the input tuple. Intention is to avoid numpy
+    single-item arrays with ndim >0. Reason being that newer numpy has
+    deprecated automatic conversion to scalars from these types of arrays and
+    this would result in errors in some future numpy releases.
+    Seems like we rely on this automatic conversion to scalars a lot. This very
+    likely could be done faster and more elegant, not sure if this is impacting
+    execution speed of our taup routines.
+    """
+    def _item_or_return(x):
+        try:
+            return x.item()
+        except AttributeError:
+            return x
+
+    return tuple(_item_or_return(x) for x in list_or_tuple)


### PR DESCRIPTION
### What does this PR do?

Fix some failing tests, mostly due to warnings

 - avoid scipy 1.11 for now in CI to clean up test reports (cartopy has a plotting issue with it right now that will certainly get fixed)
 - matplotlib seems to warn now when using `tight_layout()` in some cases
 - automatic conversion from numpy single-item arrays to scalars is deprecated and will be removed in a future numpy release
 - fix some numpy misuse of setting an array element with a slice of a single-item array

### Why was it initiated?  Any relevant Issues?

Warnings in current test runs

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
