### PR TITLE
Stats: subclasses for NSLC and Station Identifier

### DIFF
--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -11,6 +11,7 @@ Module for handling ObsPy :class:`~obspy.core.trace.Trace` and
 """
 import inspect
 import math
+import re
 import warnings
 from copy import copy, deepcopy
 
@@ -24,6 +25,23 @@ from obspy.core.util.base import _get_function_from_entry_point
 from obspy.core.util.decorator import raise_if_masked, skip_if_no_data
 from obspy.core.util.misc import (flat_not_masked_contiguous, get_window_times,
                                   limit_numpy_fft_cache)
+
+
+# list of keys we handle that are common to NSLC and FDSN Source Identifier
+BASE_STATS_KEYS = (
+    'starttime', 'endtime', 'sampling_rate', 'delta', 'npts', 'calib')
+# complete list of all parts of a NSLC
+NSLC_KEYS = ('network', 'station', 'location', 'channel')
+# name for the FDSN Source Identifier composed of all of its parts
+SOURCE_ID_KEY = 'source_identifier'
+# complete list of all parts of a FDSN Source Identifier
+SOURCE_ID_KEYS = ('namespace', 'network', 'station', 'location', 'band',
+                  'source', 'subsource')
+# these are specific to FDSN Source Identifier, so if these appear it can not
+# be a plain NSLC description
+SOURCE_ID_SPECIFIC_KEYS = ('namespace', 'band', 'source', 'subsource')
+SOURCE_ID_REGEX = re.compile(
+    r'(.*):([^_]*)_([^_]*)_([^_]*)_([^_]*)_([^_]*)_(.*)')
 
 
 class Stats(AttribDict):
@@ -43,6 +61,14 @@ class Stats(AttribDict):
         :class:`~obspy.core.trace.Trace` object. Possible keywords are
         summarized in the following `Default Attributes`_ section.
 
+    .. note::
+
+        Initializing a ``Stats`` object will actually return an appropriate
+        subclass depending on the metadata style (``NSLC`` or
+        ``(FDSN) Source ID``) of the provided metadata.
+        By default, the well known classic ``NSLC`` style is used. For full
+        control subclasses can also be initialized directly.
+
     .. rubric:: Basic Usage
 
     >>> stats = Stats()
@@ -55,6 +81,10 @@ class Stats(AttribDict):
 
     .. rubric:: _`Default Attributes`
 
+    The following are default attributes shared with all subclasses of
+    :class:`~obspy.core.trace.Stats`. Subclasses define additional default
+    attributes specific to them.
+
     ``sampling_rate`` : float, optional
         Sampling rate in hertz (default value is 1.0).
     ``delta`` : float, optional
@@ -64,14 +94,6 @@ class Stats(AttribDict):
     ``npts`` : int, optional
         Number of sample points (default value is 0, which implies that no data
         is present).
-    ``network`` : string, optional
-        Network code (default is an empty string).
-    ``location`` : string, optional
-        Location code (default is an empty string).
-    ``station`` : string, optional
-        Station code (default is an empty string).
-    ``channel`` : string, optional
-        Channel code (default is an empty string).
     ``starttime`` : :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
         Date and time of the first data sample given in UTC (default value is
         "1970-01-01T00:00:00.0Z").
@@ -111,11 +133,11 @@ class Stats(AttribDict):
         >>> stats.endtime = UTCDateTime(2009, 1, 1, 12, 0, 0)
         Traceback (most recent call last):
         ...
-        AttributeError: Attribute "endtime" in Stats object is read only!
+        AttributeError: Attribute "endtime" in NSLCStats object is read only!
         >>> stats['endtime'] = UTCDateTime(2009, 1, 1, 12, 0, 0)
         Traceback (most recent call last):
         ...
-        AttributeError: Attribute "endtime" in Stats object is read only!
+        AttributeError: Attribute "endtime" in NSLCStats object is read only!
 
     (4)
         The attribute ``npts`` will be automatically updated from the
@@ -128,48 +150,41 @@ class Stats(AttribDict):
         >>> trace.stats.npts
         4
 
-    (5)
-        The attribute ``component`` can be used to get or set the component,
-        i.e. the last character of the ``channel`` attribute.
-
-        >>> stats = Stats()
-        >>> stats.channel = 'HHZ'
-        >>> stats.component  # doctest: +SKIP
-        'Z'
-        >>> stats.component = 'L'
-        >>> stats.channel  # doctest: +SKIP
-        'HHL'
-
     """
     # set of read only attrs
     readonly = ['endtime']
