### PR TITLE
try building docset in github actions

### DIFF
--- a/.github/docs_conda_env.yml
+++ b/.github/docs_conda_env.yml
@@ -27,3 +27,4 @@ dependencies:
   - sphinx_rtd_theme
   # deps used in tutorial but not working anymore
   #- mlpy
+  - doc2dash  # for building docset for dash/zeal

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -45,7 +45,9 @@ jobs:
         run: |
           cd misc/docs/build
           python -c 'import obspy; print(obspy.__version__)'
-          echo "DOCSETVERSION=$(shell head -3 html/objects.inv | grep ' ObsPy Documentation ' | sed 's#.*(\(.*\)).*#\1#')" >> "$GITHUB_ENV"
+          echo "DOCSETVERSION=$(head -3 html/objects.inv | grep ' ObsPy Documentation ' | sed 's#.*(\(.*\)).*#\1#')" >> "$GITHUB_ENV"
+          ls -l *
+          ls -l */*
           doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy-logo_32x32.png --online-redirect-url https://docs.obspy.org/ html/
           ls -l *
           sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -43,13 +43,8 @@ jobs:
       - name: build docset
         shell: bash -l {0}
         run: |
-          cd misc/docs/build
-          python -c 'import obspy; print(obspy.__version__)'
-          echo "DOCSETVERSION=$(head -3 html/objects.inv | grep ' ObsPy Documentation ' | sed 's#.*(\(.*\)).*#\1#')" >> "$GITHUB_ENV"
-          doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-          sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
-          cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
-          tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"
+          cd misc/docs
+          make docset
       - name: compress with tar
         shell: bash -l {0}
         run: |

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -46,10 +46,7 @@ jobs:
           cd misc/docs/build
           python -c 'import obspy; print(obspy.__version__)'
           echo "DOCSETVERSION=$(head -3 html/objects.inv | grep ' ObsPy Documentation ' | sed 's#.*(\(.*\)).*#\1#')" >> "$GITHUB_ENV"
-          ls -l *
-          ls -l */*
-          doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy-logo_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-          ls -l *
+          doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
           sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
           cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
           tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -40,6 +40,17 @@ jobs:
         run: |
           cd misc/docs
           make html
+      - name: build docset
+        shell: bash -l {0}
+        run: |
+          cd misc/docs/build
+          python -c 'import obspy; print(obspy.__version__)'
+          echo "DOCSETVERSION=$(shell head -3 html/objects.inv | grep ' ObsPy Documentation ' | sed 's#.*(\(.*\)).*#\1#')" >> "$GITHUB_ENV"
+          doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy-logo_32x32.png --online-redirect-url https://docs.obspy.org/ html/
+          ls -l *
+          sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
+          cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
+          tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"
       - name: compress with tar
         shell: bash -l {0}
         run: |
@@ -49,3 +60,7 @@ jobs:
         with:
           name: obspydoc
           path: misc/docs/build/html/obspydoc.tar.xz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: obspydocset
+          path: misc/docs/build/obspy-*.docset.tgz

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -40,21 +40,23 @@ jobs:
         run: |
           cd misc/docs
           make html
+      - name: compress docs with tar
+        shell: bash -l {0}
+        run: |
+          cd misc/docs/build/html/
+          tar cfJ obspydoc.tar.xz *
+      - name: actions/upload-artifact@v4 for docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: obspydoc
+          path: misc/docs/build/html/obspydoc.tar.xz
       - name: build docset
         shell: bash -l {0}
         run: |
           cd misc/docs
           bash make_docset.sh
-      - name: compress with tar
-        shell: bash -l {0}
-        run: |
-          cd misc/docs/build/html/
-          tar cfJ obspydoc.tar.xz *
-      - uses: actions/upload-artifact@v4
-        with:
-          name: obspydoc
-          path: misc/docs/build/html/obspydoc.tar.xz
-      - uses: actions/upload-artifact@v4
+      - name: actions/upload-artifact@v4 for docset
+        uses: actions/upload-artifact@v4
         with:
           name: obspydocset
           path: misc/docs/build/obspy-*.docset.tgz

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd misc/docs
-          make docset
+          bash make_docset.sh
       - name: compress with tar
         shell: bash -l {0}
         run: |

