### PR TITLE
Fix a scipy deprecation (function cumtrapz renamed)

### DIFF
--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -21,7 +21,7 @@ import warnings
 
 from matplotlib.dates import datestr2num
 import numpy as np
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 from obspy.core import Stream
 from obspy.signal.headers import clibsignal
@@ -830,7 +830,7 @@ def array_transff_freqslowness(coords, slim, sstep, fmin, fmax, fstep,
                         complex(0., (coords[l, 0] * sx + coords[l, 1] * sy) *
                                 2 * np.pi * f))
                 buff[k] = abs(_sum) ** 2
-            transff[i, j] = cumtrapz(buff, dx=fstep)[-1]
+            transff[i, j] = cumulative_trapezoid(buff, dx=fstep)[-1]
 
     transff /= transff.max()
     return transff

--- a/obspy/signal/cpxtrace.py
+++ b/obspy/signal/cpxtrace.py
@@ -17,7 +17,7 @@ Complex Trace Analysis
 """
 import numpy as np
 from scipy import signal
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 from . import util
 
@@ -94,7 +94,7 @@ def normalized_envelope(data, fs, smoothie, fk):
             # (dA/dt) / 2*PI*smooth(A)*fs/2
             t_ = t / (2. * np.pi * (a_win_smooth) * (fs / 2.0))
             # Integral within window
-            t_ = cumtrapz(t_, dx=(1. / fs))
+            t_ = cumulative_trapezoid(t_, dx=(1. / fs))
             t_ = np.concatenate((t_[0:1], t_))
             anorm[i] = ((np.exp(np.mean(t_))) - 1) * 100
             i = i + 1
@@ -123,7 +123,7 @@ def normalized_envelope(data, fs, smoothie, fk):
         a_win_smooth[a_win_smooth < 1] = 1
         t_ = t / (2. * np.pi * (a_win_smooth) * (fs / 2.0))
         # Integral within window
-        t_ = cumtrapz(t_, dx=(1.0 / fs))
+        t_ = cumulative_trapezoid(t_, dx=(1.0 / fs))
         t_ = np.concatenate((t_[0:1], t_))
         anorm = ((np.exp(np.mean(t_))) - 1) * 100
         return anorm


### PR DESCRIPTION
### What does this PR do?

Scipy changed the name of a function, so adjust. Already present with new name in our minimum scipy version.

### Why was it initiated?  Any relevant Issues?

see https://tests.obspy.org/137273/#13

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
