### PR TITLE
Fix rec_handler CFUNCTYPE return type in _write_mseed (void* vs void)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes:
  - obspy.io.mseed:
    * fix the type of exception raised when trying to read an empty file
      (see #3709)
+   * fix a void return type in write mseed ctypes wrapper (see #3735)
  - obspy.clients:
    * SDS client: fix handling of empty files (see #3709)
  - obspy.taup:

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -1115,7 +1115,7 @@ def _write_mseed(stream, filename, encoding=None, reclen=None, byteorder=None,
         def record_handler(record, reclen, _stream):
             f.write(record[0:reclen])
         # Define Python callback function for use in C function
-        rec_handler = C.CFUNCTYPE(C.c_void_p, C.POINTER(C.c_char), C.c_int,
+        rec_handler = C.CFUNCTYPE(None, C.POINTER(C.c_char), C.c_int,
                                   C.c_void_p)(record_handler)
 
         # Fill up msr record structure, this is already contained in


### PR DESCRIPTION
The `rec_handler` callback in `_write_mseed` is created with `C.c_void_p` as the CFUNCTYPE return type, but the C function it wraps returns `void` — as declared in [libmseed.h lines 618, 672, and 676](https://github.com/obspy/obspy/blob/0481d44798d839c776bea9bd973ed017d5586926/obspy/io/mseed/src/libmseed/libmseed.h#L618-L676). `c_void_p` means "returns a pointer", which is a different thing from no return value. The correct ctypes return type is `None`. The inconsistency is already visible within ObsPy: [headers.py line 688](https://github.com/obspy/obspy/blob/0481d44798d839c776bea9bd973ed017d5586926/obspy/io/mseed/headers.py#L688-L689) correctly declares the same callback as `CFUNCTYPE(None, ...)` in `mst_packgroup.argtypes`, while `core.py` creates the instance with `c_void_p`.

On native platforms this has probably no observable effect: `mst_pack` declares the callback as `void (*)( ...)` in C, and it never reads the return register after the call, so the mismatch is harmless. It does matter on emscripten/WASM (JupyterLite, pyjs, etc.), where every indirect call checks the function table entry's type signature exactly. `CFUNCTYPE(c_void_p, ...)` registers the libffi trampoline as WASM type `iiii` (i32 return + 3×i32 args), but `mst_pack` calls it as `viii` (void + 3×i32), producing `RuntimeError: function signature mismatch` in the browser and making MiniSEED writing completely broken in those environments.

The fix is changing `C.c_void_p` to `None` as the restype of the `rec_handler` CFUNCTYPE.

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run