### PR TITLE
tests: adjust to scipy deprecation warning for moved window functions

### DIFF
--- a/obspy/signal/tests/test_cpxtrace.py
+++ b/obspy/signal/tests/test_cpxtrace.py
@@ -73,7 +73,7 @@ class TestCpxTrace():
         # [42] plan
         # [43] dplan
         self.data_win, self.nwin, self.no_win = \
-            util.enframe(self.data, signal.hamming(self.n), self.inc)
+            util.enframe(self.data, signal.windows.hamming(self.n), self.inc)
         # cls.data_win = data
 
     def test_normenvelope(self):

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -77,7 +77,7 @@ class TestFreqTrace():
         # [42] plan
         # [43] dplan
         self.data_win, self.nwin, self.no_win = \
-            util.enframe(self.data, signal.hamming(self.n), self.inc)
+            util.enframe(self.data, signal.windows.hamming(self.n), self.inc)
         self.data_win_bc, self.nwin_, self.no_win_ = \
             util.enframe(self.data, np.ones(self.n), self.inc)
         # self.data_win = data

--- a/obspy/signal/tests/test_hoctavbands.py
+++ b/obspy/signal/tests/test_hoctavbands.py
@@ -75,7 +75,7 @@ class TestHoctavbands():
         # [42] plan
         # [43] dplan
         self.data_win, self.nwin, self.no_win = \
-            util.enframe(data, signal.hamming(self.n), self.inc)
+            util.enframe(data, signal.windows.hamming(self.n), self.inc)
 
     def test_hoctavbands(self):
         """

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -55,11 +55,11 @@ class TestPolarization():
         fs = 75
         inc = int(0.05 * fs)
         self.data_win_z, self.nwin, self.no_win = \
-            util.enframe(data_z, signal.hamming(n), inc)
+            util.enframe(data_z, signal.windows.hamming(n), inc)
         self.data_win_e, self.nwin, self.no_win = \
-            util.enframe(data_e, signal.hamming(n), inc)
+            util.enframe(data_e, signal.windows.hamming(n), inc)
         self.data_win_n, self.nwin, self.no_win = \
-            util.enframe(data_n, signal.hamming(n), inc)
+            util.enframe(data_n, signal.windows.hamming(n), inc)
         # global test input
         self.fk = [2, 1, 0, -1, -2]
         self.norm = pow(np.max(data_z), 2)


### PR DESCRIPTION
### What does this PR do?

Adjust to some scipy changes, complementary to #3329

### Why was it initiated?  Any relevant Issues?

missed some occurences of what was fixed in #3329

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
