### PR TITLE
more distinct miniseed read errors, print zero size instead of unknown format

### DIFF
--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -435,16 +435,16 @@ class TestWaveformPlugins:
         st2 = read(ascii_path / 'slist.ascii')
         assert st1 == st2
 
-    def test_raise_on_unknown_format(self):
+    def test_raise_on_empty_file(self):
         """
-        Test case for issue #338:
+        Test reading an empty file.
         """
         with NamedTemporaryFile() as tf:
             tmpfile = tf.name
             # create empty file
             open(tmpfile, 'wb').close()
             # using format keyword
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError, match="File is empty"):
                 read(tmpfile)
 
     def test_deepcopy(self):

--- a/obspy/core/tests/test_waveform_plugins.py
+++ b/obspy/core/tests/test_waveform_plugins.py
@@ -435,16 +435,16 @@ class TestWaveformPlugins:
         st2 = read(ascii_path / 'slist.ascii')
         assert st1 == st2
 
-    def test_raise_on_empty_file(self):
+    def test_raise_on_unknown_format(self):
         """
-        Test reading an empty file.
+        Writes and reads a small non-empty file.
         """
         with NamedTemporaryFile() as tf:
             tmpfile = tf.name
-            # create empty file
-            open(tmpfile, 'wb').close()
+            # create small non-empty file
+            open(tmpfile, 'wb').write(b'\x82\x00\x00')
             # using format keyword
-            with pytest.raises(ValueError, match="File is empty"):
+            with pytest.raises(TypeError):
                 read(tmpfile)
 
     def test_deepcopy(self):

--- a/obspy/core/util/base.py
+++ b/obspy/core/util/base.py
@@ -536,6 +536,9 @@ def _read_from_plugin(plugin_type, filename, format=None, **kwargs):
             if is_format:
                 break
         else:
+            if isinstance(filename, str) and \
+                    Path(filename).stat().st_size == 0:
+                raise ValueError("File is empty: {}".format(filename))
             raise TypeError('Unknown format for file %s' % filename)
     else:
         # format given via argument

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -606,15 +606,20 @@ def _get_record_information(file_object, offset=0, endian=None):
     elif _code == b' ':
         try:
             _t = file_object.read(120).decode().strip()
-        except Exception:
-            raise ValueError("Invalid MiniSEED file.")
+        except UnicodeDecodeError:
+            file_object.seek(0, 2)
+            if file_object.tell() == 0:
+                raise ValueError("MiniSEED file is empty.")
+            raise ValueError("Invalid MiniSEED file: "
+                             "unable to decode header bytes.")
         if not _t:
             info = _get_record_information(file_object=file_object,
                                            endian=endian)
             file_object.seek(initial_position, 0)
             return info
         else:
-            raise ValueError("Invalid MiniSEED file.")
+            raise ValueError("Invalid MiniSEED file: "
+                             "unexpected content in noise record.")
     file_object.seek(record_start, 0)
 
     # check if full SEED or MiniSEED

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -606,7 +606,7 @@ def _get_record_information(file_object, offset=0, endian=None):
     elif _code == b' ':
         try:
             _t = file_object.read(120).decode().strip()
-        except UnicodeDecodeError:
+        except Exception:
             raise ValueError("Invalid MiniSEED file: "
                              "unable to decode header bytes.")
         if not _t:

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -607,9 +607,6 @@ def _get_record_information(file_object, offset=0, endian=None):
         try:
             _t = file_object.read(120).decode().strip()
         except UnicodeDecodeError:
-            file_object.seek(0, 2)
-            if file_object.tell() == 0:
-                raise ValueError("MiniSEED file is empty.")
             raise ValueError("Invalid MiniSEED file: "
                              "unable to decode header bytes.")
         if not _t:


### PR DESCRIPTION
### What does this PR do?

the "Invalid MiniSEED file" error messages are often a bit too vague to determine what is happening (e.g. #3549). Now expanded somewhat.

Also catches the read in base.py-- after all attempts to determine format it will finally check if the file is zero before printing the "unknown format".

on master

### AI used?

for sanity washing