### PR TITLE
Fix dynamic construction of doc strings (resolve_seedid and co)

### DIFF
--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -4,7 +4,7 @@
 Utility objects.
 
 :copyright:
-    Lion Krischer (krischer@geophysik.uni-muenchen.de), 2013
+    Lion Krischer (krischer@geophysik.uni-muenchen.de), Tom Eulenfeld 2013-2024
 :license:
     GNU Lesser General Public License, Version 3
     (https://www.gnu.org/copyleft/lesser.html)
@@ -1130,7 +1130,7 @@ def _warn_on_invalid_uri(uri):
 
 
 def _add_resolve_seedid_doc(func):
-    """
+    doc = """
     The following parameters deal with the problem, that the format
     only stores station names for the picks, but the Pick object expects
     a SEED id. The SEED id is looked up for every pick by the
@@ -1158,18 +1158,18 @@ def _add_resolve_seedid_doc(func):
        (no matching data found or ambiguous results) in the inventory
     """
     if func.__doc__ is not None:
-        func.__doc__ = func.__doc__ + __doc__
+        func.__doc__ = func.__doc__ + doc
     return func
 
 
 def _add_resolve_seedid_ph2comp_doc(func):
-    """
+    doc = """
     :param dict ph2comp: mapping of phases to components if format does not
         specify the component or if the component ends with '?'. Set it to
         `None` for no mapping of components. (default: {'P': 'Z', 'S': 'N'})
     """
     if func.__doc__ is not None:
-        func.__doc__ = func.__doc__ + __doc__
+        func.__doc__ = func.__doc__ + doc
     return func
 
 

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -376,3 +376,7 @@ class TestNLLOC():
         assert cat[0].origins[0].evaluation_status == "rejected"
         assert cat[0].origins[0].comments[1].text == expected_comment
         assert cat[0].comments[1].text == expected_comment
+
+    def test_read_nlloc_doc_resolve_seedid(self):
+        assert 'seedid_map:' in read_nlloc_hyp.__doc__
+        assert 'ph2comp:' in read_nlloc_hyp.__doc__


### PR DESCRIPTION
Accidentally, the module doc string was added, instead of the function doc string.
For example see: https://docs.obspy.org/packages/autogen/obspy.io.hypodd.pha._read_pha.html#obspy.io.hypodd.pha._read_pha

This PR fixes this issue.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
