### PR TITLE
CI: add py 3.12 and fix artifact upload

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -8,9 +8,7 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
-  # see #3330 and SciTools/cartopy#2199
-  # unpin again later on when this is fixed
-  - scipy < 1.11
+  - scipy
   - requests
   - setuptools
   # see #3258

--- a/.github/test_mindep_conda_env.yml
+++ b/.github/test_mindep_conda_env.yml
@@ -8,9 +8,7 @@ dependencies:
   - lxml
   - matplotlib
   - numpy
-  # see #3330 and SciTools/cartopy#2199
-  # unpin again later on when this is fixed
-  - scipy < 1.11
+  - scipy
   - requests
   - setuptools
   # see #3258

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -85,10 +85,19 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+  merge_artifacts:
+    name: merge sdist and wheel artifacts together
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: artifact
+
   publish_test:
     name: publish tag to testpypi
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: [build_wheels, build_sdist]
+    needs: merge_artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -105,7 +114,7 @@ jobs:
   publish:
     name: publish release
     if: github.event_name == 'release'
-    needs: [build_wheels, build_sdist]
+    needs: merge_artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -94,6 +94,7 @@ jobs:
       - uses: actions/upload-artifact/merge@v4
         with:
           name: artifact
+          delete-merged: true
 
   publish_test:
     name: publish tag to testpypi

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ./wheelhouse
+          path: ./wheelhouse/*.whl
           name: wheel-${{ matrix.os }}-${{ matrix.build }}
 
   build_sdist:
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
+          name: sdist
 
   merge_artifacts:
     name: merge sdist and wheel artifacts together

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        build: [cp38, cp39, cp310, cp311]
+        build: [cp38, cp39, cp310, cp311, cp312]
         exclude-flag:
           - ${{ github.ref_name == 'master' && github.event_name == 'push' }}
         exclude:
@@ -39,6 +39,8 @@ jobs:
           - build: cp39
             exclude-flag: true
           - build: cp310
+            exclude-flag: true
+          - build: cp311
             exclude-flag: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -65,7 +65,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse
+          name: wheel-${{ matrix.os }}-${{ matrix.build }}
 
   build_sdist:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test_wheels')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         options: [default]
         include:
           # The mindep option indicates optional dependencies should not be installed.
@@ -110,20 +110,20 @@ jobs:
             python-version: '3.8'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network mindepversion' || 'default' }}
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.12'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.12'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
           # With warnings option pytest will fail on warnings.
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.12'
             options: default warnings
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.12'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network warnings' || 'default' }}
     name: ${{ matrix.options }} (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/obspy/signal/tests/test_quality_control.py
+++ b/obspy/signal/tests/test_quality_control.py
@@ -675,7 +675,7 @@ class TestQualityControl():
 
         # Check if the record lenghts matches the total length
         total_time = md.meta["end_time"] - md.meta["start_time"]
-        assert abs(sum(record_lengths) - (total_time)) < 1e-6
+        assert abs(sum(record_lengths) - (total_time)) < 1.001e-6
 
         # Calculate the percentage of clock_locked seconds
         percentage = 100 * sum(record_lengths_flagged) / sum(record_lengths)

--- a/setup.py
+++ b/setup.py
@@ -793,6 +793,7 @@ def setupPackage():
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Physics'],
         keywords=KEYWORDS,


### PR DESCRIPTION

### What does this PR do?

Add Python 3.12 to CI also for maintenance_1.4.x branch and fix the artifact upload action

### Why was it initiated?  Any relevant Issues?

see #3360 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
