### PR TITLE
CI: avoid a broken setuptools package version

### DIFF
--- a/.github/docs_conda_env.yml
+++ b/.github/docs_conda_env.yml
@@ -14,7 +14,8 @@ dependencies:
   - numpy
   - scipy
   - requests  
-  - setuptools
+  # see pypa/setuptools#4480
+  - setuptools !=71.0.1
   # see #3258
   - sqlalchemy < 2.0
   # docs

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -10,7 +10,8 @@ dependencies:
   - numpy
   - scipy
   - requests
-  - setuptools
+  # see pypa/setuptools#4480
+  - setuptools !=71.0.1
   # see #3258
   - sqlalchemy < 2.0
   # soft dependencies

--- a/.github/test_mindep_conda_env.yml
+++ b/.github/test_mindep_conda_env.yml
@@ -10,7 +10,8 @@ dependencies:
   - numpy
   - scipy
   - requests
-  - setuptools
+  # see pypa/setuptools#4480
+  - setuptools !=71.0.1
   # see #3258
   - sqlalchemy < 2.0
   # tests

--- a/.github/test_mindepversion_conda_env.yml
+++ b/.github/test_mindepversion_conda_env.yml
@@ -10,7 +10,8 @@ dependencies:
   - decorator
   - lxml
   - requests
-  - setuptools
+  # see pypa/setuptools#4480
+  - setuptools !=71.0.1
   # see #3258
   - sqlalchemy < 2.0
   # soft dependencies


### PR DESCRIPTION
### What does this PR do?

avoid a broken setuptools package version in CI, which crashes our test runner script "obspy-runtests"


### Why was it initiated?  Any relevant Issues?

see pypa/setuptools#4480

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
