### PR TITLE
add publicID to station.extra when reading SCML (supercedes #3194)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,9 @@ master
 ======
 
 Changes:
- - ...
+ - General
+ - obspy.io.seiscomp:
+   * Add publicID to station.extra for select (see #3193 #3194)
 
 maintenance_1.5.x
 =================

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ master
 Changes:
  - General
  - obspy.io.seiscomp:
-   * Add publicID to station.extra for select (see #3193 #3194)
+   * Add publicID to station.extra for select (see #3718 #3193 #3194)
 
 maintenance_1.5.x
 =================

--- a/obspy/core/inventory/inventory.py
+++ b/obspy/core/inventory/inventory.py
@@ -540,7 +540,8 @@ class Inventory(ComparingObject):
                time=None, starttime=None, endtime=None, sampling_rate=None,
                keep_empty=False, minlatitude=None, maxlatitude=None,
                minlongitude=None, maxlongitude=None, latitude=None,
-               longitude=None, minradius=None, maxradius=None):
+               longitude=None, minradius=None, maxradius=None,
+               public_id=None):
         r"""
         Return a copy of the inventory filtered on various parameters.
 
@@ -639,6 +640,9 @@ class Inventory(ComparingObject):
         :param maxradius: Only include stations/channels within the specified
             maximum number of degrees from the geographic point defined by the
             latitude and longitude parameters.
+        :type public_id: str, optional
+        :param public_id: Only include stations matching with extra.public_id
+            (only added when reading SCML)
         """
         networks = []
         for net in self.networks:
@@ -661,7 +665,8 @@ class Inventory(ComparingObject):
                 minlatitude=minlatitude, maxlatitude=maxlatitude,
                 minlongitude=minlongitude, maxlongitude=maxlongitude,
                 latitude=latitude, longitude=longitude,
-                minradius=minradius, maxradius=maxradius)
+                minradius=minradius, maxradius=maxradius,
+                public_id=public_id)
 
             # If the network previously had stations but no longer has any
             # and keep_empty is False: Skip the network.

--- a/obspy/core/inventory/network.py
+++ b/obspy/core/inventory/network.py
@@ -364,7 +364,8 @@ class Network(BaseNode):
                starttime=None, endtime=None, sampling_rate=None,
                keep_empty=False, minlatitude=None, maxlatitude=None,
                minlongitude=None, maxlongitude=None, latitude=None,
-               longitude=None, minradius=None, maxradius=None):
+               longitude=None, minradius=None, maxradius=None,
+               public_id=None):
         r"""
         Returns the :class:`Network` object with only the
         :class:`~obspy.core.inventory.station.Station`\ s /
@@ -457,6 +458,9 @@ class Network(BaseNode):
             will be included in the result. This flag has no effect for
             initially empty stations which will always be retained if they
             are matched by the other parameters.
+        :type public_id: str, optional
+        :param public_id: Only include stations matching with extra.public_id
+            (only added when reading SCML)
         """
         stations = []
         for sta in self.stations:
@@ -465,6 +469,14 @@ class Network(BaseNode):
                 if not fnmatch.fnmatch(sta.code.upper(),
                                        station.upper()):
                     continue
+
+            if public_id is not None:
+                if not (hasattr(sta, 'extra') and
+                        hasattr(sta.extra, 'publicID') and
+                        fnmatch.fnmatch(sta.extra['publicID'].value,
+                                        public_id)):
+                    continue
+
             if any([t is not None for t in (time, starttime, endtime)]):
                 if not sta.is_active(time=time, starttime=starttime,
                                      endtime=endtime):

--- a/obspy/core/tests/test_inventory.py
+++ b/obspy/core/tests/test_inventory.py
@@ -403,6 +403,9 @@ class TestInventory:
         assert sum_stations(inv.select(station="RJOB")) == 9
         assert sum_stations(inv.select(station="R?O*")) == 9
 
+        # Only Stations with public_id
+        assert sum_stations(inv.select(public_id="TEST")) == 0
+
         out = inv.select(
             minlatitude=47.5, maxlatitude=47.9,
             minlongitude=11.9, maxlongitude=13.3
@@ -436,7 +439,8 @@ class TestInventory:
             "latitude": None,
             "longitude": None,
             "minradius": None,
-            "maxradius": None}
+            "maxradius": None,
+            "public_id": None}
         with mock.patch("obspy.core.inventory.network.Network.select") as p:
             p.return_value = obspy.core.inventory.network.Network("BW")
             inv.select(**select_kwargs)

