### PR TITLE
inventory: fix `measurement_units` not accepted in some objects

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,11 +7,15 @@ Changes:
      mimicks the behavior of numpy <2.5, which is to downcast results to real
      valued arrays when possible. Replacing all `numpy.linalg.eig` calls in the
      code base with this wrapper (see #3760)
+ - obspy.core:
+   * inventory: fix a bug that Latitude, Longitude and Distance did not accept
+     'measurement_units' when being initialized (see #3623)
  - obspy.clients.fdsn:
    * update URL endpoint for IGN to https (see #3744)
  - obspy.clients.filesystem:
    * tsindex: improve handling of sql sessions, less connections staying open
      (see #3736)
+   * SDS client: fix handling of empty files (see #3709)
  - obspy.clients.iris:
    * deprecate flinnengdahl web service, which EarthScope announced will be
      retired in July 2026. Users should use obspy.geodetics instead.
@@ -21,8 +25,6 @@ Changes:
      (see #3709)
    * fix a void return type in write mseed ctypes wrapper (see #3735)
    * fix reading in case when numpy.memmap is not implemented (see #3741)
- - obspy.clients:
-   * SDS client: fix handling of empty files (see #3709)
  - obspy.taup:
    * fix an issue with obspy.taup not being usable with specific Python
      versions 3.13.10 and 3.14.1 (see #3650)

--- a/obspy/core/inventory/channel.py
+++ b/obspy/core/inventory/channel.py
@@ -45,13 +45,13 @@ class Channel(BaseNode):
         :param code: The SEED channel code for this channel
         :type location_code: str
         :param location_code: The SEED location code for this channel
-        :type latitude: :class:`~obspy.core.inventory.util.Latitude`
+        :type latitude: :class:`~obspy.core.inventory.util.Latitude` or float
         :param latitude: Latitude coordinate of this channel's sensor.
-        :type longitude: :class:`~obspy.core.inventory.util.Longitude`
+        :type longitude: :class:`~obspy.core.inventory.util.Longitude` or float
         :param longitude: Longitude coordinate of this channel's sensor.
-        :type elevation: float
+        :type elevation: :class:`~obspy.core.inventory.util.Distance` or float
         :param elevation: Elevation of the sensor.
-        :type depth: float
+        :type depth: :class:`~obspy.core.inventory.util.Distance` or float
         :param depth: The local depth or overburden of the instrument's
             location. For downhole instruments, the depth of the instrument
             under the surface ground level. For underground vaults, the

--- a/obspy/core/inventory/util.py
+++ b/obspy/core/inventory/util.py
@@ -790,13 +790,14 @@ class Latitude(FloatWithUncertaintiesFixedUnit):
     _unit = "DEGREES"
 
     def __init__(self, value, lower_uncertainty=None, upper_uncertainty=None,
-                 datum=None):
+                 datum=None, measurement_method=None):
         """
         """
         self.datum = datum
         super(Latitude, self).__init__(
             value, lower_uncertainty=lower_uncertainty,
-            upper_uncertainty=upper_uncertainty)
+            upper_uncertainty=upper_uncertainty,
+            measurement_method=measurement_method)
 
 
 class Longitude(FloatWithUncertaintiesFixedUnit):
@@ -819,13 +820,14 @@ class Longitude(FloatWithUncertaintiesFixedUnit):
     unit = "DEGREES"
 
     def __init__(self, value, lower_uncertainty=None, upper_uncertainty=None,
-                 datum=None):
+                 datum=None, measurement_method=None):
         """
         """
         self.datum = datum
         super(Longitude, self).__init__(
             value, lower_uncertainty=lower_uncertainty,
-            upper_uncertainty=upper_uncertainty)
+            upper_uncertainty=upper_uncertainty,
+            measurement_method=measurement_method)
 
 
 class Distance(FloatWithUncertaintiesAndUnit):
@@ -844,10 +846,11 @@ class Distance(FloatWithUncertaintiesAndUnit):
     :param measurement_method: Method used in the measurement.
     """
     def __init__(self, value, lower_uncertainty=None, upper_uncertainty=None,
-                 unit="METERS"):
+                 unit="METERS", measurement_method=None):
         super(Distance, self).__init__(
             value, lower_uncertainty=lower_uncertainty,
-            upper_uncertainty=upper_uncertainty)
+            upper_uncertainty=upper_uncertainty,
+            measurement_method=measurement_method)
         self._unit = unit
 
 

--- a/obspy/io/stationxml/tests/test_stationxml.py
+++ b/obspy/io/stationxml/tests/test_stationxml.py
@@ -18,12 +18,13 @@ from lxml import etree
 
 import obspy
 import obspy.io.stationxml.core
-from obspy import UTCDateTime
+from obspy import UTCDateTime, read_inventory
 from obspy.core.util import AttribDict, CatchAndAssertWarnings
 from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.core.inventory import (
     Inventory, Network, ResponseStage, Response, Channel, Station)
-from obspy.core.inventory.util import DataAvailability
+from obspy.core.inventory.util import (
+    DataAvailability, Latitude, Longitude, Distance)
 from obspy.core.util.base import NamedTemporaryFile
 from obspy.io.stationxml.core import _read_stationxml
 import pytest
@@ -1293,3 +1294,35 @@ class TestStationXML():
         # if it is present, at least it should have empty value, but let's just
         # make sure it's not present at all for now
         # assert matches[0].text is None
+
+    def test_measurement_units(self):
+        """
+        Regression test for #3623
+
+        Make sure that measurement units are expected in some classes derived
+        from obspy custom float classes that override the base classes' init
+        method
+        """
+        lat = Latitude(49.18, lower_uncertainty=0.1, upper_uncertainty=0.1,
+                       measurement_method='guesstimate')
+        lon = Longitude(-2.15, lower_uncertainty=0.1, upper_uncertainty=0.1,
+                        measurement_method='rule of thumb')
+        elev = Distance(-10., lower_uncertainty=1, upper_uncertainty=1,
+                        measurement_method='echo sounder')
+        depth = Distance(0.)
+        cha_orig = Channel('CHZ', '00', lat, lon, elev, depth)
+        channels = [cha_orig]
+        stations = [Station('JERB', lat, lon, elev, channels=channels)]
+        networks = [Network('XX', stations=stations)]
+        inventory = Inventory(networks=networks)
+
+        with io.BytesIO() as bio:
+            inventory.write(bio, 'STATIONXML')
+            bio.seek(0)
+            inv_got = read_inventory(bio, 'STATIONXML')
+
+        cha_got = inv_got[0][0][0]
+        assert cha_got.latitude.measurement_method == 'guesstimate'
+        assert cha_got.longitude.measurement_method == 'rule of thumb'
+        assert cha_got.elevation.measurement_method == 'echo sounder'
+        assert cha_got.depth.measurement_method is None


### PR DESCRIPTION
<!--
Before submitting a PR, please review the pull request guidelines:
https://github.com/obspy/obspy/blob/master/CONTRIBUTING.md#submitting-a-pull-request
-->

### What does this PR do?

Fixes a bug that `measurement_units` was not being accepted when making new objects of type `Latitude`, `Longitude` and `Distance` in inventory type classes.

Thanks to @WayneCrawford for the detailed breakdown and proposed fix in #3623

### Links to other Issues?

fixes #3623

### AI used?

No

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
