### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -37,6 +37,7 @@ Eulenfeld, Tom
 Fabbri, Tommaso
 Falco, Nicholas
 Fee, Jeremy
+Ferdman, Emmanuel
 Grellier, Clément
 Grunberg, Marc
 Hagerty, Mike

--- a/obspy/io/nlloc/tests/test_core.py
+++ b/obspy/io/nlloc/tests/test_core.py
@@ -104,8 +104,8 @@ class TestNLLOC():
 
         # remove (changing) obspy version number from output
         re_pattern = '<version>ObsPy .*?</version>'
-        quakeml_expected = re.sub(re_pattern, '', quakeml_expected, 1)
-        quakeml_got = re.sub(re_pattern, '', quakeml_got, 1)
+        quakeml_expected = re.sub(re_pattern, '', quakeml_expected, count=1)
+        quakeml_got = re.sub(re_pattern, '', quakeml_got, count=1)
 
         compare_xml_strings(quakeml_expected.encode(), quakeml_got.encode())
 


### PR DESCRIPTION


### What does this PR do?
This small PR resolves the `re` deprecation warnings:
```python
DeprecationWarning: 'count' is passed as positional argument
```

### Why was it initiated?  Any relevant Issues?

*Please fill in (link relevant issues with "see #123456", mark issues that get resolved with "fixes #12345")*

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
