### PR TITLE
MSEED: memory leak fixed, msr_free not called in one case

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changes:
      (see #3709)
    * fix a void return type in write mseed ctypes wrapper (see #3735)
    * fix reading in case when numpy.memmap is not implemented (see #3741)
+   * Memory leak fixed in obspy-readbuffer.c (see #3714)
  - obspy.taup:
    * fix an issue with obspy.taup not being usable with specific Python
      versions 3.13.10 and 3.14.1 (see #3650)

--- a/obspy/io/mseed/src/libmseed/unpack.c
+++ b/obspy/io/mseed/src/libmseed/unpack.c
@@ -123,15 +123,17 @@ msr_unpack (char *record, int reclen, MSRecord **ppmsr,
       unpackdatabyteorder == -2 ||
       unpackencodingformat == -2 ||
       unpackencodingfallback == -2)
-    if (check_environment (verbose))
+    if (check_environment (verbose)) {
+      msr_free(&msr);
       return MS_GENERROR;
-
+    }
   /* Allocate and copy fixed section of data header */
   msr->fsdh = realloc (msr->fsdh, sizeof (struct fsdh_s));
 
   if (msr->fsdh == NULL)
   {
     ms_log (2, "msr_unpack(): Cannot allocate memory\n");
+    msr_free(&msr);
     return MS_GENERROR;
   }
 
@@ -179,6 +181,7 @@ msr_unpack (char *record, int reclen, MSRecord **ppmsr,
   if (msr_srcname (msr, srcname, 1) == NULL)
   {
     ms_log (2, "msr_unpack(): Cannot generate srcname\n");
+    msr_free(&msr);
     return MS_GENERROR;
   }
 

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -331,11 +331,6 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
 
     // Read all records and save them in a linked list.
     while (offset < buflen) {
-        msr = msr_init(NULL);
-        if ( msr == NULL ) {
-            ms_log (2, "readMSEEDBuffer(): Error initializing msr\n");
-            return NULL;
-        }
         if (verbose > 1) {
             ms_log(0, "readMSEEDBuffer(): calling msr_parse with "
                       "mseed+offset=%d+%d, buflen=%d, reclen=%d, dataflag=%d, verbose=%d\n",
@@ -346,7 +341,6 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
         if (reclen != -1) {
             if (offset + reclen > buflen) {
                 ms_log(1, "readMSEEDBuffer(): Last reclen exceeds buflen, skipping.\n");
-                msr_free(&msr);
                 break;
             }
         }
@@ -357,7 +351,6 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
                 ms_log(1, "readMSEEDBuffer(): Last record only has %i byte(s) which "
                           "is not enough to constitute a full SEED record. Corrupt data? "
                           "Record will be skipped.\n", buflen - offset);
-                msr_free(&msr);
                 break;
             }
         }
@@ -365,8 +358,13 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
         // Skip empty or noise records.
         if (OBSPY_ISVALIDBLANK(mseed + offset)) {
             offset += MINRECLEN;
-            msr_free(&msr);
             continue;
+        }
+
+        msr = msr_init(NULL);
+        if ( msr == NULL ) {
+            ms_log (2, "readMSEEDBuffer(): Error initializing msr\n");
+            return NULL;
         }
 
         // Pass (buflen - offset) because msr_parse() expects only a single record. This

--- a/obspy/io/mseed/src/obspy-readbuffer.c
+++ b/obspy/io/mseed/src/obspy-readbuffer.c
@@ -365,6 +365,7 @@ readMSEEDBuffer (char *mseed, int buflen, Selections *selections, flag
         // Skip empty or noise records.
         if (OBSPY_ISVALIDBLANK(mseed + offset)) {
             offset += MINRECLEN;
+            msr_free(&msr);
             continue;
         }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request
-->

### What does this PR do?

I believe I found a memory leak in obspy-readbuffer.c.
```
        if (OBSPY_ISVALIDBLANK(mseed + offset)) {
            offset += MINRECLEN;
            msr_free(&msr);
            continue;
        }
```
I added msr_free(&msr), otherwise msr_free is not called in the current iteration, leading to msr not being freed.

### Links to other Issues?

No.

### AI used?

Used MS Copilot, which gave a lot of hints, most of them irrelevant. I believe this one is the one which matters in my use case.

### PR Checklist

- [X] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
