### PR TITLE
regression test for #3373

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,8 @@ Changes:
    * fix a problem in Stream.plot() failing to remove the "min-max-plot zoom
      warning" when interactively zooming into and then again out of a plot with
      reduced number of points plotted with matplotlib >=3.6 (see #3318)
+   * fix an issue with Stream.rotate() when there are dots in e.g. station code
+     (see #3373)
  - obspy.clients.fdsn:
    * update URL for raspberryshake FDSN web service (see #3264)
    * properly include server response in error messages on bad requests (see

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -2755,7 +2755,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # handled separately
         seed_id_groups = {}
         for tr in self:
-            net, sta, loc, cha = tr.id.split(".")
+            net = tr.stats.network
+            sta = tr.stats.station
+            loc = tr.stats.location
+            cha = tr.stats.channel
             if not len(cha):
                 msg = "Channel code must be at least one character long."
                 raise ValueError(msg)

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2003,6 +2003,11 @@ class TestStream:
         Testing the rotate method.
         """
         st = read()
+        # test for #3373
+        # add some weird dots in station/location code
+        for tr in st:
+            tr.stats.station = 'RJ.OB'
+            tr.stats.location = '0.'
         st += st.copy()
         st[3:].normalize()
         st2 = st.copy()


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with `Stream.rotate()` throwing an exception when there is a dot inside one of the trace's e.g. station code.

### Why was it initiated?  Any relevant Issues?

Fixes #3373 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [x] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [x] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
