### PR TITLE
FDSN tests: Make many more tests run by default which need no network access

### DIFF
--- a/obspy/clients/fdsn/tests/test_base_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_base_routing_client.py
@@ -23,7 +23,6 @@ from obspy.clients.fdsn.routing.federator_routing_client import (
     FederatorRoutingClient)
 
 
-pytestmark = pytest.mark.network
 _DummyResponse = collections.namedtuple("_DummyResponse", ["content"])
 
 

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -52,7 +52,6 @@ from obspy.geodetics import locations2degrees
 
 
 USER_AGENT = "ObsPy (test suite) " + " ".join(DEFAULT_USER_AGENT.split())
-pytestmark = pytest.mark.network
 
 
 def _normalize_stats(obj):
@@ -99,6 +98,7 @@ def normalize_version_number(string):
     return [line.strip() for line in repl.splitlines()]
 
 
+@pytest.mark.network
 class TestClient():
     """
     Test cases for obspy.clients.fdsn.client.Client.
@@ -1673,3 +1673,11 @@ class TestClient():
         with CatchAndAssertWarnings(expected=[(ObsPyDeprecationWarning, msg)]):
             client = Client('IRIS', _discover_services=False)
         assert client.base_url == 'http://service.iris.edu'
+
+
+class TestClientNoNetwork():
+    """
+    Test cases for obspy.clients.fdsn.client.Client that do not need network
+    access.
+    """
+    pass

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -110,212 +110,6 @@ class TestClient():
             Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                    user="nobody@iris.edu", password="anonymous")
 
-    def test_empty_bulk_string(self):
-        """
-        Makes sure an exception is raised if an empty bulk string would be
-        produced (e.g. empty list as input for `get_bulk_string()`)
-        """
-        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
-               "of all available data")
-        for bad_input in [[], '', None]:
-            with pytest.raises(FDSNInvalidRequestException, match=msg):
-                get_bulk_string(bulk=bad_input, arguments={})
-
-    def test_validate_base_url(self):
-        """
-        Tests the _validate_base_url() method.
-        """
-
-        test_urls_valid = list(URL_MAPPINGS.values())
-        test_urls_valid += [
-            "http://something.ethz.ch",
-            "http://example.org",
-            "https://webservices.rm.ingv.it",
-            "http://localhost:8080/test/",
-            "http://93.63.40.85/",
-            "http://[::1]:80/test/",
-            "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]",
-            "http://[2001:db8::ff00:42:8329]",
-            "http://[::ffff:192.168.89.9]",
-            "http://jane",
-            "http://localhost",
-            "http://hyphenated-internal-hostname",
-            "http://internal-machine.private",
-            "https://long-public-tld.international",
-            "http://punycode-tld.xn--fiqs8s"]
-
-        test_urls_fails = [
-            "http://",
-            "http://127.0.1",
-            "http://127.=.0.1",
-            "http://127.0.0.0.1",
-            "http://tld.too.long." + ("x" * 64)]
-        test_urls_fails += [
-            "http://[]",
-            "http://[1]",
-            "http://[1:2]",
-            "http://[1::2::3]",
-            "http://[1::2:3::4]",
-            "http://[1:2:2:4:5:6:7]"]
-
-        for url in test_urls_valid:
-            assert self.client._validate_base_url(url), \
-                '%s should be valid' % url
-
-        for url in test_urls_fails:
-            assert not self.client._validate_base_url(url), \
-                '%s should be invalid' % url
-
-    def test_url_building(self):
-        """
-        Tests the build_url() functions.
-        """
-        # Application WADL
-        assert build_url("http://service.iris.edu", "dataselect", 1,
-                         "application.wadl") == \
-            "http://service.iris.edu/fdsnws/dataselect/1/application.wadl"
-        assert build_url("http://service.iris.edu", "event", 1,
-                         "application.wadl") == \
-            "http://service.iris.edu/fdsnws/event/1/application.wadl"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "application.wadl") == \
-            "http://service.iris.edu/fdsnws/station/1/application.wadl"
-
-        # Test one parameter.
-        assert build_url("http://service.iris.edu", "dataselect", 1,
-                         "query", {"network": "BW"}) == \
-            "http://service.iris.edu/fdsnws/dataselect/1/query?network=BW"
-        assert build_url("http://service.iris.edu", "dataselect", 1,
-                         "queryauth", {"network": "BW"}) == \
-            "http://service.iris.edu/fdsnws/dataselect/1/queryauth?network=BW"
-        # Test two parameters. Note random order, two possible results.
-        assert build_url("http://service.iris.edu", "dataselect", 1,
-                         "query", {"net": "A", "sta": "BC"}) in \
-            ("http://service.iris.edu/fdsnws/dataselect/1/query?net=A&sta=BC",
-             "http://service.iris.edu/fdsnws/dataselect/1/query?sta=BC&net=A")
-
-        # A wrong service raises a ValueError
-        with pytest.raises(ValueError):
-            build_url("http://service.iris.edu", "obspy", 1, "query")
-
-    def test_location_parameters(self):
-        """
-        Tests how the variety of location values are handled.
-
-        Why location? Mostly because it is one tricky parameter. It is not
-        uncommon to assume that a non-existent location is "--", but in reality
-        "--" is "<space><space>". This substitution exists because mostly
-        because various applications have trouble digesting spaces (spaces in
-        the URL, for example).
-        The confusion begins when location is treated as empty instead, which
-        would imply "I want all locations" instead of "I only want locations of
-        <space><space>"
-        """
-        # requests with no specified location should be treated as a wildcard
-        assert not ("--" in build_url(
-            "http://service.iris.edu", "station", 1, "query",
-            {"network": "IU", "station": "ANMO", "starttime": "2013-01-01"}))
-        # location of "  " is the same as "--"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "  "}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?location=--"
-        # wildcard locations are valid. Will be encoded.
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "*"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?location=%2A"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "A?"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?location=A%3F"
-
-        # lists are valid, including <space><space> lists. Again encoded
-        # result.
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "  ,1?,?0"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?" \
-            "location=--%2C1%3F%2C%3F0"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "1?,--,?0"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?" \
-            "location=1%3F%2C--%2C%3F0"
-
-        # Test all three special cases with empty parameters into lists.
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "  ,AA,BB"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?" \
-            "location=--%2CAA%2CBB"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "AA,  ,BB"}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?" \
-            "location=AA%2C--%2CBB"
-        assert build_url("http://service.iris.edu", "station", 1,
-                         "query", {"location": "AA,BB,  "}) == \
-            "http://service.iris.edu/fdsnws/station/1/query?" \
-            "location=AA%2CBB%2C--"
-
-        # The location parameter is also passed through the
-        # _create_url_from_parameters() method and thus has to survive it!
-        # This guards against a regression where all empty location codes
-        # where removed by this function!
-        for service in ["station", "dataselect"]:
-            for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
-                        u"", u" ", u"  ", u"--"]:
-                assert "location=--" in \
-                    self.client._create_url_from_parameters(
-                        service, [],
-                        {"location": loc, "starttime": 0, "endtime": 1})
-
-        # Also check the full call with a mock test.
-        for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
-                    u"", u" ", u"  ", u"--"]:
-            with mock.patch("obspy.clients.fdsn.Client._download") as p:
-                self.client.get_stations(0, 0, location=loc,
-                                         filename=mock.Mock())
-            assert p.call_count == 1
-            assert "location=--" in p.call_args[0][0]
-            with mock.patch("obspy.clients.fdsn.Client._download") as p:
-                self.client.get_waveforms(1, 2, loc, 4, 0, 0,
-                                          filename=mock.Mock())
-            assert p.call_count == 1
-            assert "location=--" in p.call_args[0][0]
-
-    def test_url_building_with_auth(self):
-        """
-        Tests the Client._build_url() method with authentication.
-
-        Necessary on top of test_url_building test case because clients with
-        authentication have to build different URLs for dataselect.
-        """
-        # no authentication
-        got = self.client._build_url("dataselect", "query", {'net': "BW"})
-        expected = "http://service.iris.edu/fdsnws/dataselect/1/query?net=BW"
-        assert got == expected
-        # with authentication
-        got = self.client_auth._build_url("dataselect", "query", {'net': "BW"})
-        expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
-                    "queryauth?net=BW")
-        assert got == expected
-
-    def test_set_credentials(self):
-        """
-        Test for issue #2146
-
-        When setting credentials not during `__init__` but using
-        `set_credentials`, waveform queries should still properly go to
-        "queryauth" endpoint.
-        """
-        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT)
-        user = "nobody@iris.edu"
-        password = "anonymous"
-        client.set_credentials(user=user, password=password)
-        got = client._build_url("dataselect", "query", {'net': "BW"})
-        expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
-                    "queryauth?net=BW")
-        assert got == expected
-        # more basic test: check that set_credentials has set Client.user
-        # (which is tested when checking which endpoint to use, query or
-        # queryauth)
-        assert client.user == user
-
     @pytest.mark.skip(reason='data no longer available')
     def test_trim_stream_after_get_waveform(self):
         """