--- a/obspy/core/tests/test_network.py
+++ b/obspy/core/tests/test_network.py
@@ -179,6 +179,8 @@ class TestNetwork:
 
         # No matching station.
         assert sum(len(i) for i in net.select(station="RR")) == 0
+        # Only stations with public_id
+        assert sum(len(i) for i in net.select(public_id="TEST")) == 0
         # keep_empty does not do anything in these cases.
         sub = sum(len(i) for i in net.select(station="RR", keep_empty=True))
         assert sub == 0

--- a/obspy/io/seiscomp/inventory.py
+++ b/obspy/io/seiscomp/inventory.py
@@ -134,7 +134,7 @@ def _read_scml(path_or_file_object, **kwargs):
         sender = "ObsPy Inventory"
 
     # Set source to this script
-    source = "scml import"
+    source = "ObsPy SCML import"
     module = None
     module_uri = None
 
@@ -286,10 +286,23 @@ def _read_station(instrumentation_register, sta_element, _ns):
                                datum=True)
     elevation = _read_floattype(sta_element, _ns("elevation"), Distance,
                                 unit=True)
+
+    public_id = sta_element.get("publicID")
+    extra_tag = obspy.core.util.AttribDict()
+    if public_id:
+        extra_tag.publicID = obspy.core.util.AttribDict({
+                'value': public_id,
+                'namespace': sta_element.nsmap[None],
+                'type': 'attribute',
+            }
+        )
+
     station = obspy.core.inventory.Station(code=sta_element.get("code"),
                                            latitude=latitude,
                                            longitude=longitude,
                                            elevation=elevation)
+    if extra_tag:
+        station.extra = extra_tag
     station.site = _read_site(sta_element, _ns)
 
     # There is no relevant info in the base node