-    # default values
-    defaults = {
-        'sampling_rate': 1.0,
-        'delta': 1.0,
-        'starttime': UTCDateTime(0),
-        'endtime': UTCDateTime(0),
-        'npts': 0,
-        'calib': 1.0,
-        'network': '',
-        'station': '',
-        'location': '',
-        'channel': '',
-    }
     # keys which need to refresh derived values
     _refresh_keys = {'delta', 'sampling_rate', 'starttime', 'npts'}
-    # dict of required types for certain attrs
-    _types = {
-        'network': str,
-        'station': str,
-        'location': str,
-        'channel': str,
-    }
+
+    def __new__(cls, header={}):
+        """
+        Slightly abusive, to be able to have ``Stats`` both as a base class but
+        also as an instance factory for the subclasses.
+        """
+        # check for a mix of FDSN Source ID and NSLC codes or Source ID parts
+        # and gracefully decline to work with a mix of both
+        if SOURCE_ID_KEY in header and \
+                any(key in header for key in NSLC_KEYS + SOURCE_ID_KEYS):
+            msg = ('Initializing Stats with a mix of a full (FDSN) Source '
+                   'Identifier and NSLC codes or parts of a Source Identifier '
+                   'is not allowed.')
+            raise ValueError(msg)
+        # if (FDSN) Source ID is provided, then use that, otherwise default to
+        # good old plain NSLC style, which most users know best and probably
+        # expect
+        if SOURCE_ID_KEY in header:
+            return SourceIdentifierStats(header=header)
+        else:
+            return NSLCStats(header=header)
 
     def __init__(self, header={}):
         """
+        This routine should never get entered, since on initializing
+        ``Stats()`` it will first go to ``Stats.__new__()`` which in turn
+        creates an instance of one of the subclasses and then the
+        ``__init__()`` method of that subroutine gets called instead.
         """
