### PR TITLE
Read the origin-specific data from the Phase Block in the ISF Bulletin

### DIFF
--- a/obspy/io/iaspei/tests/data/19670130012028.xml
+++ b/obspy/io/iaspei/tests/data/19670130012028.xml
@@ -1,21 +1,22 @@
 <?xml version='1.0' encoding='utf-8'?>
-<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
-  <eventParameters publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13">
+<q:quakeml xmlns="http://quakeml.org/xmlns/bed/1.2" xmlns:q="http://quakeml.org/xmlns/quakeml/1.2">
+  <eventParameters publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24">
     <description>ISC Bulletin</description>
-    <event publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/event/840268">
+    <event publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/event/840268">
+      <preferredOriginID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</preferredOriginID>
       <type>earthquake</type>
       <typeCertainty>known</typeCertainty>
       <description>
         <text>Western Caucasus</text>
         <type>region name</type>
       </description>
-      <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+      <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
         <text>2008    175   185   201 Geophys. J. Int.</text>
       </comment>
-      <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+      <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
         <text>1970           29    31 Earthquakes in USSR</text>
       </comment>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838610">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838610">
         <time>
           <value>1967-01-30T01:20:27.000000Z</value>
         </time>
@@ -34,7 +35,7 @@
           <author>BCIS</author>
         </creationInfo>
       </origin>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838611">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838611">
         <time>
           <value>1967-01-30T01:20:27.700000Z</value>
         </time>
@@ -45,7 +46,7 @@
           <value>44.335</value>
         </longitude>
         <depth>
-          <value>6.0</value>
+          <value>6000.0</value>
         </depth>
         <timeFixed>false</timeFixed>
         <epicenterFixed>false</epicenterFixed>
@@ -53,7 +54,7 @@
           <author>USCGS</author>
         </creationInfo>
       </origin>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/9093437">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/9093437">
         <time>
           <value>1967-01-30T01:20:28.170000Z</value>
         </time>
@@ -64,20 +65,20 @@
           <value>44.2685</value>
         </longitude>
         <depth>
-          <value>5.0</value>
+          <value>5000.0</value>
         </depth>
         <timeFixed>false</timeFixed>
         <epicenterFixed>true</epicenterFixed>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> (Spitak, Armenia)</text>
         </comment>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> (GT5 produced by HDC-RCA methodology)</text>
         </comment>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> (Bondár, I., E. Bergman, E.R. Engdahl, B. Kohl, Y-L. Kung, and K. McLaughlin,  A hybrid multiple event location technique to obtain ground)</text>
         </comment>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> ( truth event locations,  Geophys. J. Int., 175, 185-201, doi: 10.1111/j.1365-246X.2008.03867.x, 2008.)</text>
         </comment>
         <creationInfo>
@@ -85,13 +86,13 @@
         </creationInfo>
         <originUncertainty>
           <preferredDescription>uncertainty ellipse</preferredDescription>
-          <minHorizontalUncertainty>2.719</minHorizontalUncertainty>
-          <maxHorizontalUncertainty>4.091</maxHorizontalUncertainty>
+          <minHorizontalUncertainty>2719.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>4091.0</maxHorizontalUncertainty>
           <azimuthMaxHorizontalUncertainty>49.0</azimuthMaxHorizontalUncertainty>
           <confidenceLevel>90.0</confidenceLevel>
         </originUncertainty>
       </origin>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838612">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838612">
         <time>
           <value>1967-01-30T01:20:30.000000Z</value>
         </time>
@@ -102,7 +103,7 @@
           <value>44.3</value>
         </longitude>
         <depth>
-          <value>33.0</value>
+          <value>33000.0</value>
         </depth>
         <timeFixed>false</timeFixed>
         <epicenterFixed>false</epicenterFixed>
@@ -110,7 +111,7 @@
           <author>MOS</author>
         </creationInfo>
       </origin>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/9212463">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/9212463">
         <time>
           <value>1967-01-30T01:20:30.030000Z</value>
         </time>
@@ -121,7 +122,7 @@
           <value>44.267</value>
         </longitude>
         <depth>
-          <value>10.0</value>
+          <value>10000.0</value>
         </depth>
         <timeFixed>false</timeFixed>
         <epicenterFixed>true</epicenterFixed>
@@ -130,13 +131,13 @@
         </creationInfo>
         <originUncertainty>
           <preferredDescription>uncertainty ellipse</preferredDescription>
-          <minHorizontalUncertainty>5.4</minHorizontalUncertainty>
-          <maxHorizontalUncertainty>7.1</maxHorizontalUncertainty>
+          <minHorizontalUncertainty>5400.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>7100.0</maxHorizontalUncertainty>
           <azimuthMaxHorizontalUncertainty>18.0</azimuthMaxHorizontalUncertainty>
           <confidenceLevel>90.0</confidenceLevel>
         </originUncertainty>
       </origin>
