### PR TITLE
suppress a DeprecationWarning in a dependency

### DIFF
--- a/obspy/conftest.py
+++ b/obspy/conftest.py
@@ -7,6 +7,7 @@ import os
 import platform
 import shutil
 import sys
+import warnings
 from pathlib import Path
 from subprocess import run
 from contextlib import suppress
@@ -17,8 +18,23 @@ import pytest
 import obspy
 from obspy.core.util import NETWORK_MODULES
 # import some fixtures for reuse in imaging tests
-from obspy.signal.tests.test_spectral_estimation import (   # NOQA
-    _ppsd, _sample_data, _internal_sample_data)
+# work around dateutil running into this new DeprecationWarning on Python 3.12
+# This fails our CI runner that fails on any uncaught Warning. In principle we
+# ignore all DeprecationWarnings coming from our dependencies, but as this file
+# is imported during the pytest startup phase the warning ignore rules we have
+# in pytest.ini are not yet in effect at that time.
+# dateutil has this deprecation fixed in it's development branch already with
+# dateutil/dateutil#1285, but it turns out dateutil's last release was done in
+# 2023 0_o
+# Other approach would be to move those helpers here maybe, but that might be
+# quite a bit of work, so this seems fine for now
+with warnings.catch_warnings(record=True) as w:
+    msg = ('datetime.datetime.utcfromtimestamp.. is deprecated and scheduled '
+           'for removal in a future version. Use timezone-aware objects ')
+    warnings.filterwarnings(
+        'ignore', message=msg, category=DeprecationWarning, module='dateutil')
+    from obspy.signal.tests.test_spectral_estimation import (   # NOQA
+        _ppsd, _sample_data, _internal_sample_data)
 
 
 OBSPY_PATH = os.path.dirname(obspy.__file__)


### PR DESCRIPTION
### What does this PR do?

Suppress a new deprecation warning on Python 3.12 in `dateutil`.

### Why was it initiated?  Any relevant Issues?

This warning pops up before our `pytest.ini` takes effect, so it isn't ignored by our pytest rules and immediately fails on `pytest -W error` which we use in one of our CI test runners, causing overall CI fail.
This was fixed in `dateutil` 4 months ahead of Python 3.12 final release with dateutil/dateutil#1285, but looks like `dateutil` hasn't seen any releases since 2021.. 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
