### PR TITLE
Trace.taper(): Remove 'slepian', add 'dpss' window

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@ Changes:
    * improve error messages when traces fail to get merged due to differing
      data type, sampling rate etc (see #3418)
    * add helper methods to change/unify byteorder on trace/stream (see #3418)
+   * window 'slepian' was removed in Trace/Stream.taper() as it was removed
+     from scipy with version 1.6 (see #3331)
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility (see #3269)
  - obspy.clients.fdsn

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,7 +15,8 @@ Changes:
      data type, sampling rate etc (see #3418)
    * add helper methods to change/unify byteorder on trace/stream (see #3418)
    * window 'slepian' was removed in Trace/Stream.taper() as it was removed
-     from scipy with version 1.6 (see #3331)
+     from scipy with version 1.6, add new window 'dpss' that scipy promotes as
+     replacement but might need other parameters passed in (see #3331)
  - obspy.clients.filesystem:
    * update syntax for SQLAlchemy 2.0 compatibility (see #3269)
  - obspy.clients.fdsn

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2147,6 +2147,9 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             Parzen window. (uses: :func:`scipy.signal.windows.parzen`)
         ``'triang'``
             Triangular window. (uses: :func:`scipy.signal.windows.triang`)
+        ``'dpss'``
+            Discrete Prolate Spheroidal Sequences window. (uses:
+            :func:`scipy.signal.windows.dpss`)
         """
         type = type.lower()
         side = side.lower()

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2145,8 +2145,6 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             (uses: :func:`scipy.signal.windows.nuttall`)
         ``'parzen'``
             Parzen window. (uses: :func:`scipy.signal.windows.parzen`)
-        ``'slepian'``
-            Slepian window. (uses: :func:`scipy.signal.windows.slepian`)
         ``'triang'``
             Triangular window. (uses: :func:`scipy.signal.windows.triang`)
         """

--- a/setup.py
+++ b/setup.py
@@ -552,10 +552,6 @@ ENTRY_POINTS = {
         'kaiser = scipy.signal.windows:kaiser',
         'nuttall = scipy.signal.windows:nuttall',
         'parzen = scipy.signal.windows:parzen',
-        # TODO slepian has been removed from scipy with version 1.6.0
-        # see https://docs.scipy.org/doc/scipy/release/1.1.0-notes.html
-        # see https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html
-        'slepian = scipy.signal.windows:slepian',
         'triang = scipy.signal.windows:triang',
         ],
     'obspy.plugin.trigger': [

--- a/setup.py
+++ b/setup.py
@@ -553,6 +553,7 @@ ENTRY_POINTS = {
         'nuttall = scipy.signal.windows:nuttall',
         'parzen = scipy.signal.windows:parzen',
         'triang = scipy.signal.windows:triang',
+        'dpss = scipy.signal.windows:dpss',
         ],
     'obspy.plugin.trigger': [
         'recstalta = obspy.signal.trigger:recursive_sta_lta',


### PR DESCRIPTION
### What does this PR do?

Removes 'slepian' from `Trace.taper()` scipy plugins points as it was removed in scipy 1.6 and add 'dpss' as replacement. Don't know how to exactly mimic old slepian with new dpss function so can't prevent user code breaking, though, but at least a replacement is in place for people that used it.

### Why was it initiated?  Any relevant Issues?

fixes #3331

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
