### PR TITLE
Availability webservice support, continuing #3002

### DIFF
--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -561,7 +561,7 @@ class Client(object):
     def get_availability(self, network=None, station=None, location=None,
                          channel=None, starttime=None, endtime=None,
                          quality=None, orderby=None, limit=None,
-                         format=None, mergegaps=None, filename=None, **kwargs):
+                         format='geocsv', mergegaps=None, filename=None, **kwargs):
         if "availability" not in self.services:
             msg = "The current client does not have an availability service."
             raise ValueError(msg)
@@ -573,11 +573,9 @@ class Client(object):
             "availability", DEFAULT_PARAMETERS['availability'], kwargs)
 
         availability = self._download(url)
-        lines = [line.decode().split()
-                 for line in availability.readlines()[1:]]
-        extents = [(line[0], line[1], line[2], line[3], UTCDateTime(
-            line[6]), UTCDateTime(line[7])) for line in lines]
-        return extents
+        lines = [line.decode().splitlines()[0].split('|')
+                 for line in availability.readlines()[5:]]
+        return lines
 
     def get_stations(self, starttime=None, endtime=None, startbefore=None,
                      startafter=None, endbefore=None, endafter=None,

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -52,7 +52,8 @@ import urllib.request as urllib_request
 import queue
 
 
-DEFAULT_SERVICE_VERSIONS = {'dataselect': 1, 'station': 1, 'event': 1}
+DEFAULT_SERVICE_VERSIONS = {'dataselect': 1,
+                            'station': 1, 'event': 1, 'availability': 1}
 
 
 class CustomRedirectHandler(urllib_request.HTTPRedirectHandler):
@@ -191,7 +192,7 @@ class Client(object):
         :param service_mappings: For advanced use only. Allows the direct
             setting of the endpoints of the different services. (e.g.
             ``service_mappings={'station': 'http://example.com/test/stat/1'}``)
-            Valid keys are ``event``, ``station``, and ``dataselect``. This
+            Valid keys are ``event``, ``station``, ``dataselect``, and ``availability``. This
             will overwrite the ``base_url`` and ``major_versions`` arguments.
             For all services not specified, the default default locations
             indicated by ``base_url`` and ``major_versions`` will be used. Any
@@ -556,6 +557,27 @@ class Client(object):
             cat = obspy.read_events(data_stream, format="quakeml")
             data_stream.close()
             return cat
+
+    def get_availability(self, network=None, station=None, location=None,
+                         channel=None, starttime=None, endtime=None,
+                         quality=None, orderby=None, limit=None,
+                         format=None, mergegaps=None, filename=None, **kwargs):
+        if "availability" not in self.services:
+            msg = "The current client does not have an availability service."
+            raise ValueError(msg)
+
+        locs = locals()
+        setup_query_dict('availability', locs, kwargs)
+
+        url = self._create_url_from_parameters(
+            "availability", DEFAULT_PARAMETERS['availability'], kwargs)
+
+        availability = self._download(url)
+        lines = [line.decode().split()
+                 for line in availability.readlines()[1:]]
+        extents = [(line[0], line[1], line[2], line[3], UTCDateTime(
+            line[6]), UTCDateTime(line[7])) for line in lines]
+        return extents
 
     def get_stations(self, starttime=None, endtime=None, startbefore=None,
                      startafter=None, endbefore=None, endafter=None,
@@ -1276,9 +1298,11 @@ class Client(object):
         """
         service_params = self.services[service]
         # Get all required parameters and make sure they are available!
+
         required_parameters = [
             key for key, value in service_params.items()
             if value["required"] is True]
+
         for req_param in required_parameters:
             if req_param not in parameters:
                 msg = "Parameter '%s' is required." % req_param
@@ -1495,7 +1519,7 @@ class Client(object):
         """
         # authenticated dataselect queries have different target URL
         if self.user is not None:
-            if service == "dataselect" and resource_type == "query":
+            if service in ("dataselect", "availability") and resource_type == "query":
                 resource_type = "queryauth"
         return build_url(self.base_url, service, self.major_versions[service],
                          resource_type, parameters,
@@ -1509,7 +1533,7 @@ class Client(object):
         They are discovered by downloading the corresponding WADL files. If a
         WADL does not exist, the services are assumed to be non-existent.
         """
-        services = ["dataselect", "event", "station"]
+        services = ["dataselect", "event", "station", "availability"]
         # omit manually deactivated services
         for service, custom_target in self._service_mappings.items():
             if custom_target is None:
@@ -1606,6 +1630,10 @@ class Client(object):
                     self.services["eida-auth"] = True
                 if self.debug is True:
                     print("Discovered dataselect service")
+            elif "availability" in url:
+                self.services["availability"] = WADLParser(wadl).parameters
+                if self.debug is True:
+                    print("Discovered availability service")
             elif "event" in url and "application.wadl" in url:
                 self.services["event"] = WADLParser(wadl).parameters
                 if self.debug is True:
@@ -1744,9 +1772,9 @@ def build_url(base_url, service, major_version, resource_type,
         service_mappings = {}
 
     # Only allow certain resource types.
-    if service not in ["dataselect", "event", "station"]:
+    if service not in ["dataselect", "event", "station", "availability"]:
         msg = "Resource type '%s' not allowed. Allowed types: \n%s" % \
-            (service, ",".join(("dataselect", "event", "station")))
+            (service, ",".join(("dataselect", "event", "station", "availability")))
         raise ValueError(msg)
 
     # Special location handling.
@@ -1897,7 +1925,6 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
         return None, e
 
     code = url_obj.getcode()
-
     # Unpack gzip if necessary.
     if url_obj.info().get("Content-Encoding") == "gzip":
         if debug is True:
@@ -1915,7 +1942,6 @@ def download_url(url, opener, timeout=10, headers={}, debug=False,
         f = gzip.GzipFile(fileobj=buf)
     else:
         f = url_obj
-
     if return_string is False:
         data = io.BytesIO(f.read())
     else:
@@ -1944,7 +1970,6 @@ def setup_query_dict(service, locs, kwargs):
             value = kwargs.pop(key)
             if value is not None:
                 kwargs[PARAMETER_ALIASES[key]] = value
-
     for param in DEFAULT_PARAMETERS[service] + OPTIONAL_PARAMETERS[service]:
         param = PARAMETER_ALIASES.get(param, param)
         value = locs[param]

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -9,7 +9,6 @@ FDSN Web service client for ObsPy.
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
 """
-import collections.abc
 import copy
 import gzip
 import io
@@ -19,7 +18,7 @@ from socket import timeout as socket_timeout
 import textwrap
 import threading
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple, abc
 from http.client import HTTPException, IncompleteRead
 from urllib.parse import urlparse
 
@@ -561,7 +560,8 @@ class Client(object):
     def get_availability(self, network=None, station=None, location=None,
                          channel=None, starttime=None, endtime=None,
                          quality=None, orderby=None, limit=None,
-                         format='geocsv', mergegaps=None, filename=None, **kwargs):
+                         format='geocsv', mergegaps=None,
+                         merge=None, show=None, **kwargs):
         if "availability" not in self.services:
             msg = "The current client does not have an availability service."
             raise ValueError(msg)
@@ -569,13 +569,51 @@ class Client(object):
         locs = locals()
         setup_query_dict('availability', locs, kwargs)
 
+        if mergegaps is not None and kwargs.get("details") == False:
+            msg = "Extent method does not support parameter 'mergegaps'"
+            raise ValueError(msg)
+        if format is not None and format not in ["text", "geocsv", "json", "request"]:
+            msg = "Unsupported value for parameter 'format'"
+            raise ValueError(msg)
+        if orderby is not None and orderby not in ["nslc_time_quality_samplerate", "latestupdate", "latestupdate_desc", "timespancount", "timespancount_desc"]:
+            msg = "Unsupported value for parameter 'orderby'"
+            raise ValueError(msg)
+        if show is not None and show != "latestupdate":
+            msg = "Unsupported value for parameter 'show'"
+            raise ValueError(msg)
+        if merge is not None:
+            parts = merge.split(',')
+            for p in parts:
+                if p not in ["samplerate", "quality", "overlap"]:
+                    msg = "Unsupported value for parameter 'merge'"
+                    raise ValueError(msg)
+        if "details" not in kwargs:
+            kwargs["details"] = True
+
         url = self._create_url_from_parameters(
             "availability", DEFAULT_PARAMETERS['availability'], kwargs)
 
         availability = self._download(url)
+
+        Availability = namedtuple(
+            'Availability',
+            ['network', 'station', 'location', 'channel', 'quality', 'sampling_rate',
+             'earliest', 'latest', 'updated', 'time_spans', 'restriction'],
+            defaults=(None, None, None))
+
         lines = [line.decode().splitlines()[0].split('|')
                  for line in availability.readlines()[5:]]
-        return lines
+
+        to_return = []
+        for l in lines:
+            l[5] = float(l[5])
+            l[6] = UTCDateTime(l[6])
+            l[7] = UTCDateTime(l[7])
+            if len(l) > 8:
+                l[8] = UTCDateTime(l[8])
+            to_return.append(Availability(*l))
+
+        return to_return
 
     def get_stations(self, starttime=None, endtime=None, startbefore=None,
                      startafter=None, endbefore=None, endafter=None,
@@ -1308,6 +1346,9 @@ class Client(object):
 
         final_parameter_set = {}
 
+        endpoint = "extent" if service == "availability" and not parameters.get("details") else "query"
+        if service == "availability" and "details" in parameters:
+            del parameters["details"]
         # Now loop over all parameters, convert them and make sure they are
         # accepted by the service.
         for key, value in parameters.items():
@@ -1351,7 +1392,7 @@ class Client(object):
             value = convert_to_string(value)
             final_parameter_set[key] = value
 
-        return self._build_url(service, "query",
+        return self._build_url(service, endpoint,
                                parameters=final_parameter_set)
 
     def __str__(self):

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -176,15 +176,26 @@ OPTIONAL_EVENT_PARAMETERS = [
     "includearrivals", "eventid", "limit", "offset", "catalog", "contributor",
     "updatedafter"]
 
+DEFAULT_AVAILABILITY_PARAMETERS = [
+    "starttime", "endtime", "network", "station", "location", "channel"
+]
+
+OPTIONAL_AVAILABILITY_PARAMETERS = [
+    "quality", "orderby", "limit", "format", "mergegaps"
+]
+
 DEFAULT_PARAMETERS = {
     "dataselect": DEFAULT_DATASELECT_PARAMETERS,
     "event": DEFAULT_EVENT_PARAMETERS,
-    "station": DEFAULT_STATION_PARAMETERS}
+    "station": DEFAULT_STATION_PARAMETERS,
+    "availability": DEFAULT_AVAILABILITY_PARAMETERS}
 
 OPTIONAL_PARAMETERS = {
     "dataselect": OPTIONAL_DATASELECT_PARAMETERS,
     "event": OPTIONAL_EVENT_PARAMETERS,
-    "station": OPTIONAL_STATION_PARAMETERS}
+    "station": OPTIONAL_STATION_PARAMETERS,
+    "availability": OPTIONAL_AVAILABILITY_PARAMETERS
+    }
 
 PARAMETER_ALIASES = {
     "net": "network",

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -181,7 +181,7 @@ DEFAULT_AVAILABILITY_PARAMETERS = [
 ]
 
 OPTIONAL_AVAILABILITY_PARAMETERS = [
-    "quality", "orderby", "limit", "format", "mergegaps"
+    "quality", "orderby", "limit", "format", "mergegaps", "merge", "show"
 ]
 
 DEFAULT_PARAMETERS = {
@@ -262,6 +262,8 @@ DEFAULT_TYPES = {
     "updatedafter": UTCDateTime,
     "format": str,
     "mergegaps": float,
+    "merge": str,
+    "show": str,
     }
 
 DEFAULT_VALUES = {
@@ -307,6 +309,8 @@ DEFAULT_VALUES = {
     "contributor": None,
     "updatedafter": None,
     "mergegaps": 0.0,
+    "merge": None,
+    "show": None,
 }
 
 # This creates a services dictionary containing default and optional services,

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -260,7 +260,9 @@ DEFAULT_TYPES = {
     "catalog": str,
     "contributor": str,
     "updatedafter": UTCDateTime,
-    "format": str}
+    "format": str,
+    "mergegaps": float,
+    }
 
 DEFAULT_VALUES = {
     "starttime": None,
@@ -269,7 +271,7 @@ DEFAULT_VALUES = {
     "station": None,
     "location": None,
     "channel": None,
-    "quality": "B",
+    "quality": None,
     "minimumlength": 0.0,
     "longestonly": False,
     "startbefore": None,
@@ -300,10 +302,11 @@ DEFAULT_VALUES = {
     "eventtype": None,
     "limit": None,
     "offset": 1,
-    "orderby": "time",
+    "orderby": None,
     "catalog": None,
     "contributor": None,
     "updatedafter": None,
+    "mergegaps": 0.0,
 }
 
 # This creates a services dictionary containing default and optional services,
@@ -312,7 +315,7 @@ DEFAULT_VALUES = {
 # minimal and very permissive service provider, without actually having to
 # do the query.
 DEFAULT_SERVICES = {}
-for service in ["dataselect", "event", "station"]:
+for service in ["dataselect", "event", "station", "availability"]:
     DEFAULT_SERVICES[service] = {}
 
     for default_param in DEFAULT_PARAMETERS[service]:
@@ -326,8 +329,10 @@ for service in ["dataselect", "event", "station"]:
         if optional_param == "format":
             if service == "dataselect":
                 default_val = "miniseed"
-            else:
+            elif service == "station":
                 default_val = "xml"
+            elif service == "availability":
+                default_val = "geocsv"
         else:
             default_val = DEFAULT_VALUES[optional_param]
 

--- a/obspy/clients/fdsn/tests/data/availability.wadl
+++ b/obspy/clients/fdsn/tests/data/availability.wadl
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<application xmlns="http://wadl.dev.java.net/2009/02">
+  <doc title="fdsnws-availability web service 1.0"/>
+  <grammars/>
+  <resources base="http://service.iris.edu/fdsnws/availability/1/">
+    <resource path="/">
+      <method name="GET" id="root">
+        <response>
+          <representation mediaType="text/html"/>
+        </response>
+      </method>
+      <resource path="query">
+        <method name="GET" id="query">
+          <request>
+            <param name="starttime" style="query" type="xs:date">
+              <doc xml:lang="english" title="limit to channels that are active on or after the specified start time">
+                Examples: endtime=2014-11-24 or 2014-11-24T10:00:00 or 2014-11-24T10:00:00.000
+              </doc>
+            </param>
+            <param name="endtime" style="query" type="xs:date">
+              <doc xml:lang="english" title="limit to channels that are active on or before the specified end time">
+                Examples: endtime=2014-11-24 or 2014-11-24T15:00:00 or 2014-11-24T15:00:00.000
+              </doc>
+            </param>
+            <param name="network" style="query" type="xs:string">
+              <doc xml:lang="english" title="Select one or more network codes. Lists and wildcards are accepted">
+                Examples:network=TT or network=TT,YW or network=T?
+              </doc>
+             </param>
+             <param name="station" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED station codes. Lists and wildcards are accepted">
+                 Examples: station=1001 or station=1001,1001 or station=1* or station=?00?
+               </doc>
+             </param>
+             <param name="location" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED location codes. Use -- for spaces. Lists and wildcards are accepted">
+                 Examples: location=-- or location=?0 or location=--,10
+               </doc>
+             </param>
+             <param name="channel" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED channel codes. Lists and wildcards are accepted">
+                 Example:channel=BHZ or channel=BH1,BH2 or channel=*Z or channel=BH?
+               </doc>
+             </param>
+             <param name="quality" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select based on SEED quality codes D, M, Q, R. Wildcard * as well as a comma selected list are accepted">
+                 Example:quality=M or quality=Q,M
+               </doc>
+             </param>
+             <param name="merge" style="query" type="xs:string">
+               <doc xml:lang="english" title="If set to one or more of the following values, time spans are merged as described. Multiple values may be specified as a comma-delimited list. Choose from samplerate, quality, and overlap.">
+                 Example: merge=samplerate,quality
+               </doc>
+             </param>
+             <param name="orderby" style="query" type="xs:string">
+               <doc xml:lang="english" title="Sort results by one of the following values in the order specified. Choose from nslc_time_quality_samplerate, latestupdate, and latestupdate_desc.">
+                 Example: orderby=latestupdate
+               </doc>
+             </param>
+             <param name="limit" style="query" type="xs:integer">
+               <doc xml:lang="english" title="Limit results to the specified number of timespans.">
+                 Example: limit=100
+               </doc>
+             </param>
+             <param name="includerestricted" style="query" type="xs:boolean">
+               <doc xml:lang="english" title="If true, all data are reported. If false, only data that can be openly accessed.">
+                 Example: includerestricted=true
+               </doc>
+             </param>
+             <param name="mergegaps" style="query" type="xs:float">
+               <doc xml:lang="english" title="If set, merge time spans that are separated by the specified tolerance in seconds.">
+                 Example: mergegaps=60.0
+               </doc>
+             </param>
+             <param name="show" style="query" type="xs:string">
+               <doc xml:lang="english" title="If set to latestupdate, the latest times at which data contributing to the returned time spans were loaded into the repository are included in the result.">
+                 Example: show=latestupdate
+               </doc>
+             </param>
+             <param name="format" style="query" type="xs:string" default="xml">
+               <doc xml:lang="english" title="Specify output format. Accepted values are text (the default), geocsv, and json."/>
+               <option value="text" mediaType="text/plain"/>
+               <option value="geocsv" mediaType="text/plain"/>
+               <option value="json" mediaType="application/json"/>
+             </param>
+             <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="nodata" style="query" type="xs:int" default="204">
+               <doc xml:lang="english" title="Specify which HTML Status code is returned when no data is found. This is an IRIS extension to the FDSN specification"/>
+               <option value="204"/>
+               <option value="404"/>
+             </param>
+           </request>
+           <response>
+             <representation mediaType="text/plain"/>
+             <representation mediaType="application/json"/>
+           </response>
+         </method>
+         <method name="POST" id="postQuery">
+           <request>
+             <representation mediaType="*/*"/>
+           </request>
+           <response>
+             <representation mediaType="text/plain"/>
+             <representation mediaType="application/xml"/>
+            </response>
+         </method>
+       </resource>
+      <resource path="extent">
+        <method name="GET" id="extent">
+          <request>
+            <param name="starttime" style="query" type="xs:date">
+              <doc xml:lang="english" title="limit to channels that are active on or after the specified start time">
+                Examples: endtime=2014-11-24 or 2014-11-24T10:00:00 or 2014-11-24T10:00:00.000
+              </doc>
+            </param>
+            <param name="endtime" style="query" type="xs:date">
+              <doc xml:lang="english" title="limit to channels that are active on or before the specified end time">
+                Examples: endtime=2014-11-24 or 2014-11-24T15:00:00 or 2014-11-24T15:00:00.000
+              </doc>
+            </param>
+            <param name="network" style="query" type="xs:string">
+              <doc xml:lang="english" title="Select one or more network codes. Lists and wildcards are accepted">
+                Examples:network=TT or network=TT,YW or network=T?
+              </doc>
+             </param>
+             <param name="station" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED station codes. Lists and wildcards are accepted">
+                 Examples: station=1001 or station=1001,1001 or station=1* or station=?00?
+               </doc>
+             </param>
+             <param name="location" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED location codes. Use -- for spaces. Lists and wildcards are accepted">
+                 Examples: location=-- or location=?0 or location=--,10
+               </doc>
+             </param>
+             <param name="channel" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select one or more SEED channel codes. Lists and wildcards are accepted">
+                 Example:channel=BHZ or channel=BH1,BH2 or channel=*Z or channel=BH?
+               </doc>
+             </param>
+             <param name="quality" style="query" type="xs:string">
+               <doc xml:lang="english" title="Select based on SEED quality codes D, M, Q, R. Wildcard * as well as a comma selected list are accepted">
+                 Example:quality=M or quality=Q,M
+               </doc>
+             </param>
+             <param name="merge" style="query" type="xs:string">
+               <doc xml:lang="english" title="If set to one or more of the following values, time spans are merged as described. Multiple values may be specified as a comma-delimited list. Choose from samplerate, quality, and overlap.">
+                 Example: merge=samplerate,quality
+               </doc>
+             </param>
+             <param name="orderby" style="query" type="xs:string">
+               <doc xml:lang="english" title="Sort results by one of the following values in the order specified. Choose from nslc_time_quality_samplerate, latestupdate, latestupdate_desc, timespancount, and timespancount_desc.">
+                 Example: orderby=latestupdate
+               </doc>
+             </param>
+             <param name="limit" style="query" type="xs:integer">
+               <doc xml:lang="english" title="Limit results to the specified number of timespans.">
+                 Example: limit=100
+               </doc>
+             </param>
+             <param name="includerestricted" style="query" type="xs:boolean">
+               <doc xml:lang="english" title="If true, all data are reported. If false, only data that can be openly accessed.">
+                 Example: includerestricted=true
+               </doc>
+             </param>
+             <param name="format" style="query" type="xs:string" default="xml">
+               <doc xml:lang="english" title="Specify output format. Accepted values are text (the default), geocsv, json, and request."/>
+               <option value="text" mediaType="text/plain"/>
+               <option value="geocsv" mediaType="text/plain"/>
+               <option value="json" mediaType="application/json"/>
+               <option value="request" mediaType="text/plain"/>
+             </param>
+             <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="nodata" style="query" type="xs:int" default="204">
+               <doc xml:lang="english" title="Specify which HTML Status code is returned when no data is found. This is an IRIS extension to the FDSN specification"/>
+               <option value="204"/>
+               <option value="404"/>
+             </param>
+           </request>
+           <response>
+             <representation mediaType="text/plain"/>
+             <representation mediaType="application/xml"/>
+           </response>
+         </method>
+         <method name="POST" id="postExtent">
+           <request>
+             <representation mediaType="*/*"/>
+           </request>
+           <response>
+             <representation mediaType="text/plain"/>
+             <representation mediaType="application/json"/>
+            </response>
+         </method>
+       </resource>
+       <resource path="version">
+         <method name="GET" id="version">
+           <response>
+             <representation mediaType="text/plain"/>
+           </response>
+         </method>
+       </resource>
+       <resource path="application.wadl">
+         <method name="GET" id="application.wadl">
+           <response>
+             <representation mediaType="application/xml"/>
+           </response>
+         </method>
+       </resource>
+     </resource>
+  </resources>
+</application>

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -281,18 +281,13 @@ class TestClient():
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
                 self.client.get_waveforms(1, 2, loc, 4, 0, 0,
                                           filename=mock.Mock())
-<<<<<<< HEAD
             assert p.call_count == 1
             assert "location=--" in p.call_args[0][0]
-=======
-            self.assertEqual(p.call_count, 1)
-            self.assertIn("location=--", p.call_args[0][0])
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
                 self.client.get_availability(1, 2, loc, 4, 0, 0,
                                              filename=mock.Mock())
-            self.assertEqual(p.call_count, 1)
-            self.assertIn("location=--", p.call_args[0][0])
->>>>>>> contributor/fdsn-client-getavailability
+            assert p.call_count == 1
+            assert "location=--" in p.call_args[0][0]
 
     def test_url_building_with_auth(self):
         """
@@ -355,7 +350,6 @@ class TestClient():
         This will have to be adjusted once IRIS changes their implementation.
         """
         client = self.client
-<<<<<<< HEAD
         assert {*client.services.keys()} == \
             {"dataselect", "event", "station", "available_event_contributors",
              "available_event_catalogs"}
@@ -381,45 +375,6 @@ class TestClient():
              "updatedafter", "includeallorigins", "includeallmagnitudes",
              "includearrivals", "eventid",
              "originid"}  # XXX: This is currently just specified in the WADL
-=======
-        self.assertEqual(set(client.services.keys()),
-                         set(("dataselect", "event", "station",
-                              "available_event_contributors",
-                              "available_event_catalogs", "availability")))
-
-        # The test sets are copied from the IRIS webpage.
-        self.assertEqual(
-            set(client.services["dataselect"].keys()),
-            set(("starttime", "endtime", "network", "station", "location",
-                 "channel", "quality", "minimumlength", "longestonly")))
-        self.assertEqual(
-            set(client.services["station"].keys()),
-            set(("starttime", "endtime", "startbefore", "startafter",
-                 "endbefore", "endafter", "network", "station", "location",
-                 "channel", "minlatitude", "maxlatitude", "minlongitude",
-                 "maxlongitude", "latitude", "longitude", "minradius",
-                 "maxradius", "level", "includerestricted", "format",
-                 "includeavailability", "updatedafter", "matchtimeseries")))
-        self.assertEqual(
-            set(client.services["event"].keys()),
-            set(("starttime", "endtime", "minlatitude", "maxlatitude",
-                 "minlongitude", "maxlongitude", "latitude", "longitude",
-                 "maxradius", "minradius", "mindepth", "maxdepth",
-                 "minmagnitude", "maxmagnitude",
-                 "magnitudetype", "format",
-                 "catalog", "contributor", "limit", "offset", "orderby",
-                 "updatedafter", "includeallorigins", "includeallmagnitudes",
-                 "includearrivals", "eventid",
-                 "originid"  # XXX: This is currently just specified in the
-                             #      WADL.
-                 )))
-        self.assertEqual(
-            set(client.services['availability'].keys()),
-            set(('starttime', 'endtime', 'network', 'station', 'location',
-                 'channel', 'merge', 'show', 'format', 'mergegaps', 'orderby',
-                 'location', 'limit', 'includerestricted', 'quality'
-                 )))
->>>>>>> contributor/fdsn-client-getavailability
 
         # Also check an exemplary value in more detail.
         minradius = client.services["event"]["minradius"]
@@ -1370,16 +1325,7 @@ class TestClient():
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
                         service_mappings={"event": None})
-<<<<<<< HEAD
         assert sorted(client.services.keys()) == ['dataselect', 'station']
-=======
-        self.assertEqual(sorted(client.services.keys()),
-                         ['availability', 'dataselect', 'station'])
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
-                        service_mappings={"availability": None})
-        self.assertEqual(sorted(client.services.keys()),
-                         ['available_event_catalogs', 'available_event_contributors', 'dataselect', 'event', 'station'])
->>>>>>> contributor/fdsn-client-getavailability
 
     @mock.patch("obspy.clients.fdsn.client.download_url")
     def test_download_urls_for_custom_mapping(

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -102,12 +102,16 @@ class TestClient():
     """
     Test cases for obspy.clients.fdsn.client.Client.
     """
+    maxDiff = None
+
     @classmethod
     def setup_class(cls):
         cls.client = Client(base_url="IRIS", user_agent=USER_AGENT)
         cls.client_auth = \
             Client(base_url="IRIS", user_agent=USER_AGENT,
                    user="nobody@iris.edu", password="anonymous")
+        # cls.log = logging.getLogger("TestLog")
+        # cls.log.setLevel(logging.DEBUG)
 
     def test_empty_bulk_string(self):
         """
@@ -179,6 +183,9 @@ class TestClient():
         assert build_url("http://service.iris.edu", "station", 1,
                          "application.wadl") == \
             "http://service.iris.edu/fdsnws/station/1/application.wadl"
+        assert build_url("http://service.iris.edu", "availability", 1,
+                         "application.wadl") == \
+            "http://service.iris.edu/fdsnws/availability/1/application.wadl"
 
         # Test one parameter.
         assert build_url("http://service.iris.edu", "dataselect", 1,
@@ -255,7 +262,7 @@ class TestClient():
         # _create_url_from_parameters() method and thus has to survive it!
         # This guards against a regression where all empty location codes
         # where removed by this function!
-        for service in ["station", "dataselect"]:
+        for service in ["station", "dataselect", "availability"]:
             for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
                         u"", u" ", u"  ", u"--"]:
                 assert "location=--" in \
@@ -274,8 +281,18 @@ class TestClient():
             with mock.patch("obspy.clients.fdsn.Client._download") as p:
                 self.client.get_waveforms(1, 2, loc, 4, 0, 0,
                                           filename=mock.Mock())
+<<<<<<< HEAD
             assert p.call_count == 1
             assert "location=--" in p.call_args[0][0]
+=======
+            self.assertEqual(p.call_count, 1)
+            self.assertIn("location=--", p.call_args[0][0])
+            with mock.patch("obspy.clients.fdsn.Client._download") as p:
+                self.client.get_availability(1, 2, loc, 4, 0, 0,
+                                             filename=mock.Mock())
+            self.assertEqual(p.call_count, 1)
+            self.assertIn("location=--", p.call_args[0][0])
+>>>>>>> contributor/fdsn-client-getavailability
 
     def test_url_building_with_auth(self):
         """
@@ -338,6 +355,7 @@ class TestClient():
         This will have to be adjusted once IRIS changes their implementation.
         """
         client = self.client
+<<<<<<< HEAD
         assert {*client.services.keys()} == \
             {"dataselect", "event", "station", "available_event_contributors",
              "available_event_catalogs"}
@@ -363,6 +381,45 @@ class TestClient():
              "updatedafter", "includeallorigins", "includeallmagnitudes",
              "includearrivals", "eventid",
              "originid"}  # XXX: This is currently just specified in the WADL
+=======
+        self.assertEqual(set(client.services.keys()),
+                         set(("dataselect", "event", "station",
+                              "available_event_contributors",
+                              "available_event_catalogs", "availability")))
+
+        # The test sets are copied from the IRIS webpage.
+        self.assertEqual(
+            set(client.services["dataselect"].keys()),
+            set(("starttime", "endtime", "network", "station", "location",
+                 "channel", "quality", "minimumlength", "longestonly")))
+        self.assertEqual(
+            set(client.services["station"].keys()),
+            set(("starttime", "endtime", "startbefore", "startafter",
+                 "endbefore", "endafter", "network", "station", "location",
+                 "channel", "minlatitude", "maxlatitude", "minlongitude",
+                 "maxlongitude", "latitude", "longitude", "minradius",
+                 "maxradius", "level", "includerestricted", "format",
+                 "includeavailability", "updatedafter", "matchtimeseries")))
+        self.assertEqual(
+            set(client.services["event"].keys()),
+            set(("starttime", "endtime", "minlatitude", "maxlatitude",
+                 "minlongitude", "maxlongitude", "latitude", "longitude",
+                 "maxradius", "minradius", "mindepth", "maxdepth",
+                 "minmagnitude", "maxmagnitude",
+                 "magnitudetype", "format",
+                 "catalog", "contributor", "limit", "offset", "orderby",
+                 "updatedafter", "includeallorigins", "includeallmagnitudes",
+                 "includearrivals", "eventid",
+                 "originid"  # XXX: This is currently just specified in the
+                             #      WADL.
+                 )))
+        self.assertEqual(
+            set(client.services['availability'].keys()),
+            set(('starttime', 'endtime', 'network', 'station', 'location',
+                 'channel', 'merge', 'show', 'format', 'mergegaps', 'orderby',
+                 'location', 'limit', 'includerestricted', 'quality'
+                 )))
+>>>>>>> contributor/fdsn-client-getavailability
 
         # Also check an exemplary value in more detail.
         minradius = client.services["event"]["minradius"]
@@ -482,6 +539,130 @@ class TestClient():
         cat = client.get_events(catalog='8A')
         assert len(cat) == 19
         assert cat[0].event_type == 'controlled explosion'
+
+    def test_get_availability_unbounded_query_auth(self):
+        """
+        Extent information for all network IU, station ANMO channel BHZ
+        http://service.iris.edu/fdsnws/availability/1/query?network=IU&station=ANMO&channel=BHZ
+        """
+
+        client = self.client_auth
+
+        avail = client.get_availability('IU', 'ANMO', '', 'BHZ')
+
+        # check that we have a list
+        self.assertIsInstance(avail, list)
+        self.assertTrue(len(avail) >= 1)
+
+        # check that the structure of the list is as we expect
+        self.assertTrue(
+            all([type(list_item) == tuple for list_item in avail]))
+        self.assertTrue(all([len(list_item) == 6 for list_item in avail]))
+        self.assertTrue(all([[type(x) for x in list_item] == [
+                        str, str, str, str, UTCDateTime, UTCDateTime] for list_item in avail]))
+
+        # check that the network and station are as we expect
+        self.assertTrue(all([list_item[0] == 'IU' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[1] == 'ANMO' for list_item in avail]))
+
+    def test_get_availability_unbounded_query(self):
+        """
+        Extent information for all network IU, station ANMO channel BHZ
+        http://service.iris.edu/fdsnws/availability/1/query?network=IU&station=ANMO&channel=BHZ
+        """
+
+        client = self.client
+
+        avail = client.get_availability('IU', 'ANMO', '', 'BHZ')
+
+        # check that we have a list
+        self.assertIsInstance(avail, list)
+        self.assertTrue(len(avail) >= 1)
+
+        # check that the structure of the list is as we expect
+        self.assertTrue(
+            all([type(list_item) == tuple for list_item in avail]))
+        self.assertTrue(all([len(list_item) == 6 for list_item in avail]))
+        self.assertTrue(all([[type(x) for x in list_item] == [
+                        str, str, str, str, UTCDateTime, UTCDateTime] for list_item in avail]))
+
+        # check that the network and station are as we expect
+        self.assertTrue(all([list_item[0] == 'IU' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[1] == 'ANMO' for list_item in avail]))
+
+    def test_get_availability_bounded_query_auth(self):
+        """
+        Tests a bounded (in time) example query
+        Available Data from network IU, station ANMO, channel BHZ for a given time interval
+        http://service.iris.edu/fdsnws/availability/1/query?network=IU&station=ANMO&channel=BHZ&start=2000-03-23T00:00:00&end=2001-03-23T00:00:00
+        """
+        client = self.client_auth
+        starttime = UTCDateTime('2000-03-23T00:00:00')
+        endtime = UTCDateTime('2001-03-23T00:00:00')
+        avail = client.get_availability(
+            network='IU', station='ANMO', channel="BHZ", starttime=starttime, endtime=endtime)
+
+        # check that we have a list
+        self.assertIsInstance(avail, list)
+        self.assertTrue(len(avail) >= 1)
+
+        # check that the structure of the list is as we expect
+        self.assertTrue(
+            all([type(list_item) == tuple for list_item in avail]))
+        self.assertTrue(all([len(list_item) == 6 for list_item in avail]))
+        self.assertTrue(all([[type(x) for x in list_item] == [
+                    str, str, str, str, UTCDateTime, UTCDateTime] for list_item in avail]))
+
+        # check that the network, station, and channel are as we expect
+        self.assertTrue(all([list_item[0] == 'IU' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[1] == 'ANMO' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[3] == 'BHZ' for list_item in avail]))
+
+        # check that all returned data are within bounds
+        self.assertTrue(
+            all([list_item[4] >= starttime for list_item in avail]))
+        self.assertTrue(
+            all([list_item[5] <= endtime for list_item in avail]))
+
+    def test_get_availability_bounded_query(self):
+        """
+        Tests a bounded (in time) example query
+        Available Data from network IU, station ANMO, channel BHZ for a given time interval
+        http://service.iris.edu/fdsnws/availability/1/query?network=IU&station=ANMO&channel=BHZ&start=2000-03-23T00:00:00&end=2001-03-23T00:00:00
+        """
+        client = self.client
+        starttime = UTCDateTime('2000-03-23T00:00:00')
+        endtime = UTCDateTime('2001-03-23T00:00:00')
+        avail = client.get_availability(
+            network='IU', station='ANMO', channel="BHZ", starttime=starttime, endtime=endtime)
+
+        # check that we have a list
+        self.assertIsInstance(avail, list)
+        self.assertTrue(len(avail) >= 1)
+
+        # check that the structure of the list is as we expect
+        self.assertTrue(
+            all([type(list_item) == tuple for list_item in avail]))
+        self.assertTrue(all([len(list_item) == 6 for list_item in avail]))
+        self.assertTrue(all([[type(x) for x in list_item] == [
+                    str, str, str, str, UTCDateTime, UTCDateTime] for list_item in avail]))
+
+        # check that the network, station, and channel are as we expect
+        self.assertTrue(all([list_item[0] == 'IU' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[1] == 'ANMO' for list_item in avail]))
+        self.assertTrue(
+            all([list_item[3] == 'BHZ' for list_item in avail]))
+
+        # check that all returned data are within bounds
+        self.assertTrue(
+            all([list_item[4] >= starttime for list_item in avail]))
+        self.assertTrue(
+            all([list_item[5] <= endtime for list_item in avail]))
 
     def test_iris_example_queries_station(self):
         """
@@ -858,7 +1039,7 @@ class TestClient():
         expected = (
             "FDSN Webservice Client (base url: http://service.iris.edu)\n"
             "Available Services: 'dataselect' (v1.0.0), 'event' (v1.0.6), "
-            "'station' (v1.0.7), 'available_event_catalogs', "
+            "'station' (v1.0.7), 'availability', 'available_event_catalogs', "
             "'available_event_contributors'\n\n"
             "Use e.g. client.help('dataselect') for the\n"
             "parameter description of the individual services\n"
@@ -1044,6 +1225,7 @@ class TestClient():
             "%s/fdsnws/event/1/application.wadl" % base_url,
             "%s/fdsnws/station/1/application.wadl" % base_url,
             "%s/fdsnws/dataselect/1/application.wadl" % base_url,
+            "%s/fdsnws/availability/1/application.wadl" % base_url,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1071,6 +1253,7 @@ class TestClient():
             "%s/fdsnws/event/1/application.wadl" % base_url,
             "%s/fdsnws/station/1/application.wadl" % base_url,
             "%s/fdsnws/dataselect/1/application.wadl" % base_url,
+            "%s/fdsnws/availability/1/application.wadl" % base_url,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1079,7 +1262,8 @@ class TestClient():
         # Replace all
         download_url_mock.reset_mock()
         download_url_mock.return_value = (404, None)
-        major_versions = {"event": 7, "station": 8, "dataselect": 9}
+        major_versions = {"event": 7, "station": 8,
+                          "dataselect": 9, "availability": 10}
         # An exception will be raised if not actual WADLs are returned.
         try:
             Client(base_url=base_url, major_versions=major_versions)
@@ -1091,6 +1275,7 @@ class TestClient():
             "%s/fdsnws/event/7/application.wadl" % base_url,
             "%s/fdsnws/station/8/application.wadl" % base_url,
             "%s/fdsnws/dataselect/9/application.wadl" % base_url,
+            "%s/fdsnws/availability/10/application.wadl" % base_url,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1111,6 +1296,7 @@ class TestClient():
             "%s/fdsnws/event/7/application.wadl" % base_url,
             "%s/fdsnws/station/8/application.wadl" % base_url,
             "%s/fdsnws/dataselect/1/application.wadl" % base_url,
+            "%s/fdsnws/availability/1/application.wadl" % base_url,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1129,12 +1315,14 @@ class TestClient():
         base_url_event = "http://other_url.com/beta/event_service/11"
         base_url_station = "http://some_url.com/beta2/stat_serv/7"
         base_url_ds = "http://new.com/beta3/waveforms/8"
+        base_url_avail = "http://something.org/beta4/availability/9"
         # An exception will be raised if not actual WADLs are returned.
         try:
             Client(base_url=base_url, service_mappings={
                 "event": base_url_event,
                 "station": base_url_station,
                 "dataselect": base_url_ds,
+                "availability": base_url_avail,
             })
         except FDSNException:
             pass
@@ -1144,6 +1332,7 @@ class TestClient():
             "%s/application.wadl" % base_url_event,
             "%s/application.wadl" % base_url_station,
             "%s/application.wadl" % base_url_ds,
+            "%s/application.wadl" % base_url_avail,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1169,6 +1358,7 @@ class TestClient():
             "%s/fdsnws/event/1/application.wadl" % base_url,
             "%s/application.wadl" % base_url_station,
             "%s/application.wadl" % base_url_ds,
+            "%s/fdsnws/availability/1/application.wadl" % base_url,
         ])
         got_urls = sorted([_i[0][0] for _i in
                            download_url_mock.call_args_list])
@@ -1180,7 +1370,16 @@ class TestClient():
         """
         client = Client(base_url="IRIS", user_agent=USER_AGENT,
                         service_mappings={"event": None})
+<<<<<<< HEAD
         assert sorted(client.services.keys()) == ['dataselect', 'station']
+=======
+        self.assertEqual(sorted(client.services.keys()),
+                         ['availability', 'dataselect', 'station'])
+        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+                        service_mappings={"availability": None})
+        self.assertEqual(sorted(client.services.keys()),
+                         ['available_event_catalogs', 'available_event_contributors', 'dataselect', 'event', 'station'])
+>>>>>>> contributor/fdsn-client-getavailability
 
     @mock.patch("obspy.clients.fdsn.client.download_url")
     def test_download_urls_for_custom_mapping(
@@ -1205,14 +1404,19 @@ class TestClient():
                 with open(testdata["2014-01-07_iris_dataselect.wadl"],
                           "rb") as fh:
                     return 200, fh.read()
+            elif "availability" in args[0]:
+                with open(os.path.join(
+                       self.datapath,
+                        "availability.wadl"), "rb") as fh:
+                    return 200, fh.read()
             return 404, None
-
         download_url_mock.side_effect = custom_side_effects
 
         # Some custom urls
         base_url_event = "http://example.com/beta/event_service/11"
         base_url_station = "http://example.org/beta2/station/7"
         base_url_ds = "http://example.edu/beta3/dataselect/8"
+        base_url_avail = "http://example.edu/beta3/availability/5"
 
         # An exception will be raised if not actual WADLs are returned.
         # Catch warnings to avoid them being raised for the tests.
@@ -1222,6 +1426,7 @@ class TestClient():
                 "event": base_url_event,
                 "station": base_url_station,
                 "dataselect": base_url_ds,
+                "availability": base_url_avail,
             })
         for warning in w:
             assert "Could not parse" in str(warning) or \
@@ -1257,6 +1462,17 @@ class TestClient():
         except Exception:
             pass
         assert base_url_event in download_url_mock.call_args_list[0][0][0]
+
+        # Test the availability downloading.
+        download_url_mock.reset_mock()
+        download_url_mock.side_effect = None
+        download_url_mock.return_value = 404, None
+        try:
+            c.get_availability()
+        except Exception:
+            pass
+        self.assertTrue(
+            base_url_avail in download_url_mock.call_args_list[0][0][0])
 
     def test_redirection(self):
         """

--- a/obspy/clients/fdsn/tests/test_wadl_parser.py
+++ b/obspy/clients/fdsn/tests/test_wadl_parser.py
@@ -119,7 +119,32 @@ class TestWADLParser():
             "(case insensitive)"
         assert params["magnitudetype"]["doc"] == "Examples: Ml,Ms,mb,Mw\""
 
-    def test_station_wadl_parsing(self, testdata):
+    def test_availability_wadl_parsing(self):
+        """
+        Tests the parsing of an availability wadl.
+        """
+        parser, w = self._parse_wadl_file("availability.wadl")
+        params = parser.parameters
+
+        assert "starttime" in params
+        assert "endtime" in params
+        assert "network" in params
+        assert "station" in params
+        assert "location" in params
+        assert "channel" in params
+        assert "quality" in params
+        assert "merge" in params
+        assert "orderby" in params
+        assert "limit" in params
+        assert "includerestricted" in params
+        assert "mergegaps" in params
+        assert "show" in params
+        assert "format" in params
+
+        # The nodata attribute should not be parsed.
+        assert not ("nodata" in params)
+
+    def test_station_wadl_parsing(self):
         """
         Tests the parsing of a station wadl.
         """

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -40,6 +40,8 @@ class WADLParser(object):
             self._wadl_type = "station"
         elif "event" in url:
             self._wadl_type = "event"
+        elif "availability" in url:
+            self._wadl_type = "availability"
         else:
             raise NotImplementedError
         self._default_parameters = DEFAULT_PARAMETERS[self._wadl_type]


### PR DESCRIPTION
Hello,

This is an attempt to continue [this](https://github.com/obspy/obspy/pull/3002) PR for including the [fdsn availability service](https://www.fdsn.org/webservices/fdsnws-availability-1.0.pdf) in the retrieval capabilities of the fdsn client. 

The above PR seems to be frozen for a couple of years. I hope I have taken care the latest issues that were mentioned there and I am waiting for any comments.