### PR TITLE
Update deploy_docs to select the right artifact for deployment of the doc

### DIFF
--- a/misc/scripts/docs_deploybot/deploy_docs.py
+++ b/misc/scripts/docs_deploybot/deploy_docs.py
@@ -133,7 +133,8 @@ def deploy_artifact(run, other_path=None, other_docset_path=None,
 
     log.info(f'Deploy obspydocset to {pathd}')
     log.info('Download obspydocset artifact')
-    url = arts[1]['archive_download_url']
+    art = next(a for a in arts if a['name'] == 'obspydocset')
+    url = art['archive_download_url']
     r = requests.get(url, **RKW)
     # the artifact is a zipped tar file
     with ZipFile(BytesIO(r.content)) as z1:


### PR DESCRIPTION
Update deploy_docs to select the right artifact for deployment of the doc

The doc deployment failed recently by not finding the tar.xz file inside the artifact, linked to the ordering of the artifacts in the JSON - this should be better, selecting the right artifact by name.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `maintenance_...` for bug fixes
- [x] If the PR is making changes to documentation, docs pages can be built automatically.
      Just add the `build_docs` tag to this PR.
      Docs will be served at [docs.obspy.org/pr/{branch_name}](https://docs.obspy.org/pr/) (do not use master branch).
      Please post a link to the relevant piece of documentation.
- [ ] Add the yellow `ready for review` label when you are ready for the PR to be reviewed.
