### PR TITLE
Stream dayplot: Fix some issues with x tick positioning and labeling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,8 @@ Changes:
    * fix a problem in Stream.plot() failing to remove the "min-max-plot zoom
      warning" when interactively zooming into and then again out of a plot with
      reduced number of points plotted with matplotlib >=3.6 (see #3318)
+   * fix some issues with bad x-tick positioning and labeling in dayplots
+     (see #3361)
  - obspy.io.gcf:
    * Fixed an issue in algorithm to split and encode last few data into GCF 
      blocks (see #3252)

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -11,63 +11,64 @@ from obspy.core.util import AttribDict
 import pytest
 
 
+def _create_stream(starttime, endtime, sampling_rate):
+    """
+    Helper method to create a Stream object that can be used for testing
+    waveform plotting.
+
+    Takes the time frame of the Stream to be created and a sampling rate.
+    Any other header information will have to be adjusted on a case by case
+    basis. Please remember to use the same sampling rate for one Trace as
+    merging and plotting will not work otherwise.
+
+    This method will create a single sine curve to a first approximation
+    with superimposed 10 smaller sine curves on it.
+
+    :return: Stream object
+    """
+    time_delta = endtime - starttime
+    number_of_samples = int(time_delta * sampling_rate) + 1
+    # Calculate first sine wave.
+    curve = np.linspace(0, 2 * np.pi, number_of_samples // 2)
+    # Superimpose it with a smaller but shorter wavelength sine wave.
+    curve = np.sin(curve) + 0.2 * np.sin(10 * curve)
+    # To get a thick curve alternate between two curves.
+    data = np.empty(number_of_samples)
+    # Check if even number and adjust if necessary.
+    if number_of_samples % 2 == 0:
+        data[0::2] = curve
+        data[1::2] = curve + 0.2
+    else:
+        data[-1] = 0.0
+        data[0:-1][0::2] = curve
+        data[0:-1][1::2] = curve + 0.2
+    tr = Trace()
+    tr.stats.starttime = starttime
+    tr.stats.sampling_rate = float(sampling_rate)
+    # Fill dummy header.
+    tr.stats.network = 'BW'
+    tr.stats.station = 'OBSPY'
+    tr.stats.channel = 'TEST'
+    tr.data = data
+    return Stream(traces=[tr])
+
+
 class TestWaveformPlot:
     """
     Test cases for waveform plotting.
     """
-    def _create_stream(self, starttime, endtime, sampling_rate):
-        """
-        Helper method to create a Stream object that can be used for testing
-        waveform plotting.
-
-        Takes the time frame of the Stream to be created and a sampling rate.
-        Any other header information will have to be adjusted on a case by case
-        basis. Please remember to use the same sampling rate for one Trace as
-        merging and plotting will not work otherwise.
-
-        This method will create a single sine curve to a first approximation
-        with superimposed 10 smaller sine curves on it.
-
-        :return: Stream object
-        """
-        time_delta = endtime - starttime
-        number_of_samples = int(time_delta * sampling_rate) + 1
-        # Calculate first sine wave.
-        curve = np.linspace(0, 2 * np.pi, number_of_samples // 2)
-        # Superimpose it with a smaller but shorter wavelength sine wave.
-        curve = np.sin(curve) + 0.2 * np.sin(10 * curve)
-        # To get a thick curve alternate between two curves.
-        data = np.empty(number_of_samples)
-        # Check if even number and adjust if necessary.
-        if number_of_samples % 2 == 0:
-            data[0::2] = curve
-            data[1::2] = curve + 0.2
-        else:
-            data[-1] = 0.0
-            data[0:-1][0::2] = curve
-            data[0:-1][1::2] = curve + 0.2
-        tr = Trace()
-        tr.stats.starttime = starttime
-        tr.stats.sampling_rate = float(sampling_rate)
-        # Fill dummy header.
-        tr.stats.network = 'BW'
-        tr.stats.station = 'OBSPY'
-        tr.stats.channel = 'TEST'
-        tr.data = data
-        return Stream(traces=[tr])
-
     def test_data_remains_unchanged(self):
         """
         Data should not be changed when plotting.
         """
         # Use once with straight plotting with random calibration factor
-        st = self._create_stream(UTCDateTime(0), UTCDateTime(1000), 1)
+        st = _create_stream(UTCDateTime(0), UTCDateTime(1000), 1)
         st[0].stats.calib = 0.2343
         org_st = st.copy()
         st.plot(format='png')
         assert st == org_st
         # Now with min-max list creation (more than 400000 samples).
-        st = self._create_stream(UTCDateTime(0), UTCDateTime(600000), 1)
+        st = _create_stream(UTCDateTime(0), UTCDateTime(600000), 1)
         st[0].stats.calib = 0.2343
         org_st = st.copy()
         st.plot(format='png')
@@ -92,8 +93,8 @@ class TestWaveformPlot:
         and different sampling rates should raise an exception.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 10, 1.0)
-        st += self._create_stream(start + 10, start + 20, 10.0)
+        st = _create_stream(start, start + 10, 1.0)
+        st += _create_stream(start + 10, start + 20, 10.0)
         with pytest.raises(Exception):
             st.plot()
 
@@ -106,7 +107,7 @@ class TestWaveformPlot:
         approach to plot the data.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600, 1000.0)
+        st = _create_stream(start, start + 3600, 1000.0)
         # create and compare image
         st.plot(outfile=image_path)
 
@@ -117,7 +118,7 @@ class TestWaveformPlot:
         Uses a frequency of 10 Hz.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600, 10.0)
+        st = _create_stream(start, start + 3600, 10.0)
         # create and compare image
         st.plot(outfile=image_path)
 
@@ -129,8 +130,8 @@ class TestWaveformPlot:
         the end.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600 * 3 / 4, 500.0)
-        st += self._create_stream(start + 2.25 * 3600, start + 3 * 3600, 500.0)
+        st = _create_stream(start, start + 3600 * 3 / 4, 500.0)
+        st += _create_stream(start + 2.25 * 3600, start + 3 * 3600, 500.0)
         # create and compare image
         st.plot(outfile=image_path)
 
@@ -142,8 +143,8 @@ class TestWaveformPlot:
         the end.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600 * 3 / 4, 5.0)
