### PR TITLE
fix new datetime deprecation warning on py 3.12

### DIFF
--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1269,8 +1269,9 @@ class Indexer(object):
                     break
 
         if expired is not None:
-            isostring = (datetime.datetime.
-                         utcfromtimestamp(expiration).isoformat())
+            isostring = (
+                datetime.datetime.fromtimestamp(
+                    expiration, tz=datetime.timezone.utc).isoformat())
             logger.debug("Leap seconds file `{}` expires: {}, expired: {}".
                          format(file_path, isostring, expired))
 

--- a/obspy/core/utcdatetime.py
+++ b/obspy/core/utcdatetime.py
@@ -312,7 +312,8 @@ class UTCDateTime(object):
                     timestamp_seconds = int(value.__dict__['timestamp'])
                     timestamp_microseconds = round(
                         (value.__dict__['timestamp'] % 1.0) * 1e6)
-                    dt_ = datetime.datetime.utcfromtimestamp(timestamp_seconds)
+                    dt_ = datetime.datetime.fromtimestamp(
+                        timestamp_seconds, tz=datetime.timezone.utc)
                     dt_ = dt_.replace(microsecond=timestamp_microseconds)
                     self._from_datetime(dt_)
                 return
@@ -685,7 +686,8 @@ class UTCDateTime(object):
             return TIMESTAMP0 + dt
         except OverflowError:
             # for very large future / past dates
-            return datetime.datetime.utcfromtimestamp(self.timestamp)
+            return datetime.datetime.fromtimestamp(
+                self.timestamp, tz=datetime.timezone.utc)
 
     datetime = property(_get_datetime)
 


### PR DESCRIPTION
### What does this PR do?

Replaces `utcfromtimestamp` with `fromtimestamp(.., tz=..)`

### Why was it initiated?  Any relevant Issues?

`datetime` method `utcfromtimestamp()` got deprecated in favor of `fromtimestamp(.., tz=datetime.timezone.utc)`, see https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp


### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
