### PR TITLE
slice() now working on reference instead of copy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@ Changes:
      (see #3709)
  - obspy.clients:
    * SDS client: fix handling of empty files (see #3709)
+ - obpsy.core.trace: 
+   * slice now works on references instead of making a copy of the trace
 
 1.5.0 (doi: 10.5281/zenodo.19005357)
 ====================================

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2281,7 +2281,7 @@ class TestStream:
         assert "filter" in pr[4] and "lowpass" in pr[4]
         assert "differentiate" in pr[5]
         assert "integrate" in pr[6]
-        assert "trim" in pr[7]
+        assert "slice" in pr[7]
         assert "detrend" in pr[8]
         assert "taper" in pr[9]
         assert "normalize" in pr[10]

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -602,7 +602,7 @@ class TestTrace:
         tr2 = tr.slice(tr.stats.starttime)
         assert "processing" not in tr.stats
         assert "processing" in tr2.stats
-        assert "trim" in tr2.stats.processing[0]
+        assert "slice" in tr2.stats.processing[0]
 
     def test_slice_no_starttime_or_endtime(self):
         """
@@ -620,7 +620,10 @@ class TestTrace:
         # test 1: only removing data at left side
         tr_trim = tr_orig.copy()
         tr_trim.trim(starttime=t2)
-        assert tr_trim == tr.slice(starttime=t2)
+        tr_slice = tr.slice(starttime=t2)
+        self.__remove_processing(tr_trim)
+        self.__remove_processing(tr_slice)
+        assert tr_trim == tr_slice
         tr2 = tr.slice(starttime=t2, endtime=t4)
         self.__remove_processing(tr_trim)
         self.__remove_processing(tr2)
@@ -629,10 +632,14 @@ class TestTrace:
         # test 2: only removing data at right side
         tr_trim = tr_orig.copy()
         tr_trim.trim(endtime=t3)
-        assert tr_trim == tr.slice(endtime=t3)
+        tr_slice = tr.slice(endtime=t3)
+        self.__remove_processing(tr_trim)
+        self.__remove_processing(tr_slice)
+        assert tr_trim == tr_slice
         tr2 = tr.slice(starttime=t1, endtime=t3)
         self.__remove_processing(tr_trim)
         self.__remove_processing(tr2)
+        print(tr_trim.stats, tr2.stats)
         assert tr_trim == tr2
 
         # test 3: not removing data at all
@@ -680,8 +687,13 @@ class TestTrace:
         # test 4: removing data at left and right side
         tr_trim = tr_orig.copy()
         tr_trim.trim(starttime=t2, endtime=t3)
-        assert tr_trim == tr.slice(t2, t3)
-        assert tr_trim == tr.slice(starttime=t2, endtime=t3)
+        tr_slice = tr.slice(t2, t3)
+        self.__remove_processing(tr_trim)
+        self.__remove_processing(tr_slice)
+        assert tr_trim == tr_slice
+        tr_slice = tr.slice(starttime=t2, endtime=t3)
+        self.__remove_processing(tr_slice)
+        assert tr_trim == tr_slice
 
         # test 5: no data left after operation
         tr_trim = tr_orig.copy()

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -258,6 +258,16 @@ class Stats(AttribDict):
         self.__setitem__('sampling_rate', state['sampling_rate'])
 
 
+def _add_to_return_value(func, *args, **kwargs):
+    """
+    Modifies behaviour of _add_processing_info depending
+    on whether processing info should be written to return
+    value or self.
+    """
+    func._writes_return_value = True
+    return func
+
+
 @decorator
 def _add_processing_info(func, *args, **kwargs):
     """
@@ -284,7 +294,15 @@ def _add_processing_info(func, *args, **kwargs):
     result = func(*args, **kwargs)
     # Attach after executing the function to avoid having it attached
     # while the operation failed.
-    self._internal_add_processing_info(info)
+
+    # attach to return value
+    if getattr(func, "_writes_return_value", False):
+        if result:
+            result._internal_add_processing_info(info)
+
+    # attach to self
+    else:
+        self._internal_add_processing_info(info)
     return result
 
 
@@ -1198,6 +1216,8 @@ class Trace(object):
                 pass
         return self
 
+    @_add_processing_info
+    @_add_to_return_value
     def slice(self, starttime=None, endtime=None, nearest_sample=True):
         """
         Return a new Trace object with data going from start to end time.
@@ -1233,10 +1253,31 @@ class Trace(object):
         >>> tr2.data
         array([2, 3, 4, 5, 6, 7, 8])
         """
-        tr = copy(self)
+        tr = Trace()
         tr.stats = deepcopy(self.stats)
-        tr.trim(starttime=starttime, endtime=endtime,
-                nearest_sample=nearest_sample)
+        if not starttime:
+            startpoint = 0
+        else:
+            startpoint = (starttime - self.stats.starttime) / self.stats.delta
+        if not endtime:
+            endpoint = len(self.data)
+        else:
+            endpoint = (endtime - self.stats.starttime) / self.stats.delta
+        if nearest_sample:
+            i0 = int(round(startpoint))
+            i1 = int(round(endpoint))
+        else:
+            i0 = int(np.ceil(startpoint))
+            i1 = int(np.floor(endpoint))
+        if i1 < i0 or i1 < 0 or i0 >= len(self.data):
+            tr.data = np.array([], dtype=self.data.dtype)
+        else:
+            if i0 < 0:
+                i0 = 0
+            if i1 >= len(self.data):
+                i1 = len(self.data)
+            tr.data = self.data[i0:i1+1]
+        tr.stats.starttime = self.stats.starttime + self.stats.delta * i0
         return tr
 
     def slide(self, window_length, step, offset=0,


### PR DESCRIPTION
…aking a full copy.

<!--
Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request
-->

### What does this PR do?

The current situation is as follows:
```
"""
[...]
        :return: New :class:`~obspy.core.trace.Trace` object. Does not copy
            data but just passes a reference to it.
[...]
"""
tr = copy(self)

```
The proposed change replaces the current code with code which works on references, reducing time and memory consumption in cases a program uses a lot of slices. In theory, this could cause trouble for people relying on the fact, that the current code would make a deep copy of the data, although it is clearly stated differently in the manual. I am not sure whether pushing this to maintenance is appropriate.

### AI used?

Copilot used to make the code look pythonic.

### PR Checklist

- [X] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [X] **Tests**: Added new tests for any new features or fixed regressions
- [X] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
