### PR TITLE
rebrand IRIS -> EarthScope pt. 2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -90,6 +90,17 @@ Changes:
      #3306)
    * IRIS/Earthscope: fix all "catalogs" and "contributors" being suffixed with
      '\n ' (see #3438)
+   * IRIS is now Earthscope. Adjusted all mention in docs accordingly and using
+     'IRIS' as short URL in FDSN client initialization as well as using
+     'iris-federator' in FDSN routing client initialization will show
+     deprecation warnings to use 'EARTHSCOPE' and 'earthscope-federator'
+     instead, respectively, but both old namings will still work (see #3448 and
+     #3456)
+ - obspy.clients.iris:
+   * IRIS is now Earthscope. Adjusted all mention in docs accordingly. The
+     module name will stay as 'obspy.clients.iris', though, to avoid breaking
+     users' codes  (see #3448 and
+     #3456)
  - obspy.clients.nrl:
    * better handling of individual stages units when combining sensor and
      datalogger response from a full downloaded offline version of the new NRL

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -161,7 +161,8 @@ only support the ``dataselect`` and the ``station`` FDSNWS services.
 
 ObsPy has support for two routing services:
 
-(i) The `IRISWS Federator  <https://service.iris.edu/irisws/fedcatalog/1/>`_.
+(i) The `EarthScope (former IRIS) Federator
+    <https://service.iris.edu/irisws/fedcatalog/1/>`_.
 (ii) The `EIDAWS Routing Service
      <http://www.orfeus-eu.org/data/eida/webservices/routing/>`_.
 
@@ -171,7 +172,7 @@ To use them, call the
 
 >>> from obspy.clients.fdsn import RoutingClient
 
-Get an instance of a routing client using the IRISWS Federator:
+Get an instance of a routing client using the EarthScope Federator:
 
 >>> client = RoutingClient("iris-federator")
 >>> print(type(client))  # doctest: +ELLIPSIS
@@ -188,10 +189,10 @@ They can be used like the normal FDSNWS clients, meaning the
 
 To be able to do geographic waveform queries with the EIDA service,
 ObsPy will internally perform a station query before downloading the
-waveforms. This results in a similar usage between the EIDA and EarthScope/IRIS
-routing services from a user's perspective.
+waveforms. This results in a similar usage between the EIDA and EarthScope
+(former IRIS) routing services from a user's perspective.
 
-The following snippet will call the EarthScope/IRIS federator to figure out who
+The following snippet will call the EarthScope federator to figure out who
 has waveform data for that particular query and subsequently call the
 individual data centers to actually get the data. This happens fully
 automatically - please note that the clients also supports non-standard

--- a/obspy/clients/fdsn/__init__.py
+++ b/obspy/clients/fdsn/__init__.py
@@ -174,7 +174,7 @@ To use them, call the
 
 Get an instance of a routing client using the EarthScope Federator:
 
->>> client = RoutingClient("iris-federator")
+>>> client = RoutingClient("earthscope-federator")
 >>> print(type(client))  # doctest: +ELLIPSIS
 <class '...fdsn.routing.federator_routing_client.FederatorRoutingClient'>
 
@@ -199,7 +199,7 @@ automatically - please note that the clients also supports non-standard
 waveform query parameters like geographical constraints.
 
 >>> from obspy import UTCDateTime
->>> client = RoutingClient("iris-federator")
+>>> client = RoutingClient("earthscope-federator")
 >>> st = client.get_waveforms(
 ...     channel="LHZ", starttime=UTCDateTime(2017, 1, 1),
 ...     endtime=UTCDateTime(2017, 1, 1, 0, 5), latitude=10,
@@ -211,7 +211,7 @@ II.MBAR.10.LHZ | 2017-01-01T00:00:00Z - ... | 1.0 Hz, 300 samples
 
 The same works for stations:
 
->>> client = RoutingClient("iris-federator")
+>>> client = RoutingClient("earthscope-federator")
 >>> inv = client.get_stations(
 ...     channel="LHZ", starttime=UTCDateTime(2017, 1, 1),
 ...     endtime=UTCDateTime(2017, 1, 1, 0, 5), latitude=10,

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -228,6 +228,12 @@ class Client(object):
         # the client more convenient.
         self.__version_cache = {}
 
+        if base_url.upper() == 'IRIS':
+            base_url = 'EARTHSCOPE'
+            msg = ("IRIS is now EarthScope, please consider changing the FDSN "
+                   "client short URL to 'EARTHSCOPE'.")
+            warnings.warn(msg, DeprecationWarning)
+
         if base_url.upper() in URL_MAPPINGS:
             url_mapping = base_url.upper()
             base_url = URL_MAPPINGS[url_mapping]

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -27,6 +27,7 @@ from lxml import etree
 
 import obspy
 from obspy import UTCDateTime, read_inventory
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from .header import (DEFAULT_PARAMETERS, DEFAULT_USER_AGENT, FDSNWS,
                      OPTIONAL_PARAMETERS, PARAMETER_ALIASES,
                      URL_DEFAULT_SUBPATH, URL_MAPPINGS, URL_MAPPING_SUBPATHS,
@@ -232,7 +233,7 @@ class Client(object):
             base_url = 'EARTHSCOPE'
             msg = ("IRIS is now EarthScope, please consider changing the FDSN "
                    "client short URL to 'EARTHSCOPE'.")
-            warnings.warn(msg, DeprecationWarning)
+            warnings.warn(msg, ObsPyDeprecationWarning)
 
         if base_url.upper() in URL_MAPPINGS:
             url_mapping = base_url.upper()

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -78,14 +78,13 @@ class MassDownloader(object):
                 del providers["RASPISHAKE"]
 
             if "IRIS" in providers or "EARTHSCOPE" in providers:
+                has_earthscope = True
                 if "IRIS" in providers:
-                    has_iris = True
                     del providers["IRIS"]
                 if "EARTHSCOPE" in providers:
-                    has_iris = True
                     del providers["EARTHSCOPE"]
             else:
-                has_iris = False
+                has_earthscope = False
 
             if "ODC" in providers:
                 providers["ORFEUS"] = providers["ODC"]
@@ -105,8 +104,8 @@ class MassDownloader(object):
             _p = sorted(providers)
             if has_orfeus:
                 _p.append("ORFEUS")
-            if has_iris:
-                _p.append("IRIS")
+            if has_earthscope:
+                _p.append("EARTHSCOPE")
 
             providers = _p
 

--- a/obspy/clients/fdsn/routing/eidaws_routing_client.py
+++ b/obspy/clients/fdsn/routing/eidaws_routing_client.py
@@ -27,7 +27,8 @@ class EIDAWSRoutingClient(BaseRoutingClient):
     station information at each data center with additional constraints
     (e.g. latitude/longitude/...) and use that information for the final
     waveform query. This means that with ObsPy the EIDA routing client
-    behaves very similar to the EarthScope IRISWS federator routing client.
+    behaves very similar to the EarthScope (former IRIS) federator routing
+    client.
     """
     def __init__(self, url="http://www.orfeus-eu.org/eidaws/routing/1",
                  include_providers=None, exclude_providers=None,

--- a/obspy/clients/fdsn/routing/federator_routing_client.py
+++ b/obspy/clients/fdsn/routing/federator_routing_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Routing client for the EarthScope IRISWS federator routing service.
+Routing client for the EarthScope (former IRIS) federator routing service.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
@@ -63,9 +63,8 @@ class FederatorRoutingClient(BaseRoutingClient):
         provider FDSN client are not supported.
 
         This can route on a number of different parameters, please see the
-        web site of the
-        `IRISWS Federator  <https://service.iris.edu/irisws/fedcatalog/1/>`_
-        for details.
+        web site of the `EarthScope (former IRIS) Federator
+        <https://service.iris.edu/irisws/fedcatalog/1/>`_ for details.
         """
         bulk_params = ["network", "station", "location", "channel",
                        "starttime", "endtime"]
@@ -99,9 +98,8 @@ class FederatorRoutingClient(BaseRoutingClient):
         supported.
 
         This can route on a number of different parameters, please see the
-        web site of the
-        `IRISWS Federator  <https://service.iris.edu/irisws/fedcatalog/1/>`_
-        for details.
+        web site of the `EarthScope (foremer IRIS) Federator
+        <https://service.iris.edu/irisws/fedcatalog/1/>`_ for details.
         """
         return super(FederatorRoutingClient, self).get_stations(**kwargs)
 
@@ -118,9 +116,8 @@ class FederatorRoutingClient(BaseRoutingClient):
         supported.
 
         This can route on a number of different parameters, please see the
-        web site of the
-        `IRISWS Federator  <https://service.iris.edu/irisws/fedcatalog/1/>`_
-        for details.
+        web site of the `EarthScope (former IRIS) Federator
+        <https://service.iris.edu/irisws/fedcatalog/1/>`_ for details.
         """
         bulk_params = ["network", "station", "location", "channel",
                        "starttime", "endtime"]

--- a/obspy/clients/fdsn/routing/federator_routing_client.py
+++ b/obspy/clients/fdsn/routing/federator_routing_client.py
@@ -98,7 +98,7 @@ class FederatorRoutingClient(BaseRoutingClient):
         supported.
 
         This can route on a number of different parameters, please see the
-        web site of the `EarthScope (foremer IRIS) Federator
+        web site of the `EarthScope (former IRIS) Federator
         <https://service.iris.edu/irisws/fedcatalog/1/>`_ for details.
         """
         return super(FederatorRoutingClient, self).get_stations(**kwargs)

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -6,7 +6,7 @@ Base class for all FDSN routers.
 :copyright:
     The ObsPy Development Team (devs@obspy.org)
     Celso G Reyes, 2017
-    EarthScope/IRIS-DMC
+    EarthScope (former IRIS-DMC)
 :license:
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
@@ -45,7 +45,8 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
 
     >>> from obspy.clients.fdsn import RoutingClient
 
-    Get an instance of a routing client using the EarthScope IRISWS Federator:
+    Get an instance of a routing client using the EarthScope (former IRIS)
+    Federator:
 
     >>> c = RoutingClient("iris-federator")
     >>> print(type(c))  # doctest: +ELLIPSIS
@@ -355,9 +356,9 @@ class BaseRoutingClient(HTTPClient):
         supported.
 
         This can route on a number of different parameters, please see the
-        web sites of the
-        `IRISWS Federator  <https://service.iris.edu/irisws/fedcatalog/1/>`_
-        and of the `EIDAWS Routing Service
+        web sites of the `EarthScope (former IRIS) Federator
+        <https://service.iris.edu/irisws/fedcatalog/1/>`_ and of the
+        `EIDAWS Routing Service
         <http://www.orfeus-eu.org/data/eida/webservices/routing/>`_ for
         details.
         """

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -34,9 +34,10 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
 
     :type routing_type: str
     :param routing_type: The type of router to initialize.
-        ``"iris-federator"`` or ``"eida-routing"``. Will consequently return
-        either a :class:`~.federator_routing_client.FederatorRoutingClient` or
-        a :class:`~.eidaws_routing_client.EIDAWSRoutingClient` object,
+        ``"earthscope-federator"`` or ``"eida-routing"``. Will consequently
+        return either a
+        :class:`~.federator_routing_client.FederatorRoutingClient` or a
+        :class:`~.eidaws_routing_client.EIDAWSRoutingClient` object,
         respectively.
 
     Remaining ``args`` and ``kwargs`` will be passed to the underlying classes.
@@ -48,7 +49,7 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
     Get an instance of a routing client using the EarthScope (former IRIS)
     Federator:
 
-    >>> c = RoutingClient("iris-federator")
+    >>> c = RoutingClient("earthscope-federator")
     >>> print(type(c))  # doctest: +ELLIPSIS
     <class '...routing.federator_routing_client.FederatorRoutingClient'>
 
@@ -59,16 +60,22 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
     >>> print(type(c))  # doctest: +ELLIPSIS
     <class '...routing.eidaws_routing_client.EIDAWSRoutingClient'>
     """
+    if routing_type.lower() == "iris-federator":
+        routing_type = "earthscope-federator"
+        msg = ("IRIS is now EarthScope, please consider changing the "
+               "'routing_type' to 'earthscope-federator'.")
+        warnings.warn(msg, DeprecationWarning)
+
     if routing_type.lower() == "eida-routing":
         from .eidaws_routing_client import EIDAWSRoutingClient
         return EIDAWSRoutingClient(*args, **kwargs)
-    if routing_type.lower() == "iris-federator":
+    elif routing_type.lower() == "earthscope-federator":
         from .federator_routing_client import FederatorRoutingClient
         return FederatorRoutingClient(*args, **kwargs)
     else:
         raise NotImplementedError(
             "Routing type '%s' is not implemented. Available types: "
-            "`iris-federator`, `eida-routing`" % routing_type)
+            "`earthscope-federator`, `eida-routing`" % routing_type)
 
 
 @decorator.decorator

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -21,6 +21,7 @@ import warnings
 from urllib.parse import urlparse
 
 import obspy
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 
 from ...base import HTTPClient
 from .. import client
@@ -64,7 +65,7 @@ def RoutingClient(routing_type, *args, **kwargs):  # NOQA
         routing_type = "earthscope-federator"
         msg = ("IRIS is now EarthScope, please consider changing the "
                "'routing_type' to 'earthscope-federator'.")
-        warnings.warn(msg, DeprecationWarning)
+        warnings.warn(msg, ObsPyDeprecationWarning)
 
     if routing_type.lower() == "eida-routing":
         from .eidaws_routing_client import EIDAWSRoutingClient

--- a/obspy/clients/fdsn/tests/test_base_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_base_routing_client.py
@@ -51,17 +51,17 @@ class TestBaseRoutingClient():
         c = RoutingClient("eida-routing")
         assert isinstance(c, EIDAWSRoutingClient)
 
-        c = RoutingClient("iris-federator")
+        c = RoutingClient("earthscope-federator")
         assert isinstance(c, FederatorRoutingClient)
 
         msg = "Routing type 'random' is not implemented. Available types: " \
-              "`iris-federator`, `eida-routing`"
+              "`earthscope-federator`, `eida-routing`"
         with pytest.raises(NotImplementedError, match=msg):
             RoutingClient("random")
 
     def test_expansion_of_include_and_exclude_providers(self):
         c = self._cls_object(
-            include_providers=["IRIS", "http://example.com"],
+            include_providers=["EARTHSCOPE", "http://example.com"],
             exclude_providers=["BGR", "http://example2.com"])
         assert c.include_providers == ["service.iris.edu", "example.com"]
         assert c.exclude_providers == ["eida.bgr.de", "example2.com"]
@@ -72,7 +72,7 @@ class TestBaseRoutingClient():
         assert c.exclude_providers == []
 
         # Single strings.
-        c = self._cls_object(include_providers="IRIS",
+        c = self._cls_object(include_providers="EARTHSCOPE",
                              exclude_providers="BGR")
         assert c.include_providers == ["service.iris.edu"]
         assert c.exclude_providers == ["eida.bgr.de"]
@@ -91,13 +91,15 @@ class TestBaseRoutingClient():
             "http://service.iris.edu": "1234"
         }
 
-        c = self._cls_object(include_providers=["IRIS", "http://example.com"])
+        c = self._cls_object(include_providers=["EARTHSCOPE",
+                                                "http://example.com"])
         assert c._filter_requests(split) == {
             "https://example.com": "1234",
             "http://service.iris.edu": "1234"
         }
 
-        c = self._cls_object(exclude_providers=["IRIS", "http://example.com"])
+        c = self._cls_object(exclude_providers=["EARTHSCOPE",
+                                                "http://example.com"])
         assert c._filter_requests(split) == {
             "http://example2.com": "1234",
             "http://example3.com": "1234"
@@ -105,8 +107,9 @@ class TestBaseRoutingClient():
 
         # Both filters are always applied - it might result in zero
         # remaining providers.
-        c = self._cls_object(include_providers=["IRIS", "http://example.com"],
-                             exclude_providers=["IRIS", "http://example.com"])
+        c = self._cls_object(
+            include_providers=["EARTHSCOPE", "http://example.com"],
+            exclude_providers=["EARTHSCOPE", "http://example.com"])
         assert c._filter_requests(split) == {}
 
     def test_downloading_waveforms(self):

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -25,6 +25,7 @@ import requests
 
 from obspy import UTCDateTime, read, read_inventory, Stream, Trace
 from obspy.core.util.base import NamedTemporaryFile, CatchAndAssertWarnings
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import (build_url, parse_simple_xml,
                                        get_bulk_string, _cleanup_earthscope)
@@ -1669,6 +1670,6 @@ class TestClient():
         """
         msg = ("IRIS is now EarthScope, please consider changing the FDSN "
                "client short URL to 'EARTHSCOPE'.")
-        with CatchAndAssertWarnings(expected=[(DeprecationWarning, msg)]):
+        with CatchAndAssertWarnings(expected=[(ObsPyDeprecationWarning, msg)]):
             client = Client('IRIS', _discover_services=False)
         assert client.base_url == 'http://service.iris.edu'

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -104,9 +104,9 @@ class TestClient():
     """
     @classmethod
     def setup_class(cls):
-        cls.client = Client(base_url="IRIS", user_agent=USER_AGENT)
+        cls.client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT)
         cls.client_auth = \
-            Client(base_url="IRIS", user_agent=USER_AGENT,
+            Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                    user="nobody@iris.edu", password="anonymous")
 
     def test_empty_bulk_string(self):
@@ -302,7 +302,7 @@ class TestClient():
         `set_credentials`, waveform queries should still properly go to
         "queryauth" endpoint.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT)
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT)
         user = "nobody@iris.edu"
         password = "anonymous"
         client.set_credentials(user=user, password=password)
@@ -332,17 +332,18 @@ class TestClient():
 
     def test_service_discovery_iris(self):
         """
-        Tests the automatic discovery of services with the IRIS endpoint. The
-        test parameters are taken from IRIS' website.
+        Tests the automatic discovery of services with the EARTHSCOPE endpoint.
+        The test parameters are taken from EARTHSCOPE website.
 
-        This will have to be adjusted once IRIS changes their implementation.
+        This will have to be adjusted once EARTHSCOPE changes their
+        implementation.
         """
         client = self.client
         assert {*client.services.keys()} == \
             {"dataselect", "event", "station", "available_event_contributors",
              "available_event_catalogs"}
 
-        # The test sets are copied from the IRIS webpage.
+        # The test sets are copied from the EARTHSCOPE webpage.
         assert {*client.services["dataselect"].keys()} == \
             {"starttime", "endtime", "network", "station", "location",
              "channel", "quality", "minimumlength", "longestonly"}
@@ -403,7 +404,7 @@ class TestClient():
         any services/WADL queries on the endpoint, and should show only the
         default service parameters.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
         assert client.services == DEFAULT_SERVICES
 
@@ -427,7 +428,7 @@ class TestClient():
 
     def test_iris_example_queries_event(self):
         """
-        Tests the (sometimes modified) example queries given on the IRIS
+        Tests the (sometimes modified) example queries given on the EARTHSCOPE
         web page.
 
         Used to be tested against files but that was not maintainable. It
@@ -466,9 +467,9 @@ class TestClient():
             assert event.origins[0].latitude > -170.1
             assert 170.1 > event.origins[0].latitude
             # events returned by FDSNWS can contain many magnitudes with a wide
-            # range, and currently (at least for IRIS) the magnitude threshold
-            # sent to the server checks if at least one magnitude matches, it
-            # does not only check the preferred magnitude..
+            # range, and currently (at least for EARTHSCOPE) the magnitude
+            # threshold sent to the server checks if at least one magnitude
+            # matches, it does not only check the preferred magnitude..
             assert any(m.mag >= 3.999 for m in event.magnitudes)
 
     @pytest.mark.filterwarnings('ignore:.*cannot deal with')
@@ -486,7 +487,8 @@ class TestClient():
 
     def test_iris_example_queries_station(self):
         """
-        Tests the (sometimes modified) example queries given on IRIS webpage.
+        Tests the (sometimes modified) example queries given on EARTHSCOPE
+        webpage.
 
         This test used to download files but that is almost impossible to
         keep up to date - thus it is now a bit smarter and tests the
@@ -556,7 +558,8 @@ class TestClient():
 
     def test_iris_example_queries_dataselect(self, testdata):
         """
-        Tests the (sometimes modified) example queries given on IRIS webpage.
+        Tests the (sometimes modified) example queries given on EARTHSCOPE
+        webpage.
         """
         client = self.client
 
@@ -616,13 +619,13 @@ class TestClient():
 
     def test_iris_example_queries_event_discover_services_false(self):
         """
-        Tests the (sometimes modified) example queries given on the IRIS
+        Tests the (sometimes modified) example queries given on the EARTHSCOPE
         web page, without service discovery.
 
         Used to be tested against files but that was not maintainable. It
         now tests if the queries return what was asked for.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
 
         # Event id query.
@@ -656,21 +659,21 @@ class TestClient():
             assert event.origins[0].latitude > -170.1
             assert 170.1 > event.origins[0].latitude
             # events returned by FDSNWS can contain many magnitudes with a wide
-            # range, and currently (at least for IRIS) the magnitude threshold
-            # sent to the server checks if at least one magnitude matches, it
-            # does not only check the preferred magnitude..
+            # range, and currently (at least for EARTHSCOPE) the magnitude
+            # threshold sent to the server checks if at least one magnitude
+            # matches, it does not only check the preferred magnitude..
             assert any(m.mag >= 3.999 for m in event.magnitudes)
 
     def test_iris_example_queries_station_discover_services_false(self):
         """
-        Tests the (sometimes modified) example queries given on IRIS webpage,
-        without service discovery.
+        Tests the (sometimes modified) example queries given on EARTHSCOPE
+        webpage, without service discovery.
 
         This test used to download files but that is almost impossible to
         keep up to date - thus it is now a bit smarter and tests the
         returned inventory in different ways.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
 
         # Radial query.
@@ -736,10 +739,10 @@ class TestClient():
     def test_iris_example_queries_dataselect_discover_services_false(
             self, testdata):
         """
-        Tests the (sometimes modified) example queries given on IRIS webpage,
-        without discovering services first.
+        Tests the (sometimes modified) example queries given on EARTHSCOPE
+        webpage, without discovering services first.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
 
         queries = [
@@ -789,9 +792,9 @@ class TestClient():
 
     def test_help_function_with_iris(self, testdata):
         """
-        Tests the help function with the IRIS example.
+        Tests the help function with the EARTHSCOPE example.
 
-        This will have to be adopted any time IRIS changes their
+        This will have to be adopted any time EARTHSCOPE changes their
         implementation.
         """
         try:
@@ -888,7 +891,8 @@ class TestClient():
                 ("IU", "ANMO", "*", "HHZ",
                  UTCDateTime("2010-03-25T00:00:00"),
                  UTCDateTime("2010-03-25T00:00:08")))
-        # As of 03 December 2018, it looks like IRIS is ignoring minimumlength?
+        # As of 03 December 2018, it looks like EARTHSCOPE is ignoring
+        # minimumlength?
         params = dict(quality="B", longestonly=False, minimumlength=5)
         for client in clients:
             # test output to stream
@@ -1179,7 +1183,7 @@ class TestClient():
         """
         Test manually deactivating a single service.
         """
-        client = Client(base_url="IRIS", user_agent=USER_AGENT,
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         service_mappings={"event": None})
         assert sorted(client.services.keys()) == ['dataselect', 'station']
 
@@ -1264,12 +1268,12 @@ class TestClient():
         Tests the redirection of GET and POST requests. We redirect
         everything if not authentication is used.
 
-        IRIS runs three services to test it:
+        EARTHSCOPE runs three services to test it:
             http://ds.iris.edu/files/redirect/307/station/1
             http://ds.iris.edu/files/redirect/307/dataselect/1
             http://ds.iris.edu/files/redirect/307/event/1
         """
-        c = Client("IRIS", service_mappings={
+        c = Client("EARTHSCOPE", service_mappings={
             "station":
                 "http://ds.iris.edu/files/redirect/307/station/1",
             "dataselect":
@@ -1340,11 +1344,11 @@ class TestClient():
             # I was not able to fix in the code
             warnings.filterwarnings('ignore', 'unclosed')
             with pytest.raises(FDSNRedirectException):
-                Client("IRIS", service_mappings=service_mappings,
+                Client("EARTHSCOPE", service_mappings=service_mappings,
                        user="nobody@iris.edu", password="anonymous",
                        user_agent=USER_AGENT)
             # The force_redirect flag overwrites that behaviour.
-            c_auth = Client("IRIS", service_mappings=service_mappings,
+            c_auth = Client("EARTHSCOPE", service_mappings=service_mappings,
                             user="nobody@iris.edu", password="anonymous",
                             user_agent=USER_AGENT, force_redirect=True)
         st = c_auth.get_waveforms(
@@ -1451,7 +1455,7 @@ class TestClient():
                 Client(eida_token="TEST")
 
         with pytest.raises(FDSNDoubleAuthenticationException):
-            Client("IRIS", eida_token="TEST", user="TEST")
+            Client("EARTHSCOPE", eida_token="TEST", user="TEST")
 
         download_url_mock.return_value = (401, None)
         with pytest.raises(FDSNUnauthorizedException):

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -24,7 +24,7 @@ import pytest
 import requests
 
 from obspy import UTCDateTime, read, read_inventory, Stream, Trace
-from obspy.core.util.base import NamedTemporaryFile
+from obspy.core.util.base import NamedTemporaryFile, CatchAndAssertWarnings
 from obspy.clients.fdsn import Client, RoutingClient
 from obspy.clients.fdsn.client import (build_url, parse_simple_xml,
                                        get_bulk_string, _cleanup_earthscope)
@@ -1657,3 +1657,14 @@ class TestClient():
                "does not seem to contain a valid PGP message.")
         with pytest.raises(ValueError, match=msg):
             client = Client('GFZ', eida_token=testdata['event_helpstring.txt'])
+
+    def test_iris_earthscope_message(self):
+        """
+        Test that using "IRIS" short URL in FDSN client shows a warning message
+        and switches to "EARTHSCOPE" short URL.
+        """
+        msg = ("IRIS is now EarthScope, please consider changing the FDSN "
+               "client short URL to 'EARTHSCOPE'.")
+        with CatchAndAssertWarnings(expected=[(DeprecationWarning, msg)]):
+            client = Client('IRIS', _discover_services=False)
+        assert client.base_url == 'http://service.iris.edu'

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -15,6 +15,7 @@ import pytest
 
 import obspy
 from obspy.core.util.base import CatchAndAssertWarnings
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.clients.fdsn import RoutingClient
 from obspy.clients.fdsn.routing.federator_routing_client import \
     FederatorRoutingClient
@@ -355,6 +356,7 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
                "'routing_type' to 'earthscope-federator'.")
         with mock.patch(mock_path) as p:
             p.return_value = None
-            with CatchAndAssertWarnings(expected=[(DeprecationWarning, msg)]):
+            with CatchAndAssertWarnings(
+                    expected=[(ObsPyDeprecationWarning, msg)]):
                 client = RoutingClient("iris-federator")
         assert isinstance(client, FederatorRoutingClient)

--- a/obspy/clients/fdsn/tests/test_federator_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_federator_routing_client.py
@@ -14,6 +14,8 @@ from packaging.version import parse as parse_version
 import pytest
 
 import obspy
+from obspy.core.util.base import CatchAndAssertWarnings
+from obspy.clients.fdsn import RoutingClient
 from obspy.clients.fdsn.routing.federator_routing_client import \
     FederatorRoutingClient
 
@@ -341,3 +343,18 @@ AK CAPN -- LHZ 2017-01-01T00:00:00 2017-01-02T00:00:00
         # because times stamps and also order might change slightly.
         # But the get_contents() method should be safe enough.
         assert inv.get_contents() == inv2.get_contents()
+
+    def test_iris_deprecation(self):
+        """
+        Test deprecation warning for "iris-federator" routing type
+        """
+        mock_path = (
+            'obspy.clients.fdsn.routing.federator_routing_client.'
+            'FederatorRoutingClient.__init__')
+        msg = ("IRIS is now EarthScope, please consider changing the "
+               "'routing_type' to 'earthscope-federator'.")
+        with mock.patch(mock_path) as p:
+            p.return_value = None
+            with CatchAndAssertWarnings(expected=[(DeprecationWarning, msg)]):
+                client = RoutingClient("iris-federator")
+        assert isinstance(client, FederatorRoutingClient)

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -2534,13 +2534,13 @@ class TestDownloadHelper():
         # The amount of services is variable and more and more get added.
         # Assert it's larger then 8 and contains a couple stable ones.
         assert len(d.providers) > 8
-        assert "IRIS" in d.providers
+        assert "EARTHSCOPE" in d.providers
         assert "ORFEUS" in d.providers
         patch.reset_mock()
 
-        d = MassDownloader(providers=["A", "B", "IRIS"])
+        d = MassDownloader(providers=["A", "B", "EARTHSCOPE"])
         assert patch.call_count == 1
-        assert d.providers == ("A", "B", "IRIS")
+        assert d.providers == ("A", "B", "EARTHSCOPE")
         patch.reset_mock()
 
     @mock.patch("obspy.clients.fdsn.client.Client._discover_services",
@@ -2571,9 +2571,9 @@ class TestDownloadHelper():
             logger.setLevel(_l)
 
         assert len(d._initialized_clients) > 10
-        assert not ("IRIS" in d._initialized_clients)
-        assert not ("RESIF" in d._initialized_clients)
-        assert not ("GFZ" in d._initialized_clients)
+        assert "EARTHSCOPE" not in d._initialized_clients
+        assert "RESIF" not in d._initialized_clients
+        assert "GFZ" not in d._initialized_clients
         assert "ORFEUS" in d._initialized_clients
 
     @mock.patch("obspy.clients.fdsn.client.Client._discover_services",
@@ -2585,7 +2585,7 @@ class TestDownloadHelper():
             self.services = {"dataselect": "dummy", "station": "dummy"}
         patch.side_effect = side_effect
 
-        client = Client("IRIS", user="random", password="something")
+        client = Client("EARTHSCOPE", user="random", password="something")
 
         assert patch.call_count == 1
         patch.reset_mock()
@@ -2649,7 +2649,7 @@ class TestDownloadHelper():
         d = MassDownloader()
 
         def avail(self):
-            if self.client_name == "IRIS":
+            if self.client_name == "EARTHSCOPE":
                 self.is_availability_reliable = True
             else:
                 self.is_availability_reliable = False

--- a/obspy/core/util/deprecation_helpers.py
+++ b/obspy/core/util/deprecation_helpers.py
@@ -12,7 +12,7 @@ Library name handling for ObsPy.
 
 class ObsPyDeprecationWarning(UserWarning):
     """
-    Make a custom deprecation warning as deprecation warnings or hidden by
+    Make a custom deprecation warning as deprecation warnings are hidden by
     default since Python 2.7 and 3.2 and we really want users to notice these.
     """
     pass


### PR DESCRIPTION
### What does this PR do?

This is a follow up for #3448 following https://github.com/obspy/obspy/pull/3448#issuecomment-2118469083

This changes some more docstring wordings to EarthScope and will show deprecation warnings when using `'IRIS'` short URL to initialize an FDSN client and `'iris-federator'` when initializing an federator client.

### Why was it initiated?  Any relevant Issues?

see #3448 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
