### PR TITLE
Fix #3634: add max_bulk_lines to BaseRoutingClient to prevent 413 errors

### DIFF
--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -113,6 +113,7 @@ Schneider, Simon
 Shimizu, Toshiya
 Sippl, Christian
 Snoke, Arthur
+Sokos, Nikos
 Stähler, Simon C.
 Stange, Stefan
 Strutz, Dominik

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -15,9 +15,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 
 import decorator
 import io
-import logging
 import sys
-import time
 import traceback
 import warnings
 from urllib.parse import urlparse
@@ -29,9 +27,6 @@ from ...base import HTTPClient
 from .. import client
 from ..client import raise_on_error
 from ..header import FDSNException, URL_MAPPINGS, FDSNNoDataException
-
-
-logger = logging.getLogger(__name__)
 
 
 def RoutingClient(routing_type, *args, **kwargs):  # NOQA
@@ -303,7 +298,6 @@ class BaseRoutingClient(HTTPClient):
                     new_dl_requests.append(new_req)
             dl_requests = new_dl_requests
 
-        t0 = time.time()
         pool = ThreadPool(processes=len(dl_requests))
         results = pool.map(_try_download_bulk, dl_requests)
 
@@ -325,15 +319,6 @@ class BaseRoutingClient(HTTPClient):
         # Explitly close the thread pool as somehow this does not work
         # automatically under linux. See #2342.
         pool.close()
-
-        t1 = time.time()
-        failed_count = len([r for r in results if r is None])
-        status = "INCOMPLETE" if failed_count > 0 else "COMPLETE"
-        logger.info("RoutingClient: Download completed in %.2f seconds. "
-                    "Total chunks: %i, Success: %i, Failed: %i (%s)",
-                    t1 - t0, len(dl_requests),
-                    len([r for r in results if r is not None]),
-                    failed_count, status)
 
         return collection
 

--- a/obspy/clients/fdsn/routing/routing_client.py
+++ b/obspy/clients/fdsn/routing/routing_client.py
@@ -15,7 +15,9 @@ from multiprocessing.dummy import Pool as ThreadPool
 
 import decorator
 import io
+import logging
 import sys
+import time
 import traceback
 import warnings
 from urllib.parse import urlparse
@@ -27,6 +29,9 @@ from ...base import HTTPClient
 from .. import client
 from ..client import raise_on_error
 from ..header import FDSNException, URL_MAPPINGS, FDSNNoDataException
+
+
+logger = logging.getLogger(__name__)
 
 
 def RoutingClient(routing_type, *args, **kwargs):  # NOQA
@@ -160,7 +165,8 @@ def _strip_protocol(url):
 # get_events() but also others).
 class BaseRoutingClient(HTTPClient):
     def __init__(self, debug=False, timeout=120, include_providers=None,
-                 exclude_providers=None, credentials=None):
+                 exclude_providers=None, credentials=None,
+                 max_bulk_lines=100):
         """
         :type routing_type: str
         :param routing_type: The type of
@@ -185,10 +191,15 @@ class BaseRoutingClient(HTTPClient):
             center specific credentials.
             You can also use a URL mapping as for the normal FDSN client
             instead of the URL.
+        :type max_bulk_lines: int
+        :param max_bulk_lines: If the bulk request is larger than this number
+            of lines, it will be split into multiple requests. Defaults to
+            100 to match `fdsnws_fetch`.
         """
         HTTPClient.__init__(self, debug=debug, timeout=timeout)
         self.include_providers = include_providers
         self.exclude_providers = exclude_providers
+        self.max_bulk_lines = max_bulk_lines
 
         # Parse credentials.
         self.credentials = {}
@@ -275,6 +286,24 @@ class BaseRoutingClient(HTTPClient):
                 "data_type": data_type,
                 "kwargs": kwargs,
                 "credentials": self.credentials})