@@ -398,34 +192,6 @@ class TestClient():
         assert len(expected) > 5
         assert {*self.client.services["available_event_contributors"]} == \
             expected
-
-    def test_discover_services_defaults(self):
-        """
-        A Client initialized with _discover_services=False shouldn't perform
-        any services/WADL queries on the endpoint, and should show only the
-        default service parameters.
-        """
-        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
-                        _discover_services=False)
-        assert client.services == DEFAULT_SERVICES
-
-    def test_simple_xml_parser(self):
-        """
-        Tests the simple XML parsing helper function.
-        """
-        catalogs = parse_simple_xml("""
-            <?xml version="1.0"?>
-            <Catalogs>
-              <total>6</total>
-              <Catalog>ANF</Catalog>
-              <Catalog>GCMT</Catalog>
-              <Catalog>TEST</Catalog>
-              <Catalog>ISC</Catalog>
-              <Catalog>UofW</Catalog>
-              <Catalog>NEIC PDE</Catalog>
-            </Catalogs>""")
-        assert catalogs == {"catalogs": set(
-            ("ANF", "GCMT", "TEST", "ISC", "UofW", "NEIC PDE"))}
 
     def test_iris_example_queries_event(self):
         """
@@ -784,12 +550,6 @@ class TestClient():
                     expected = fh.read()
             assert got == expected, \
                 "Dataselect failed for query %s" % repr(query)
-
-    def test_conflicting_params(self):
-        """
-        """
-        with pytest.raises(FDSNInvalidRequestException):
-            self.client.get_stations(network="IU", net="IU")
 
     def test_help_function_with_iris(self, testdata):
         """
