### PR TITLE
Perf: make carl_sta_trig O(n) regardless of window size

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,10 @@ master
 ======
 
 Changes:
- - ...
+ - obspy.signal:
+   * trigger: vectorize carl_sta_trig() using cumulative sums, replacing
+     O(m*(nsta+nlta)) loop+concatenate with O(m) computation. ~100-500x
+     speedup for typical parameters. Add unit tests for carl_sta_trig.
 
 maintenance_1.5.x
 =================

--- a/obspy/CONTRIBUTORS.txt
+++ b/obspy/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Bagagli, Matteo
 Bank, Markus
 Barsch, Robert
 Behr, Yannik
+Berg, Jonathan
 Bernardi, Fabrizio
 Bernauer, Felix
 Bes de Berc, Maxime

--- a/obspy/signal/tests/test_trigger.py
+++ b/obspy/signal/tests/test_trigger.py
@@ -13,7 +13,8 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from obspy import Stream, UTCDateTime, read
 from obspy.signal.trigger import (
-    ar_pick, classic_sta_lta, classic_sta_lta_py, coincidence_trigger, pk_baer,
+    ar_pick, carl_sta_trig, classic_sta_lta, classic_sta_lta_py,
+    coincidence_trigger, pk_baer,
     recursive_sta_lta, recursive_sta_lta_py, trigger_onset, aic_simple,
     energy_ratio, modified_energy_ratio)
 from obspy.signal.util import clibsignal
@@ -621,6 +622,66 @@ class TestEnergyRatio():
             f'nsta ({nsta}) must not be equal to or less than zero.')
         with pytest.raises(ValueError, match=expected_msg):
             energy_ratio(self.a, nsta)
+
+
+class TestCarlStaTrig():
+    """Tests for carl_sta_trig characteristic function."""
+
+    def test_simple_integers(self):
+        """Test with simple integer sequence, hand-verified values."""
+        a = np.arange(1, 11, dtype=np.float64)
+        result = carl_sta_trig(a, nsta=2, nlta=3, ratio=0.8, quiet=0.0)
+        # First nlta elements are always -1.0
+        assert_array_equal(result[:3], [-1.0, -1.0, -1.0])
+        # Hand-computed reference values
+        expected = np.array([
+            -1.0, -1.0, -1.0,
+            -0.4, -0.56666667, -0.91666667,
+            -1.15, -1.70555556, -2.07777778, -2.14444444
+        ])
+        np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+    def test_output_length_and_dtype(self):
+        """Output should be same length as input, and always f64."""
+        a = np.arange(100)  # integer array
+        result = carl_sta_trig(a, nsta=5, nlta=10, ratio=0.8, quiet=0.5)
+        assert len(result) == len(a)
+        assert result.dtype == np.float64
+
+    def test_leading_values_are_minus_one(self):
+        """First nlta values should always be -1.0."""
+        a = np.random.randn(200)
+        for nlta in [5, 20, 50]:
+            result = carl_sta_trig(a, nsta=3, nlta=nlta, ratio=0.8, quiet=0.5)
+            assert_array_equal(result[:nlta], np.full(nlta, -1.0))
+
+    def test_constant_input(self):
+        """For constant input, eta should converge toward a stable value."""
+        a = np.full(100, 5.0)
+        result = carl_sta_trig(a, nsta=3, nlta=5, ratio=0.8, quiet=0.0)
+        # After warmup, |a - lta| should be ~0, so star and ltar -> 0,
+        # and eta -> -|sta - lta| which also -> 0.
+        # Check the tail is stable (not diverging or oscillating).
+        tail = result[50:]
+        assert np.std(tail) < 1e-10
+
+    def test_sensitivity_to_ratio(self):
+        """Smaller ratio should produce larger (more sensitive) eta values."""
+        np.random.seed(42)
+        a = np.random.randn(500)
+        r1 = carl_sta_trig(a, 10, 50, ratio=0.5, quiet=0.0)
+        r2 = carl_sta_trig(a, 10, 50, ratio=0.9, quiet=0.0)
+        # Smaller ratio means less suppression from ltar, so higher eta
+        assert np.mean(r1[50:]) > np.mean(r2[50:])
+
+    def test_sensitivity_to_quiet(self):
+        """Larger quiet should produce smaller (less sensitive) eta values."""
+        np.random.seed(42)
+        a = np.random.randn(500)
+        r1 = carl_sta_trig(a, 10, 50, ratio=0.8, quiet=0.0)
+        r2 = carl_sta_trig(a, 10, 50, ratio=0.8, quiet=1.0)
+        # quiet is subtracted directly, so larger quiet = smaller eta
+        np.testing.assert_allclose(r1[50:] - 1.0, r2[50:])
 
 
 class TestModifiedEnergyRatio():

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -153,7 +153,7 @@ def carl_sta_trig(a, nsta, nlta, ratio, quiet):
     # shifted by one sample
     lta = _rolling_sum(sta, nlta) / nlta
     lta = np.concatenate(([0.0], lta[:-1]))