--- a/obspy/io/seiscomp/tests/data/4k_fissle.scml
+++ b/obspy/io/seiscomp/tests/data/4k_fissle.scml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp xmlns="http://geofon.gfz.de/ns/seiscomp-schema/0.14" version="0.14">
+  <Inventory>
+    <sensor publicID="Sensor/20260322032606.102854.7" name="4K.FIS02.DPN.2024.268.05.48.34" response="ResponsePAZ/20260322032606.102885.8">
+      <description>DT-SOLO 16HR-3C 5Hz node (SP)</description>
+      <model>DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s</model>
+      <unit>M/S</unit>
+      <remark>{"unit":"Velocity in Meters per Second"}</remark>
+    </sensor>
+    <sensor publicID="Sensor/20260322032606.103224.11" name="4K.FIS02.DPZ.2024.268.05.48.34" response="ResponsePAZ/20260322032606.102885.8">
+      <description>DT-SOLO 16HR-3C 5Hz node (SP)</description>
+      <model>DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s</model>
+      <unit>M/S</unit>
+      <remark>{"unit":"Velocity in Meters per Second"}</remark>
+    </sensor>
+    <sensor publicID="Sensor/20260322032606.103567.17" name="4K.FIS03.DPN.2024.268.21.57.34" response="ResponsePAZ/20260322032606.102885.8">
+      <description>DT-SOLO 16HR-3C 5Hz node (SP)</description>
+      <model>DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s</model>
+      <unit>M/S</unit>
+      <remark>{"unit":"Velocity in Meters per Second"}</remark>
+    </sensor>
+    <sensor publicID="Sensor/20260322032606.103758.21" name="4K.FIS03.DPZ.2024.268.21.57.34" response="ResponsePAZ/20260322032606.102885.8">
+      <description>DT-SOLO 16HR-3C 5Hz node (SP)</description>
+      <model>DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s</model>
+      <unit>M/S</unit>
+      <remark>{"unit":"Velocity in Meters per Second"}</remark>
+    </sensor>
+    <datalogger publicID="Datalogger/20260322032606.102761.6" name="4K.FIS02.DPN.2024.268.05.48.34">
+      <digitizerModel>16HR-3C 5Hz (built-in)</digitizerModel>
+      <gain>3355500</gain>
+      <decimation sampleRateNumerator="250" sampleRateDenominator="1"/>
+    </datalogger>
+    <datalogger publicID="Datalogger/20260322032606.103187.10" name="4K.FIS02.DPZ.2024.268.05.48.34">
+      <digitizerModel>16HR-3C 5Hz (built-in)</digitizerModel>
+      <gain>3355500</gain>
+      <decimation sampleRateNumerator="250" sampleRateDenominator="1"/>
+    </datalogger>
+    <datalogger publicID="Datalogger/20260322032606.103532.16" name="4K.FIS03.DPN.2024.268.21.57.34">
+      <digitizerModel>16HR-3C 5Hz (built-in)</digitizerModel>
+      <gain>3355500</gain>
+      <decimation sampleRateNumerator="250" sampleRateDenominator="1"/>
+    </datalogger>
+    <datalogger publicID="Datalogger/20260322032606.103726.20" name="4K.FIS03.DPZ.2024.268.21.57.34">
+      <digitizerModel>16HR-3C 5Hz (built-in)</digitizerModel>
+      <gain>3355500</gain>
+      <decimation sampleRateNumerator="250" sampleRateDenominator="1"/>
+    </datalogger>
+    <responsePAZ publicID="ResponsePAZ/20260322032606.102885.8" name="ResponsePAZ/20260322032606.102885.8">
+      <type>A</type>
+      <gain>76.6</gain>
+      <gainFrequency>50</gainFrequency>
+      <normalizationFactor>1</normalizationFactor>
+      <normalizationFrequency>50</normalizationFrequency>
+      <numberOfZeros>2</numberOfZeros>
+      <numberOfPoles>2</numberOfPoles>
+      <zeros>(0,0) (0,0)</zeros>
+      <poles>(-22.211059,22.217768) (-22.211059,-22.217768)</poles>
+    </responsePAZ>
+    <network publicID="NET/4K/20260322032606.102091.205" code="4K">
+      <start>2024-09-24T04:55:50.0000Z</start>
+      <end>2024-10-25T00:50:18.0000Z</end>
+      <description>Fiordland Seismological Sending of Landslides and Earthquakes (FISSLE)</description>
+      <restricted>false</restricted>
+      <shared>true</shared>
+      <station publicID="STA/4K/FIS02/20260322032606.102384.208" code="FIS02">
+        <start>2024-09-24T05:48:34.0000Z</start>
+        <end>2024-10-23T17:22:10.0000Z</end>
+        <description>Lodge Road</description>
+        <latitude>-44.677106</latitude>
+        <longitude>167.940306</longitude>
+        <elevation>16</elevation>
+        <place>Milford Sound</place>
+        <country>NZ</country>
+        <restricted>false</restricted>
+        <shared>true</shared>
+        <sensorLocation publicID="LOC/4K/FIS02//20260322032606.102506.209" code="">
+          <start>2024-09-24T05:48:34.0000Z</start>
+          <end>2024-10-23T17:22:10.0000Z</end>
+          <latitude>-44.677106</latitude>
+          <longitude>167.940306</longitude>
+          <elevation>16</elevation>
+          <stream publicID="Stream/20260322032606.102639.5" code="DPN" datalogger="Datalogger/20260322032606.102761.6" sensor="Sensor/20260322032606.102854.7">
+            <start>2024-09-24T05:48:34.0000Z</start>
+            <end>2024-10-23T17:22:10.0000Z</end>
+            <dataloggerSerialNumber>453022016</dataloggerSerialNumber>
+            <dataloggerChannel>1</dataloggerChannel>
+            <sensorSerialNumber>453022016</sensorSerialNumber>
+            <sensorChannel>1</sensorChannel>
+            <sampleRateNumerator>250</sampleRateNumerator>
+            <sampleRateDenominator>1</sampleRateDenominator>
+            <depth>0</depth>
+            <azimuth>0</azimuth>
+            <dip>0</dip>
+            <gain>257019225.5510831</gain>
+            <gainFrequency>50</gainFrequency>
+            <gainUnit>M/S</gainUnit>
+            <comment>
+              <text>{"type":"SP","description":"DT-SOLO 16HR-3C 5Hz node (SP)","model":"DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s","serialNumber":"453022016"}</text>
+              <id>FDSNXML:Sensor</id>
+            </comment>
+            <comment>
+              <text>{"model":"16HR-3C 5Hz (built-in)","serialNumber":"453022016"}</text>
+              <id>FDSNXML:DataLogger</id>
+            </comment>
+          </stream>
+          <stream publicID="Stream/20260322032606.103104.9" code="DPZ" datalogger="Datalogger/20260322032606.103187.10" sensor="Sensor/20260322032606.103224.11">
+            <start>2024-09-24T05:48:34.0000Z</start>
+            <end>2024-10-23T17:22:10.0000Z</end>
+            <dataloggerSerialNumber>453022016</dataloggerSerialNumber>
+            <dataloggerChannel>0</dataloggerChannel>
+            <sensorSerialNumber>453022016</sensorSerialNumber>
+            <sensorChannel>0</sensorChannel>
+            <sampleRateNumerator>250</sampleRateNumerator>
+            <sampleRateDenominator>1</sampleRateDenominator>
+            <depth>0</depth>
+            <azimuth>0</azimuth>
+            <dip>-90</dip>
+            <gain>257019225.5510831</gain>
+            <gainFrequency>50</gainFrequency>
+            <gainUnit>M/S</gainUnit>
+            <comment>
+              <text>{"type":"SP","description":"DT-SOLO 16HR-3C 5Hz node (SP)","model":"DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s","serialNumber":"453022016"}</text>
+              <id>FDSNXML:Sensor</id>
+            </comment>
+            <comment>
+              <text>{"model":"16HR-3C 5Hz (built-in)","serialNumber":"453022016"}</text>
+              <id>FDSNXML:DataLogger</id>
+            </comment>
+          </stream>
+        </sensorLocation>
+      </station>
+      <station publicID="STA/4K/FIS03/20260322032606.103369.227" code="FIS03">
+        <start>2024-09-24T21:57:34.0000Z</start>
+        <end>2024-10-25T00:50:18.0000Z</end>
+        <description>Helicopter Pad</description>
+        <latitude>-44.764044</latitude>
+        <longitude>167.994378</longitude>
+        <elevation>885</elevation>
+        <place>Homer Tunnel</place>
+        <country>NZ</country>
+        <restricted>false</restricted>
+        <shared>true</shared>
+        <sensorLocation publicID="LOC/4K/FIS03//20260322032606.103419.228" code="">
+          <start>2024-09-24T21:57:34.0000Z</start>
+          <end>2024-10-25T00:50:18.0000Z</end>
+          <latitude>-44.764044</latitude>
+          <longitude>167.994378</longitude>
+          <elevation>885</elevation>
+          <stream publicID="Stream/20260322032606.103454.15" code="DPN" datalogger="Datalogger/20260322032606.103532.16" sensor="Sensor/20260322032606.103567.17">
+            <start>2024-09-24T21:57:34.0000Z</start>
+            <end>2024-10-25T00:50:18.0000Z</end>
+            <dataloggerSerialNumber>453021945</dataloggerSerialNumber>
+            <dataloggerChannel>1</dataloggerChannel>
+            <sensorSerialNumber>453021945</sensorSerialNumber>
+            <sensorChannel>1</sensorChannel>
+            <sampleRateNumerator>250</sampleRateNumerator>
+            <sampleRateDenominator>1</sampleRateDenominator>
+            <depth>0</depth>
+            <azimuth>0</azimuth>
+            <dip>0</dip>
+            <gain>257019225.5510831</gain>
+            <gainFrequency>50</gainFrequency>
+            <gainUnit>M/S</gainUnit>
+            <comment>
+              <text>{"type":"SP","description":"DT-SOLO 16HR-3C 5Hz node (SP)","model":"DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s","serialNumber":"453021945"}</text>
+              <id>FDSNXML:Sensor</id>
+            </comment>
+            <comment>
+              <text>{"model":"16HR-3C 5Hz (built-in)","serialNumber":"453021945"}</text>
+              <id>FDSNXML:DataLogger</id>
+            </comment>
+          </stream>
+          <stream publicID="Stream/20260322032606.103645.19" code="DPZ" datalogger="Datalogger/20260322032606.103726.20" sensor="Sensor/20260322032606.103758.21">
+            <start>2024-09-24T21:57:34.0000Z</start>
+            <end>2024-10-25T00:50:18.0000Z</end>
+            <dataloggerSerialNumber>453021945</dataloggerSerialNumber>
+            <dataloggerChannel>0</dataloggerChannel>
+            <sensorSerialNumber>453021945</sensorSerialNumber>
+            <sensorChannel>0</sensorChannel>
+            <sampleRateNumerator>250</sampleRateNumerator>
+            <sampleRateDenominator>1</sampleRateDenominator>
+            <depth>0</depth>
+            <azimuth>0</azimuth>
+            <dip>-90</dip>
+            <gain>257019225.5510831</gain>
+            <gainFrequency>50</gainFrequency>
+            <gainUnit>M/S</gainUnit>
+            <comment>
+              <text>{"type":"SP","description":"DT-SOLO 16HR-3C 5Hz node (SP)","model":"DTCC SmartSolo 16HR-3C 5 Hz 76.6 V/m/s","serialNumber":"453021945"}</text>
+              <id>FDSNXML:Sensor</id>
+            </comment>
+            <comment>
+              <text>{"model":"16HR-3C 5Hz (built-in)","serialNumber":"453021945"}</text>
+              <id>FDSNXML:DataLogger</id>
+            </comment>
+          </stream>
+        </sensorLocation>
+      </station>
+    </network>
+  </Inventory>
+</seiscomp>

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -109,7 +109,7 @@ class TestSCML():
         # scml lacks
         for scml, stationxml in zip(scml_arr, stationxml_arr):
             if scml != stationxml:
