### PR TITLE
CI: test new windows runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,7 @@ jobs:
       # this does not apply to tags
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2025-vs2026, macos-latest]
         build: [cp38, cp39, cp310, cp311, cp312, cp313, cp314]
         exclude-flag:
           - ${{ github.ref_name == 'master' && github.event_name == 'push' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025-vs2026]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         options: [default]
         include:
@@ -102,7 +102,7 @@ jobs:
           - os: macos-latest
             python-version: '3.10'
             options: default mindepversion
-          - os: windows-latest
+          - os: windows-2025-vs2026
             python-version: '3.10'
             options: default mindepversion
           # For push events and for test_network labels, options is set to 'network' and runs for network tests are added.
@@ -116,7 +116,7 @@ jobs:
           - os: macos-latest
             python-version: '3.14'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
-          - os: windows-latest
+          - os: windows-2025-vs2026
             python-version: '3.14'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
           # With warnings option pytest will fail on warnings.


### PR DESCRIPTION

### What does this PR do?

Test new windows runners that github will switch the `windows-latest` target to in June 2026 before the switch happens. If everything goes well we can just close this PR unmerged and stay with the `windows-latest` target.

see https://github.com/actions/runner-images/labels/Announcement

### Links to other Issues?

-- 

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
