### PR TITLE
Ppsd fix processing time info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,9 @@ Changes:
  - obspy.io.zmap:
    * Fix writing events with origins that have no depth or depth errors given
      (see #3343)
+ - obspy.signal:
+   * PPSD: Fix some time slices getting skipped if sampling rate does not align
+     well with the length of one PSD slice. (see #3387)
  - obspy.taup:
    * bugfix to allow calculations for a model with no discontinuities
      (see #3070, #3244)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -905,7 +905,7 @@ class PPSD(object):
                         if verbose:
                             print(t1)
                         changed = True
-                t1 += (1 - self.overlap) * self.ppsd_length  # advance
+                t1 += self.step  # advance
 
             # enforce time limits, pad zeros if gaps
             # tr.trim(t, t+PPSD_LENGTH, pad=True)

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -900,7 +900,7 @@ class PPSD(object):
                                      tr.stats.delta)
                     # XXX not good, should be working in place somehow
                     # XXX how to do it with the padding, though?
-                    success = self.__process(slice)
+                    success = self.__process(slice, t1)
                     if success:
                         if verbose:
                             print(t1)
@@ -913,7 +913,7 @@ class PPSD(object):
             self.__invalidate_histogram()
         return changed
 
-    def __process(self, tr):
+    def __process(self, tr, t):
         """
         Processes a segment of data and save the psd information.
         Whether `Trace` is compatible (station, channel, ...) has to
@@ -921,6 +921,11 @@ class PPSD(object):
 
         :type tr: :class:`~obspy.core.trace.Trace`
         :param tr: Compatible Trace with data of one PPSD segment
+        :type t: :class:`~obspy.core.utcdatetime.UTCDateTime`
+        :param t: Start time of the time window the data was cut for. This can
+            be different usually on a subsample scale and then in some cases
+            can lead to a directly following time segment being left out as
+            they seem to overlap.
         :returns: `True` if segment was successfully processed,
             `False` otherwise.
         """
@@ -1011,7 +1016,7 @@ class PPSD(object):
                          (self.psd_periods <= per_right)]
             smoothed_psd.append(specs.mean())
         smoothed_psd = np.array(smoothed_psd, dtype=np.float32)
-        self.__insert_processed_data(tr.stats.starttime, smoothed_psd)
+        self.__insert_processed_data(t, smoothed_psd)
         return True
 
     def _get_times_all_details(self):


### PR DESCRIPTION
### What does this PR do?

Fixes a problem that can lead to every second time slice not getting processed in PPSD. I'll leave this as a draft for now, since the issue mostly seems to come from an issue with the core modules, and still looking into that.

### Why was it initiated?  Any relevant Issues?

See https://discourse.obspy.org/t/ppsd-plot-temporal-doesnt-work/1846/11

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
