### PR TITLE
Trace/Stream: add methods to switch byteorder

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,9 @@ Changes:
      (see #3261)
    * allow to specify Trace and Stream filter frequencies as arguments
      (see #3294)
+   * improve error messages when traces fail to get merged due to differing
+     data type, sampling rate etc (see #3418)
+   * add helper methods to change/unify byteorder on trace/stream (see #3418)
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility (see #3269)
  - obspy.clients.fdsn

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3639,6 +3639,17 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             self.traces += traces
         return self
 
+    def newbyteorder(self, byteorder='native'):
+        """
+        Change byteorder of the data
+
+        For details see
+        :meth:`Trace.newbyteorder <obspy.core.trace.Trace.newbyteorder>`.
+        """
+        for tr in self:
+            tr.newbyteorder(byteorder)
+        return self
+
 
 def _is_pickle(filename):  # @UnusedVariable
     """

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -1972,20 +1972,23 @@ class Stream(object):
             # Check sampling rate.
             sr.setdefault(trace.id, trace.stats.sampling_rate)
             if trace.stats.sampling_rate != sr[trace.id]:
-                msg = "Can't merge traces with same ids but differing " + \
-                      "sampling rates!"
+                msg = (f"Can not merge traces with same ids ({trace.id}) but "
+                       f"differing sampling rates ({sr[trace.id]}, "
+                       f"{trace.stats.sampling_rate})!")
                 raise Exception(msg)
             # Check dtype.
             dtype.setdefault(trace.id, trace.data.dtype)
             if trace.data.dtype != dtype[trace.id]:
-                msg = "Can't merge traces with same ids but differing " + \
-                      "data types!"
+                msg = (f"Can not merge traces with same ids ({trace.id}) but "
+                       f"differing data types ({dtype[trace.id]}, "
+                       f"{trace.data.dtype})!")
                 raise Exception(msg)
             # Check calibration factor.
             calib.setdefault(trace.id, trace.stats.calib)
             if trace.stats.calib != calib[trace.id]:
-                msg = "Can't merge traces with same ids but differing " + \
-                      "calibration factors.!"
+                msg = (f"Can not merge traces with same ids ({trace.id}) but "
+                       f"differing calibration factors ({calib[trace.id]}, "
+                       f"{trace.stats.calib})!")
                 raise Exception(msg)
 
     def merge(self, method=0, fill_value=None, interpolation_samples=0,

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -3026,6 +3026,19 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         self.data = self.data / response.instrument_sensitivity.value
         return self
 
+    def newbyteorder(self, byteorder='native'):
+        """
+        Change byteorder of the data
+
+        :type byteorder: str
+        :param byteorder: Byte order to set on the numpy data array, e.g.
+            ``'native'``, ``'little'`` or ``'big'``. See
+            :meth:`numpy.dtype.newbyteorder`.
+        """
+        dtype = self.data.dtype.newbyteorder(byteorder)
+        self.data = np.require(self.data, dtype=dtype)
+        return self
+
 
 def _data_sanity_checks(value):
     """


### PR DESCRIPTION
### What does this PR do?

Show up some ways how to work around exceptions getting raised when trying to merge traces with different byteorder but otherwise being mergable.
Still not sure if we want to automatically adjust byteorder when needed as this might have side effects we don't think of right now maybe.. so maybe a more conservative option would be to show a meaningful error message if a merge is failing solely due to a byteorder mismatch that points at the option to manually force byteorder to a common one.

Kinda would like to hear thoughts.


### Why was it initiated?  Any relevant Issues?

fixes #3417 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
