### PR TITLE
seedlink: fix a bug in basic client get_info()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,8 +16,9 @@ Changes:
  - obspy.clients.seedlink:
    * fix a bug in basic client `get_info()` which leaded to exceptions when
      querying with `level="channel"` in presence of stations with no current
-     data available. Stations without data are now excluded from results (see
-     #2808)
+     data available. Also, stations without data are now excluded from the
+     results. See docs for `get_info()` for information how to see the excluded
+     stations (see #2808)
  - obspy.io:
    * add read and write support for CSV, EVENTTXT and CSZ formats (see #3285)
  - obspy.io.cybershake:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,11 @@ Changes:
    * update syntax for SQLAlchemy 2.0 compatibility (see #3269)
  - obspy.clients.fdsn
    * Natural Resources Canada (NRCAN) added to list of known clients
+ - obspy.clients.seedlink:
+   * fix a bug in basic client `get_info()` which leaded to exceptions when
+     querying with `level="channel"` in presence of stations with no current
+     data available. Stations without data are now excluded from results (see
+     #2808)
  - obspy.io:
    * add read and write support for CSV, EVENTTXT and CSZ formats (see #3285)
  - obspy.io.cybershake:

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -80,6 +80,7 @@ Michelini, Alberto
 Miller, Nathaniel C.
 Mizuno, Naoto
 Morgenstern, Bernhard
+Moushall, Brenainn
 Münchmeyer, Jannes
 Muñoz Mesa, Jesús A.
 Murray-Bergquist, Louisa

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -193,7 +193,7 @@ class Client(object):
         return stream
 
     def get_info(self, network=None, station=None, location=None, channel=None,
-                 level='station', cache=True, warn_on_excluded_stations=True):
+                 level='station', cache=True, warn_on_excluded_stations=False):
         """
         Request available stations information from the seedlink server.
 
@@ -201,13 +201,11 @@ class Client(object):
         ``station``, ``location`` and ``channel``.
 
         >>> client = Client('rtserver.ipgp.fr')
-        >>> info = client.get_info(
-        ...     station="FDFM", warn_on_excluded_stations=False)
+        >>> info = client.get_info(station="FDFM")
         >>> print(info)
         [('G', 'FDFM')]
         >>> info = client.get_info(
-        ...     station="FD?M", channel='*Z', level='channel',
-        ...     warn_on_excluded_stations=False)
+        ...     station="FD?M", channel='*Z', level='channel')
         >>> print(info)  # doctest: +NORMALIZE_WHITESPACE
         [('G', 'FDFM', '00', 'BHZ'), ('G', 'FDFM', '00', 'HHZ'),
          ('G', 'FDFM', '00', 'HNZ'), ('G', 'FDFM', '00', 'LHZ'),
@@ -223,11 +221,12 @@ class Client(object):
             Stations/channels are excluded from the results for which the
             server indicates it is serving them in general but it also states
             no data are in ring buffer currently.
-            If interested in these "no data" stations/channels, currently
-            please use ``debug=True`` when initializing the client which will
-            print the raw server ``seedlink INFO`` response which will show
-            these stations listed with ``begin_seq`` and ``end_seq`` both with
-            value ``'000000'``.
+            If interested in these "no data" stations/channels, either set
+            ``warn_on_excluded_stations=True`` which will show a warning
+            message with excluded stations or use ``debug=True`` when
+            initializing the client which will print the raw server ``seedlink
+            INFO`` xml response which will show these stations listed with
+            ``begin_seq`` and ``end_seq`` both with value ``'000000'``.
 
         :type network: str
         :param network: Network code. Supports ``fnmatch`` wildcards, e.g.

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -201,11 +201,13 @@ class Client(object):
         ``station``, ``location`` and ``channel``.
 
         >>> client = Client('rtserver.ipgp.fr')
-        >>> info = client.get_info(station="FDFM")
+        >>> info = client.get_info(
+        ...     station="FDFM", warn_on_excluded_stations=False)
         >>> print(info)
         [('G', 'FDFM')]
-        >>> info = client.get_info(station="FD?M", channel='*Z',
-        ...                        level='channel')
+        >>> info = client.get_info(
+        ...     station="FD?M", channel='*Z', level='channel',
+        ...     warn_on_excluded_stations=False)
         >>> print(info)  # doctest: +NORMALIZE_WHITESPACE
         [('G', 'FDFM', '00', 'BHZ'), ('G', 'FDFM', '00', 'HHZ'),
          ('G', 'FDFM', '00', 'HNZ'), ('G', 'FDFM', '00', 'LHZ'),

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -46,6 +46,7 @@ class TestClient():
         else:
             raise
 
+    @pytest.mark.filterwarnings('ignore:.*Some stations were excluded.*')
     def test_get_info(self):
         """
         Test fetching station information

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -46,7 +46,6 @@ class TestClient():
         else:
             raise
 
-    @pytest.mark.filterwarnings('ignore:.*Some stations were excluded.*')
     def test_get_info(self):
         """
         Test fetching station information


### PR DESCRIPTION
### What does this PR do?

Handles a bug in seedlink basic client `get_info()`, first reported in #2808 

Channels for stations without data made it into the info results and caused an exception due to fnmatch chocking on `None` values. No-data stations will now be removed from results and a warning is shown indicating what stations were removed (with a kwarg option to suppress the warning)


### Why was it initiated?  Any relevant Issues?

closes #2808 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
