### PR TITLE
fdsn client : raise a FDSNNoServiceException rather than a ValueError…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,8 @@ Changes:
      current msindex (see #3403)
  - obspy.clients.fdsn
    * Natural Resources Canada (NRCAN) added to list of known clients
+   * A FDSNNoServiceException is now raised instead of a ValueError when
+     querying a webservice not present in Client.services  (see #3483)
  - obspy.clients.seedlink:
    * fix a bug in basic client `get_info()` which leaded to exceptions when
      querying with `level="channel"` in presence of stations with no current

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -86,6 +86,7 @@ Muñoz Mesa, Jesús A.
 Murray-Bergquist, Louisa
 Nesbitt, Ian M.
 Nof, Ran Novitsky
+Panay, Simon
 Panning, Mark P.
 Parker, Tom
 Pestourie, Romain

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -546,7 +546,7 @@ class Client(object):
         """
         if "event" not in self.services:
             msg = "The current client does not have an event service."
-            raise ValueError(msg)
+            raise FDSNNoServiceException(msg)
 
         locs = locals()
         setup_query_dict('event', locs, kwargs)
@@ -744,7 +744,7 @@ class Client(object):
         """
         if "station" not in self.services:
             msg = "The current client does not have a station service."
-            raise ValueError(msg)
+            raise FDSNNoServiceException(msg)
 
         locs = locals()
         setup_query_dict('station', locs, kwargs)
@@ -862,7 +862,7 @@ class Client(object):
         """
         if "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
-            raise ValueError(msg)
+            raise FDSNNoServiceException(msg)
 
         locs = locals()
         setup_query_dict('dataselect', locs, kwargs)
@@ -1044,7 +1044,7 @@ class Client(object):
         """
         if "dataselect" not in self.services:
             msg = "The current client does not have a dataselect service."
-            raise ValueError(msg)
+            raise FDSNNoServiceException(msg)
 
         arguments = OrderedDict(
             quality=quality,
@@ -1231,7 +1231,7 @@ class Client(object):
         """
         if "station" not in self.services:
             msg = "The current client does not have a station service."
-            raise ValueError(msg)
+            raise FDSNNoServiceException(msg)
 
         arguments = OrderedDict(
             minlatitude=minlatitude,

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -551,7 +551,6 @@ class TestClient():
             assert got == expected, \
                 "Dataselect failed for query %s" % repr(query)
 
-
     def test_help_function_with_iris(self, testdata):
         """
         Tests the help function with the EARTHSCOPE example.

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1716,20 +1716,27 @@ class TestClientNoNetwork():
         available but a get_(waveforms|stations|events) method is called
         nonetheless
         """
-        # Lets make those three services disappear from the client
-        services = ["dataselect", "event", "station"]
-        for service in services:
-            self.client.services.pop(service)
+        start = UTCDateTime(2020, 1, 1)
+        end = start + 10
 
-        start = None
-        end = None
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        client.services.pop('dataselect')
         with pytest.raises(FDSNNoServiceException):
             self.client.get_waveforms('G', 'PEL', '*', 'LHZ', start, end)
         with pytest.raises(FDSNNoServiceException):
             self.client.get_waveforms_bulk('G', 'PEL', '*', 'LHZ', start, end)
+
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        client.services.pop('station')
         with pytest.raises(FDSNNoServiceException):
             self.client.get_stations('G', 'PEL', '*', 'LHZ', start, end)
         with pytest.raises(FDSNNoServiceException):
             self.client.get_stations_bulk('G', 'PEL', '*', 'LHZ', start, end)
+
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        client.services.pop('event')
         with pytest.raises(FDSNNoServiceException):
             self.client.get_events(start, end)

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -551,6 +551,19 @@ class TestClient():
             assert got == expected, \
                 "Dataselect failed for query %s" % repr(query)
 
+    def test_dataselect_when_not_present_in_services(self):
+        """
+        Tests get_waveforms when dataselect is not present in Client.services
+        Should raise a FDSNNoServiceException
+        """
+        client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                        _discover_services=False)
+        client.services.pop("dataselect")
+        starttime = UTCDateTime('2016-11-01T00:00:00')
+        endtime = UTCDateTime('2016-11-01T00:00:10')
+        with pytest.raises(FDSNNoServiceException):
+            _ = client.get_waveforms('G', 'PEL', '*', 'LHZ', starttime, endtime)
+
     def test_help_function_with_iris(self, testdata):
         """
         Tests the help function with the EARTHSCOPE example.


### PR DESCRIPTION
… if service is not present in Client.services

### What does this PR do?

This PR replace ValueError raised with FDSNNoServiceException when dataselect|station|event is not present in Client.services and get_waveforms|stations|events[_bulk] is called.

### Why was it initiated?  Any relevant Issues?

fixes #3483 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