-    # # compute star, average of abs diff between trace and lta
+    # compute star, average of abs diff between trace and lta
     star = _rolling_sum(np.abs(a - lta), nsta) / nsta
     # LTAR: rolling mean of star over nlta samples
     ltar = _rolling_sum(star, nlta) / nlta

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -118,14 +118,12 @@ def _rolling_sum(a, n):
     :param n: Window length (must be >= 1 and <= len(a)).
     :rtype: NumPy :class:`~numpy.ndarray`
     """
-    if n < 1 or n > len(a):
-        raise ValueError(
-            f"Window length n={n} out of range for array of length {len(a)}")
-    cs = np.cumsum(a, dtype=np.float64)
-    out = np.zeros(len(a), dtype=np.float64)
-    out[n] = cs[n - 1]
-    if len(a) > n + 1:
-        out[n + 1:] = cs[n:-1] - cs[:len(a) - n - 1]
+    m = len(a)
+    if n < 1 or n > m:
+        raise ValueError(f"Window n={n} out of range for array of length {m}")
+    cs = np.concatenate(([0.0], np.cumsum(a, dtype=np.float64)))
+    out = np.zeros(m, dtype=np.float64)
+    out[n:] = cs[n:m] - cs[:m - n]
     return out
 
 
@@ -155,7 +153,7 @@ def carl_sta_trig(a, nsta, nlta, ratio, quiet):
     # shifted by one sample
     lta = _rolling_sum(sta, nlta) / nlta
     lta = np.concatenate(([0.0], lta[:-1]))
-    # STAR: rolling mean of |a - lta| over nsta samples
+    # # compute star, average of abs diff between trace and lta
     star = _rolling_sum(np.abs(a - lta), nsta) / nsta
     # LTAR: rolling mean of star over nlta samples
     ltar = _rolling_sum(star, nlta) / nlta

--- a/obspy/signal/trigger.py
+++ b/obspy/signal/trigger.py
@@ -103,6 +103,32 @@ def recursive_sta_lta_py(a, nsta, nlta):
     return charfct
 
 
+def _rolling_sum(a, n):
+    """
+    Compute a causal rolling sum of *a* with window size *n*.
+
+    out[j] = sum(a[j-n : j]) for j >= n, and 0 for j < n.
+
+    Uses a cumulative-sum approach so that runtime is O(len(a))
+    regardless of window size *n*.
+
+    :type a: NumPy :class:`~numpy.ndarray`
+    :param a: Input array.
+    :type n: int
+    :param n: Window length (must be >= 1 and <= len(a)).
+    :rtype: NumPy :class:`~numpy.ndarray`
+    """
+    if n < 1 or n > len(a):
+        raise ValueError(
+            f"Window length n={n} out of range for array of length {len(a)}")
+    cs = np.cumsum(a, dtype=np.float64)
+    out = np.zeros(len(a), dtype=np.float64)
+    out[n] = cs[n - 1]
+    if len(a) > n + 1:
+        out[n + 1:] = cs[n:-1] - cs[:len(a) - n - 1]
+    return out
+
+
 def carl_sta_trig(a, nsta, nlta, ratio, quiet):
     """
     Computes the carlSTAtrig characteristic function.
