### PR TITLE
fdsn: another regression fix for server response handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,10 @@ Changes:
      instance while skipping service discovery, to avoid accidental changes to
      `DEFAULT_SERVICES` (see #3493)
    * make it possible to opt out of server side gzip compression (see #3469)
+   * fix a regression introduced by #3306 which lead to some network errors not
+     getting raised as an FDSNException but some low-level exceptions like
+     AttributeError, which in turn caused problems in Mass Downloader (see
+     #3513)
  - obspy.clients.seedlink:
    * fix a bug in basic client `get_info()` which leaded to exceptions when
      querying with `level="channel"` in presence of stations with no current

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ from setuptools import Extension, find_packages, setup
 
 
 # The minimum python version which can be used to run ObsPy
+# XXX when dropping Python 3.9, get rid of socket.timeout and just use
+# TimeoutError, e.g. in fdsn/client.py
 MIN_PYTHON_VERSION = (3, 8)
 
 # Fail fast if the user is on an unsupported version of python.


### PR DESCRIPTION
### What does this PR do?

With #3306 some problems in extracting detailed server response were fixed, but unfortunately the treatment for some other cases inadvertently worsened, namely errors without a proper HTTP response like socket timeout and temporary address resolution problems (so e.g. random network glitches).
Before #3306 they were handled in a quite ugly (but robust) way, so it went unnoticed that errors without a proper HTTP response code did not get handled anymore (in raising `FDSNException` or its subclasses), resulting in unexpected low-level exceptions happening (namely `AttributeError` and maybe others too), which was tripping up FDSN Mass Downloader.

This pre-processing preparing the server info message before #3306 was ugly but worked for unexpected errors and we eventually lost the middle part handling everything unexpected.

```python
    if code != 200:
        try:
            server_info = data.read()
        except Exception:
            server_info = None
        else:
            server_info = server_info.decode('ASCII', errors='ignore')
```

This should fix it again and also reorganizes the handling for all "no HTTP response" exceptions to happen in one place before handling any HTTP responses.

Also adds non-networked tests for the `raise_on_error` function, which we just should have had in the first place to prevent this regression from happening alltogether.

### Why was it initiated?  Any relevant Issues?

Should finally comprehensively handle regression issues introduced by #3306, fixes #3496, fixes #3510

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
