### PR TITLE
MassDownloader, use threads_per_client for StationXML downloads

### DIFF
--- a/obspy/clients/fdsn/mass_downloader/download_helpers.py
+++ b/obspy/clients/fdsn/mass_downloader/download_helpers.py
@@ -648,7 +648,7 @@ class ClientDownloadHelper(object):
                 stationxml_storage=self.stationxml_storage,
                 logger=self.logger)
 
-    def download_stationxml(self, threads_per_client=3):
+    def download_stationxml(self, threads=3):
         """
         Actually download the StationXML files.
 
@@ -690,7 +690,7 @@ class ClientDownloadHelper(object):
 
         # Download it.
         s_time = timeit.default_timer()
-        pool = ThreadPool(min(threads_per_client, len(arguments)))
+        pool = ThreadPool(min(threads, len(arguments)))
         results = pool.map(star_download_station, arguments)
         pool.close()
         e_time = timeit.default_timer()

--- a/obspy/clients/fdsn/mass_downloader/mass_downloader.py
+++ b/obspy/clients/fdsn/mass_downloader/mass_downloader.py
@@ -213,7 +213,7 @@ class MassDownloader(object):
 
             # Download StationXML data.
             helper.prepare_stationxml_download()
-            helper.download_stationxml(threads_per_client=threads_per_client)
+            helper.download_stationxml(threads=threads_per_client)
 
             # Sanitize the downloaded things if desired. Assures that all
             # waveform data also has the corresponding station information.


### PR DESCRIPTION

### What does this PR do?

Uses the existing `MassDownloader.download(threads_per_client)` value for StationXML downloads.
Previously this value is used to control miniSEED downloads.  All values defaulted to 3, but the 
StationXML download helper was fixed at 3 with no connection to the caller's desired number 
of threads.

### Why was it initiated?  Any relevant Issues?

Seems reasonable that the caller can control both the miniSEED and StationXML download concurrency.

The documentation for .download contains a statement that is very general about downloads
being controlled  by this value:
```:param threads_per_client: The number of download threads launched per client.```

So I assumed that it controlled all downloads and only happen to notice when looking at the code.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [x] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [x] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
