### PR TITLE
update docs building workflow to include tags and maintenance branches for docsets (fixes #3607)

### DIFF
--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -5,10 +5,11 @@ on:
   push:
     branches:
       - master
-    tags-ignore:
-      - '**'
+      - 'maintenance_**' # Will build for maintenance branches like maintenance_1.2.x
+    tags:
+      - '**' # Will build for tags like 1.2.3
   release:
-    types: [published]
+    types: [published] # Will build for tags like 1.2.3
 
 # cancel previous runs, but only in PRs, do not cancel previous runs if this run will be skipped
 concurrency:
@@ -17,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    # only run if on master branch OR if PR is updated and build_docs label present OR if build_docs_label is added
+    # only run if on master branch OR if PR is updated and build_docs label present OR if build_docs_label is added OR if it's a tag push
     if: github.event_name != 'pull_request' || ((github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'build_docs')) || github.event.label.name == 'build_docs')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR should enable docsets building & upload for releases (tag) , in `master `& in `maintenance_*` branches.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
- [ ] All tests still pass.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
