### PR TITLE
fdsn Client: make it possible to opt out of gzip compression on server side

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changes:
    * make sure to use a copy of `DEFAULT_SERVICES` when initializing a client
      instance while skipping service discovery, to avoid accidental changes to
      `DEFAULT_SERVICES` (see #3493)
+   * make it possible to opt out of server side gzip compression (see #3469)
  - obspy.clients.seedlink:
    * fix a bug in basic client `get_info()` which leaded to exceptions when
      querying with `level="channel"` in presence of stations with no current

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -150,7 +150,7 @@ class Client(object):
     def __init__(self, base_url="EARTHSCOPE", major_versions=None, user=None,
                  password=None, user_agent=DEFAULT_USER_AGENT, debug=False,
                  timeout=120, service_mappings=None, force_redirect=False,
-                 eida_token=None, _discover_services=True):
+                 eida_token=None, _discover_services=True, use_gzip=True):
         """
         Initializes an FDSN Web Service client.
 
@@ -219,11 +219,19 @@ class Client(object):
             to ``False``, no service discovery is performed and default
             parameter support is assumed. This parameter is experimental and
             will likely be removed in the future.
+        :type use_gzip: bool
+        :param use_gzip: Can be set to ``False`` to opt out of gzip
+            compression, i.e. not tell the server that gzip compressed response
+            is acceptable which should make the server not try gzip compression
+            on results. Can be used if servers experience server side issues
+            with gzip compression but results in downloads being larger in
+            size.
         """
         self.debug = debug
         self.user = user
         self.timeout = timeout
         self._force_redirect = force_redirect
+        self.use_gzip = use_gzip
 
         # Cache for the webservice versions. This makes interactive use of
         # the client more convenient.
@@ -406,7 +414,7 @@ class Client(object):
 
         # Already does the error checking with fdsnws semantics.
         response = self._download(url=url, data=token.encode(),
-                                  use_gzip=True, return_string=True,
+                                  return_string=True,
                                   content_type='application/octet-stream')
 
         user, password = response.decode().split(':')
@@ -1481,8 +1489,13 @@ class Client(object):
 
         print("\n".join(msg))
 
-    def _download(self, url, return_string=False, data=None, use_gzip=True,
+    def _download(self, url, return_string=False, data=None, use_gzip=None,
                   content_type=None):
+        # make it possible to have a default for gzip set on client
+        # initialization but also be able to override it here (for dataselect
+        # requests)
+        if use_gzip is None:
+            use_gzip = self.use_gzip
         headers = self.request_headers.copy()
         if content_type:
             headers['Content-Type'] = content_type


### PR DESCRIPTION
### What does this PR do?

Makes it possible for users to opt out of gzip server side compression (`Client(.., use_gzip=False)`) in all requests made to the connected server.

### Why was it initiated?  Any relevant Issues?

see #3465 
If server has bugs in gzip compression currently it's not doable for users to deactivate gzip compression without subclassing `Client`

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
