### PR TITLE
faster packet handler for basic client

### DIFF
--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -11,13 +11,13 @@ SeedLink request client for ObsPy.
 import fnmatch
 import warnings
 
+import numpy as np
 from lxml import etree
 
 from obspy import Stream
 from .slclient import SLClient, SLPacket
 from .client.seedlinkconnection import SeedLinkConnection
 from obspy.io.mseed.core import _read_mseed
-import numpy as np
 
 
 class Client(object):


### PR DESCRIPTION
The existing code of obspy.clients.seedlink.basic_client.py calls _packet_handler for every single record.
This will then convert, add and merge every single record, leading to memory resizing every time, resulting
in O(N²) behaviour.

The proposed change will store all miniseed records and convert them in one large batch, resulting in O(N) behaviour.
Downloading five minutes of broadband data from the CH network took 5 minutes with the existing code and takes
30 seconds with the proposed change, resulting in a reduction of about 90%.

I had to adjust obspy.io.core.mseed to make it read numpy.ndarrays directly. This is taken from my changes in github.com/obspy/obspy/pull/3622. I tried to be as minimal as possible, so that these two PRs do not depend on each other.

<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

*Please fill in*

### Why was it initiated?  Any relevant Issues?

*Please fill in (link relevant issues with "see #123456", mark issues that get resolved with "fixes #12345")*

### PR Checklist
- [X] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [X] All tests still pass.
- [X] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
