### PR TITLE
Make the sphinx build a little more talkative

### DIFF
--- a/.github/workflows/docs_building.yml
+++ b/.github/workflows/docs_building.yml
@@ -52,15 +52,16 @@ jobs:
           # Summarize
           echo "=== WARNING count ===" && grep -c "WARNING" /tmp/sphinx_warnings.txt || true
           echo "=== ERROR count ===" && grep -c "ERROR" /tmp/sphinx_warnings.txt || true
-          # Fail the job if any ERRORs exist
-          ! grep -q "ERROR" /tmp/sphinx_warnings.txt
+          # IN THE FUTURE we should Fail the job if any ERRORs exist, but not now, otherwise the
+          # docs deployment code will never see it (deploy_docs.py checks for /success state).
+          # ! grep -q "ERROR" /tmp/sphinx_warnings.txt
 
-      - name: upload sphinx diagnostics
-        if: always()   # upload even if previous step failed
-        uses: actions/upload-artifact@v4
-        with:
-          name: sphinx-diagnostics
-          path: /tmp/sphinx_warnings.txt
+#      - name: upload sphinx diagnostics (not now, the deploy_doc expects only 2 artifacts)
+#        if: always()   # upload even if previous step failed
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: sphinx-diagnostics
+#          path: /tmp/sphinx_warnings.txt
 
       - name: compress with tar
         if: always()   # compress even if previous step failed
@@ -81,9 +82,15 @@ jobs:
         run: |
           cd misc/docs
           bash make_docset.sh
+
       - name: actions/upload-artifact@v4 for docset
         if: always()   # upload even if previous step failed
         uses: actions/upload-artifact@v4
         with:
           name: obspydocset
           path: misc/docs/build/obspy-*.docset.tgz
+
+      - name: Report Warnings
+        if: always()
+        run: |
+          cat /tmp/sphinx_warnings.txt


### PR DESCRIPTION
These changes should allow users to see a list of WARNING and ERRORS summarized at the end of the build, and uploaded as an artifact. Ideally, later, the if: always() should be removed, so only the totally successful builds are uploaded & converted to docsets.

e.g. this CI Action had a few warnings, linked to a new tutorial snippet:

https://github.com/obspy/obspy/actions/runs/22671551677/job/65716713542



### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
