### PR TITLE
RESP: Fix reading Poles/zeros uncertainties

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changes:
  - obspy.io.xseed:
    * Fixed reading SEED frequency-amplitude-phase response lists that are
      spread out over multiple blockettes (see #3277)
+   * Fix reading uncertainties of poles/zeros complex numbers (see #3401)
  - obspy.io.zmap:
    * Fix writing events with origins that have no depth or depth errors given
      (see #3343)

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -1438,7 +1438,7 @@ class Parser(object):
                             _list(b53.real_zero_error),
                             _list(b53.imaginary_zero_error)):
                         z = ComplexWithUncertainties(r, i)
-                        err = ComplexWithUncertainties(r_err, i_err)
+                        err = complex(r_err, i_err)
                         z.lower_uncertainty = err
                         z.upper_uncertainty = err
                         zeros.append(z)
@@ -1450,7 +1450,7 @@ class Parser(object):
                             _list(b53.real_pole_error),
                             _list(b53.imaginary_pole_error)):
                         p = ComplexWithUncertainties(r, i)
-                        err = ComplexWithUncertainties(r_err, i_err)
+                        err = complex(r_err, i_err)
                         p.lower_uncertainty = err
                         p.upper_uncertainty = err
                         poles.append(p)

--- a/obspy/io/xseed/parser.py
+++ b/obspy/io/xseed/parser.py
@@ -1439,8 +1439,8 @@ class Parser(object):
                             _list(b53.imaginary_zero_error)):
                         z = ComplexWithUncertainties(r, i)
                         err = ComplexWithUncertainties(r_err, i_err)
-                        z.lower_uncertainty = z - err
-                        z.upper_uncertainty = z + err
+                        z.lower_uncertainty = err
+                        z.upper_uncertainty = err
                         zeros.append(z)
                 poles = []
                 # Might somehow also not have zeros.
@@ -1451,8 +1451,8 @@ class Parser(object):
                             _list(b53.imaginary_pole_error)):
                         p = ComplexWithUncertainties(r, i)
                         err = ComplexWithUncertainties(r_err, i_err)
-                        p.lower_uncertainty = p - err
-                        p.upper_uncertainty = p + err
+                        p.lower_uncertainty = err
+                        p.upper_uncertainty = err
                         poles.append(p)
 
                 try:

--- a/obspy/io/xseed/tests/data/RESP.HRV.IU.00.BHZ_cropped
+++ b/obspy/io/xseed/tests/data/RESP.HRV.IU.00.BHZ_cropped
@@ -1,0 +1,40 @@
+# response is cropped to first stage, original data from
+# https://service.iris.edu/irisws/resp/1/query?net=IU&sta=HRV
+B050F03 Station:     HRV
+B050F16 Network:     IU
+B052F03 Location:    00
+B052F04 Channel:     BHZ
+B052F22 Start date:  2010,048,03:08:00
+B052F23 End date:    2010,119,15:13:00
+B053F03 Transfer function type:    A - Laplace transform analog response, in rad/sec
+B053F04 Stage sequence number:     1
+B053F05 Response in units lookup:  m/s - Velocity in Meters Per Second
+B053F06 Response out units lookup: V - Volts
+B053F07 A0 normalization factor:   +3.94300E+03
+B053F08 Normalization frequency:   +5.00000E-02
+B053F09 Number of zeroes:          4
+B053F14 Number of poles:           6
+B053F10-13 0  +0.00000E+00  +0.00000E+00  +0.00000E+00  +0.00000E+00
+B053F10-13 1  +0.00000E+00  +0.00000E+00  +0.00000E+00  +0.00000E+00
+B053F10-13 2  -2.60811E-02  +0.00000E+00  +2.37885E-02  +0.00000E+00
+B053F10-13 3  -2.60811E-02  +0.00000E+00  +2.37885E-02  +0.00000E+00
+B053F15-18 0  -1.54713E-02  -1.23400E-02  +6.11428E-04  +7.35041E-04
+B053F15-18 1  -1.54713E-02  +1.23400E-02  +6.11428E-04  +7.35041E-04
+B053F15-18 2  -2.16466E-02  +0.00000E+00  +4.62419E-03  +0.00000E+00
+B053F15-18 3  -2.17396E-02  +0.00000E+00  +4.68987E-03  +0.00000E+00
+B053F15-18 4  -3.91800E+01  -4.91200E+01  +0.00000E+00  +0.00000E+00
+B053F15-18 5  -3.91800E+01  +4.91200E+01  +0.00000E+00  +0.00000E+00
+B057F03 Stage sequence number:         1
+B057F04 Input sample rate (HZ):        2.0000E+01
+B057F05 Decimation factor:             00001
+B057F06 Decimation offset:             00000
+B057F07 Estimated delay (seconds):    +0.0000E+00
+B057F08 Correction applied (seconds): +0.0000E+00
+B058F03 Stage sequence number:        1
+B058F04 Sensitivity:                  +2.39900E+03
+B058F05 Frequency of sensitivity:     +5.00000E-02
+B058F06 Number of calibrations:       0
+B058F03 Stage sequence number:        0
+B058F04 Sensitivity:                  +4.02513E+09
+B058F05 Frequency of sensitivity:     +5.00000E-02
+B058F06 Number of calibrations:       0

--- a/obspy/io/xseed/tests/test_parser.py
+++ b/obspy/io/xseed/tests/test_parser.py
@@ -8,7 +8,7 @@ import numpy as np
 from lxml import etree
 
 import obspy
-from obspy import UTCDateTime, read
+from obspy import UTCDateTime, read, read_inventory
 from obspy.core.util import NamedTemporaryFile
 from obspy.io.xseed.blockette.blockette010 import Blockette010
 from obspy.io.xseed.blockette.blockette051 import Blockette051
@@ -572,6 +572,22 @@ class TestParser():
             p = Parser(fh.read())
         # Weak but at least tests that something has been read.
         assert set(p.blockettes.keys()) == {34, 50, 52, 53, 54, 57, 58}
+
+    def test_read_resp_paz_uncertainties(self, testdata):
+        """
+        Regression test for correctly reading uncertainties in PAZ complex
+        numbers
+        """
+        inv = read_inventory(testdata['RESP.HRV.IU.00.BHZ_cropped'], "RESP")
+        resp = inv[0][0][0].response
+        pole = resp.response_stages[0].poles[0]
+        assert round(pole.imag, 4) == -0.0123
+        assert round(pole.imag.upper_uncertainty, 6) == 0.000735
+        assert round(pole.imag.lower_uncertainty, 6) == 0.000735
+        zero = resp.response_stages[0].zeros[2]
+        assert round(zero.real, 4) == -0.0261
+        assert round(zero.real.lower_uncertainty, 4) == 0.0238
+        assert round(zero.real.upper_uncertainty, 4) == 0.0238
 
     def clean_unit_string(self, string):
         """


### PR DESCRIPTION
### What does this PR do?

Fix properly interpreting poles/zeros complex uncertainties stored in RESP files (already done correctly reading StationXML files)

### Why was it initiated?  Any relevant Issues?

Fixes #3401 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