-        st += self._create_stream(start + 2.25 * 3600, start + 3 * 3600, 5.0)
+        st = _create_stream(start, start + 3600 * 3 / 4, 5.0)
+        st += _create_stream(start + 2.25 * 3600, start + 3 * 3600, 5.0)
         # create and compare image
         st.plot(outfile=image_path)
 
@@ -155,12 +156,12 @@ class TestWaveformPlot:
         the end.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600 * 3 / 4, 500.0)
-        st += self._create_stream(start + 2.25 * 3600, start + 3 * 3600, 500.0)
+        st = _create_stream(start, start + 3600 * 3 / 4, 500.0)
+        st += _create_stream(start + 2.25 * 3600, start + 3 * 3600, 500.0)
         st[0].stats.location = '01'
         st[1].stats.location = '01'
-        temp_st = self._create_stream(start + 3600 * 3 / 4,
-                                      start + 2.25 * 3600, 500.0)
+        temp_st = _create_stream(start + 3600 * 3 / 4,
+                                 start + 2.25 * 3600, 500.0)
         temp_st[0].stats.location = '02'
         st += temp_st
         # create and compare image
@@ -174,12 +175,12 @@ class TestWaveformPlot:
         the end.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600 * 3 / 4, 5.0)
-        st += self._create_stream(start + 2.25 * 3600, start + 3 * 3600, 5.0)
+        st = _create_stream(start, start + 3600 * 3 / 4, 5.0)
+        st += _create_stream(start + 2.25 * 3600, start + 3 * 3600, 5.0)
         st[0].stats.location = '01'
         st[1].stats.location = '01'
