### PR TITLE
Decide on a fixed scheme for dependency versions for the future like SPEC0, bump dependency versions for next major release, update CI and docs building accordingly

### DIFF
--- a/.github/docs_conda_env.yml
+++ b/.github/docs_conda_env.yml
@@ -21,9 +21,8 @@ dependencies:
   # docs
   - cartopy>=0.20
   - pip
-  - pip:
-    - pybtex
-    - m2r2 >= 0.3.2  # latest version which is not yet included in conda-forge
+  - pybtex
+  - m2r2 >= 0.3.2
   - sphinx>=4.2.0
   - sphinx_rtd_theme
   # deps used in tutorial but not working anymore

--- a/.github/test_mindep_conda_env.yml
+++ b/.github/test_mindep_conda_env.yml
@@ -13,7 +13,7 @@ dependencies:
   # see pypa/setuptools#4480
   - setuptools !=71.0.1
   # see #3258
-  - sqlalchemy < 2.0
+  - sqlalchemy
   # tests
   - pytest
   - pytest-cov

--- a/.github/test_mindepversion_conda_env.yml
+++ b/.github/test_mindepversion_conda_env.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
 dependencies:
   # obspy
-  - numpy=1.25
-  - scipy=1.11
-  - matplotlib=3.8
+  - numpy=2.2
+  - scipy=1.15
+  - matplotlib=3.10
   - decorator
   - lxml
   - requests
   # see pypa/setuptools#4480
   - setuptools !=71.0.1
   # see #3258
-  - sqlalchemy < 2.0
+  - sqlalchemy
   # soft dependencies
   - cartopy
   - geographiclib
@@ -20,7 +20,7 @@ dependencies:
   - pyshp != 3.0.0
   # tests
   - packaging
-  - pyproj < 3.5
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-json-report >= 1.4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,18 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        build: [cp38, cp39, cp310, cp311, cp312, cp313, cp314]
+        build: [cp312, cp313, cp314]
         exclude-flag:
           - ${{ github.ref_name == 'master' && github.event_name == 'push' }}
         exclude:
-          - build: cp38
-            exclude-flag: true
-          - build: cp39
-            exclude-flag: true
-          - build: cp310
-            exclude-flag: true
-          - build: cp311
-            exclude-flag: true
           - build: cp312
             exclude-flag: true
           - build: cp313

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -32,7 +32,11 @@ jobs:
           python-version: '3.12'
           activate-environment: obspydoc
           environment-file: .github/docs_conda_env.yml
-
+      - name: print package info
+        shell: bash -l {0}
+        run: |
+          conda info -a
+          conda list
       - name: install obspy
         shell: bash -l {0}
         run: |

--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -29,7 +29,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: 'latest'
-          python-version: '3.11'
+          python-version: '3.12'
           activate-environment: obspydoc
           environment-file: .github/docs_conda_env.yml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,27 +88,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
         options: [default]
         include:
           # The mindep option indicates optional dependencies should not be installed.
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.12'
             options: default mindep
           # The mindepversion option indicates dependencies should be installed with minimal supported version.
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.12'
             options: default mindepversion
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.12'
             options: default mindepversion
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.12'
             options: default mindepversion
           # For push events and for test_network labels, options is set to 'network' and runs for network tests are added.
           # Otherwise these include statements do nothing, because options='default' is already present in matrix.
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.12'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network mindepversion' || 'default' }}
           - os: ubuntu-latest
             python-version: '3.14'
@@ -172,23 +172,6 @@ jobs:
         run: conda env update -n test -f ${{ env.env_file }}
         if: steps.cache.outputs.cache-hit != 'true'
         timeout-minutes: 5
-
-      - name: Fix for missing libtiff.so.5 for Python3.8 on Ubuntu
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
-        shell: bash -l {0}
-        run: |
-          # Create symlink in conda environment
-          if [ -f $CONDA_PREFIX/lib/libtiff.so.6 ]; then
-            ln -sf $CONDA_PREFIX/lib/libtiff.so.6 $CONDA_PREFIX/lib/libtiff.so.5
-            echo "Created symlink: libtiff.so.6 -> libtiff.so.5"
-          elif [ -f $CONDA_PREFIX/lib/libtiff.so ]; then
-            ln -sf $CONDA_PREFIX/lib/libtiff.so $CONDA_PREFIX/lib/libtiff.so.5
-            echo "Created symlink: libtiff.so -> libtiff.so.5"
-          else
-            echo "Warning: Could not find libtiff library to link"
-            ls -la $CONDA_PREFIX/lib/libtiff* || echo "No libtiff files found"
-          fi
-
 
       - name: print package info
         shell: bash -l {0}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ master
 ======
 
 Changes:
