### PR TITLE
tests: speed up flinn engdahl test

### DIFF
--- a/obspy/geodetics/tests/test_util_flinnengdahl.py
+++ b/obspy/geodetics/tests/test_util_flinnengdahl.py
@@ -8,13 +8,14 @@ from obspy.core.util.misc import CatchOutput
 class TestUtilFlinnEngdahl:
 
     def test_coordinates(self, testdata):
+        flinn_engdahl = FlinnEngdahl()
         with open(testdata['flinnengdahl.csv'], 'r') as fh:
             for line in fh:
                 longitude, latitude, checked_region = line.strip().split('\t')
                 longitude = float(longitude)
                 latitude = float(latitude)
 
-                region = FlinnEngdahl().get_region(longitude, latitude)
+                region = flinn_engdahl.get_region(longitude, latitude)
                 assert region == \
                     checked_region, \
                     "(%f, %f) got %s instead of %s" % (


### PR DESCRIPTION
..which was made super slow inadvertantly during transition to pytest and new test style

### What does this PR do?

speed up flinn engdahl test which was made super slow for now reason (70+ seconds) inadvertantly during transition to pytest and new test style

### Why was it initiated?  Any relevant Issues?

slow tests

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