-        temp_st = self._create_stream(start + 3600 * 3 / 4,
-                                      start + 2.25 * 3600, 5.0)
+        temp_st = _create_stream(start + 3600 * 3 / 4,
+                                 start + 2.25 * 3600, 5.0)
         temp_st[0].stats.location = '02'
         st += temp_st
         # create and compare image
@@ -274,7 +275,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
         # create and compare image
         st.plot(outfile=image_path, type='section')
@@ -286,7 +287,7 @@ class TestWaveformPlot:
         start = UTCDateTime(0)
         st = Stream()
         for _i in range(10):
-            st += self._create_stream(start, start + 3600, 100)
+            st += _create_stream(start, start + 3600, 100)
             st[-1].stats.coordinates = AttribDict({
                 'latitude': _i,
                 'longitude': _i})
@@ -301,7 +302,7 @@ class TestWaveformPlot:
         start = UTCDateTime(0)
         st = Stream()
         for _i in range(10):
-            st += self._create_stream(start, start + 3600, 100)
+            st += _create_stream(start, start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
         # create and compare image
         st.plot(outfile=image_path, type='section', orientation='horizontal')
@@ -315,7 +316,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
         # create and compare image
         st.plot(outfile=image_path, type='section', reftime=reftime)
@@ -328,7 +329,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
             st[-1].stats.channel = str(_i % 3)
         # create and compare image
@@ -343,7 +344,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
             st[-1].stats.channel = str(_i % 3)
         # create and compare image
@@ -359,7 +360,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
             st[-1].stats.channel = str(_i % 3)
         # create and compare image
@@ -374,7 +375,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
             st[-1].stats.channel = str(_i % 3)
         # create and compare image
@@ -389,7 +390,7 @@ class TestWaveformPlot:
         st = Stream()
         for _i in range(10):
             this_start = start + 300 * np.sin(np.pi * _i / 9)
-            st += self._create_stream(this_start, this_start + 3600, 100)
+            st += _create_stream(this_start, this_start + 3600, 100)
             st[-1].stats.distance = _i * 10e3
             st[-1].stats.channel = str(_i % 3)
         # create and compare image
@@ -401,7 +402,7 @@ class TestWaveformPlot:
         Plots one hour, starting Jan 1970, with a relative scale.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3600, 100)
+        st = _create_stream(start, start + 3600, 100)
         # create and compare image
         st.plot(outfile=image_path, type='relative')
 
@@ -413,7 +414,7 @@ class TestWaveformPlot:
         """
         start = UTCDateTime(0)
         ref = UTCDateTime(300)
-        st = self._create_stream(start, start + 3600, 100)
+        st = _create_stream(start, start + 3600, 100)
         # create and compare image
         st.plot(outfile=image_path, type='relative', reftime=ref)
 
@@ -422,7 +423,7 @@ class TestWaveformPlot:
         Plots day plot, starting Jan 1970.
         """
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3 * 3600, 100)
+        st = _create_stream(start, start + 3 * 3600, 100)
         # create and compare image
         st.plot(outfile=image_path, type='dayplot',
                 timezone='EST', time_offset=-5)
@@ -431,7 +432,7 @@ class TestWaveformPlot:
     def test_plot_day_plot_interval(self, interval):
         """Plot day plot, with different intervals."""
         start = UTCDateTime(0)
-        st = self._create_stream(start, start + 3 * 3600, 100)
+        st = _create_stream(start, start + 3 * 3600, 100)
         st.plot(type='dayplot', timezone='EST', time_offset=-5,
                 interval=interval)
 
@@ -445,7 +446,7 @@ class TestWaveformPlot:
         event3 = UTCDateTime(46 * 60)  # Event: Bottom left; Note: above right
         event4 = UTCDateTime(59 * 60)  # Event: Bottom right; Note: above left
         event5 = UTCDateTime(61 * 60)  # Should be ignored