+ - General:
+   * adjusted minimum dependency versions to Python >=3.12, numpy >=2.2,
+     scipy >=1.15 and matplotlib >=3.9 (see #3570)
  - obspy.signal:
    * spectral estimation: add getter functions for rotational noise models
      (see #3732)

--- a/misc/docs/source/_ext/plot_directive.py
+++ b/misc/docs/source/_ext/plot_directive.py
@@ -103,6 +103,7 @@ class PlotDirective(Directive):
     optional_arguments = 2
     final_argument_whitespace = False
     option_spec = {
+        'target': directives.unchanged,
         'alt': directives.unchanged,
         'height': directives.length_or_unitless,
         'width': directives.length_or_percentage_or_unitless,
@@ -757,6 +758,13 @@ def run(arguments, content, options, state_machine, state, lineno):
             srcset = None
             template = TEMPLATE
 
+        #  hide source link and additional formats if image is linked
+        html_show_formats = config.plot_html_show_formats and len(images)
+        if 'target' in options:
+            src_name = None
+            html_show_formats = False
+            opts.append(f':target: {options["target"]}')
+
         result = jinja2.Template(config.plot_template or template).render(
             default_fmt=default_fmt,
             build_dir=build_dir_link,
@@ -766,7 +774,7 @@ def run(arguments, content, options, state_machine, state, lineno):
             srcset=srcset,
             images=images,
             source_code=source_code,
-            html_show_formats=config.plot_html_show_formats and len(images),
+            html_show_formats=html_show_formats,
             caption=caption)
         total_lines.extend(result.split("\n"))
         total_lines.extend("\n")

--- a/misc/docs/source/_ext/plot_directive.py
+++ b/misc/docs/source/_ext/plot_directive.py
@@ -1,13 +1,16 @@
 """
+Content of this file was copied and modified after matplotlib v3.10.1, file
+``lib/matplotlib/sphinxext/plot_directive.py``. Module docstring removed, see
+matplotlib for details.
+Copyright (c) 2012- Matplotlib Development Team; All Rights Reserved
+
 A directive for including a Matplotlib plot in a Sphinx document
 ================================================================
 
-Shameless copy of
-https://matplotlib.org/3.2.2/_modules/matplotlib/sphinxext/plot_directive.html
-modified in order to use also :target: in plots.
 """
 
 import contextlib
+import doctest
 from io import StringIO
 import itertools
 import os
@@ -23,13 +26,14 @@ from docutils.parsers.rst import directives, Directive
 from docutils.parsers.rst.directives.images import Image
 import jinja2  # Sphinx dependency.
 
+from sphinx.errors import ExtensionError
+
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
 import matplotlib.pyplot as plt
 from matplotlib import _pylab_helpers, cbook
 
 matplotlib.use("agg")
-align = Image.align
 
 __version__ = 2
 
@@ -37,6 +41,7 @@ __version__ = 2
 # -----------------------------------------------------------------------------
 # Registration hook
 # -----------------------------------------------------------------------------
+
 
 def _option_boolean(arg):
     if not arg or not arg.strip():
@@ -47,22 +52,17 @@ def _option_boolean(arg):
     elif arg.strip().lower() in ('yes', '1', 'true'):
         return True
     else:
-        raise ValueError('"%s" unknown boolean' % arg)
+        raise ValueError(f'{arg!r} unknown boolean')
 
 
 def _option_context(arg):
     if arg in [None, 'reset', 'close-figs']:
         return arg
-    raise ValueError("argument should be None or 'reset' or 'close-figs'")
+    raise ValueError("Argument should be None or 'reset' or 'close-figs'")
 
 
 def _option_format(arg):
     return directives.choice(arg, ('python', 'doctest'))
-
-
-def _option_align(arg):
-    return directives.choice(arg, ("top", "middle", "bottom", "left", "center",
-                                   "right"))
 
 
 def mark_plot_labels(app, document):
@@ -96,38 +96,46 @@ def mark_plot_labels(app, document):
 
 
 class PlotDirective(Directive):
-    """Implementation of the ``.. plot::`` directive.
-
-    See the module docstring for details.
-    """
+    """The ``.. plot::`` directive, as documented in the module's docstring."""
 
     has_content = True
     required_arguments = 0
     optional_arguments = 2
     final_argument_whitespace = False
     option_spec = {
-        'target': directives.unchanged,
         'alt': directives.unchanged,
         'height': directives.length_or_unitless,
         'width': directives.length_or_percentage_or_unitless,
         'scale': directives.nonnegative_int,
-        'align': _option_align,
+        'align': Image.align,
         'class': directives.class_option,
         'include-source': _option_boolean,
+        'show-source-link': _option_boolean,
         'format': _option_format,
         'context': _option_context,
         'nofigs': directives.flag,
-        'encoding': directives.encoding,
+        'caption': directives.unchanged,
         }
 
     def run(self):
         """Run the plot directive."""
-        return run(self.arguments, self.content, self.options,
-                   self.state_machine, self.state, self.lineno)
+        try:
+            return run(self.arguments, self.content, self.options,
+                       self.state_machine, self.state, self.lineno)
+        except Exception as e:
+            raise self.error(str(e))
+
+
+def _copy_css_file(app, exc):
+    if exc is None and app.builder.format == 'html':
+        src = cbook._get_data_path('plot_directive/plot_directive.css')
+        dst = app.outdir / Path('_static')
+        dst.mkdir(exist_ok=True)
+        # Use copyfile because we do not want to copy src's permissions.
+        shutil.copyfile(src, dst / Path('plot_directive.css'))
 
 
 def setup(app):
-    import matplotlib
     setup.app = app
     setup.config = app.config
     setup.confdir = app.confdir
@@ -142,9 +150,10 @@ def setup(app):
     app.add_config_value('plot_apply_rcparams', False, True)
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
-
+    app.add_config_value('plot_srcset', [], True)
     app.connect('doctree-read', mark_plot_labels)
-
+    app.add_css_file('plot_directive.css')
+    app.connect('build-finished', _copy_css_file)
     metadata = {'parallel_read_safe': True, 'parallel_write_safe': True,
                 'version': matplotlib.__version__}
     return metadata
@@ -167,70 +176,96 @@ def contains_doctest(text):
     return bool(m)
 
 
-def unescape_doctest(text):
-    """
-    Extract code from a piece of text, which contains either Python code
-    or doctests.
-    """
-    if not contains_doctest(text):
-        return text
-
-    code = ""
-    for line in text.split("\n"):
-        m = re.match(r'^\s*(>>>|\.\.\.) (.*)$', line)
-        if m:
-            code += m.group(2) + "\n"
-        elif line.strip():
-            code += "# " + line.strip() + "\n"
-        else:
-            code += "\n"
-    return code
-
-
-def split_code_at_show(text):
+def _split_code_at_show(text, function_name):
     """Split code at plt.show()."""
-    parts = []
-    is_doctest = contains_doctest(text)
 
-    part = []
-    for line in text.split("\n"):
-        if (not is_doctest and line.strip() == 'plt.show()') or \
-               (is_doctest and line.strip() == '>>> plt.show()'):
-            part.append(line)
+    is_doctest = contains_doctest(text)
+    if function_name is None:
+        parts = []
+        part = []
+        for line in text.split("\n"):
+            if ((not is_doctest and line.startswith('plt.show(')) or
+                   (is_doctest and line.strip() == '>>> plt.show()')):
+                part.append(line)
+                parts.append("\n".join(part))
+                part = []
+            else:
+                part.append(line)
+        if "\n".join(part).strip():
             parts.append("\n".join(part))
-            part = []
-        else:
-            part.append(line)
-    if "\n".join(part).strip():
-        parts.append("\n".join(part))
-    return parts
+    else:
+        parts = [text]
+    return is_doctest, parts
 
 
 # -----------------------------------------------------------------------------
 # Template
 # -----------------------------------------------------------------------------
 
-
-TEMPLATE = """
+_SOURCECODE = """
 {{ source_code }}
 
 .. only:: html
 
-   {% if source_link or (html_show_formats and not multi_image) %}
+   {% if src_name or (html_show_formats and not multi_image) %}
    (
-   {%- if source_link -%}
-   `Source code <{{ source_link }}>`__
+   {%- if src_name -%}
+   :download:`Source code <{{ build_dir }}/{{ src_name }}>`
    {%- endif -%}
    {%- if html_show_formats and not multi_image -%}
      {%- for img in images -%}
        {%- for fmt in img.formats -%}
-         {%- if source_link or not loop.first -%}, {% endif -%}
-         `{{ fmt }} <{{ dest_dir }}/{{ img.basename }}.{{ fmt }}>`__
+         {%- if src_name or not loop.first -%}, {% endif -%}
+         :download:`{{ fmt }} <{{ build_dir }}/{{ img.basename }}.{{ fmt }}>`
        {%- endfor -%}
      {%- endfor -%}
    {%- endif -%}
    )
    {% endif %}
+"""
+
+TEMPLATE_SRCSET = _SOURCECODE + """
+   {% for img in images %}
+   .. figure-mpl:: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
+      {% for option in options -%}
+      {{ option }}
+      {% endfor %}
+      {%- if caption -%}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
+      {% endif -%}
+      {%- if srcset -%}
+        :srcset: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
+        {%- for sr in srcset -%}
+            , {{ build_dir }}/{{ img.basename }}.{{ sr }}.{{ default_fmt }} {{sr}}
+        {%- endfor -%}
+      {% endif %}
+
+   {% if html_show_formats and multi_image %}
+   (
+    {%- for fmt in img.formats -%}
+    {%- if not loop.first -%}, {% endif -%}
+    :download:`{{ fmt }} <{{ build_dir }}/{{ img.basename }}.{{ fmt }}>`
+    {%- endfor -%}
+   )
+   {% endif %}
+
+
+   {% endfor %}
+
+.. only:: not html
+
+   {% for img in images %}
+   .. figure-mpl:: {{ build_dir }}/{{ img.basename }}.*
+      {% for option in options -%}
+      {{ option }}
+      {% endfor -%}
+
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
+   {% endfor %}
+
+"""
+
+TEMPLATE = _SOURCECODE + """
 
    {% for img in images %}
    .. figure:: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
@@ -242,12 +277,12 @@ TEMPLATE = """
         (
         {%- for fmt in img.formats -%}
         {%- if not loop.first -%}, {% endif -%}
-        `{{ fmt }} <{{ dest_dir }}/{{ img.basename }}.{{ fmt }}>`__
+        :download:`{{ fmt }} <{{ build_dir }}/{{ img.basename }}.{{ fmt }}>`
         {%- endfor -%}
         )
       {%- endif -%}
 
-      {{ caption }}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
    {% endfor %}
 
 .. only:: not html
@@ -256,9 +291,9 @@ TEMPLATE = """
    .. figure:: {{ build_dir }}/{{ img.basename }}.*
       {% for option in options -%}
       {{ option }}
-      {% endfor %}
+      {% endfor -%}
 
-      {{ caption }}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
    {% endfor %}
 
 """
@@ -284,27 +319,39 @@ class ImageFile:
         self.formats = []
 
     def filename(self, format):
-        return os.path.join(self.dirname, "%s.%s" % (self.basename, format))
+        return os.path.join(self.dirname, f"{self.basename}.{format}")
 
     def filenames(self):
         return [self.filename(fmt) for fmt in self.formats]
 
 
-def out_of_date(original, derived):
+def out_of_date(original, derived, includes=None):
     """
-    Return whether *derived* is out-of-date relative to *original*, both of
-    which are full file paths.
+    Return whether *derived* is out-of-date relative to *original* or any of
+    the RST files included in it using the RST include directive (*includes*).
+    *derived* and *original* are full paths, and *includes* is optionally a
+    list of full paths which may have been included in the *original*.
     """
-    return (not os.path.exists(derived) or
-            (os.path.exists(original) and
-             os.stat(derived).st_mtime < os.stat(original).st_mtime))
+    if not os.path.exists(derived):
+        return True
+
+    if includes is None:
+        includes = []
+    files_to_check = [original, *includes]
+
+    def out_of_date_one(original, derived_mtime):
+        return (os.path.exists(original) and
+                derived_mtime < os.stat(original).st_mtime)
+
+    derived_mtime = os.stat(derived).st_mtime
+    return any(out_of_date_one(f, derived_mtime) for f in files_to_check)
 
 
 class PlotError(RuntimeError):
     pass
 
 
-def run_code(code, code_path, ns=None, function_name=None):
+def _run_code(code, code_path, ns=None, function_name=None):
     """
     Import a Python module from a path, and run the function given by
     name, if function_name is not None.
@@ -318,13 +365,13 @@ def run_code(code, code_path, ns=None, function_name=None):
         try:
             os.chdir(setup.config.plot_working_directory)
         except OSError as err:
-            raise OSError(str(err) + '\n`plot_working_directory` option in'
-                          'Sphinx configuration file must be a valid '
-                          'directory path')
+            raise OSError(f'{err}\n`plot_working_directory` option in '
+                          f'Sphinx configuration file must be a valid '
+                          f'directory path') from err
         except TypeError as err:
-            raise TypeError(str(err) + '\n`plot_working_directory` option in '
-                            'Sphinx configuration file must be a string or '
-                            'None')
+            raise TypeError(f'{err}\n`plot_working_directory` option in '
+                            f'Sphinx configuration file must be a string or '
+                            f'None') from err
     elif code_path is not None:
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
@@ -333,7 +380,6 @@ def run_code(code, code_path, ns=None, function_name=None):
             sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
             contextlib.redirect_stdout(StringIO()):
         try:
-            code = unescape_doctest(code)
             if ns is None:
                 ns = {}
             if not ns:
@@ -351,8 +397,8 @@ def run_code(code, code_path, ns=None, function_name=None):
                 if function_name is not None:
                     exec(function_name + "()", ns)
 
-        except (Exception, SystemExit):
-            raise PlotError(traceback.format_exc())
+        except (Exception, SystemExit) as err:
+            raise PlotError(traceback.format_exc()) from err
         finally:
             os.chdir(pwd)
     return ns
@@ -383,36 +429,55 @@ def get_plot_formats(config):
     return formats
 
 
+def _parse_srcset(entries):
+    """
+    Parse srcset for multiples...
+    """
+    srcset = {}
+    for entry in entries:
+        entry = entry.strip()
+        if len(entry) >= 2:
+            mult = entry[:-1]
+            srcset[float(mult)] = entry
+        else:
+            raise ExtensionError(f'srcset argument {entry!r} is invalid.')
+    return srcset
+
+
 def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False,
-                   close_figs=False):
+                   close_figs=False,
+                   code_includes=None):
     """
     Run a pyplot script and save the images in *output_dir*.
 
     Save the images under *output_dir* with file names derived from
     *output_base*
     """
+
+    if function_name is not None:
+        output_base = f'{output_base}_{function_name}'
     formats = get_plot_formats(config)
 
-    # -- Try to determine if all images already exist
+    # Try to determine if all images already exist
 
-    code_pieces = split_code_at_show(code)
-
+    is_doctest, code_pieces = _split_code_at_show(code, function_name)
     # Look for single-figure output files first
-    all_exists = True
     img = ImageFile(output_base, output_dir)
     for format, dpi in formats:
-        if out_of_date(code_path, img.filename(format)):
+        if context or out_of_date(code_path, img.filename(format),
+                                  includes=code_includes):
             all_exists = False
             break
         img.formats.append(format)
+    else:
+        all_exists = True
 
     if all_exists:
         return [(code, [img])]
 
     # Then look for multi-figure output files
     results = []
-    all_exists = True
     for i, code_piece in enumerate(code_pieces):
         images = []
         for j in itertools.count():
@@ -422,7 +487,8 @@ def render_figures(code, code_path, output_dir, output_base, context,
             else:
                 img = ImageFile('%s_%02d' % (output_base, j), output_dir)
             for fmt, dpi in formats:
-                if out_of_date(code_path, img.filename(fmt)):
+                if context or out_of_date(code_path, img.filename(fmt),
+                                          includes=code_includes):
                     all_exists = False
                     break
                 img.formats.append(fmt)
@@ -435,6 +501,8 @@ def render_figures(code, code_path, output_dir, output_base, context,
         if not all_exists:
             break
         results.append((code_piece, images))
+    else:
+        all_exists = True
 
     if all_exists:
         return results
@@ -442,10 +510,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
     # We didn't find the files, so build them
 
     results = []
-    if context:
-        ns = plot_context
-    else:
-        ns = {}
+    ns = plot_context if context else {}
 
     if context_reset:
         clear_state(config.plot_rcparams)
@@ -460,7 +525,9 @@ def render_figures(code, code_path, output_dir, output_base, context,
         elif close_figs:
             plt.close('all')
 
-        run_code(code_piece, code_path, ns, function_name)
+        _run_code(doctest.script_from_examples(code_piece) if is_doctest
+                  else code_piece,
+                  code_path, ns, function_name)
 
         images = []
         fig_managers = _pylab_helpers.Gcf.get_all_fig_managers()
@@ -473,11 +540,20 @@ def render_figures(code, code_path, output_dir, output_base, context,
                 img = ImageFile("%s_%02d_%02d" % (output_base, i, j),
                                 output_dir)
             images.append(img)
+
             for fmt, dpi in formats:
                 try:
                     figman.canvas.figure.savefig(img.filename(fmt), dpi=dpi)
-                except Exception:
-                    raise PlotError(traceback.format_exc())
+                    if fmt == formats[0][0] and config.plot_srcset:
+                        # save a 2x, 3x etc version of the default...
+                        srcset = _parse_srcset(config.plot_srcset)
+                        for mult, suffix in srcset.items():
+                            fm = f'{suffix}.{fmt}'
+                            img.formats.append(fm)
+                            figman.canvas.figure.savefig(img.filename(fm),
+                                                         dpi=int(dpi * mult))
+                except Exception as err:
+                    raise PlotError(traceback.format_exc()) from err
                 img.formats.append(fmt)
 
         results.append((code_piece, images))
@@ -493,10 +569,23 @@ def run(arguments, content, options, state_machine, state, lineno):
     config = document.settings.env.config
     nofigs = 'nofigs' in options
 
+    if config.plot_srcset and setup.app.builder.name == 'singlehtml':
+        raise ExtensionError(
+            'plot_srcset option not compatible with single HTML writer')
+
     formats = get_plot_formats(config)
     default_fmt = formats[0][0]
 
     options.setdefault('include-source', config.plot_include_source)
+    options.setdefault('show-source-link', config.plot_html_show_source_link)
+
+    if 'class' in options:
+        # classes are parsed into a list of string, and output by simply
+        # printing the list, abusing the fact that RST guarantees to strip
+        # non-conforming characters
+        options['class'] = ['plot-directive'] + options['class']
+    else:
+        options.setdefault('class', ['plot-directive'])
     keep_context = 'context' in options
     context_opt = None if not keep_context else options['context']
 
@@ -510,9 +599,18 @@ def run(arguments, content, options, state_machine, state, lineno):
         else:
             source_file_name = os.path.join(setup.confdir, config.plot_basedir,
                                             directives.uri(arguments[0]))
-
         # If there is content, it will be passed as a caption.
         caption = '\n'.join(content)
+
+        # Enforce unambiguous use of captions.
+        if "caption" in options:
+            if caption:
+                raise ValueError(
+                    'Caption specified in both content and options.'
+                    ' Please remove ambiguity.'
+                )
+            # Use caption option
+            caption = options["caption"]
 
         # If the optional function name is provided, use it
         if len(arguments) == 2:
@@ -530,7 +628,7 @@ def run(arguments, content, options, state_machine, state, lineno):
         base, ext = os.path.splitext(os.path.basename(source_file_name))
         output_base = '%s-%d.py' % (base, counter)
         function_name = None
-        caption = ''
+        caption = options.get('caption', '')
 
     base, source_ext = os.path.splitext(output_base)
     if source_ext in ('.py', '.rst', '.txt'):
@@ -551,9 +649,7 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     # determine output directory name fragment
     source_rel_name = relpath(source_file_name, setup.confdir)
-    source_rel_dir = os.path.dirname(source_rel_name)
-    while source_rel_dir.startswith(os.path.sep):
-        source_rel_dir = source_rel_dir[1:]
+    source_rel_dir = os.path.dirname(source_rel_name).lstrip(os.path.sep)
 
     # build_dir: where to place output files (temporarily)
     build_dir = os.path.join(os.path.dirname(setup.app.doctreedir),
@@ -563,38 +659,55 @@ def run(arguments, content, options, state_machine, state, lineno):
     # see note in Python docs for warning about symbolic links on Windows.
     # need to compare source and dest paths at end
     build_dir = os.path.normpath(build_dir)
-
-    if not os.path.exists(build_dir):
-        os.makedirs(build_dir)
-
-    # output_dir: final location in the builder's directory
-    dest_dir = os.path.abspath(os.path.join(setup.app.builder.outdir,
-                                            source_rel_dir))
-    if not os.path.exists(dest_dir):
-        os.makedirs(dest_dir)  # no problem here for me, but just use built-ins
+    os.makedirs(build_dir, exist_ok=True)
 
     # how to link to files from the RST file
-    dest_dir_link = os.path.join(relpath(setup.confdir, rst_dir),
-                                 source_rel_dir).replace(os.path.sep, '/')
     try:
         build_dir_link = relpath(build_dir, rst_dir).replace(os.path.sep, '/')
     except ValueError:
         # on Windows, relpath raises ValueError when path and start are on
         # different mounts/drives
         build_dir_link = build_dir
-    source_link = dest_dir_link + '/' + output_base + source_ext
+
+    # get list of included rst files so that the output is updated when any
+    # plots in the included files change. These attributes are modified by the
+    # include directive (see the docutils.parsers.rst.directives.misc module).
+    try:
+        source_file_includes = [os.path.join(os.getcwd(), t[0])
+                                for t in state.document.include_log]
+    except AttributeError:
+        # the document.include_log attribute only exists in docutils >=0.17,
+        # before that we need to inspect the state machine
+        possible_sources = {os.path.join(setup.confdir, t[0])
+                            for t in state_machine.input_lines.items}
+        source_file_includes = [f for f in possible_sources
+                                if os.path.isfile(f)]
+    # remove the source file itself from the includes
+    try:
+        source_file_includes.remove(source_file_name)
+    except ValueError:
+        pass
+
+    # save script (if necessary)
+    if options['show-source-link']:
+        Path(build_dir, output_base + source_ext).write_text(
+            doctest.script_from_examples(code)
+            if source_file_name == rst_file and is_doctest
+            else code,
+            encoding='utf-8')
 
     # make figures
     try:
-        results = render_figures(code,
-                                 source_file_name,
-                                 build_dir,
-                                 output_base,
-                                 keep_context,
-                                 function_name,
-                                 config,
+        results = render_figures(code=code,
+                                 code_path=source_file_name,
+                                 output_dir=build_dir,
+                                 output_base=output_base,
+                                 context=keep_context,
+                                 function_name=function_name,
+                                 config=config,
                                  context_reset=context_opt == 'reset',
-                                 close_figs=context_opt == 'close-figs')
+                                 close_figs=context_opt == 'close-figs',
+                                 code_includes=source_file_includes)
         errors = []
     except PlotError as err:
         reporter = state.memo.reporter
@@ -606,9 +719,11 @@ def run(arguments, content, options, state_machine, state, lineno):
         errors = [sm]
 
     # Properly indent the caption
-    caption = '\n'.join('      ' + line.strip()
-                        for line in caption.split('\n'))
-
+    if caption and config.plot_srcset:
+        caption = f':caption: {caption}'
+    elif caption:
+        caption = '\n' + '\n'.join('      ' + line.strip()
+                                   for line in caption.split('\n'))
     # generate output restructuredtext
     total_lines = []
     for j, (code_piece, images) in enumerate(results):
@@ -626,54 +741,37 @@ def run(arguments, content, options, state_machine, state, lineno):
             images = []
 
         opts = [
-            ':%s: %s' % (key, val) for key, val in options.items()
+            f':{key}: {val}' for key, val in options.items()
             if key in ('alt', 'height', 'width', 'scale', 'align', 'class')]
 
-        # Not-None src_link signals the need for a source link in the generated
-        # html
-        if j == 0 and config.plot_html_show_source_link:
-            src_link = source_link
+        # Not-None src_name signals the need for a source download in the
+        # generated html
+        if j == 0 and options['show-source-link']:
+            src_name = output_base + source_ext
         else:
-            src_link = None
+            src_name = None
+        if config.plot_srcset:
+            srcset = [*_parse_srcset(config.plot_srcset).values()]
+            template = TEMPLATE_SRCSET
+        else:
+            srcset = None
+            template = TEMPLATE
 
-        #  hide source link and additional formats if image is linked
-        html_show_formats = config.plot_html_show_formats and len(images)
-        if 'target' in options:
-            src_link = None
-            html_show_formats = False
-            opts.append(':target: %s' % (options['target']))
-
-        result = jinja2.Template(config.plot_template or TEMPLATE).render(
+        result = jinja2.Template(config.plot_template or template).render(
             default_fmt=default_fmt,
-            dest_dir=dest_dir_link,
             build_dir=build_dir_link,
-            source_link=src_link,
+            src_name=src_name,
             multi_image=len(images) > 1,
             options=opts,
+            srcset=srcset,
             images=images,
             source_code=source_code,
-            html_show_formats=html_show_formats,
+            html_show_formats=config.plot_html_show_formats and len(images),
             caption=caption)
-
         total_lines.extend(result.split("\n"))
         total_lines.extend("\n")
 
     if total_lines:
         state_machine.insert_input(total_lines, source=source_file_name)
-
-    # copy image files to builder's output directory, if necessary
-    Path(dest_dir).mkdir(parents=True, exist_ok=True)
-
-    for code_piece, images in results:
-        for img in images:
-            for fn in img.filenames():
-                destimg = os.path.join(dest_dir, os.path.basename(fn))
-                if fn != destimg:
-                    shutil.copyfile(fn, destimg)
-
-    # copy script (if necessary)
-    Path(dest_dir, output_base + source_ext).write_text(
-        unescape_doctest(code) if source_file_name == rst_file else code,
-        encoding='utf-8')
 
     return errors

--- a/misc/scripts/spec0.py
+++ b/misc/scripts/spec0.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python
+"""
+SPEC-0 support-window planner for ObsPy.
+
+Draws a Gantt chart of dependency support windows (SPEC-0000: 3 years for
+Python, 2 years for core packages) and overlays *tentative* ObsPy release
+dates, so you can read off which dependency versions each planned release
+would have to support.
+
+Edit OBSPY_RELEASES (and CORE_PACKAGES) below, then run:
+
+    python obspy_spec0_plot.py                 # uses cached PyPI data if present
+    python obspy_spec0_plot.py --refresh       # re-query PyPI
+    python obspy_spec0_plot.py -o plan.png
+
+Outputs: <name>.png  and  <name>.md (markdown table of the same info).
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+from datetime import datetime, timedelta
+
+import matplotlib.dates as mdates
+import matplotlib.patheffects as pe
+import matplotlib.pyplot as plt
+from matplotlib.legend_handler import HandlerTuple
+from matplotlib.patches import Patch
+import requests
+from packaging.version import InvalidVersion, Version
+
+# --------------------------------------------------------------------------
+# CONFIGURATION -- this is the part you edit
+# --------------------------------------------------------------------------
+
+#: Tentative ObsPy releases: name -> date (YYYY-MM-DD).
+#: Past releases are fine too, they just get a solid line instead of dashed.
+OBSPY_RELEASES = {
+    "1.5.0": "2026-03-01",
+    "1.6.0": "2026-09-01",   # tentative
+    "1.7.0": "2027-03-01",   # tentative
+}
+
+#: The release currently being worked on. Bars are faded when their SPEC-0
+#: window has already closed by this date, so the shading does not silently
+#: change meaning when you append a further release to OBSPY_RELEASES.
+REFERENCE_RELEASE = "1.6.0"
+
+#: Package colours. Deliberately no red in here -- red is reserved for the
+#: "extended support" hatching, so adding packages never steals it.
+PALETTE = [
+    "#1f77b4",  # blue
+    "#ff7f0e",  # orange
+    "#2ca02c",  # green
+    "#9467bd",  # purple
+    "#8c564b",  # brown
+    "#17becf",  # cyan
+    "#bcbd22",  # olive
+    "#7f7f7f",  # grey
+]
+
+#: What ObsPy *actually* declared as its floor, per release.
+#: 1.5.0 values are verbatim from setup.py at tag 1.5.0:
+#:   MIN_PYTHON_VERSION = (3, 8)  (classifiers list up to 3.14)
+#:   numpy>=1.21, scipy>=1.7, matplotlib>=3.3
+#: Anything below its SPEC-0 floor is drawn as "extended support".
+OBSPY_ACTUAL_FLOOR = {
+    "1.5.0": {
+        "python": "3.8",
+        "numpy": "1.21",
+        "scipy": "1.7",
+        "matplotlib": "3.3",
+    },
+}
+
+#: Core dependencies queried from PyPI (2-year window under SPEC-0).
+#: Add anything you like: "lxml", "sqlalchemy", "requests", "pandas", ...
+CORE_PACKAGES = ["numpy", "scipy", "matplotlib"]
+
+#: Python release dates (PyPI cannot tell us these).
+PYTHON_RELEASES = {
+    "3.8": "2019-10-14",
+    "3.9": "2020-10-05",
+    "3.10": "2021-10-04",
+    "3.11": "2022-10-24",
+    "3.12": "2023-10-02",
+    "3.13": "2024-10-07",
+    "3.14": "2025-10-07",
+    "3.15": "2026-10-07",  # projected
+    "3.16": "2027-10-05",  # projected
+}
+
+#: SPEC-0000 support windows.
+WINDOW_PYTHON = timedelta(days=int(365.25 * 3))
+WINDOW_CORE = timedelta(days=int(365.25 * 2))
+
+#: How much history to draw before the first ObsPy release on the chart.
+#: Versions whose support window ended before that are simply not shown.
+HISTORY = timedelta(days=365 * 3)
+
+#: Extrapolate future dependency releases from each project's median cadence,
+#: so that the *upper* bound of a 2027 release is not artificially capped by
+#: whatever is on PyPI today. Projected versions are hatched and marked "*".
+PROJECT_FUTURE = True
+
+CACHE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec0_cache.json")
+
+
+# --------------------------------------------------------------------------
+# DATA COLLECTION
+# --------------------------------------------------------------------------
+
+
+def _parse_upload_time(value: str):
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def query_pypi(package: str) -> dict[str, str]:
+    """Return {minor version: ISO release date} for a package on PyPI.
+
+    Only X.Y.0 final releases are considered, and the release date is the
+    upload time of the *first* file for that version.
+    """
+    print(f"Querying pypi.org for {package} ...", end="", flush=True)
+    response = requests.get(
+        f"https://pypi.org/simple/{package}",
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    files = response.json()["files"]
+    print(" OK")
+
+    file_dates = collections.defaultdict(list)
+    for f in files:
+        try:
+            raw = f["filename"].split("-")[1]
+            version = Version(raw)
+        except (IndexError, InvalidVersion):
+            continue
+        if version.is_prerelease or version.micro != 0:
+            continue
+        stamp = _parse_upload_time(f.get("upload-time", ""))
+        if stamp is not None:
+            file_dates[f"{version.major}.{version.minor}"].append(stamp)
+
+    return {v: min(dates).isoformat() for v, dates in file_dates.items()}
+
+
+def load_releases(refresh: bool = False) -> dict[str, dict[str, datetime]]:
+    """Collect release dates for Python + all core packages, with caching."""
+    cache = {}
+    if os.path.exists(CACHE_FILE) and not refresh:
+        with open(CACHE_FILE) as fh:
+            cache = json.load(fh)
+
+    missing = [p for p in CORE_PACKAGES if p not in cache]
+    if refresh or missing:
+        for package in CORE_PACKAGES if refresh else missing:
+            cache[package] = query_pypi(package)
+        with open(CACHE_FILE, "w") as fh:
+            json.dump(cache, fh, indent=1, sort_keys=True)
+        print(f"Cached PyPI data in {CACHE_FILE}")
+
+    releases = {
+        "python": {v: datetime.fromisoformat(d) for v, d in PYTHON_RELEASES.items()}
+    }
+    for package in CORE_PACKAGES:
+        releases[package] = {
+            v: datetime.fromisoformat(d) for v, d in cache[package].items()
+        }
+    return releases
+
+
+def window_for(package: str) -> timedelta:
+    return WINDOW_PYTHON if package == "python" else WINDOW_CORE
+
+
+# --------------------------------------------------------------------------
+# SPEC-0 LOGIC
+# --------------------------------------------------------------------------
+
+
+def project_future(releases: dict[str, datetime], until: datetime, n_hist: int = 6):
+    """Append plausible future minor releases based on the median cadence.
+
+    Returns the set of version strings that were invented (not real releases).
+    """
+    known = sorted(releases, key=Version)
+    if len(known) < 3:
+        return set()
+    dates = [releases[v] for v in known[-n_hist:]]
+    gaps = sorted((b - a).days for a, b in zip(dates, dates[1:]))
+    cadence = timedelta(days=max(60, gaps[len(gaps) // 2]))
+
+    version, date = Version(known[-1]), releases[known[-1]]
+    projected = set()
+    while date + cadence <= until:
+        date += cadence
+        version = Version(f"{version.major}.{version.minor + 1}")
+        releases[str(version)] = date
+        projected.add(str(version))
+    return projected
+
+
+def global_floor(package: str) -> str | None:
+    """Lowest version any listed ObsPy release declares for this package."""
+    floors = [
+        f[package] for f in OBSPY_ACTUAL_FLOOR.values() if package in f
+    ]
+    return min(floors, key=Version) if floors else None
+
+
+def trim(releases: dict[str, datetime], package: str, start: datetime, end: datetime):
+    """Keep versions that are relevant to the chart.
+
+    The lower bound is ObsPy's own declared floor when we know it (that is the
+    whole point of the figure), otherwise the SPEC-0 history window.
+    """
+    floor = global_floor(package)
+    window = window_for(package)
+    return {
+        v: d
+        for v, d in releases.items()
+        if d <= end
+        and (Version(v) >= Version(floor) if floor else d + window >= start)
+    }
+
+
+def supported_at(releases: dict[str, datetime], date: datetime, window: timedelta):
+    """Versions still supported at `date` under SPEC-0.
+
+    A version is supported until `release_date + window`. If that would leave
+    nothing (a very quiet upstream project), the most recent release is kept
+    so the answer is never empty.
+    """
+    released = {v: d for v, d in releases.items() if d <= date}
+    if not released:
+        return []
+    keep = [v for v, d in released.items() if d + window > date]
+    if not keep:
+        keep = [max(released, key=released.get)]
+    return sorted(keep, key=Version)
+
+
+def build_matrix(releases, obspy_releases):
+    """{obspy version: {package: (min_version, max_version)}}."""
+    matrix = {}
+    for name, date in obspy_releases.items():
+        row = {}
+        for package, vers in releases.items():
+            sup = supported_at(vers, date, window_for(package))
+            row[package] = (sup[0], sup[-1]) if sup else (None, None)
+        matrix[name] = row
+    return matrix
+
+
+# --------------------------------------------------------------------------
+# PLOT
+# --------------------------------------------------------------------------
+
+
+def plot(releases, obspy_releases, matrix, projected, xlim, outfile):
+    packages = list(releases)
+    colors = {p: PALETTE[i % len(PALETTE)] for i, p in enumerate(packages)}
+    extended_color = "#b2182b"
+
+    # one row per (package, version): packages top to bottom, oldest first
+    rows = []
+    for package in packages:
+        for version in sorted(releases[package], key=Version):
+            rows.append((package, version))
+    rows.reverse()
+    y_of = {row: y for y, row in enumerate(rows)}
+
+    reference = obspy_releases.get(REFERENCE_RELEASE, max(obspy_releases.values()))
+    xmin, xmax = xlim
+    n_rows = len(rows)
+
+    height = 3.3 + 0.24 * n_rows
+    fig, ax = plt.subplots(figsize=(15, height))
+    fig.subplots_adjust(
+        left=0.10, right=0.985,
+        top=1 - 2.15 / height, bottom=0.75 / height,
+    )
+
+    # ---- SPEC-0 support windows -----------------------------------------
+    labels = []
+    for y, (package, version) in enumerate(rows):
+        released = releases[package][version]
+        dropped = released + window_for(package)
+        # leader line from the tick label to where the bar actually starts
+        ax.hlines(
+            y, mdates.date2num(xmin), mdates.date2num(released),
+            color=colors[package], lw=0.7, ls=(0, (1, 2.5)), alpha=0.8, zorder=1,
+        )
+        ax.barh(
+            y,
+            mdates.date2num(dropped) - mdates.date2num(released),
+            left=mdates.date2num(released),
+            height=0.60,
+            color=colors[package],
+            alpha=0.30 if dropped <= reference else 0.85,
+            edgecolor=colors[package],
+            linewidth=1.0,
+            hatch="///" if version in projected[package] else None,
+            zorder=3,
+        )
+        star = "*" if version in projected[package] else ""
+        labels.append(f"{version}{star}")
+
+    # ---- what ObsPy actually kept alive beyond the SPEC-0 window ---------
+    for name, floors in OBSPY_ACTUAL_FLOOR.items():
+        if name not in obspy_releases:
+            continue
+        obspy_date = obspy_releases[name]
+        for package, floor in floors.items():
+            if package not in releases:
+                continue
+            for version, released in releases[package].items():
+                if Version(version) < Version(floor) or released > obspy_date:
+                    continue
+                dropped = released + window_for(package)
+                if dropped >= obspy_date:
+                    continue  # still inside its SPEC-0 window, nothing extended
+                ax.barh(
+                    y_of[(package, version)],
+                    mdates.date2num(obspy_date) - mdates.date2num(dropped),
+                    left=mdates.date2num(dropped),
+                    height=0.60,
+                    color=extended_color,
+                    alpha=0.28,
+                    edgecolor=extended_color,
+                    linewidth=0.6,
+                    hatch="\\\\",
+                    zorder=2,
+                )
+            # bracket + label on the floor row
+            y_floor = y_of[(package, floor)]
+            n_supported = sum(
+                1 for v, d in releases[package].items()
+                if Version(v) >= Version(floor) and d <= obspy_date
+            )
+            ax.annotate(
+                f"obspy {name}: {package} >= {floor}  ({n_supported} versions)",
+                xy=(mdates.date2num(obspy_date), y_floor),
+                xytext=(-7, 0), textcoords="offset points",
+                va="center", ha="right", fontsize=8.5,
+                color=extended_color, fontweight="bold", zorder=7,
+            )
+
+    # ---- SPEC-0 floor markers -------------------------------------------
+    # a row can be the floor for several ObsPy releases; the version number is
+    # written once, next to the earliest dot on that row.
+    floor_dots = collections.defaultdict(list)
+    for name, date in obspy_releases.items():
+        for package in packages:
+            floor = matrix[name][package][0]
+            if floor is not None:
+                floor_dots[(package, floor)].append(date)
+
+    for (package, version), dates in floor_dots.items():
+        y = y_of[(package, version)]
+        for date in dates:
+            ax.plot(
+                mdates.date2num(date), y,
+                marker="o", ms=7, color="white", mec="black", mew=1.4, zorder=6,
+            )
+        # label to the left of the first dot, inside the bar -- unless the bar
+        # only just started there, in which case flip to the right
+        first = min(dates)
+        room = (first - releases[package][version]).days
+        ax.annotate(
+            version,
+            xy=(mdates.date2num(first), y),
+            xytext=(-8 if room > 220 else 8, 0),
+            textcoords="offset points",
+            ha="right" if room > 220 else "left",
+            va="center", fontsize=7.5, fontweight="bold", color="black",
+            zorder=7,
+            path_effects=[pe.withStroke(linewidth=2.2, foreground="white")],
+        )
+
+    # ---- ObsPy release lines --------------------------------------------
+    for name, date in obspy_releases.items():
+        future = date > datetime.now()
+        is_ref = name == REFERENCE_RELEASE
+        ax.axvline(
+            mdates.date2num(date), color="black", lw=2.6 if is_ref else 1.4,
+            ls="--" if future else "-", alpha=0.9 if is_ref else 0.65, zorder=5,
+        )
+        ax.text(
+            mdates.date2num(date), 1.004,
+            f"obspy {name}",
+            transform=ax.get_xaxis_transform(),
+            rotation=90, va="bottom", ha="center",
+            fontsize=10.5 if is_ref else 9.5, fontweight="bold",
+            zorder=8, clip_on=False,
+        )
+
+    ax.axvspan(
+        mdates.date2num(datetime.now()), mdates.date2num(xmax),
+        color="grey", alpha=0.07, zorder=0,
+    )
+
+    # ---- cosmetics -------------------------------------------------------
+    ax.set_yticks(range(n_rows))
+    ax.set_yticklabels(labels, fontsize=8.5, color="#333333")
+    ax.tick_params(axis="y", length=0, pad=4)
+
+    # package name once per block, as a bracket in the left margin
+    trans = ax.get_yaxis_transform()
+    for package in packages:
+        ys = [y for y, (pkg, _) in enumerate(rows) if pkg == package]
+        lo, hi = min(ys) - 0.42, max(ys) + 0.42
+        ax.plot(
+            [-0.043, -0.043], [lo, hi], transform=trans, clip_on=False,
+            color=colors[package], lw=2.4, solid_capstyle="butt", zorder=9,
+        )
+        ax.text(
+            -0.056, (lo + hi) / 2, package, transform=trans, clip_on=False,
+            rotation=90, va="center", ha="center", fontsize=11,
+            fontweight="bold", color=colors[package], zorder=9,
+        )
+        # faint separator between blocks
+        ax.axhline(hi, color="0.85", lw=0.8, zorder=0)
+    ax.set_ylim(-0.8, n_rows - 0.2)
+    ax.set_xlim(mdates.date2num(xmin), mdates.date2num(xmax))
+    ax.xaxis.set_major_locator(mdates.YearLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
+    ax.xaxis.set_minor_locator(mdates.MonthLocator(bymonth=(1, 4, 7, 10)))
+    ax.grid(axis="x", which="major", ls=":", alpha=0.5, zorder=1)
+    ax.set_axisbelow(True)
+    ax.set_title(
+        f"ObsPy releases vs. SPEC-0 support windows  (shading keyed to {REFERENCE_RELEASE}, in progress)\n"
+        "bar = inside the SPEC-0 window (3 yr Python / 2 yr core)  ·  "
+        "hatched red = support ObsPy 1.5.0 carried beyond it  ·  "
+        "○ = SPEC-0 floor  ·  * = projected release",
+        fontsize=11, pad=88,
+    )
+    # the first handle is a strip of all four package colours, so the legend
+    # swatch actually looks like something present in the figure
+    fig.legend(
+        handles=[
+            tuple(
+                Patch(facecolor=colors[p], edgecolor=colors[p], alpha=0.85)
+                for p in packages
+            ),
+            tuple(
+                Patch(facecolor=colors[p], edgecolor=colors[p], alpha=0.30)
+                for p in packages
+            ),
+            Patch(facecolor=extended_color, alpha=0.28, hatch="\\\\",
+                  edgecolor=extended_color),
+        ],
+        labels=[
+            f"SPEC-0 window still open at {REFERENCE_RELEASE}",
+            f"window already closed by {REFERENCE_RELEASE}",
+            "extended support carried by ObsPy 1.5.0",
+        ],
+        handler_map={tuple: HandlerTuple(ndivide=None, pad=0.0)},
+        handlelength=4.0,
+        loc="lower right", bbox_to_anchor=(0.985, 0.002),
+        ncol=3, fontsize=9, framealpha=0.95,
+    )
+
+    fig.savefig(outfile, dpi=150)
+    print(f"Saved {outfile}")
+    return fig
+
+
+def format_range(bounds, projected):
+    lo, hi = bounds
+    if lo is None:
+        return "-"
+    hi_str = f"{hi}*" if hi in projected else f"{hi}"
+    return hi_str if lo == hi else f"{lo} – {hi_str}"
+
+
+def write_markdown(matrix, obspy_releases, packages, projected, outfile):
+    lines = ["| ObsPy | date | " + " | ".join(packages) + " |"]
+    lines.append("|" + "---|" * (len(packages) + 2))
+    for name, date in sorted(obspy_releases.items(), key=lambda kv: kv[1]):
+        cells = [
+            format_range(matrix[name][p], projected[p]) for p in packages
+        ]
+        lines.append(
+            f"| {name} | {date:%Y-%m-%d} | " + " | ".join(cells) + " |"
+        )
+    text = "\n".join(lines) + "\n"
+    with open(outfile, "w") as fh:
+        fh.write(text)
+    print(f"Saved {outfile}\n")
+    print(text)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--refresh", action="store_true", help="re-query PyPI")
+    parser.add_argument("-o", "--output", default="obspy_spec0.png")
+    parser.add_argument("--show", action="store_true")
+    args = parser.parse_args()
+
+    releases = load_releases(refresh=args.refresh)
+    obspy_releases = {
+        k: datetime.fromisoformat(v) for k, v in OBSPY_RELEASES.items()
+    }
+
+    start = min(obspy_releases.values()) - HISTORY
+    for name, floors in OBSPY_ACTUAL_FLOOR.items():
+        if name not in obspy_releases:
+            continue
+        for package, floor in floors.items():
+            if floor in releases.get(package, {}):
+                start = min(start, releases[package][floor] - timedelta(days=90))
+    end = max(obspy_releases.values()) + timedelta(days=270)
+
+    projected = {}
+    for package in releases:
+        projected[package] = (
+            project_future(releases[package], end) if PROJECT_FUTURE else set()
+        )
+        releases[package] = trim(releases[package], package, start, end)
+        projected[package] &= set(releases[package])
+
+    matrix = build_matrix(releases, obspy_releases)
+
+    plot(releases, obspy_releases, matrix, projected, (start, end), args.output)
+    write_markdown(
+        matrix, obspy_releases, list(releases), projected,
+        os.path.splitext(args.output)[0] + ".md",
+    )
+    if args.show:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -21,14 +21,6 @@ import warnings
 from collections import OrderedDict
 from http.client import HTTPException, IncompleteRead
 from urllib.parse import urlparse
-# since python 3.10 socket.timeout is just an alias for builtin TimeoutError
-# and python docs state that it is a "deprecated alias", so that alias might
-# get removed at some point (or probably just kept forever), so be ready for it
-# here
-try:
-    from socket import timeout as socket_timeout
-except ImportError:
-    socket_timeout = TimeoutError
 
 from lxml import etree
 
@@ -1570,7 +1562,7 @@ class Client(object):
                             raise
                     except urllib_request.URLError:
                         wadl_queue.put((url, "timeout"))
-                    except socket_timeout:
+                    except TimeoutError:
                         wadl_queue.put((url, "timeout"))
             threadurl = ThreadURL()
             threadurl._timeout = self.timeout
@@ -1824,7 +1816,7 @@ def raise_on_error(code, data):
     # there can be random network issues that prevent us getting a proper HTTP
     # response and they need to handled differently
     if code is None:
-        if (isinstance(data, (socket_timeout, TimeoutError)) or
+        if (isinstance(data, TimeoutError) or
                 "timeout" in str(data).lower() or
                 "timed out" in str(data).lower()):
             raise FDSNTimeoutException("Timed Out")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ from setuptools import Extension, find_packages, setup
 # the entry point lookup routines, see #3333
 # XXX when dropping Python 3.9, get rid of socket.timeout and just use
 # TimeoutError, e.g. in fdsn/client.py
-MIN_PYTHON_VERSION = (3, 8)
+MIN_PYTHON_VERSION = (3, 12)
 
 # Fail fast if the user is on an unsupported version of python.
 if sys.version_info < MIN_PYTHON_VERSION:
@@ -88,9 +88,9 @@ EXTERNAL_LIBMSEED = False
 # Backwards compatibility hacks to be removed later:
 #  - matplotlib 3.3 (/3.4?): imaging (see #3242)
 INSTALL_REQUIRES = [
-    'numpy>=1.21',
-    'scipy>=1.7',
-    'matplotlib>=3.3',
+    'numpy>=2.2',
+    'scipy>=1.15',
+    'matplotlib>=3.10',
     'lxml',
     'setuptools',
     'sqlalchemy>=1.4',
@@ -827,10 +827,6 @@ def setupPackage():
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
             'Programming Language :: Python :: 3.13',
             'Programming Language :: Python :: 3.14',


### PR DESCRIPTION
### What does this PR do?

**1.** Adjusts minimum dependency versions for next major release 1.5.0 and also adjusts CI build matrix accordingly. For python+numpy we decided to follow [NEP029](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule) which leaves scipy and matplotlib minimum versions open for discussion, but probably could just go by release date of scipy+matplotlib and allow maybe 2-3 years backwards (like [numpy recommends](https://numpy.org/neps/nep-0029-deprecation_policy.html#implementation) in terms of clarity of wording and policy)

from NEP029:
```
On Apr 05, 2024 drop support for Python 3.9 (initially released on Oct 05, 2020)
On Jun 22, 2024 drop support for NumPy 1.23 (initially released on Jun 22, 2022)
On Dec 18, 2024 drop support for NumPy 1.24 (initially released on Dec 18, 2022)
On Apr 04, 2025 drop support for Python 3.10 (initially released on Oct 04, 2021)
<--  May 2025  -->
On Jun 17, 2025 drop support for NumPy 1.25 (initially released on Jun 17, 2023)
On Sep 16, 2025 drop support for NumPy 1.26 (initially released on Sep 16, 2023)
<--  Mar 2026  -->
On Apr 24, 2026 drop support for Python 3.11 (initially released on Oct 24, 2022)
On Jun 16, 2026 drop support for NumPy 2.0 (initially released on Jun 15, 2024)
```

scipy release dates:
```
1.9  -- Jul 29, 2022
1.10 -- Jan 03, 2023    <--  May 2025
1.11 -- Jun 25, 2023
1.12 -- Jan 20, 2024
1.13 -- Apr 02, 2024
1.14 -- Jun 24, 2024
1.15 -- Jan 02, 2025
1.16 -- Jun 22, 2025
1.17 -- Jan 10, 2026    <-- latest
```

matplotlib release dates:
```
3.6  -- Sep 16, 2022
3.7  -- Feb 13, 2023     <--  May 2025
3.8  -- Sep 15, 2023
3.9  -- May 16, 2024
3.10 -- Dec 14, 2024     <-- latest
```

--

**2.** Adjust some CI envs, build matrix and workflows accordingly

**3.** Update outdated `plot_directive` sphinx extension

### Why was it initiated?  Any relevant Issues?

see #3228 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