-        super(Stats, self).__init__(header)
+        raise NotImplementedError()
 
     def __setitem__(self, key, value):
         """
@@ -204,13 +219,6 @@ class Stats(AttribDict):
                 timediff = float(self.npts - 1) * delta
             self.__dict__['endtime'] = self.starttime + timediff
             return
-        if key == 'component':
-            key = 'channel'
-            value = str(value)
-            if len(value) != 1:
-                msg = 'Component must be set with single character'
-                raise ValueError(msg)
-            value = self.channel[:-1] + value
         # prevent a calibration factor of 0
         if key == 'calib' and value == 0:
             msg = 'Calibration factor set to 0.0!'
@@ -226,19 +234,7 @@ class Stats(AttribDict):
     def __getitem__(self, key, default=None):
         """
         """
-        if key == 'component':
-            return super(Stats, self).__getitem__('channel', default)[-1:]
-        else:
-            return super(Stats, self).__getitem__(key, default)
-
-    def __str__(self):
-        """
-        Return better readable string representation of Stats object.
-        """
-        priorized_keys = ['network', 'station', 'location', 'channel',
-                          'starttime', 'endtime', 'sampling_rate', 'delta',
-                          'npts', 'calib']
-        return self._pretty_str(priorized_keys)
+        return super(Stats, self).__getitem__(key, default)
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
@@ -254,6 +250,307 @@ class Stats(AttribDict):
         self.__dict__.update(state)
         # trigger refreshing
         self.__setitem__('sampling_rate', state['sampling_rate'])
+
+
+class NSLCStats(Stats):
+    """
+    A :class:`~obspy.core.trace.Stats` subclass for the widely used,
+    conventional style of identifying a measurement system by a combination of
+    network, station, location and channel code ("NSLC" sometimes also referred
+    to "SCNL" etc.), often (but not necessarily) following the conventions laid
+    out in the SEED 2.4 standard.
+
+    For other basic information see :class:`~obspy.core.trace.Stats`.
+
+    .. rubric:: Basic Usage
+
+    >>> header = {'network': 'BW', 'station': 'MANZ', 'location': '',
+    ...           'channel': 'BHZ'}
+    >>> stats = Stats(header=header)
+    >>> print(stats['network'])
+    BW
+    >>> print(stats.network)
+    BW
+    >>> print(stats.station)
+    MANZ
+    >>> print(stats.channel)
+    BHZ
+
+    Or explicitly using this :class:`~obspy.core.trace.Stats` subclass:
+
+    >>> header = {'network': 'BW', 'station': 'MANZ', 'location': '',
+    ...           'channel': 'BHZ'}
+    >>> stats = NSLCStats(header=header)
+    >>> print(stats.network)
+    BW
+    >>> print(stats.station)
+    MANZ
+    >>> print(stats.channel)
+    BHZ
+
+    .. rubric:: _`Default Attributes`
+
+    The following are default attributes specific to the
+    :class:`~obspy.core.trace.NSLCStats` subclass of
+    :class:`~obspy.core.trace.Stats`. For default attributes shared by all
+    subclasses (like ``starttime`` etc.), see :class:`~obspy.core.trace.Stats`.
+
+    ``network`` : string, optional
+        Network code (default is an empty string).
+    ``location`` : string, optional
+        Location code (default is an empty string).
+    ``station`` : string, optional
+        Station code (default is an empty string).
+    ``channel`` : string, optional
+        Channel code (default is an empty string).
+
+    .. rubric:: Notes
+
+    (1)
+        The attribute ``component`` can be used to get or set the component,
+        i.e. the last character of the ``channel`` attribute, which by
+        ``SEED 2.4`` standard defines the component code as part of an assumed
+        three character length channel code. This convenience functionality
+        should only be used with channel codes conforming to ``SEED 2.4``
+        conventions.
+
+        >>> stats = NSLCStats()
+        >>> stats.channel = 'BHZ'
+        >>> print(stats.component)
+        Z
+        >>> stats.component = 'L'
+        >>> print(stats.channel)
+        BHL
+
+    """
+    # default values
+    defaults = {
+        'sampling_rate': 1.0,
+        'delta': 1.0,
+        'starttime': UTCDateTime(0),
+        'endtime': UTCDateTime(0),
+        'npts': 0,
+        'calib': 1.0,
+        'network': '',
+        'station': '',
+        'location': '',
+        'channel': '',
+    }
+    # dict of required types for certain attrs
+    _types = {
+        'network': str,
+        'station': str,
+        'location': str,
+        'channel': str,
+    }
+
+    def __new__(cls, *args, **kwargs):
+        """
+        """
+        # we want to call the method of Stats' parent here, so two levels up
+        return super(Stats, cls).__new__(cls)
+
+    def __init__(self, header={}):
+        """
+        """
+        # we want to call the method of Stats' parent here, so two levels up
+        super(Stats, self).__init__(header)
+
+    def __setitem__(self, key, value):
+        """
+        """
+        # things specific to NSLC
+        if key == 'component':
+            key = 'channel'
+            value = str(value)
+            if len(value) != 1:
+                msg = 'Component must be set with single character'
+                raise ValueError(msg)
+            value = self.channel[:-1] + value
+        # defer to Stats
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key, default=None):
+        """
+        """
+        if key == 'component':
+            return super().__getitem__('channel', default)[-1:]
+        return super().__getitem__(key, default)
+
+    def __str__(self):
+        """
+        Return better readable string representation of Stats object.
+        """
+        priorized_keys = list(NSLC_KEYS) + list(BASE_STATS_KEYS)
+        return self._pretty_str(priorized_keys)
+
+
+class SourceIdentifierStats(Stats):
+    """
+    A :class:`~obspy.core.trace.Stats` subclass for the new
+    ``FDSN Source Identifier`` convention of identifying a measurement system
+    by a Source Identifier string. This standard is aming to supersede the old
+    SEED 2.4 conventions which have limitations in the length of the individual
+    fields.
+
+    For other basic information see :class:`~obspy.core.trace.Stats`.
+
+    .. rubric:: Basic Usage
+
+    >>> header = {'namespace': 'FDSN', 'network': 'BW', 'station': 'MANZ',
+    ...           'location': '', 'band': 'B', 'source': 'H', 'subsource': 'Z'}
+    >>> stats = Stats(header=header)
+    >>> print(stats.source_identifier)
+    FDSN:BW_MANZ__B_H_Z
+    >>> print(stats.network)
+    BW
+    >>> print(stats.station)
+    MANZ
+    >>> print(stats.band)
+    B
+    >>> print(stats.source)
+    H
+    >>> print(stats.subsource)
+    Z
+    # convenience alias for a concatenation of band, source and subsource code
+    >>> print(stats.channel)
+    BHZ
+    >>> print(stats.component)  # convenience alias for subsource code
+    Z
+
+    Or explicitly using this :class:`~obspy.core.trace.Stats` subclass and also
+    alternatively providing the full source identifier string as a whole
+    instead of its parts:
+
+    >>> header = {'source_identifier': 'FDSN:BW_MANZ__B_H_Z'}
+    >>> stats = SourceIdentifierStats(header=header)
+    >>> print(stats.network)
+    BW
+    >>> print(stats.station)
+    MANZ
+    >>> print(stats.band)
+    B
+
+    .. rubric:: _`Default Attributes`
+
+    The following are default attributes specific to the
+    :class:`~obspy.core.trace.SourceIdentifierStats` subclass of
+    :class:`~obspy.core.trace.Stats`. For default attributes shared by all
+    subclasses (like ``starttime`` etc.), see :class:`~obspy.core.trace.Stats`.
+
+    ``source_identifier`` : str, optional
+        Date and time of the last data sample given in UTC
+        (default value is "1970-01-01T00:00:00.0Z").
+
+    .. rubric:: Notes
+
+    (1)
+        The attribute ``component`` can be used to get or set the component,
+        i.e. the last character of the ``channel`` attribute, which by ``SEED
+        2.4`` standard defines the component code as part of an assumed three
+        character length channel code. This convenience functionality should
+        only be used with channel codes conforming to ``SEED 2.4`` conventions.
+
+        >>> stats = Stats()
+        >>> stats.channel = 'HHZ'
+        >>> stats.component  # doctest: +SKIP
+        'Z'
+        >>> stats.component = 'L'
+        >>> stats.channel  # doctest: +SKIP
+        'HHL'
+
+    """
+    # default values
+    defaults = {
+        'sampling_rate': 1.0,
+        'delta': 1.0,
+        'starttime': UTCDateTime(0),
+        'endtime': UTCDateTime(0),
+        'npts': 0,
+        'calib': 1.0,
+        'namespace': '',
+        'network': '',
+        'station': '',
+        'location': '',
+        'band': '',
+        'source': '',
+        'subsource': '',
+    }
+    # dict of required types for certain attrs
+    _types = {
+        'namespace': str,
+        'network': str,
+        'station': str,
+        'location': str,
+        'band': str,
+        'source': str,
+        'subsource': str,
+    }
+
+    def __new__(cls, *args, **kwargs):
+        """
+        """
+        # we want to call the method of Stats' parent here, so two levels up
+        return super(Stats, cls).__new__(cls)
+
+    def __init__(self, header={}):
+        """
+        """
+        if SOURCE_ID_KEY in header:
+            if any(key in header for key in SOURCE_ID_KEYS):
+                msg = ('Initializing SourceIdentifierStats with a mix of a '
+                       'full (FDSN) Source Identifier and parts of a Source '
+                       'Identifier is not allowed.')
+                raise ValueError(msg)
+            source_identifier = header.pop(SOURCE_ID_KEY)
+            parts = self._split_source_identifier_to_parts(source_identifier)
+            for key, value in zip(SOURCE_ID_KEYS, parts):
+                header[key] = value
+        # we want to call the method of Stats' parent here, so two levels up
+        super(Stats, self).__init__(header)
+
+    def __setitem__(self, key, value):
+        """
+        """
+        # things specific to Source Identifier
+        if key == SOURCE_ID_KEY:
+            parts = self._split_source_identifier_to_parts(value)
+            for key, value in zip(SOURCE_ID_KEYS, parts):
+                super().__setitem__(key, value)
+            return
+        # otherwise defer to Stats
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key, default=None):
+        """
+        """
+        # things specific to Source Identifier
+        if key == 'component':
+            return super().__getitem__('channel', default)[-1:]
+        return super().__getitem__(key, default)
+
+    def __str__(self):
+        """
+        Return better readable string representation of Stats object.
+        """
+        priorized_keys = list(SOURCE_ID_KEYS) + list(BASE_STATS_KEYS)
+        return self._pretty_str(priorized_keys)
+
+    @staticmethod
+    def _split_source_identifier_to_parts(source_identifier):
+        """
+        Split a FDSN Source Identifier into parts.
+
+        Raise ValueError if not matching the regex.
+        It is a bit unclear if colon inside the namespace is allowed, but
+        libmseed source code does it like this, split once on the rightmost
+        colon.
+        """
+        match = re.match(SOURCE_ID_REGEX, source_identifier)
+        if not match:
+            msg = (f'Invalid FDSN Source Identifier: {source_identifier}')
+            raise ValueError(msg)
+        return match.groups()
 
 
 @decorator


### PR DESCRIPTION
### What does this PR do?

Try out a way to handle the two ways of identifying stations/channels. The old way being a combination of network, station, location and channel code, often following the definitions of the SEED 2.4 standard. And the new way being the definition of FDSN Source Identifier, used in MiniSEED v3, comprised of namespace, network, station, location, band, source and subsource channels.

One potential way to try and do this cleanly is with having two subclasses to `Stats`. The aim being to try and make it almost behave like before so to make it "easy" for most normal experience users, but silently under the hood being very clear of the two different systems, with clear exceptions being raised in scenarios with IDs that can not be mapped without ambiguity (e.g. a NSLC-type channel code with less than 3 characters) to be flexible and well defined for more experienced "power" users.

This PR is not fully done yet and still has some bugs and still missing the logic for mapping back and forth with exceptions defined for ambiguous mapping actions, But I'd like to hear some feedback, since I feel like we kind of need some change/addition to `Stats` before we can release a new major version with MiniSEED v3 support (from simplemseed or mseedlib or both).

```python
>>> from obspy.core import Stats
>>> header_nslc = {'network': 'BW', 'station': 'MANZ', 'location': '', 'channel': 'BHZ'}
>>> stats = Stats(header=header_nslc)
>>> print(stats)
         network: BW
         station: MANZ
        location: 
         channel: BHZ
       starttime: 1970-01-01T00:00:00.000000Z
         endtime: 1970-01-01T00:00:00.000000Z
   sampling_rate: 1.0
           delta: 1.0
            npts: 0
           calib: 1.0
>>> print(isinstance(stats, Stats))
True
>>> print(type(stats))
<class 'obspy.core.trace.NSLCStats'>
```

```python
>>> from obspy.core import Stats
>>> header_sid = {'namespace': 'FDSN', 'network': 'BW', 'station': 'MANZ', 'location': '',
...               'band': 'B', 'source': 'H', 'subsource': 'Z'}
>>> stats = Stats(header=header_sid)
>>> print(stats)
       namespace: FDSN
         network: BW
         station: MANZ
        location: 
            band: B
          source: H
       subsource: Z
       starttime: 1970-01-01T00:00:00.000000Z
         endtime: 1970-01-01T00:00:00.000000Z
   sampling_rate: 1.0
           delta: 1.0
            npts: 0
           calib: 1.0
>>> print(isinstance(stats, Stats))
True
>>> print(type(stats))
<class 'obspy.core.trace.SourceIdentifierStats'>
```

### Why was it initiated?  Any relevant Issues?

The two systems (NSLC vs. Source Identifier) are not fully compatible and in both directions there can be [cases where a mapping can not be made](https://docs.fdsn.org/projects/source-identifiers/en/v1.0/definition.html#mapping-of-seed-2-4-codes). This means that there is a need for some kind of logic to handle data coming in from NSLC based data formats as well as Source Identifier based data formats (MiniSEED v3), because in some cases reading one format and writing to another will not be possible with a fully automatic mapping, so we kind of want well defined exceptions being raised etc, so the users can work around issues in well defined ways. 

This is just one possible way to do it, and it would be good to discuss other options.

The main consideration is, that currently our Stats object is based on NSLC with one field for "channel". Therefore if we leave it like that while already integrating MiniSEED v3 support, we would have to make a mapping from Source Identifier to NSLC right when reading data, which can be problematic and ambiguous and make additional problems in reverse mapping back when writing the same data in MiniSEED v3 again even. So it feels the better way is to somehow make Stats Source-Identifier-ready right away and only do mappings back or forth on the fly whenever needed and not earlier, so that problems in mapping only pop up when there really is a need to map.

### PR Checklist
- [ ] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