-                tag = str(stationxml).split(">")[0][1:].split()[0]
+                tag = str(stationxml).split(">")[0][1:]
                 assert tag in excluded_tags
 
     def test_empty_depth(self, testdata):

--- a/obspy/io/seiscomp/tests/test_inventory.py
+++ b/obspy/io/seiscomp/tests/test_inventory.py
@@ -81,7 +81,7 @@ class TestSCML():
 
         # The following tags can be different between scml/stationXML
 
-        # <Source>SeisComP3</Source> | <Source>scml import</Source>
+        # <Source>SeisComP3</Source> | <Source>ObsPy SCML import</Source>
         # <Sender>ODC</Sender> | <Sender>ObsPy Inventory</Sender>
         # <Created>2015-11-23T11:52:37+00:00</Created>
         # <Coefficients> | <Coefficients name="EBR.2002.091.H" ~
@@ -90,13 +90,17 @@ class TestSCML():
         excluded_tags = ["Source", "Sender", "Created", "Name",
                          "Coefficients"]
 
-        # also ignore StorageFormat which doesnt exist anymore in
-        # StationXML 1.1 and is saved into extra / a foreign tag
-        pattern_format_line = (
-            r'<([^:]*):format xmlns:\1='
-            r'"http://geofon.gfz-potsdam.de/ns/seiscomp3?-schema/[\.0-9]*">')
+        # ignore any foreign/namespaced tags
+        # e.g. StorageFormat which doesn't exist in StationXML 1.1
+        # and is saved into extra as a foreign tag
+        pattern_ns_line = re.compile(r'<\w+:\w+')
         scml_arr = [line for line in scml_arr
-                    if not re.search(pattern_format_line, line)]
+                    if not re.search(pattern_ns_line, line)]
+        # strip any namespaced attributes
+        # e.g. ns0:publicID from remaining lines
+        pattern_ns_attr = re.compile(
+            r'\s+xmlns:\w+="[^"]*"|\s+\w+:publicID="[^"]*"')
+        scml_arr = [pattern_ns_attr.sub('', line) for line in scml_arr]
 
         # Compare the two stationXMLs line by line
         # If one XML has an entry that the other one does not, this procedure
