### PR TITLE
Add normalization factor calculation method to `PolesZerosResponseStage`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,8 @@ master
 Changes:
  - obspy.core:
    * response: allow recalculating overall sensitivity even if unit type is not
-     one of VEL/ACC/DISP (see #3235)
+     one of VEL/ACC/DISP (see #3235), add method for calculating the normalization
+     factor for pole–zero response stages (see #XXXX)
    * trace: 5x quicker retrieval of seed-id with trace.id / trace.get_id()
      (see #3251)
    * inventory: additional formatting tweaks to expanded channel information

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -203,8 +203,9 @@ class PolesZerosResponseStage(ResponseStage):
     :param zeros: All zeros of the stage.
     :type poles: list[complex]
     :param poles: All poles of the stage.
-    :type normalization_factor: float, optional
-    :param normalization_factor:
+    :type normalization_factor: float or None, optional
+    :param normalization_factor: Normalization factor. If None, it will be calculated
+        from the poles and zeros.
     """
     def __init__(self, stage_sequence_number, stage_gain,
                  stage_gain_frequency, input_units, output_units,
@@ -220,9 +221,12 @@ class PolesZerosResponseStage(ResponseStage):
         # handled by properties.
         self.pz_transfer_function_type = pz_transfer_function_type
         self.normalization_frequency = normalization_frequency
-        self.normalization_factor = float(normalization_factor)
         self.zeros = zeros
         self.poles = poles
+        # If the user sets normalization_factor to None, we calculate it
+        if normalization_factor is None:
+            normalization_factor = self.calculate_normalization_factor()
+        self.normalization_factor = float(normalization_factor)
         super(PolesZerosResponseStage, self).__init__(
             stage_sequence_number=stage_sequence_number,
             input_units=input_units,
@@ -356,6 +360,8 @@ class PolesZerosResponseStage(ResponseStage):
         More reading here:
         https://docs.fdsn.org/projects/stationxml/en/latest/response.html#poles-and-zeros
         """
+        if not self.normalization_frequency:
+            return None
         if self.pz_transfer_function_type == 'LAPLACE (RADIANS/SECOND)':
             s = 2j * np.pi * self.normalization_frequency
         elif self.pz_transfer_function_type == 'LAPLACE (HERTZ)':

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -348,6 +348,26 @@ class PolesZerosResponseStage(ResponseStage):
                    f"'LAPLACE (RADIANS/SECOND)'")
             raise ValueError(msg)
 
+    def calculate_normalization_factor(self):
+        """
+        Calculate the normalization factor, which normalizes the pole–zero expansion to
+        unity at the normalization frequency, from the response stage poles and zeros.
+
+        More reading here:
+        https://docs.fdsn.org/projects/stationxml/en/latest/response.html#poles-and-zeros
+        """
+        if self.pz_transfer_function_type == 'LAPLACE (RADIANS/SECOND)':
+            s = 2j * np.pi * self.normalization_frequency
+        elif self.pz_transfer_function_type == 'LAPLACE (HERTZ)':
+            s = 1j * self.normalization_frequency
+        else:
+            msg = (
+                'Cannot calculate normalization factor for type '
+                f'"{self.pz_transfer_function_type}"'
+            )
+            raise NotImplementedError(msg)
+        return abs((s - np.array(self.poles)).prod() / (s - np.array(self.zeros)).prod())
+
 
 class CoefficientsTypeResponseStage(ResponseStage):
     """

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -124,7 +124,7 @@ class TestResponse:
             **_paz_sts1_kwargs,
         )
         np.testing.assert_allclose(
-            paz_sts1_rads.calculate_normalization_factor(), 3948.58  # [rad/s]
+            paz_sts1_rads.calculate_normalization_factor(), 3948.58, rtol=1e-5
         )
         # Test for hertz
         paz_sts1_hz = PolesZerosResponseStage(
@@ -139,7 +139,7 @@ class TestResponse:
             **_paz_sts1_kwargs,
         )
         np.testing.assert_allclose(
-            paz_sts1_hz.calculate_normalization_factor(), 100.01869  # [Hz]
+            paz_sts1_hz.calculate_normalization_factor(), 100.01869, rtol=1e-5
         )
 
     def test_pitick2latex(self):

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -95,6 +95,53 @@ class TestResponse:
                 expected = [seed_response[i_] for i_ in indices]
                 np.testing.assert_allclose(got, expected, rtol=1E-5)
 
+    def test_calculate_normalization_factor(self):
+        """
+        Test calculation of the normalization factor for pole–zero stages given in both
+        radians/second and hertz. The test values "A0 normalization" are taken from:
+        https://docs.fdsn.org/projects/stationxml/en/latest/response.html#stage-1-the-analog-sensor
+        """
+        # Streckeisen STS-1 poles and zeros from:
+        # https://docs.fdsn.org/projects/stationxml/en/latest/response.html#stage-1-the-analog-sensor
+        _paz_sts1_kwargs = dict(
+            stage_sequence_number=1,
+            stage_gain=2400,
+            stage_gain_frequency=0.02,
+            input_units='M/S',
+            output_units='V',
+            normalization_frequency=0.02,
+        )
+        # Test for radians/second
+        paz_sts1_rads = PolesZerosResponseStage(
+            pz_transfer_function_type='LAPLACE (RADIANS/SECOND)',
+            poles=[
+                -0.01234 + 0.01234j,
+                -0.01234 - 0.01234j,
+                -39.18 + 49.12j,
+                -39.18 - 49.12j,
+            ],
+            zeros=[0j, 0j],
+            **_paz_sts1_kwargs,
+        )
+        np.testing.assert_allclose(
+            paz_sts1_rads.calculate_normalization_factor(), 3948.58  # [rad/s]
+        )
+        # Test for hertz
+        paz_sts1_hz = PolesZerosResponseStage(
+            pz_transfer_function_type='LAPLACE (HERTZ)',
+            poles=[
+                -0.0019639 + 0.0019639j,
+                -0.0019639 - 0.0019639j,
+                -6.2357 + 7.8177j,
+                -6.2357 - 7.8177j,
+            ],
+            zeros=[0j, 0j],
+            **_paz_sts1_kwargs,
+        )
+        np.testing.assert_allclose(
+            paz_sts1_hz.calculate_normalization_factor(), 100.01869  # [Hz]
+        )
+
     def test_pitick2latex(self):
         assert _pitick2latex(3 * pi / 2) == r'$\frac{3\pi}{2}$'
         assert _pitick2latex(2 * pi / 2) == r'$\pi$'


### PR DESCRIPTION
### What does this PR do?

Adds a method `calculate_normalization_factor()` to the `PolesZerosResponseStage` class. Adds option to calculate the normalization factor from the poles and zeros when a `PolesZerosResponseStage` object is created via `normalization_factor=None`.

### Why was it initiated?  Any relevant Issues?

The content of this PR is included in the much more involved PR #2592 — the purpose of this PR is to make a bite-size added feature easily merge-able. Closes #2574.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [x] Any new features or fixed regressions are covered via new tests.
- [x] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
