### PR TITLE
Speedup `import obspy` on Python 3.10+

### DIFF
--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -378,8 +378,8 @@ def _get_ordered_entry_points(group, subgroup=None, order_list=[]):
     """
     Gets a ordered dictionary of all available plug-ins of a group or subgroup.
     """
-    # get all available entry points
-    ep_dict = _get_entry_points(group, subgroup)
+    # Copy so pop() below does not modify the lru_cache result.
+    ep_dict = _get_entry_points(group, subgroup).copy()
     # loop through official supported waveform plug-ins and add them to
     # ordered dict of entry points
     entry_points = OrderedDict()


### PR DESCRIPTION
> ⚠️  Disclaimer: I used GitHub Copilot to help diagnose the issue and to write a working solution. I then reviewed the code manually.


<!--

Thank your for contributing to ObsPy!

!! Please check that you select the **correct base branch** (details see below link) !!

Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request

Also, please make sure you are following the ObsPy branching model:
https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model

-->

### What does this PR do?

Add module-level caching to reduce `entry_points()` calls from 111 to 1 during import, improving ObsPy import time by ~5x (from ~4s to ~0.74s on my machine).

### Why was it initiated?  Any relevant Issues?

On current master, import time is much slower than 1.4.2:

```bash
(master) ➜  ~ time python -c "import obspy"
python -c "import obspy"  4.04s user 1.83s system 132% cpu 4.442 total

(obspy142) ➜  ~ time python -c "import obspy"
python -c "import obspy"  0.14s user 0.07s system 55% cpu 0.379 total
```

This is related to the migration from `pkg_resources` to `importlib.metadata` (#3333). While this migration was necessary because `pkg_resources` is deprecated, it introduced a performance regression because `importlib.metadata.entry_points()` was being called 111 times during a single import.

In Python 3.10+, each call to `entry_points()` scans all installed packages in the environment, making the cumulative cost very high. With ~700 entry points installed in a typical Python 3.13 environment (mine 😉), this resulted in import times of 4+ seconds.

This PR addresses the issue by implementing module-level caching of `entry_points()`, reducing the number of calls from 111 to 1 and improving import time by ~20x (from 4.5s to 0.22s on Python 3.13 on my machine). The solution is compatible with Python 3.8-3.13, handling API differences between Python 3.8/3.9 (which return a `dict`) and Python 3.10+ (which return an `EntryPoints` object).

The new code runs much faster:

```bash
➜  ~ time python -c "import obspy"
python -c "import obspy"  1.31s user 0.15s system 371% cpu 0.392 total

# second time is even faster
➜  ~ time python -c "import obspy"
python -c "import obspy"  0.74s user 0.23s system 413% cpu 0.233 total
```

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] While the PR is still work-in-progress, the `no_ci` label can be added to skip CI builds
- [ ] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] If all tests including network modules (e.g. `clients.fdsn`) should be tested for the PR,
      just add the `test_network` tag to this PR.
- [x] All tests still pass.
- [ ] Any new features or fixed regressions are covered via new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
- [ ] If the changes affect any plotting functions you have checked that the plots
      from all the CI builds look correct. Add the "upload_plots" tag so that plotting 
      outputs are attached as artifacts. 
- [ ] New modules, add the module to `CODEOWNERS` with your github handle
- [x] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