@@ -105,7 +109,7 @@ class TestSCML():
         # scml lacks
         for scml, stationxml in zip(scml_arr, stationxml_arr):
             if scml != stationxml:
-                tag = str(stationxml).split(">")[0][1:]
+                tag = str(stationxml).split(">")[0][1:].split()[0]
                 assert tag in excluded_tags
 
     def test_empty_depth(self, testdata):
@@ -274,3 +278,23 @@ class TestSCML():
         poles = response.response_stages[1].poles
         assert zeros == []
         assert poles == []
+
+    def test_filter_public_id(self, testdata):
+        """
+        Tests various filters via public_id.
+        """
+        scml_inv = read_inventory(
+            testdata["4k_fissle.scml"]
+            )
+        s = scml_inv.select(
+            public_id="STA/4K/FIS02/20260322032606.102384.208"
+            )
+        assert s[0].stations[0].code == 'FIS02'
+        s = scml_inv.select(
+            public_id="STA/4K/FIS03/20260322032606.103369.227"
+            )
+        assert s[0].stations[0].code == 'FIS03'
+        s = scml_inv.select(
+            public_id="STA/4K/FIS03/typo"
+            )
+        assert s.networks == []


### PR DESCRIPTION
### What does this PR do?

This is a remake of the derelict #3194 which reads and logs the station-level SCML publicID attribute. I added extra tests recommended previously and based on master.

Closes #3193 

Also updates the generic "scml import" `source` attribute with "ObsPy SCML import" and adds an additional SCML 0.14 inventory test file which will come in handy later.

### AI used?

yes, to remake some re compiles in seiscomp/tests/test_inventory/test_compare_xml since I will never understand how those work