-      <origin publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838613">
+      <origin publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613">
         <time>
           <value>1967-01-30T01:20:28.700000Z</value>
         </time>
@@ -147,17 +148,17 @@
           <value>44.31</value>
         </longitude>
         <depth>
-          <value>11.0</value>
+          <value>11000.0</value>
         </depth>
         <timeFixed>false</timeFixed>
         <epicenterFixed>false</epicenterFixed>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>location method: inversion</text>
         </comment>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> (#PRIME)</text>
         </comment>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text> (Depth fixed to depth phase depth)</text>
         </comment>
         <creationInfo>
@@ -165,164 +166,207 @@
         </creationInfo>
         <originUncertainty>
           <preferredDescription>uncertainty ellipse</preferredDescription>
-          <minHorizontalUncertainty>2.51</minHorizontalUncertainty>
-          <maxHorizontalUncertainty>3.7</maxHorizontalUncertainty>
+          <minHorizontalUncertainty>2510.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>3700.0</maxHorizontalUncertainty>
           <azimuthMaxHorizontalUncertainty>0.0</azimuthMaxHorizontalUncertainty>
           <confidenceLevel>90.0</confidenceLevel>
         </originUncertainty>
+        <arrival publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/arrival/27631110">
+          <pickID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631110</pickID>
+          <phase>P*</phase>
+          <azimuth>30.0</azimuth>
+          <distance>0.73</distance>
+          <timeResidual>1.1</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/arrival/27631111">
+          <pickID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631111</pickID>
+          <phase>S</phase>
+          <distance>0.73</distance>
+          <timeWeight>0.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/arrival/27631112">
+          <pickID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631112</pickID>
+          <phase>P*</phase>
+          <azimuth>317.0</azimuth>
+          <distance>0.88</distance>
+          <timeResidual>-1.5</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/arrival/27631113">
+          <pickID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631113</pickID>
+          <phase>S</phase>
+          <distance>0.88</distance>
+          <timeWeight>0.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
       </origin>
-      <magnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/magnitude">
+      <magnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/magnitude">
         <mag>
           <value>4.5</value>
         </mag>
-        <originID>smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838610</originID>
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838610</originID>
         <creationInfo>
           <author>BCIS</author>
         </creationInfo>
       </magnitude>
-      <magnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/magnitude">
+      <magnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/magnitude">
         <mag>
           <value>5.1</value>
         </mag>
         <type>MB</type>
-        <originID>smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838611</originID>
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838611</originID>
         <stationCount>13</stationCount>
         <creationInfo>
           <author>USCGS</author>
         </creationInfo>
       </magnitude>
-      <magnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/magnitude">
+      <magnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/magnitude">
         <mag>
           <value>5.0</value>
         </mag>
         <type>mb</type>
-        <originID>smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/9093437</originID>
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/9093437</originID>
         <creationInfo>
           <author>IASPEI</author>
         </creationInfo>
       </magnitude>
-      <magnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/magnitude">
+      <magnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/magnitude">
         <mag>
           <value>5.0</value>
         </mag>
-        <originID>smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838612</originID>
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838612</originID>
         <creationInfo>
           <author>MOS</author>
         </creationInfo>
       </magnitude>
-      <magnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/magnitude">
+      <magnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/magnitude">
         <mag>
           <value>5.0</value>
         </mag>
         <type>mb</type>
-        <originID>smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/origin/1838613</originID>
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <stationCount>15</stationCount>
         <creationInfo>
           <author>ISC</author>
         </creationInfo>
       </magnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631202">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>5.4</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="LJU"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631216">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>5.5</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="KHC"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631252">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>5.5</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="STU"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631311">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>4.9</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="SHL"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631313">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>4.8</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="KOD"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631314">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>4.8</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="NAI"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <stationMagnitude publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/station_magnitude">
-        <originID>None</originID>
+      <stationMagnitude publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/station_magnitude/27631315">
+        <originID>smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/origin/1838613</originID>
         <mag>
           <value>4.5</value>
         </mag>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
+        <waveformID stationCode="LAO"></waveformID>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
           <text>min max indicator (&lt;, &gt;, or blank):  </text>
         </comment>
       </stationMagnitude>
-      <pick publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/pick">
+      <pick publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631110">
         <time>
           <value>1967-01-30T01:20:44.000000Z</value>
         </time>
         <waveformID stationCode="TIF"></waveformID>
         <phaseHint>P*</phaseHint>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
-          <text>station-to-event distance (degrees): "  0.73", event-to-station azimuth (degrees): " 30.0", time residual (seconds): "  1.1", observed azimuth (degrees): "     ", azimuth residual (degrees): "     ", observed slowness (seconds/degree): "      ", slowness residual (seconds/degree): "     ", time defining flag (T or _): "T", azimuth defining flag (A or _): "_", slowness defining flag (S or _): "_", signal-to-noise ratio: "     "</text>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
+          <text>TAS flag: "T__"</text>
         </comment>
       </pick>
-      <pick publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/pick">
+      <pick publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631111">
         <time>
           <value>1967-01-30T01:20:54.000000Z</value>
         </time>
         <waveformID stationCode="TIF"></waveformID>
         <phaseHint>S</phaseHint>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
-          <text>station-to-event distance (degrees): "  0.73", event-to-station azimuth (degrees): "     ", time residual (seconds): "     ", observed azimuth (degrees): "     ", azimuth residual (degrees): "     ", observed slowness (seconds/degree): "      ", slowness residual (seconds/degree): "     ", time defining flag (T or _): "_", azimuth defining flag (A or _): "_", slowness defining flag (S or _): "_", signal-to-noise ratio: "     "</text>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
+          <text>TAS flag: "___"</text>
         </comment>
       </pick>
-      <pick publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/pick">
+      <pick publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631112">
         <time>
           <value>1967-01-30T01:20:44.000000Z</value>
         </time>
         <waveformID stationCode="BKR"></waveformID>
         <onset>impulsive</onset>
         <phaseHint>P*</phaseHint>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
-          <text>station-to-event distance (degrees): "  0.88", event-to-station azimuth (degrees): "317.0", time residual (seconds): " -1.5", observed azimuth (degrees): "     ", azimuth residual (degrees): "     ", observed slowness (seconds/degree): "      ", slowness residual (seconds/degree): "     ", time defining flag (T or _): "T", azimuth defining flag (A or _): "_", slowness defining flag (S or _): "_", signal-to-noise ratio: "     "</text>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
+          <text>TAS flag: "T__"</text>
         </comment>
       </pick>
-      <pick publicID="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/pick">
+      <pick publicID="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/pick/27631113">
         <time>
           <value>1967-01-30T01:21:01.000000Z</value>
         </time>
         <waveformID stationCode="BKR"></waveformID>
         <phaseHint>S</phaseHint>
-        <comment id="smi:local/bc358dfb-0751-4aed-a229-49ef5c524b13/comment">
-          <text>station-to-event distance (degrees): "  0.88", event-to-station azimuth (degrees): "     ", time residual (seconds): "     ", observed azimuth (degrees): "     ", azimuth residual (degrees): "     ", observed slowness (seconds/degree): "      ", slowness residual (seconds/degree): "     ", time defining flag (T or _): "_", azimuth defining flag (A or _): "_", slowness defining flag (S or _): "_", signal-to-noise ratio: "     "</text>
+        <comment id="smi:local/a1520fea-9164-4f27-bea3-d135bf2e9b24/comment">
+          <text>TAS flag: "___"</text>
         </comment>
       </pick>
     </event>

--- a/obspy/io/iaspei/tests/data/ipe202409sel_ims.txt
+++ b/obspy/io/iaspei/tests/data/ipe202409sel_ims.txt
@@ -1,0 +1,60 @@
+https://www.ipe.muni.cz/WEB/gse/ipe202409_ims.txt
+BEGIN IMS1.0
+MSG_TYPE DATA
+DATA_TYPE BULLETIN IMS1.0:SHORT
+Selected from Preliminary Event Bulletin of the IPEC, Czech Republic, for the time period 01.09.-30.09.2024
+
+EVENT 2032247  CZECH REPUBLIC, OSTRAVA
+
+   Date       Time        Err   RMS Latitude Longitude  Smaj  Smin  Az Depth   Err Ndef Nsta Gap  mdist  Mdist Qual   Author      OrigID
+2024/09/01 11:18:16.35                                                                                         m o ki IPEC       2032247
+
+Sta     Dist  EvAz Phase        Time      TRes  Azim AzRes   Slow   SRes Def   SNR       Amp   Per Qual Magnitude    ArrID
+ (#OrigID 2032247)
+ (redundant #OrigID tag for test)
+MORC               Pg       11:18:16.350                                 ___                       m_e            19692935
+MORC               Sg       11:18:24.166                                 ___                       m_e            19692936
+VRAC               Pg       11:18:29.164                                 ___                       m_e            19692938
+KRUC               Pg       11:18:32.577                                 ___                       m_e            19692939
+VRAC               Sg       11:18:46.554                                 ___                       m_e            19692937
+KRUC               Sg       11:18:53.542                                 ___                       m_e            19692940
+
+
+EVENT 2032257  CZECH REPUBLIC, OSTRAVA
+
+   Date       Time        Err   RMS Latitude Longitude  Smaj  Smin  Az Depth   Err Ndef Nsta Gap  mdist  Mdist Qual   Author      OrigID
+2024/09/01 12:33:19.91   0.34  0.17  49.8219   18.5593   2.2   1.7  61   1.0f         9    5 280   0.66   1.60 m i km IPEC       2032257
+Magnitude  Err Nsta Author      OrigID
+ML     1.2 0.1    5 IPEC       2032257
+ (Scherbaum-Stoll ML formula)
+
+Sta     Dist  EvAz Phase        Time      TRes  Azim AzRes   Slow   SRes Def   SNR       Amp   Per Qual Magnitude    ArrID
+MORC    0.66 266.5 Pg       12:33:32.774   0.2  85.7                     T__                       m_e            19692970
+MORC    0.66 266.5 Sg       12:33:40.556  -0.1  85.7                     T__             4.7  0.20 m_e ML     1.0 19692975
+JAVC    1.13 211.4 Pg       12:33:41.838   0.2  30.8                     T__                       a_q            19692976
+ (Qual flag modified for test)
+VRAC    1.38 248.9 Pg       12:33:45.474  -0.2  67.4                     T__                       m_e            19692977
+VRAC    1.38 248.9 Sg       12:34:03.009  -0.1  67.4                     T__             3.0  0.23 m_e ML     1.3 19692978
+KRUC    1.60 242.5 Pg       12:33:49.149   0.1  60.9                     T__                       m_e            19692983
+KRUC    1.60 242.5 Sg       12:34:10.074  -0.1  60.9                     T__             2.3  0.21 m_e ML     1.3 19692980
+
+
+EVENT 2032696  CZECH REPUBLIC, OSTRAVA
+
+   Date       Time        Err   RMS Latitude Longitude  Smaj  Smin  Az Depth   Err Ndef Nsta Gap  mdist  Mdist Qual   Author      OrigID
+2024/09/10 00:25:55.18   0.31  0.12  49.8293   18.5549   2.1   1.6  62   1.0f        13    9 280   0.27   1.61 m i ki IPEC       2032696
+Magnitude  Err Nsta Author      OrigID
+ML     1.0 0.4    5 IPEC       2032696
+
+Sta     Dist  EvAz Phase        Time      TRes  Azim AzRes   Slow   SRes Def   SNR       Amp   Per Qual Magnitude    ArrID
+ (#OrigID 2032690)
+ (incorrect #OrigID tag resulting in a missing origin reference)
+MORC    0.66 265.8 Pg       00:26:07.944   0.1  85.0                     T__                       m_e            19696327
+MORC    0.66 265.8 Sg       00:26:15.590  -0.3  85.0                     T__             4.9  0.29 m_e ML     1.0 19696328
+JAVC    1.13 211.1 Pg       00:26:16.977  -0.0  30.4                     T__                       m_e            19696329
+VRAC    1.38 248.5 Pg       00:26:20.821  -0.1  67.0                     T__                       m_e            19696330
+VRAC    1.38 248.5 Sg       00:26:38.476   0.1  67.0                     T__             0.4  0.02 m_e ML     0.4 19696332
+KRUC    1.61 242.2 Pg       00:26:24.327   0.0  60.6                     T__                       m_e            19696331
+KRUC    1.61 242.2 Sg       00:26:45.547   0.1  60.6                     T__             1.5  0.24 m_e ML     1.1 19696333
+
+STOP

--- a/obspy/io/iaspei/tests/data/ipe202409sel_ims.xml
+++ b/obspy/io/iaspei/tests/data/ipe202409sel_ims.xml
@@ -1,0 +1,612 @@
+<?xml version='1.0' encoding='utf-8'?>
+<q:quakeml xmlns="http://quakeml.org/xmlns/bed/1.2" xmlns:q="http://quakeml.org/xmlns/quakeml/1.2">
+  <eventParameters publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa">
+    <description>Selected from Preliminary Event Bulletin of the IPEC, Czech Republic, for the time period 01.09.-30.09.2024</description>
+    <event publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/event/2032247">
+      <preferredOriginID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032247</preferredOriginID>
+      <type>induced or triggered event</type>
+      <typeCertainty>known</typeCertainty>
+      <description>
+        <text>CZECH REPUBLIC, OSTRAVA</text>
+        <type>region name</type>
+      </description>
+      <origin publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032247">
+        <time>
+          <value>2024-09-01T11:18:16.350000Z</value>
+        </time>
+        <latitude/>
+        <longitude/>
+        <timeFixed>false</timeFixed>
+        <epicenterFixed>false</epicenterFixed>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>location method: other</text>
+        </comment>
+        <creationInfo>
+          <author>IPEC</author>
+        </creationInfo>
+      </origin>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692935">
+        <time>
+          <value>2024-09-01T11:18:16.350000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692936">
+        <time>
+          <value>2024-09-01T11:18:24.166000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692938">
+        <time>
+          <value>2024-09-01T11:18:29.164000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692939">
+        <time>
+          <value>2024-09-01T11:18:32.577000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692937">
+        <time>
+          <value>2024-09-01T11:18:46.554000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692940">
+        <time>
+          <value>2024-09-01T11:18:53.542000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "___"</text>
+        </comment>
+      </pick>
+    </event>
+    <event publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/event/2032257">
+      <preferredOriginID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257</preferredOriginID>
+      <type>mining explosion</type>
+      <typeCertainty>known</typeCertainty>
+      <description>
+        <text>CZECH REPUBLIC, OSTRAVA</text>
+        <type>region name</type>
+      </description>
+      <origin publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257">
+        <time>
+          <value>2024-09-01T12:33:19.910000Z</value>
+        </time>
+        <latitude>
+          <value>49.8219</value>
+        </latitude>
+        <longitude>
+          <value>18.5593</value>
+        </longitude>
+        <depth>
+          <value>1000.0</value>
+        </depth>
+        <timeFixed>false</timeFixed>
+        <epicenterFixed>true</epicenterFixed>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>location method: inversion</text>
+        </comment>
+        <creationInfo>
+          <author>IPEC</author>
+        </creationInfo>
+        <originUncertainty>
+          <preferredDescription>uncertainty ellipse</preferredDescription>
+          <minHorizontalUncertainty>1700.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>2200.0</maxHorizontalUncertainty>
+          <azimuthMaxHorizontalUncertainty>61.0</azimuthMaxHorizontalUncertainty>
+          <confidenceLevel>90.0</confidenceLevel>
+        </originUncertainty>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692970">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692970</pickID>
+          <phase>Pg</phase>
+          <azimuth>266.5</azimuth>
+          <distance>0.66</distance>
+          <timeResidual>0.2</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692975">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692975</pickID>
+          <phase>Sg</phase>
+          <azimuth>266.5</azimuth>
+          <distance>0.66</distance>
+          <timeResidual>-0.1</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692976">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692976</pickID>
+          <phase>Pg</phase>
+          <azimuth>211.4</azimuth>
+          <distance>1.13</distance>
+          <timeResidual>0.2</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692977">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692977</pickID>
+          <phase>Pg</phase>
+          <azimuth>248.9</azimuth>
+          <distance>1.38</distance>
+          <timeResidual>-0.2</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692978">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692978</pickID>
+          <phase>Sg</phase>
+          <azimuth>248.9</azimuth>
+          <distance>1.38</distance>
+          <timeResidual>-0.1</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692983">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692983</pickID>
+          <phase>Pg</phase>
+          <azimuth>242.5</azimuth>
+          <distance>1.6</distance>
+          <timeResidual>0.1</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+        <arrival publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/arrival/19692980">
+          <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692980</pickID>
+          <phase>Sg</phase>
+          <azimuth>242.5</azimuth>
+          <distance>1.6</distance>
+          <timeResidual>-0.1</timeResidual>
+          <timeWeight>1.0</timeWeight>
+          <horizontalSlownessWeight>0.0</horizontalSlownessWeight>
+          <backazimuthWeight>0.0</backazimuthWeight>
+        </arrival>
+      </origin>
+      <magnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/magnitude">
+        <mag>
+          <value>1.2</value>
+        </mag>
+        <type>ML</type>
+        <originID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257</originID>
+        <stationCount>5</stationCount>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text> (Scherbaum-Stoll ML formula)</text>
+        </comment>
+        <creationInfo>
+          <author>IPEC</author>
+        </creationInfo>
+      </magnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19692975">
+        <originID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257</originID>
+        <mag>
+          <value>1.0</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692975</amplitudeID>
+        <waveformID stationCode="MORC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19692978">
+        <originID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257</originID>
+        <mag>
+          <value>1.3</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692978</amplitudeID>
+        <waveformID stationCode="VRAC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19692980">
+        <originID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032257</originID>
+        <mag>
+          <value>1.3</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692980</amplitudeID>
+        <waveformID stationCode="KRUC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692970">
+        <time>
+          <value>2024-09-01T12:33:32.774000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <backazimuth>
+          <value>85.7</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692975">
+        <time>
+          <value>2024-09-01T12:33:40.556000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <backazimuth>
+          <value>85.7</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692976">
+        <time>
+          <value>2024-09-01T12:33:41.838000Z</value>
+        </time>
+        <waveformID stationCode="JAVC"></waveformID>
+        <backazimuth>
+          <value>30.8</value>
+        </backazimuth>
+        <onset>questionable</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>automatic</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text> (Qual flag modified for test)</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692977">
+        <time>
+          <value>2024-09-01T12:33:45.474000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <backazimuth>
+          <value>67.4</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692978">
+        <time>
+          <value>2024-09-01T12:34:03.009000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <backazimuth>
+          <value>67.4</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692983">
+        <time>
+          <value>2024-09-01T12:33:49.149000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <backazimuth>
+          <value>60.9</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692980">
+        <time>
+          <value>2024-09-01T12:34:10.074000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <backazimuth>
+          <value>60.9</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692975">
+        <genericAmplitude>
+          <value>4.7e-09</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.2</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692975</pickID>
+      </amplitude>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692978">
+        <genericAmplitude>
+          <value>3e-09</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.23</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692978</pickID>
+      </amplitude>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19692980">
+        <genericAmplitude>
+          <value>2.3e-09</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.21</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19692980</pickID>
+      </amplitude>
+    </event>
+    <event publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/event/2032696">
+      <preferredOriginID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032696</preferredOriginID>
+      <type>induced or triggered event</type>
+      <typeCertainty>known</typeCertainty>
+      <description>
+        <text>CZECH REPUBLIC, OSTRAVA</text>
+        <type>region name</type>
+      </description>
+      <origin publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032696">
+        <time>
+          <value>2024-09-10T00:25:55.180000Z</value>
+        </time>
+        <latitude>
+          <value>49.8293</value>
+        </latitude>
+        <longitude>
+          <value>18.5549</value>
+        </longitude>
+        <depth>
+          <value>1000.0</value>
+        </depth>
+        <timeFixed>false</timeFixed>
+        <epicenterFixed>true</epicenterFixed>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>location method: inversion</text>
+        </comment>
+        <creationInfo>
+          <author>IPEC</author>
+        </creationInfo>
+        <originUncertainty>
+          <preferredDescription>uncertainty ellipse</preferredDescription>
+          <minHorizontalUncertainty>1600.0</minHorizontalUncertainty>
+          <maxHorizontalUncertainty>2100.0</maxHorizontalUncertainty>
+          <azimuthMaxHorizontalUncertainty>62.0</azimuthMaxHorizontalUncertainty>
+          <confidenceLevel>90.0</confidenceLevel>
+        </originUncertainty>
+      </origin>
+      <magnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/magnitude">
+        <mag>
+          <value>1.0</value>
+        </mag>
+        <type>ML</type>
+        <originID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/origin/2032696</originID>
+        <stationCount>5</stationCount>
+        <creationInfo>
+          <author>IPEC</author>
+        </creationInfo>
+      </magnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19696328">
+        <originID>None</originID>
+        <mag>
+          <value>1.0</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696328</amplitudeID>
+        <waveformID stationCode="MORC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19696332">
+        <originID>None</originID>
+        <mag>
+          <value>0.4</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696332</amplitudeID>
+        <waveformID stationCode="VRAC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <stationMagnitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/station_magnitude/19696333">
+        <originID>None</originID>
+        <mag>
+          <value>1.1</value>
+        </mag>
+        <amplitudeID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696333</amplitudeID>
+        <waveformID stationCode="KRUC"></waveformID>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>min max indicator (&lt;, &gt;, or blank):  </text>
+        </comment>
+      </stationMagnitude>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696327">
+        <time>
+          <value>2024-09-10T00:26:07.944000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <backazimuth>
+          <value>85.0</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696328">
+        <time>
+          <value>2024-09-10T00:26:15.590000Z</value>
+        </time>
+        <waveformID stationCode="MORC"></waveformID>
+        <backazimuth>
+          <value>85.0</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696329">
+        <time>
+          <value>2024-09-10T00:26:16.977000Z</value>
+        </time>
+        <waveformID stationCode="JAVC"></waveformID>
+        <backazimuth>
+          <value>30.4</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696330">
+        <time>
+          <value>2024-09-10T00:26:20.821000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <backazimuth>
+          <value>67.0</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696332">
+        <time>
+          <value>2024-09-10T00:26:38.476000Z</value>
+        </time>
+        <waveformID stationCode="VRAC"></waveformID>
+        <backazimuth>
+          <value>67.0</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696331">
+        <time>
+          <value>2024-09-10T00:26:24.327000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <backazimuth>
+          <value>60.6</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Pg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <pick publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696333">
+        <time>
+          <value>2024-09-10T00:26:45.547000Z</value>
+        </time>
+        <waveformID stationCode="KRUC"></waveformID>
+        <backazimuth>
+          <value>60.6</value>
+        </backazimuth>
+        <onset>emergent</onset>
+        <phaseHint>Sg</phaseHint>
+        <evaluationMode>manual</evaluationMode>
+        <comment id="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/comment">
+          <text>TAS flag: "T__"</text>
+        </comment>
+      </pick>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696328">
+        <genericAmplitude>
+          <value>4.9e-09</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.29</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696328</pickID>
+      </amplitude>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696332">
+        <genericAmplitude>
+          <value>4e-10</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.02</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696332</pickID>
+      </amplitude>
+      <amplitude publicID="smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/amplitude/19696333">
+        <genericAmplitude>
+          <value>1.5e-09</value>
+        </genericAmplitude>
+        <unit>m</unit>
+        <period>
+          <value>0.24</value>
+        </period>
+        <pickID>smi:local/c2a0a78c-42fa-4e19-885d-7ef2e55d45fa/pick/19696333</pickID>
+      </amplitude>
+    </event>
+  </eventParameters>
+</q:quakeml>

--- a/obspy/io/iaspei/tests/test_core.py
+++ b/obspy/io/iaspei/tests/test_core.py
@@ -6,6 +6,7 @@ import pytest
 
 from obspy import read_events
 from obspy.io.iaspei.core import _read_ims10_bulletin, _is_ims10_bulletin
+from obspy.core.event import ResourceIdentifier
 
 
 class TestIASPEI():
@@ -18,41 +19,13 @@ class TestIASPEI():
         # station magnitudes were removed from it to save space.
         self.path_to_ims = testdata['19670130012028.isf']
         self.path_to_quakeml = testdata['19670130012028.xml']
-        self.catalog_from_quakeml = testdata['19670130012028.xml']
+        self.path_to_ims_2 = testdata["ipe202409sel_ims.txt"]
+        self.path_to_quakeml_2 = testdata["ipe202409sel_ims.xml"]
 
-    def _assert_catalog(self, got):
-        got_id_prefix = str(got.resource_id).encode('UTF-8')
-        # first of all, replace the random hash in our test file with the
-        # prefix that was used during reading the ISF file
-        with open(self.path_to_quakeml, 'rb') as fh:
-            data = fh.read()
-        match = re.search(b'publicID="(smi:local/[a-z0-9-]*)"', data)
-        expected_id_prefix = match.group(1)
-        data, num_subs = re.subn(expected_id_prefix, got_id_prefix, data)
-        # 49 resource id replacements should be done in the QuakeML file we
-        # compare against
-        assert num_subs == 49
-        bio = io.BytesIO(data)
-        expected = read_events(bio, format="QUAKEML")
-        # now first check if we got the expected number of picks and station
-        # magnitudes, because the quakeml file has been stripped of picks and
-        # station magnitudes to save space and time
-        assert len(got[0].picks) == 255
-        assert len(got[0].station_magnitudes) == 15
-        # ok now crop the got catalog accordingly, afterwards it should compare
-        # equal to our comparison catalog
-        got[0].picks = got[0].picks[:4]
-        got[0].station_magnitudes = got[0].station_magnitudes[:7]
-        # # now we also have to replace comment ids in both catalogs..
-        # for cat in (got, expected):
-        #     for item in cat.events + cat[0].origins + cat[0].magnitudes + \
-        #             cat[0].station_magnitudes + cat[0].picks:
-        #         for comment in item.comments:
-        #             comment.resource_id = 'smi:local/dummy'
-
+    def prepare_comparison(self, catalog):
         # some more fixes for the comparison, these are due to buggy QuakeML
         # reader behavior and should be fixed in io.quakeml eventually
-        for event in expected:
+        for event in catalog:
             for pick in event.picks:
                 # QuakeML reader seems to set `network_code=""` if it's not in
                 # the xml file.. account for this strange behavior for this
@@ -73,18 +46,66 @@ class TestIASPEI():
                             'latitude_errors', 'depth_errors']:
                     setattr(origin, key, None)
             for station_magnitude in event.station_magnitudes:
+                setattr(station_magnitude.waveform_id, 'network_code', None)
                 # QuakeML reader seems to set origin_id to
                 # `ResourceIdentifier(id="None")`
+                if station_magnitude.origin_id == ResourceIdentifier(
+                        id="None"):
+                    setattr(station_magnitude, 'origin_id', None)
                 # QuakeML reader seems to add empty QuantityError for
                 # pick.horizontal_slowness_errors
-                for key in ['origin_id', 'mag_errors']:
+                for key in ['mag_errors']:
                     setattr(station_magnitude, key, None)
             for magnitude in event.magnitudes:
                 # QuakeML reader seems to add empty QuantityError for
                 # pick.horizontal_slowness_errors
                 for key in ['mag_errors']:
                     setattr(magnitude, key, None)
+
+    def _assert_catalog(self, got):
+        got_id_prefix = str(got.resource_id).encode('UTF-8')
+        # first of all, replace the random hash in our test file with the
+        # prefix that was used during reading the ISF file
+        with open(self.path_to_quakeml, 'rb') as fh:
+            data = fh.read()
+        match = re.search(b'publicID="(smi:local/[a-z0-9-]*)"', data)
+        expected_id_prefix = match.group(1)
+        data, num_subs = re.subn(expected_id_prefix, got_id_prefix, data)
+        # resource id replacements should be done in the QuakeML file we
+        # compare against
+        assert num_subs == 65
+        bio = io.BytesIO(data)
+        expected = read_events(bio, format="QUAKEML")
+        # now first check if we got the expected number of picks and station
+        # magnitudes, because the quakeml file has been stripped of picks and
+        # station magnitudes to save space and time
+        assert len(got[0].picks) == 255
+        assert len(got[0].station_magnitudes) == 15
+        # ok now crop the got catalog accordingly, afterwards it should compare
+        # equal to our comparison catalog
+        got[0].picks = got[0].picks[:4]
+        got[0].station_magnitudes = got[0].station_magnitudes[:7]
+        for origin in got[0].origins:
+            if origin.arrivals:
+                origin.arrivals = origin.arrivals[:4]
+        self.prepare_comparison(expected)
         # now finally these catalogs should compare equal
+        assert got == expected
+
+    def _assert_catalog2(self, got):
+        # Unify the random hash prefix of all resource_ids on the side
+        # of the ISF test file and on the QuakeML model file side.
+        # Resource id replacements should be done in the QuakeML file.
+        got_id_prefix = str(got.resource_id).encode('UTF-8')
+        with open(self.path_to_quakeml_2, 'rb') as fh:
+            data = fh.read()
+        match = re.search(b'publicID="(smi:local/[a-z0-9-]*)"', data)
+        expected_id_prefix = match.group(1)
+        data, num_subs = re.subn(expected_id_prefix, got_id_prefix, data)
+        bio = io.BytesIO(data)
+        expected = read_events(bio, format="QUAKEML")
+        self.prepare_comparison(expected)
+        # take the entire uncropped got catalog and compare against expected
         assert got == expected
 
     def test_reading(self):
@@ -159,3 +180,11 @@ class TestIASPEI():
             with io.BytesIO(fh.read()) as buf:
                 buf.seek(0, 0)
                 assert not _is_ims10_bulletin(buf)
+
+    def test_reading_2(self):
+        """
+        Test reading IMS10 bulletin format
+        """
+        cat = _read_ims10_bulletin(self.path_to_ims_2, _no_uuid_hashes=True)
+        assert len(cat) == 3
+        self._assert_catalog2(cat)

--- a/obspy/io/iaspei/util.py
+++ b/obspy/io/iaspei/util.py
@@ -52,11 +52,11 @@ def type_or_none(my_string, type_, multiplier=None):
 
 
 def float_or_none(my_string, **kwargs):
-    return type_or_none(my_string, float)
+    return type_or_none(my_string, float, **kwargs)
 
 
 def int_or_none(my_string, **kwargs):
-    return type_or_none(my_string, int)
+    return type_or_none(my_string, int, **kwargs)
 
 
 def fixed_flag(my_char):


### PR DESCRIPTION
### What does this PR do?

This PR parses phase blocks from the ISC/IMS1.0:SHORT bulletin into the Catalog, including origin-specific data.

In `obspy/io/iaspei/core.py`:
1) The `specify_preferred_origin` subroutine searches for an `origin` marked explicitly as `#PRIME` or one that can implicitly be considered preferred.
2) The `_read_phases` method, for each block of seismic phases, checks for the presence of the `#OrigID` tag, which specifies the `origin` associated with the seismic phases.
3) The `_parse_phase` method parses origin-specific data (e.g., epicentral distance and time residual) in the phase block into the Arrival object.
4) Completes the missing `Amplitude.to_pick` link.
5) Stores the list of Arrival items in the specified `origin` object.

Minor changes: 
- Adjusted parsing to be less case-sensitive for certain bulletin keywords (e.g., `Event`, `EVENT`). 
- Added tolerance for extra lines before the `DATA_TYPE` bulletin header (e.g., AutoDRM message envelope: `BEGIN IMS1.0 ...`). 
- Fixed units for hypocenter depth and uncertainties to meters, consistent with QuakeML.
- Previously, if the `_parse_phase` subroutine could not reference an `origin`, the origin-specific data was stored as a comment. I suggest removing this feature; it is now commented out.

### Why was it initiated?  Any relevant Issues?

The current processing approach for the `ISF/IMS1.0:SHORT` bulletin phase block, where origin-specific data is stored as a textual comment, appears to be a workaround.

This PR aims to align with the ISC/IMS1.0 format specification: http://isc-mirror.iris.washington.edu/standards/isf/
The documentation specifies that a preferred-origin (`#PRIME` origin) or an `#OrigID` tag should be specified for each phase block, enabling the processing of origin-specific data (Arrival object).

Additionally, there is currently no `event.magnitude.Amplitude.to_pick` link, making it impossible to associate amplitude data with the correct stations and phases.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
