### PR TITLE
fixes naming of args of rotate_rt_ne()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changes:
  - obspy.signal:
    * all butterworth filters: correct zero-phase filtering of 2-d arrays and
      filtering along non-default axis of 2-d arrays (see #3291)
+   * fix naming of input args in function "rotate_rt_ne()" (see #3383)
 
 maintenance_1.4.x
 =================

--- a/obspy/signal/rotate.py
+++ b/obspy/signal/rotate.py
@@ -50,7 +50,7 @@ def rotate_ne_rt(n, e, ba):
     return r, t
 
 
-def rotate_rt_ne(n, e, ba):
+def rotate_rt_ne(r, t, ba):
     """
     Rotates horizontal components of a seismogram.
 
@@ -59,9 +59,15 @@ def rotate_rt_ne(n, e, ba):
 
     This is the inverse transformation of the transformation described
     in :func:`rotate_ne_rt`.
+
+    :type r: :class:`~numpy.ndarray`
+    :param r: Data of the Radial component of the seismogram.
+    :type t: :class:`~numpy.ndarray`
+    :param t: Data of the Transverse component of the seismogram.
+    :returns: North and East component of seismogram.
     """
     ba = 360.0 - ba
-    return rotate_ne_rt(n, e, ba)
+    return rotate_ne_rt(r, t, ba)
 
 
 def rotate_zne_lqt(z, n, e, ba, inc):

--- a/obspy/signal/tests/test_rotate.py
+++ b/obspy/signal/tests/test_rotate.py
@@ -92,8 +92,8 @@ class TestRotate():
         data_n = np.require(data_n, np.float64)
         data_e = np.require(data_e, np.float64)
         ba = 33.3
-        new_n, new_e = rotate_ne_rt(data_n, data_e, ba)
-        new_n, new_e = rotate_rt_ne(new_n, new_e, ba)
+        r, t = rotate_ne_rt(data_n, data_e, ba)
+        new_n, new_e = rotate_rt_ne(r, t, ba)
         assert np.allclose(data_n, new_n, rtol=1E-7, atol=1E-12)
         assert np.allclose(data_e, new_e, rtol=1E-7, atol=1E-12)
 


### PR DESCRIPTION

### What does this PR do?

Properly names input arguments of function `rotate_rt_ne()` as `r` and `t` and not `n` and `e`.

Merging into master since this is a very minor change that could affect existing code in very unusual cases of using these arguments as kwargs.

### Why was it initiated?  Any relevant Issues?

fixes #3383

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
