### PR TITLE
Allow builtin beachball function to show isotropic component of momen…

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -73,6 +73,7 @@ Macpherson, Kenneth
 Maggi, Alessia
 Martin, Henri
 Massin, Frederick
+McPherson, Amanda M.
 Medlin, Andrew
 Megies, Tobias
 Meschede, Matthias


### PR DESCRIPTION

### What does this PR do?

This PR makes changes to the built-in ObsPy beachball plotter. It aims to address Issue #2388 by changing the default behavior of plot_mt in obspy/imaging/beachball.py to show the isotropic component of a moment tensor. This includes some bug fixes ensure that implosions are plotted as white, explosions as some color, fully implementing the check to see if a new segment is needed for the matplotlib patches, and ensuring that the correct "dominant" eigenvalue is chosen. These changes do not address any issues with the mopad wrapper, and as such fails the mopad wrapper test. All other tests pass.

I have based this pull request off of the most recent maintenance branch, for both my own fork and the base repository. For some measure of a test, I have attached a small script that produces expected beachballs from a test set of moment tensors as described in Issue #2388. [beachball_test.py.zip](https://github.com/user-attachments/files/21239743/beachball_test.py.zip)

### Why was it initiated?  Any relevant Issues?

This PR was initiated after I attempted to plot full moment tensor results using ObsPy and realized there was some problem. 

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [x] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