@@ -1680,4 +1440,271 @@ class TestClientNoNetwork():
     Test cases for obspy.clients.fdsn.client.Client that do not need network
     access.
     """
-    pass
+    @classmethod
+    def setup_class(cls):
+        cls.client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                            _discover_services=False)
+        cls.client_auth = \
+            Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                   user="nobody@iris.edu", password="anonymous",
+                   _discover_services=False)
+
+    def test_empty_bulk_string(self):
+        """
+        Makes sure an exception is raised if an empty bulk string would be
+        produced (e.g. empty list as input for `get_bulk_string()`)
+        """
+        msg = ("Empty 'bulk' parameter potentially leading to a FDSN request "
+               "of all available data")
+        for bad_input in [[], '', None]:
+            with pytest.raises(FDSNInvalidRequestException, match=msg):
+                get_bulk_string(bulk=bad_input, arguments={})
+
+    def test_validate_base_url(self):
+        """
+        Tests the _validate_base_url() method.
+        """
+
+        test_urls_valid = list(URL_MAPPINGS.values())
+        test_urls_valid += [
+            "http://something.ethz.ch",
+            "http://example.org",
+            "https://webservices.rm.ingv.it",
+            "http://localhost:8080/test/",
+            "http://93.63.40.85/",
+            "http://[::1]:80/test/",
+            "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]",
+            "http://[2001:db8::ff00:42:8329]",
+            "http://[::ffff:192.168.89.9]",
+            "http://jane",
+            "http://localhost",
+            "http://hyphenated-internal-hostname",
+            "http://internal-machine.private",
+            "https://long-public-tld.international",
+            "http://punycode-tld.xn--fiqs8s"]
+
+        test_urls_fails = [
+            "http://",
+            "http://127.0.1",
+            "http://127.=.0.1",
+            "http://127.0.0.0.1",
+            "http://tld.too.long." + ("x" * 64)]
+        test_urls_fails += [
+            "http://[]",
+            "http://[1]",
+            "http://[1:2]",
+            "http://[1::2::3]",
+            "http://[1::2:3::4]",
+            "http://[1:2:2:4:5:6:7]"]
+
+        for url in test_urls_valid:
+            assert self.client._validate_base_url(url), \
+                '%s should be valid' % url
+
+        for url in test_urls_fails:
+            assert not self.client._validate_base_url(url), \
+                '%s should be invalid' % url
+
+    def test_url_building(self):
+        """
+        Tests the build_url() functions.
+        """
+        # Application WADL
+        assert build_url("http://service.iris.edu", "dataselect", 1,
+                         "application.wadl") == \
+            "http://service.iris.edu/fdsnws/dataselect/1/application.wadl"
+        assert build_url("http://service.iris.edu", "event", 1,
+                         "application.wadl") == \
+            "http://service.iris.edu/fdsnws/event/1/application.wadl"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "application.wadl") == \
+            "http://service.iris.edu/fdsnws/station/1/application.wadl"
+
+        # Test one parameter.
+        assert build_url("http://service.iris.edu", "dataselect", 1,
+                         "query", {"network": "BW"}) == \
+            "http://service.iris.edu/fdsnws/dataselect/1/query?network=BW"
+        assert build_url("http://service.iris.edu", "dataselect", 1,
+                         "queryauth", {"network": "BW"}) == \
+            "http://service.iris.edu/fdsnws/dataselect/1/queryauth?network=BW"
+        # Test two parameters. Note random order, two possible results.
+        assert build_url("http://service.iris.edu", "dataselect", 1,
+                         "query", {"net": "A", "sta": "BC"}) in \
+            ("http://service.iris.edu/fdsnws/dataselect/1/query?net=A&sta=BC",
+             "http://service.iris.edu/fdsnws/dataselect/1/query?sta=BC&net=A")
+
+        # A wrong service raises a ValueError
+        with pytest.raises(ValueError):
+            build_url("http://service.iris.edu", "obspy", 1, "query")
+
+    def test_location_parameters(self):
+        """
+        Tests how the variety of location values are handled.
+
+        Why location? Mostly because it is one tricky parameter. It is not
+        uncommon to assume that a non-existent location is "--", but in reality
+        "--" is "<space><space>". This substitution exists because mostly
+        because various applications have trouble digesting spaces (spaces in
+        the URL, for example).
+        The confusion begins when location is treated as empty instead, which
+        would imply "I want all locations" instead of "I only want locations of
+        <space><space>"
+        """
+        # requests with no specified location should be treated as a wildcard
+        assert not ("--" in build_url(
+            "http://service.iris.edu", "station", 1, "query",
+            {"network": "IU", "station": "ANMO", "starttime": "2013-01-01"}))
+        # location of "  " is the same as "--"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "  "}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?location=--"
+        # wildcard locations are valid. Will be encoded.
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "*"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?location=%2A"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "A?"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?location=A%3F"
+
+        # lists are valid, including <space><space> lists. Again encoded
+        # result.
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "  ,1?,?0"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?" \
+            "location=--%2C1%3F%2C%3F0"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "1?,--,?0"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?" \
+            "location=1%3F%2C--%2C%3F0"
+
+        # Test all three special cases with empty parameters into lists.
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "  ,AA,BB"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?" \
+            "location=--%2CAA%2CBB"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "AA,  ,BB"}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?" \
+            "location=AA%2C--%2CBB"
+        assert build_url("http://service.iris.edu", "station", 1,
+                         "query", {"location": "AA,BB,  "}) == \
+            "http://service.iris.edu/fdsnws/station/1/query?" \
+            "location=AA%2CBB%2C--"
+
+        # The location parameter is also passed through the
+        # _create_url_from_parameters() method and thus has to survive it!
+        # This guards against a regression where all empty location codes
+        # where removed by this function!
+        for service in ["station", "dataselect"]:
+            for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
+                        u"", u" ", u"  ", u"--"]:
+                assert "location=--" in \
+                    self.client._create_url_from_parameters(
+                        service, [],
+                        {"location": loc, "starttime": 0, "endtime": 1})
+
+        # Also check the full call with a mock test.
+        for loc in ["", " ", "  ", "--", b"", b" ", b"  ", b"--",
+                    u"", u" ", u"  ", u"--"]:
+            with mock.patch("obspy.clients.fdsn.Client._download") as p:
+                self.client.get_stations(0, 0, location=loc,
+                                         filename=mock.Mock())
+            assert p.call_count == 1
+            assert "location=--" in p.call_args[0][0]
+            with mock.patch("obspy.clients.fdsn.Client._download") as p:
+                self.client.get_waveforms(1, 2, loc, 4, 0, 0,
+                                          filename=mock.Mock())
+            assert p.call_count == 1
+            assert "location=--" in p.call_args[0][0]
+
+    def test_url_building_with_auth(self):
+        """
+        Tests the Client._build_url() method with authentication.
+
+        Necessary on top of test_url_building test case because clients with
+        authentication have to build different URLs for dataselect.
+        """
+        # no authentication
+        got = self.client._build_url("dataselect", "query", {'net': "BW"})
+        expected = "http://service.iris.edu/fdsnws/dataselect/1/query?net=BW"
+        assert got == expected
+        # with authentication
+        got = self.client_auth._build_url("dataselect", "query", {'net': "BW"})
+        expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
+                    "queryauth?net=BW")
+        assert got == expected
+
+    def test_set_credentials(self):
+        """
+        Test for issue #2146
+
+        When setting credentials not during `__init__` but using
+        `set_credentials`, waveform queries should still properly go to
+        "queryauth" endpoint.
+        """
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        user = "nobody@iris.edu"
+        password = "anonymous"
+        client.set_credentials(user=user, password=password)
+        got = client._build_url("dataselect", "query", {'net': "BW"})
+        expected = ("http://service.iris.edu/fdsnws/dataselect/1/"
+                    "queryauth?net=BW")
+        assert got == expected
+        # more basic test: check that set_credentials has set Client.user
+        # (which is tested when checking which endpoint to use, query or
+        # queryauth)
+        assert client.user == user
+
+    def test_discover_services_defaults(self):
+        """
+        A Client initialized with _discover_services=False shouldn't perform
+        any services/WADL queries on the endpoint, and should show only the
+        default service parameters.
+        """
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        assert client.services == DEFAULT_SERVICES
+
+    def test_simple_xml_parser(self):
+        """
+        Tests the simple XML parsing helper function.
+        """
+        catalogs = parse_simple_xml("""
+            <?xml version="1.0"?>
+            <Catalogs>
+              <total>6</total>
+              <Catalog>ANF</Catalog>
+              <Catalog>GCMT</Catalog>
+              <Catalog>TEST</Catalog>
+              <Catalog>ISC</Catalog>
+              <Catalog>UofW</Catalog>
+              <Catalog>NEIC PDE</Catalog>
+            </Catalogs>""")
+        assert catalogs == {"catalogs": set(
+            ("ANF", "GCMT", "TEST", "ISC", "UofW", "NEIC PDE"))}
+
+    def test_conflicting_params(self):
+        """
+        """
+        with pytest.raises(FDSNInvalidRequestException):
+            self.client.get_stations(network="IU", net="IU")
+
+    @mock.patch(
+        "obspy.clients.fdsn.client.Client._get_webservice_versionstring")
+    def test_str_method(self, version_mock):
+        # doesn't matter what version a server would actually return, since we
+        # normalize the version numbers during testing the string anyway
+        version_mock.return_value = '1.1.9'
+        got = str(self.client)
+        expected = (
+            "FDSN Webservice Client (base url: http://service.iris.edu)\n"
+            "Available Services: 'dataselect' (v1.0.0), 'event' (v1.0.6), "
+            "'station' (v1.0.7)\n\n"
+            "Use e.g. client.help('dataselect') for the\n"
+            "parameter description of the individual services\n"
+            "or client.help() for parameter description of\n"
+            "all webservices.")
+        got = normalize_version_number(got)
+        expected = normalize_version_number(expected)
+        assert got == expected, failmsg(got, expected)

--- a/obspy/clients/fdsn/tests/test_mass_downloader.py
+++ b/obspy/clients/fdsn/tests/test_mass_downloader.py
@@ -41,9 +41,6 @@ from obspy.clients.fdsn.mass_downloader.download_helpers import (
     Channel, TimeInterval, Station, STATUS, ClientDownloadHelper)
 
 
-pytestmark = pytest.mark.network
-
-
 class TestDomain():
     """
     Test case for the domain definitions.


### PR DESCRIPTION

### What does this PR do?

Separates FDSN tests into two groups better, those that actually need network and those that can run without network access and make the latter run by default.
Hardly any changes to the test routines itself (only 2-3 routines changed a bit so they can run without network), so the long list of changes is mostly just moving routines from one test class to another, with one class being marked as "network" and the other one not.

### Why was it initiated?  Any relevant Issues?

--

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
