### PR TITLE
Reset stats.calib after applying calibration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ master
 ======
 
 Changes:
+ - ...
  - obspy.core:
    * trace: reset stats.calib after applying calibration (see #3717)
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,8 @@ master
 ======
 
 Changes:
- - ...
+ - obspy.core:
+   * trace: reset stats.calib after applying calibration (see #3717)
 
 maintenance_1.5.x
 =================

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -244,6 +244,7 @@ def read(pathname_or_url=None, format=None, headonly=False, starttime=None,
     if apply_calib:
         for tr in st:
             tr.data = tr.data * tr.stats.calib
+            tr.stats.calib = 1.0
     return st
 
 

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1971,7 +1971,8 @@ class TestStream:
         # read with apply_calib=False should not apply calib
         # and should keep the calib value in stats
         bio.seek(0)
-        st_no_calib = read(bio, format='pickle') # apply_calib=False by default
+        st_no_calib = read(bio, format='pickle')
+        # read() argument apply_calib=False was set by default
         for tr, tr_no_calib in zip(st, st_no_calib):
             np.testing.assert_array_almost_equal(tr.data, tr_no_calib.data)
             assert tr_no_calib.stats.calib == tr.stats.calib

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -1944,6 +1944,38 @@ class TestStream:
                 read('/path/to/slist_float.ascii',
                      headonly=True, starttime=0, endtime=1)
 
+    def test_read_apply_calib(self):
+        """
+        Test read function with apply_calib argument.
+        """
+        # see #3717
+        st = read()
+        # edit as if the read seismic record contained the calib value
+        # raw data scaling factor calib in [(nm/s)/count] is the inverse
+        # of the instrument sensitivity in [count/(nm/s)]
+        calib = 1.0e+9/st[0].stats.response.instrument_sensitivity.value
+        for tr in st:
+            tr.stats.calib = calib
+        # write in a format that stores the calibration and reads it back
+        bio = io.BytesIO()
+        st.write(bio, format='pickle')
+        bio.seek(0)
+        # read with apply_calib=True should apply calib
+        # and should set calib value in stats to 1.0
+        st_calib = read(bio, format='pickle', apply_calib=True)
+        for tr, tr_calib in zip(st, st_calib):
+            np.testing.assert_array_almost_equal(tr.data * tr.stats.calib,
+                                                 tr_calib.data)
+            # tr_calib.stats.calib should be 1.0 after applying calib
+            assert tr_calib.stats.calib == 1.0
+        # read with apply_calib=False should not apply calib
+        # and should keep the calib value in stats
+        bio.seek(0)
+        st_no_calib = read(bio, format='pickle') # apply_calib=False by default
+        for tr, tr_no_calib in zip(st, st_no_calib):
+            np.testing.assert_array_almost_equal(tr.data, tr_no_calib.data)
+            assert tr_no_calib.stats.calib == tr.stats.calib
+
     @pytest.mark.network
     def test_read_url_via_network(self):
         """

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1774,6 +1774,40 @@ class TestTrace:
         assert len(w) == 1
         assert w[0].category == UserWarning
 
+    def test_stats_calib_reset_after_data_unit_conversion(self):
+        """
+        Test that the stats.calib is reset to 1.0 after a data unit conversion
+        via remove_sensitivity() or remove_response().
+
+        See #3717
+        """
+        inv = read_inventory()
+        tr = read()[0]   # raw data in [count]
+        response = inv.get_response(tr.id, tr.stats.starttime)
+        # raw data scaling factor calib in [(nm/s)/count] is the inverse
+        # of the instrument sensitivity in [count/(nm/s)]
+        calib = 1.0e+9/response.instrument_sensitivity.value
+        tr.stats.calib = calib
+        # tr1 - apply the scaling factor stats.calib to the data
+        tr1 = tr.copy()
+        tr1.data = tr.data * tr.stats.calib   # [nm/s]
+        # tr2 - remove the sensitivity from the trace data
+        tr2 = tr.copy()
+        assert tr2.stats.calib == calib
+        tr2.remove_sensitivity(inventory=inv)   # [m/s]
+        # after remove_sensitivity() the stats.calib should be reset to 1.0
+        assert tr2.stats.calib == 1.0
+        # check that the data of tr1 after scaling by the calib factor
+        # is the same as the data of tr2 after removing the sensitivity
+        # and scaling by 1.0e+9 to convert from [m/s] to [nm/s]
+        assert np.allclose(tr1.data, tr2.data*1.0e+9)
+        # tr3 - remove response from the trace data
+        tr3 = tr.copy()
+        assert tr3.stats.calib == calib
+        tr3.remove_response(inventory=inv)
+        # after remove_response() the stats.calib should be reset to 1.0
+        assert tr3.stats.calib == 1.0
+
     def test_processing_info_remove_response_and_sensitivity(self):
         """
         Tests adding processing info for remove_response() and

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1778,19 +1778,20 @@ class TestTrace:
         """
         Test that the stats.calib is reset to 1.0 after a data unit conversion
         via remove_sensitivity() or remove_response().
-
-        See #3717
         """
+        # see #3717
         inv = read_inventory()
         tr = read()[0]   # raw data in [count]
         response = inv.get_response(tr.id, tr.stats.starttime)
+        # edit as if the read seismic record contained the calib value
         # raw data scaling factor calib in [(nm/s)/count] is the inverse
         # of the instrument sensitivity in [count/(nm/s)]
         calib = 1.0e+9/response.instrument_sensitivity.value
         tr.stats.calib = calib
-        # tr1 - apply the scaling factor stats.calib to the data
+        # tr1 - manually apply the scaling factor stats.calib to the data
         tr1 = tr.copy()
         tr1.data = tr.data * tr.stats.calib   # [nm/s]
+        tr1.stats.calib = 1.0  # just for the record
         # tr2 - remove the sensitivity from the trace data
         tr2 = tr.copy()
         assert tr2.stats.calib == calib

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2843,6 +2843,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         if not response.response_stages and response.instrument_polynomial:
             coefficients = response.instrument_polynomial.coefficients
             self.data = np.poly1d(coefficients[::-1])(self.data)
+            self.stats.calib = 1.0
             return self
 
         # cannot handle polynomial response we can still replicate
@@ -2868,7 +2869,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             # attempt to account for DC offset also
             if len(coefficients) >= 1 and coefficients[0] != 0:
                 self.data = self.data + coefficients[0]
-
+            self.stats.calib = 1.0
             return self
 
         # use evalresp
@@ -3007,6 +3008,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
         # assign processed data and store processing information
         self.data = data
+        self.stats.calib = 1.0
         return self
 
     @_add_processing_info
@@ -3037,6 +3039,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             response.recalculate_overall_sensitivity()
 
         self.data = self.data / response.instrument_sensitivity.value
+        self.stats.calib = 1.0
         return self
 
     def newbyteorder(self, byteorder='native'):

--- a/obspy/io/gse2/tests/test_core.py
+++ b/obspy/io/gse2/tests/test_core.py
@@ -307,10 +307,12 @@ class TestCore():
         st = read(gse2file, apply_calib=False)
         tr = st[0]
         assert tr.data[0:13].tolist() == testdata
+        # save calib before resetting it using apply_calib = True in next step
+        calib = tr.stats.calib
         # read w/ apply_calib = True
         st = read(gse2file, apply_calib=True)
         tr = st[0]
-        testdata = [n * tr.stats.calib for n in testdata]
+        testdata = [n * calib for n in testdata]
         assert tr.data[0:13].tolist() == testdata
 
     def test_write_and_read_correct_network(self):

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -80,7 +80,7 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MEMA'
-        #assert st[0].stats.calib == 1.1694431304931641e-06
+        # assert st[0].stats.calib == 1.1694431304931641e-06
         assert st[0].stats.calib == 1.0
 
         self.verify_stats_evt(st[0].stats.kinemetrics_evt)
@@ -113,7 +113,7 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MOLA'
-        #assert st[0].stats.calib == 1.170754369670621e-06
+        # assert st[0].stats.calib == 1.170754369670621e-06
         assert st[0].stats.calib == 1.0
 
     def test_read_via_obspy_and_bytesio1(self, testdata):
@@ -138,7 +138,7 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MEMA'
-        #assert st[0].stats.calib == 1.1694431304931641e-06
+        # assert st[0].stats.calib == 1.1694431304931641e-06
         assert st[0].stats.calib == 1.0
 
         self.verify_stats_evt(st[0].stats.kinemetrics_evt)
@@ -175,7 +175,7 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MOLA'
-        #assert st[0].stats.calib == 1.170754369670621e-06
+        # assert st[0].stats.calib == 1.170754369670621e-06
         assert st[0].stats.calib == 1.0
 
     def test_read_via_module1(self, testdata):

--- a/obspy/io/kinemetrics/tests/test_core.py
+++ b/obspy/io/kinemetrics/tests/test_core.py
@@ -80,7 +80,8 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MEMA'
-        assert st[0].stats.calib == 1.1694431304931641e-06
+        #assert st[0].stats.calib == 1.1694431304931641e-06
+        assert st[0].stats.calib == 1.0
 
         self.verify_stats_evt(st[0].stats.kinemetrics_evt)
         self.verify_data_evt0(st[0].data)
@@ -112,7 +113,8 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MOLA'
-        assert st[0].stats.calib == 1.170754369670621e-06
+        #assert st[0].stats.calib == 1.170754369670621e-06
+        assert st[0].stats.calib == 1.0
 
     def test_read_via_obspy_and_bytesio1(self, testdata):
         """
@@ -136,7 +138,8 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MEMA'
-        assert st[0].stats.calib == 1.1694431304931641e-06
+        #assert st[0].stats.calib == 1.1694431304931641e-06
+        assert st[0].stats.calib == 1.0
 
         self.verify_stats_evt(st[0].stats.kinemetrics_evt)
         self.verify_data_evt0(st[0].data)
@@ -172,7 +175,8 @@ class TestCore():
         assert round(abs(st[0].stats.sampling_rate-250.0), 7) == 0
         assert st[0].stats.channel == '0'
         assert st[0].stats.station == 'MOLA'
-        assert st[0].stats.calib == 1.170754369670621e-06
+        #assert st[0].stats.calib == 1.170754369670621e-06
+        assert st[0].stats.calib == 1.0
 
     def test_read_via_module1(self, testdata):
         """


### PR DESCRIPTION
### What does this PR do?

Modify `Stream.read()`, `Trace.remove_sensitivity()`, and `Trace.remove_response()` 
to automatically reset `stats.calib` to 1.0 after every Trace object data conversion to physical units. 

This ensures that the `stats.calib` attribute remains consistent with
the actual data values in `Trace.data` after applying calibration and
removing sensitivity or response. This change will help prevent incorrect
scaling in future operations, such as plotting or further processing.

### Links to other Issues?

RESOLVES: #3715 
This will help resolve open issues #3453 and #2935

### AI used?

I am learning to use Copilot as a plugin in the vim editor.

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