--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -29,17 +29,3 @@ html-docker: install-obspy-dev
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-docset: SHELL:=/bin/bash
-docset:
-	$(eval DOCSETVERSION=`python -c "import obspy; print(obspy.__version__)"`)
-	# this should equally work to get the version number
-	#$(eval DOCSETVERSION := $(shell head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
-	cd build && doc2dash --verbose --name "ObsPy $(DOCSETVERSION)" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 $(DOCSETVERSION)\2#' --in-place "build/ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
-	cat docset_css_fixes.css >> "build/ObsPy $(DOCSETVERSION).docset/Contents/Resources/Documents/_static/css/custom.css"
-	if [[ "$(DOCSETVERSION)" == *"post"* ]]; then \
-	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-master.docset.tgz" "ObsPy $(DOCSETVERSION).docset"; \
-	else \
-	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-$(DOCSETVERSION).docset.tgz" "ObsPy $(DOCSETVERSION).docset"; \
-	fi

--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -31,11 +31,14 @@ html-docker: install-obspy-dev
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 docset:
-	cd build
-	$(eval DOCSETVERSION := $(shell head -3 html/objects.inv | grep 'Version' | awk '{print $NF}'))
+	$(eval DOCSETVERSION := $(shell head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
 	# this should equally work to get the version number
 	# python -c 'import obspy; print(obspy.__version__)'
-	doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
-	cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
-	tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"
+	cd build && doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
+	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "build/ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
+	cat docset_css_fixes.css >> "build/ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
+	if [[ ${DOCSETVERSION} == *"post"* ]]; then \
+	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-master.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
+	else \
+	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
+	fi

--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -32,14 +32,14 @@ html-docker: install-obspy-dev
 
 docset: SHELL:=/bin/bash
 docset:
-	$(eval DOCSETVERSION := $(shell head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
+	$(eval DOCSETVERSION=`python -c "import obspy; print(obspy.__version__)"`)
 	# this should equally work to get the version number
-	# python -c 'import obspy; print(obspy.__version__)'
-	cd build && doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "build/ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
-	cat docset_css_fixes.css >> "build/ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
-	if [[ "${DOCSETVERSION}" == *"post"* ]]; then \
-	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-master.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
+	#$(eval DOCSETVERSION := $(shell head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
+	cd build && doc2dash --verbose --name "ObsPy $(DOCSETVERSION)" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
+	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 $(DOCSETVERSION)\2#' --in-place "build/ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
+	cat docset_css_fixes.css >> "build/ObsPy $(DOCSETVERSION).docset/Contents/Resources/Documents/_static/css/custom.css"
+	if [[ "$(DOCSETVERSION)" == *"post"* ]]; then \
+	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-master.docset.tgz" "ObsPy $(DOCSETVERSION).docset"; \
 	else \
-	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
+	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-$(DOCSETVERSION).docset.tgz" "ObsPy $(DOCSETVERSION).docset"; \
 	fi

--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -29,3 +29,13 @@ html-docker: install-obspy-dev
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+docset:
+	cd build
+	$(eval DOCSETVERSION := $(shell head -3 html/objects.inv | grep 'Version' | awk '{print $NF}'))
+	# this should equally work to get the version number
+	# python -c 'import obspy; print(obspy.__version__)'
+	doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
+	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
+	cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
+	tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"

--- a/misc/docs/Makefile
+++ b/misc/docs/Makefile
@@ -30,6 +30,7 @@ html-docker: install-obspy-dev
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+docset: SHELL:=/bin/bash
 docset:
 	$(eval DOCSETVERSION := $(shell head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
 	# this should equally work to get the version number
@@ -37,7 +38,7 @@ docset:
 	cd build && doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
 	sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "build/ObsPy $(DOCSETVERSION).docset/Contents/Info.plist"
 	cat docset_css_fixes.css >> "build/ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
-	if [[ ${DOCSETVERSION} == *"post"* ]]; then \
+	if [[ "${DOCSETVERSION}" == *"post"* ]]; then \
 	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-master.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
 	else \
 	  cd build && tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETVERSION}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \

--- a/misc/docs/make_docset.sh
+++ b/misc/docs/make_docset.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# assumes that html docs are built and ready in build/html/
+
+# exit immediately on any error
+set -e
+
+DOCSETVERSION=`python -c "import obspy; print(obspy.__version__)"`
+
+cd build/
+
+# this should equally work to get the version number but it seems the "dirty" part of the version numbering is missing there
+#DOCSETVERSION=`head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
+
+doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
+sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "build/ObsPy ${DOCSETVERSION}.docset/Contents/Info.plist"
+cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
+if [[ "${DOCSETVERSION}" == *"post"* ]]
+then
+  DOCSETNAME="master"
+else
+  DOCSETNAME=$(DOCSETVERSION)
+fi
+
+tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETNAME}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \

--- a/misc/docs/make_docset.sh
+++ b/misc/docs/make_docset.sh
@@ -4,21 +4,21 @@
 # exit immediately on any error
 set -e
 
-DOCSETVERSION=`python -c "import obspy; print(obspy.__version__)"`
+VERSION=`python -c "import obspy; print(obspy.__version__)"`
 
 cd build/
 
 # this should equally work to get the version number but it seems the "dirty" part of the version numbering is missing there
 #DOCSETVERSION=`head -3 build/html/objects.inv | grep 'Version' | awk '{print $NF}'))
 
-doc2dash --verbose --name "ObsPy ${DOCSETVERSION}" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/
-sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${DOCSETVERSION}\2#' --in-place "build/ObsPy ${DOCSETVERSION}.docset/Contents/Info.plist"
-cat ../docset_css_fixes.css >> "ObsPy ${DOCSETVERSION}.docset/Contents/Resources/Documents/_static/css/custom.css"
-if [[ "${DOCSETVERSION}" == *"post"* ]]
+doc2dash --name "ObsPy" --icon html/_static/obspy_logo_no_text_32x32.png --online-redirect-url https://docs.obspy.org/ html/  # --verbose
+# sed 's#\(<string>[Oo]bs[Pp]y\) .*\(</string>\)#\1 ${VERSION}\2#' --in-place ObsPy.docset/Contents/Info.plist
+cat ../docset_css_fixes.css >> ObsPy.docset/Contents/Resources/Documents/_static/css/custom.css
+if [[ "${VERSION}" == *"post"* ]]
 then
   DOCSETNAME="master"
 else
-  DOCSETNAME=$(DOCSETVERSION)
+  DOCSETNAME=${VERSION}
 fi
 
-tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETNAME}.docset.tgz" "ObsPy ${DOCSETVERSION}.docset"; \
+tar --exclude='.DS_Store' -cvzf "obspy-${DOCSETNAME}.docset.tgz" ObsPy.docset

--- a/misc/docs/source/packages/obspy.io.alsep.rst
+++ b/misc/docs/source/packages/obspy.io.alsep.rst
@@ -12,6 +12,6 @@
        assign
        core
        define
-       utils
+       util
 
     .. comment to end block

--- a/misc/docs/source/packages/obspy.io.gcf.rst
+++ b/misc/docs/source/packages/obspy.io.gcf.rst
@@ -10,6 +10,5 @@
        :nosignatures:
 
        core
-       libgcf
 
     .. comment to end block


### PR DESCRIPTION

### What does this PR do?

Tries to build docsets for dash/Zeal again, in github actions now

### Why was it initiated?  Any relevant Issues?

closes #3307 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
