### PR TITLE
remove usage of mamba

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           miniforge-version: latest
           activate-environment: test
-          use-mamba: true
           python-version: ${{ matrix.python-version }}
 
       - uses: actions/cache@v4
@@ -165,7 +164,7 @@ jobs:
         id: cache
 
       - name: Update environment
-        run: mamba env update -n test -f ${{ env.env_file }}
+        run: conda env update -n test -f ${{ env.env_file }}
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: print package info


### PR DESCRIPTION
<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

mamba usage has been deprecated (I think, had to remove it for msnoise). This should allow the CI to build