@@ -122,38 +148,19 @@ def carl_sta_trig(a, nsta, nlta, ratio, quiet):
     :rtype: NumPy :class:`~numpy.ndarray`
     :return: Characteristic function of CarlStaTrig
     """
-    m = len(a)
-    #
-    sta = np.zeros(len(a), dtype=np.float64)
-    lta = np.zeros(len(a), dtype=np.float64)
-    star = np.zeros(len(a), dtype=np.float64)
-    ltar = np.zeros(len(a), dtype=np.float64)
-    pad_sta = np.zeros(nsta)
-    pad_lta = np.zeros(nlta)  # avoid for 0 division 0/1=0
-    #
+    a = np.asarray(a, dtype=np.float64)  # do everything in f64
     # compute the short time average (STA)
-    for i in range(nsta):  # window size to smooth over
-        sta += np.concatenate((pad_sta, a[i:m - nsta + i]))
-    sta /= nsta
+    sta = _rolling_sum(a, nsta) / nsta
+    # long time average (LTA): rolling mean of sta over nlta samples,
+    # shifted by one sample
+    lta = _rolling_sum(sta, nlta) / nlta
+    lta = np.concatenate(([0.0], lta[:-1]))
+    # STAR: rolling mean of |a - lta| over nsta samples
+    star = _rolling_sum(np.abs(a - lta), nsta) / nsta
+    # LTAR: rolling mean of star over nlta samples
+    ltar = _rolling_sum(star, nlta) / nlta
     #
-    # compute the long time average (LTA), 8 sec average over sta
-    for i in range(nlta):  # window size to smooth over
-        lta += np.concatenate((pad_lta, sta[i:m - nlta + i]))
-    lta /= nlta
-    lta = np.concatenate((np.zeros(1), lta))[:m]  # XXX ???
-    #
-    # compute star, average of abs diff between trace and lta
-    for i in range(nsta):  # window size to smooth over
-        star += np.concatenate((pad_sta,
-                               abs(a[i:m - nsta + i] - lta[i:m - nsta + i])))
-    star /= nsta
-    #
-    # compute ltar, 8 sec average over star
-    for i in range(nlta):  # window size to smooth over
-        ltar += np.concatenate((pad_lta, star[i:m - nlta + i]))
-    ltar /= nlta
-    #
-    eta = star - (ratio * ltar) - abs(sta - lta) - quiet
+    eta = star - (ratio * ltar) - np.abs(sta - lta) - quiet
     eta[:nlta] = -1.0
     return eta
 


### PR DESCRIPTION
<!--
Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request
-->

### What does this PR do?

The previous implementation of `carl_sta_trig` on an array of `n` elements over a window size `m` was `O(nm)`. For every position in an output array, we have to compute the sum across a window of `m` elements.

The "trick" we can take advantage of here is that by computing the cumulative sum of the original array once, the window sum (for any window size!) can be computed in constant time by subtracting the value of the cumsum array at the end of the window from the value of the cumsum array at the start of the window.

To walk through an example:
```python
import numpy as np
m = 9
n = 3  # window size
a = np.arange(1, m+1)  # array([1, 2, 3, 4, 5, 6, 7, 8, 9])
# pad with a zero for lookback alignment
cs = np.concatenate(([0.0], np.cumsum(a, dtype=np.float64)))  # array([ 0.,  1.,  3.,  6., 10., 15., 21., 28., 36., 45.])
out = np.zeros(len(a), dtype=np.float64)
out[n:] = cs[n:m] - cs[:m - n]
array([ 0.,  0.,  0.,  6.,  9., 12., 15., 18., 21.])
```

For larger window sizes, the vectorization + O(n) change produces a pronounced speedup:

```
⏺ ARM MacBook (Apple Silicon)                                                                                           
                                                                                                                       
  ┌───────────────────────────────────────────────────────┬─────────┬──────────┬───────┬─────────┬─────────────┐        
  │                        Dataset                        │ Params  │   Old    │  New  │ Speedup │  Triggers   │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Virginia M5.8 @ IU.HRV (BHZ 40Hz, 7.2K samples, 6min) │ 1s/10s  │ 2.5ms    │ 0.1ms │ 19x     │ 153 = 153   │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Virginia M5.8                                         │ 5s/30s  │ 10.2ms   │ 0.2ms │ 52x     │ 36 = 36     │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Virginia M5.8                                         │ 0.5s/5s │ 1.3ms    │ 0.2ms │ 6x      │ 146 = 146   │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO continuous (BHZ 40Hz, 144K samples, 1hr)      │ 1s/10s  │ 58ms     │ 3.4ms │ 17x     │ 56 = 56     │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO                                               │ 5s/30s  │ 186ms    │ 1.8ms │ 102x    │ 466 = 466   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO                                               │ 0.5s/5s │ 29ms     │ 2.8ms │ 10x     │ 2 = 2       │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK (HHZ 100Hz, 2.16M samples, 6hr)      │ 1s/10s  │ 5,855ms  │ 58ms  │ 102x    │ 2679 = 2679 │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK                                      │ 5s/30s  │ 18,702ms │ 63ms  │ 297x    │ 780 = 780   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK                                      │ 0.5s/5s │ 3,021ms  │ 62ms  │ 49x     │ 2789 = 2789 │
  └───────────────────────────────────────────────────────┴─────────┴──────────┴───────┴─────────┴─────────────┘        
                                                            
  Intel Xeon x86_64 (GCP c2-standard-4, 3.1 GHz)                                                                        
                                                            
  ┌───────────────────────────────────────────────────────┬─────────┬──────────┬───────┬─────────┬─────────────┐        
  │                        Dataset                        │ Params  │   Old    │  New  │ Speedup │  Triggers   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Virginia M5.8 @ IU.HRV (BHZ 20Hz, 7.2K samples, 6min) │ 1s/10s  │ 2.6ms    │ 0.2ms │ 14x     │ 153 = 153   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤
  │ Virginia M5.8                                         │ 5s/30s  │ 8.2ms    │ 0.2ms │ 44x     │ 36 = 36     │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Virginia M5.8                                         │ 0.5s/5s │ 1.4ms    │ 0.2ms │ 8x      │ 146 = 146   │        
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO continuous (BHZ 40Hz, 144K samples, 1hr)      │ 1s/10s  │ 164ms    │ 4.0ms │ 41x     │ 56 = 56     │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO                                               │ 5s/30s  │ 527ms    │ 3.9ms │ 134x    │ 466 = 466   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ IU.ANMO                                               │ 0.5s/5s │ 82ms     │ 3.9ms │ 21x     │ 2 = 2       │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK (HHZ 100Hz, 2.16M samples, 6hr)      │ 1s/10s  │ 13,451ms │ 94ms  │ 143x    │ 2679 = 2679 │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK                                      │ 5s/30s  │ 43,205ms │ 95ms  │ 456x    │ 780 = 780   │
  ├───────────────────────────────────────────────────────┼─────────┼──────────┼───────┼─────────┼─────────────┤        
  │ Oklahoma OK.BCOK                                      │ 0.5s/5s │ 6,750ms  │ 95ms  │ 71x     │ 2789 = 2789 │
  └───────────────────────────────────────────────────────┴─────────┴──────────┴───────┴─────────┴─────────────┘        
                                                            
  Trigger counts match exactly in all cases. Max relative difference never exceeds 1e-11.    
```

### AI used?

I asked claude code to do some profiling on common use cases and look for python loops that could be vectorized. It flagged this pretty quickly and identified that cumsum could be a big win here. I've had to modify its output a bunch to get rid of useless extra features and make it feel more idiomatic. Also it seems to love getting rid of original code comments, even though they're very helpful.

I also used it a *lot* for writing and running benchmarking scripts both locally on my macbook and on a gcloud vm.

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