+
+        # Split requests if necessary.
+        if self.max_bulk_lines:
+            new_dl_requests = []
+            for req in dl_requests:
+                lines = req["bulk_str"].strip().splitlines()
+                if len(lines) <= self.max_bulk_lines:
+                    new_dl_requests.append(req)
+                    continue
+                # Split!
+                for i in range(0, len(lines), self.max_bulk_lines):
+                    new_req = req.copy()
+                    new_req["bulk_str"] = "\n".join(
+                        lines[i:i + self.max_bulk_lines])
+                    new_dl_requests.append(new_req)
+            dl_requests = new_dl_requests
+
+        t0 = time.time()
         pool = ThreadPool(processes=len(dl_requests))
         results = pool.map(_try_download_bulk, dl_requests)
 
@@ -296,6 +325,15 @@ class BaseRoutingClient(HTTPClient):
         # Explitly close the thread pool as somehow this does not work
         # automatically under linux. See #2342.
         pool.close()
+
+        t1 = time.time()
+        failed_count = len([r for r in results if r is None])
+        status = "INCOMPLETE" if failed_count > 0 else "COMPLETE"
+        logger.info("RoutingClient: Download completed in %.2f seconds. "
+                    "Total chunks: %i, Success: %i, Failed: %i (%s)",
+                    t1 - t0, len(dl_requests),
+                    len([r for r in results if r is not None]),
+                    failed_count, status)
 
         return collection
 

--- a/obspy/clients/fdsn/tests/test_base_routing_client.py
+++ b/obspy/clients/fdsn/tests/test_base_routing_client.py
@@ -41,7 +41,9 @@ class TestBaseRoutingClient():
 
             def _handle_requests_http_error(self, r):
                 raise NotImplementedError
-
+            def get_waveforms_bulk(self, bulk, **kwargs):
+                """Dummy method to allow mocking"""
+                pass
         cls._cls_object = _DummyBaseRoutingClient
         cls._cls = ("obspy.clients.fdsn.routing.routing_client."
                     "BaseRoutingClient")
@@ -214,3 +216,17 @@ class TestBaseRoutingClient():
             "Failed to download data of type 'station' from "
             "'https://example.com' due to:")
         assert "ValueError: random" in msg
+
+    def test_bulk_line_splitting(self):
+        # One endpoint with five lines should be split into chunks of 2, 2, and 1.
+        split = {"http://example.com": "a\nb\nc\nd\ne\n"}
+
+        with mock.patch(
+                "obspy.clients.fdsn.routing.routing_client.ThreadPool") as p:
+            p.return_value.map.return_value = [None, None, None]
+            c = self._cls_object(debug=False, timeout=240, max_bulk_lines=2)
+            c._download_waveforms(split=split)
+
+        items = p.return_value.map.call_args[0][1]
+        assert len(items) == 3
+        assert [len(req["bulk_str"].splitlines()) for req in items] == [2, 2, 1]


### PR DESCRIPTION
Split oversized bulk requests into chunks before dispatching to the ThreadPool, avoiding "Request Entity Too Large" responses from FDSNWS endpoints. Default limit is 100 lines, matching fdsnws_fetch behaviour.

<!--
Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request
-->

### What does this PR do?

Adds a `max_bulk_lines` parameter (default: 100) to `BaseRoutingClient.__init__`. When a routed bulk request exceeds this limit, `_download_parallel` splits it into smaller chunks before dispatching to the `ThreadPool`. This prevents HTTP 413 "Request Entity Too Large" errors and long-tail timeouts when downloading waveforms or station metadata for large virtual networks via `EIDAWSRoutingClient` or `FederatorRoutingClient`.

The default of 100 matches the behaviour of `fdsnws_fetch`.


### Links to other Issues?

fixes #3634 

### AI used?

Claude Sonnet 4.6 (Claude Code) was used to review the implementation for correctness, identify a redundant variable, and validate the unit test logic. All design decisions and code were authored by the contributor.

### PR Checklist

- [x] Correct **base branch** selected? [`master`](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added `test_bulk_line_splitting` in `test_base_routing_client.py` using `unittest.mock`
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [x] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"

