### PR TITLE
fdsn: avoid inadvertent changes to DEFAULT_SERVICES

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,9 @@ Changes:
    * Natural Resources Canada (NRCAN) added to list of known clients
    * A FDSNNoServiceException is now raised instead of a ValueError when
      querying a webservice not present in Client.services  (see #3483)
+   * make sure to use a copy of `DEFAULT_SERVICES` when initializing a client
+     instance while skipping service discovery, to avoid accidental changes to
+     `DEFAULT_SERVICES` (see #3493)
  - obspy.clients.seedlink:
    * fix a bug in basic client `get_info()` which leaded to exceptions when
      querying with `level="channel"` in presence of stations with no current

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -283,7 +283,7 @@ class Client(object):
         if _discover_services:
             self._discover_services()
         else:
-            self.services = DEFAULT_SERVICES
+            self.services = DEFAULT_SERVICES.copy()
 
         # Use EIDA token if provided - this requires setting new url openers.
         #

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1722,20 +1722,20 @@ class TestClientNoNetwork():
                         _discover_services=False)
         client.services.pop('dataselect')
         with pytest.raises(FDSNNoServiceException):
-            self.client.get_waveforms('G', 'PEL', '*', 'LHZ', start, end)
+            client.get_waveforms('G', 'PEL', '*', 'LHZ', start, end)
         with pytest.raises(FDSNNoServiceException):
-            self.client.get_waveforms_bulk('G', 'PEL', '*', 'LHZ', start, end)
+            client.get_waveforms_bulk('G', 'PEL', '*', 'LHZ', start, end)
 
         client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
         client.services.pop('station')
         with pytest.raises(FDSNNoServiceException):
-            self.client.get_stations('G', 'PEL', '*', 'LHZ', start, end)
+            client.get_stations('G', 'PEL', '*', 'LHZ', start, end)
         with pytest.raises(FDSNNoServiceException):
-            self.client.get_stations_bulk('G', 'PEL', '*', 'LHZ', start, end)
+            client.get_stations_bulk('G', 'PEL', '*', 'LHZ', start, end)
 
         client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
                         _discover_services=False)
         client.services.pop('event')
         with pytest.raises(FDSNNoServiceException):
-            self.client.get_events(start, end)
+            client.get_events(start, end)


### PR DESCRIPTION
### What does this PR do?

Makes sure we make a copy of `DEFAULT_SERVICES` if it is used to initialize a client instance, so that potential tinkering with its `.services` attribute does not modify `DEFAULT_SERVICES`.

Then also adds a small fix to a last minute change to the test code from #3488 

### Why was it initiated?  Any relevant Issues?

fixes a test fail resulting from interactions running through the full test suite. see #3488 


### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
