### PR TITLE
zmap: Fix writing events without origin depth

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,9 @@ Changes:
  - obspy.io.xseed:
    * Fixed reading SEED frequency-amplitude-phase response lists that are
      spread out over multiple blockettes (see #3277)
+ - obspy.io.zmap:
+   * Fix writing events with origins that have no depth or depth errors given
+     (see #3343)
  - obspy.taup:
    * bugfix to allow calculations for a model with no discontinuities
      (see #3070, #3244)

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -135,14 +135,11 @@ class Pickler(object):
             origin = ev.preferred_origin()
             if origin is None and ev.origins:
                 origin = ev.origins[0]
-            if origin and origin.depth is not None and \
-                    self._depth_error(origin) is not None:
+            if origin:
                 dec_year = self._decimal_year(origin.time)
                 dec_second = origin.time.second + \
                     origin.time.microsecond / 1e6
                 strings.update({
-                    'depth': self._num2str(origin.depth / 1000.0),  # m to km
-                    'z_err': self._num2str(self._depth_error(origin)),
                     'lat': self._num2str(origin.latitude),
                     'lon': self._num2str(origin.longitude),
                     'h_err': self._num2str(self._hz_error(origin)),
@@ -153,6 +150,13 @@ class Pickler(object):
                     'minute': self._num2str(origin.time.minute, 0),
                     'second': str(dec_second)
                 })
+                # origin depth is optional in QuakeML so it can be missing
+                if origin.depth is not None:
+                    # m to km
+                    strings['depth'] = self._num2str(origin.depth / 1000.0)
+                    z_err = self._depth_error(origin)
+                    if z_err is not None:
+                        strings['z_err'] = self._num2str(z_err)
             # magnitude
             magnitude = ev.preferred_magnitude()
             if magnitude is None and ev.magnitudes:

--- a/obspy/io/zmap/core.py
+++ b/obspy/io/zmap/core.py
@@ -98,6 +98,8 @@ class Pickler(object):
         """
         # TODO: add option to extract depth error from origin uncertainty
         # when ellipsoid is used
+        if origin.depth_errors is None:
+            return None
         if origin.depth_errors.uncertainty is None:
             return None
         return origin.depth_errors.uncertainty / 1000.0
@@ -133,7 +135,8 @@ class Pickler(object):
             origin = ev.preferred_origin()
             if origin is None and ev.origins:
                 origin = ev.origins[0]
-            if origin:
+            if origin and origin.depth is not None and \
+                    self._depth_error(origin) is not None:
                 dec_year = self._decimal_year(origin.time)
                 dec_second = origin.time.second + \
                     origin.time.microsecond / 1e6


### PR DESCRIPTION
### What does this PR do?

Fix writing events in ZMAP format when origin depth and/or depth errors are missing.

### Why was it initiated?  Any relevant Issues?

Fixes #3290 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