-        st = self._create_stream(start, start + 3600, 100)
+        st = _create_stream(start, start + 3600, 100)
         # create and compare image
         st.plot(outfile=image_path, type='dayplot',
                 timezone='EST', time_offset=-5,
@@ -461,7 +462,7 @@ class TestWaveformPlot:
         """
         start = UTCDateTime(2012, 4, 4, 14, 0, 0)
         cat = read_events()
-        st = self._create_stream(start, start + 3600, 100)
+        st = _create_stream(start, start + 3600, 100)
         # create and compare image
         st.plot(outfile=image_path, type='dayplot',
                 timezone='EST', time_offset=-5,

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -428,13 +428,22 @@ class TestWaveformPlot:
         st.plot(outfile=image_path, type='dayplot',
                 timezone='EST', time_offset=-5)
 
-    @pytest.mark.parametrize('interval', [2, 10, 23, 25])
-    def test_plot_day_plot_interval(self, interval):
+    @pytest.mark.parametrize(
+        'interval,expected_number_of_ticks,expected_all_integer_labels',
+        [(2, 16, True), (10, 11, True), (23, 10, False), (25, 6, True)])
+    def test_plot_day_plot_interval(
+            self, interval, expected_number_of_ticks,
+            expected_all_integer_labels):
         """Plot day plot, with different intervals."""
         start = UTCDateTime(0)
         st = _create_stream(start, start + 3 * 3600, 100)
-        st.plot(type='dayplot', timezone='EST', time_offset=-5,
-                interval=interval)
+        fig = st.plot(type='dayplot', timezone='EST', time_offset=-5,
+                      interval=interval)
+        ax = fig.axes[0]
+        assert len(ax.get_xticks()) == expected_number_of_ticks
+        labels_are_integers = [
+            '.' not in label.get_text() for label in ax.get_xticklabels()]
+        assert all(labels_are_integers) == expected_all_integer_labels
 
     def test_plot_day_plot_explicit_event(self, image_path):
         """

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1015,11 +1015,16 @@ class WaveformPlotting(object):
             # Otherwise determine whether they are divisible for numbers up to
             # 15. If a number is not divisible just show 10 units.
             else:
-                count = 10
                 for _i in range(15, 1, -1):
                     if time_value % _i == 0:
                         count = _i + 1
                         break
+                else:
+                    # these are really weird cases with interval being
+                    # relactively large primes like "interval=17" and will
+                    # likely lead to ugly tick labels, but not much we can do,
+                    # just weird parameter choice
+                    count = 10
             # Show at least 5 ticks.
             if count < 2:
                 msg = 'Number of x ticks ({count:s}) can not be less than two.'

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1021,7 +1021,7 @@ class WaveformPlotting(object):
                         break
                 else:
                     # these are really weird cases with interval being
-                    # relactively large primes like "interval=17" and will
+                    # relatively large primes like "interval=17" and will
                     # likely lead to ugly tick labels, but not much we can do,
                     # just weird parameter choice
                     count = 10

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1011,14 +1011,14 @@ class WaveformPlotting(object):
         if not count:
             # Up to 15 time units and if it's a full number, show every unit.
             if time_value <= 15 and time_value % 1 == 0:
-                count = int(time_value)
+                count = int(time_value) + 1
             # Otherwise determine whether they are divisible for numbers up to
             # 15. If a number is not divisible just show 10 units.
             else:
                 count = 10
                 for _i in range(15, 1, -1):
                     if time_value % _i == 0:
-                        count = _i
+                        count = _i + 1
                         break
             # Show at least 5 ticks.
             if count < 5:

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1028,7 +1028,18 @@ class WaveformPlotting(object):
             count = self.number_of_ticks
         # Calculate and set ticks.
         ticks = np.linspace(0.0, max_value, count)
-        ticklabels = ['%i' % _i for _i in np.linspace(0.0, time_value, count)]
+        ticklabels = []
+        for _i in np.linspace(0.0, time_value, count):
+            # it is not the responsibility of this tick labeling part to do
+            # anything fancy, if ticks are at points with endless decimals, the
+            # problem is with the selection of the ticks (e.g. weird choice of
+            # "number_of_ticks"). just avoid labeling with '.0' suffix if we
+            # indeed have an integer at hand
+            if int(_i) == _i:
+                _label = f'{_i:.0f}'
+            else:
+                _label = str(_i)
+            ticklabels.append(_label)
         self.axis[0].set_xticks(ticks)
         self.axis[0].set_xticklabels(ticklabels, rotation=self.tick_rotation,
                                      size=self.x_labels_size)

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -1021,8 +1021,11 @@ class WaveformPlotting(object):
                         count = _i + 1
                         break
             # Show at least 5 ticks.
-            if count < 5:
-                count = 5
+            if count < 2:
+                msg = 'Number of x ticks ({count:s}) can not be less than two.'
+                raise ValueError(msg)
+            while count < 5:
+                count *= 2
         # Everything can be overwritten by user-specified number of ticks.
         if self.number_of_ticks:
             count = self.number_of_ticks


### PR DESCRIPTION
### What does this PR do?

This PR fixes two partially interacting problems with how Stream "dayplots" (helicorder plots) are ticked and labeled on the x-Axis.

#### 1. Tick Positioning

When "number_of_ticks" is not set, in many cases with sensible choice of "interval" parameter, bad automatic choice of number of x ticks were made. E.g. with "interval=10", 10 x ticks were used (should be 11), so that all ticks fall on decimal numbers.

#### 2. Tick Labeling

The labeling of x-ticks was forced to `"%i" % x`, i.e. forcibly cutting of any decimals. In principle it is desirable to show "3" instead of "3.0" for the ticks but combined with the former problem leading to many cases of oddly placed ticks this was leading to plots having wrong labeling in many cases (e.g. labels 0, 1, 2, 3, ..., 12, 13, 15 with ticks not actually placed at these integers numbers). 

#### Examples

##### 1. Automatic routine selecting number of ticks giving picking bad number of ticks

Notice how tick labels jump from "8" to "10" on last tick label. Ticks are actually *not* at the integer number positions that are suggested by the labels, but rather oddly placed due to only 10 ticks for a range 0-10 (should be 11 ticks).

```python
from obspy import UTCDateTime
from obspy.imaging.tests.test_waveform import TestWaveformPlot
start = UTCDateTime(0)
st = TestWaveformPlot()._create_stream(start, start + 3 * 3600, 100)

st.plot(type='dayplot', interval=10)
```

**Before:**
![Figure_1](https://github.com/obspy/obspy/assets/1842780/8787ef31-3f55-4478-99e1-c8d1ee49c2c0)

**After:** 11 ticks are chosen and now ticks actually are at the integer positions
![Figure_1a](https://github.com/obspy/obspy/assets/1842780/c073b919-cfa1-4e02-9e59-b87a8ea8be86)


##### 2. User chooses weird number of ticks and labeling is wrong

User chooses weird parameters, but at first glance the plot looks OK, since it does not show correct labels, all labels are decimal numbers at weird positions.

```python
st.plot(type='dayplot', number_of_ticks=10)
```

**Before:**
![Figure_2](https://github.com/obspy/obspy/assets/1842780/e8885fca-4c9e-4baf-9c23-b9ee1198abe8)
**After:** ticks are still placed oddly due to user explicit choice, but now it is clear that ticks are off
![Figure_2a](https://github.com/obspy/obspy/assets/1842780/f502387e-5a44-467b-85b1-a44d254e2ee6)


### Why was it initiated?  Any relevant Issues?

Got contacted in private mail with an example of this problem

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
