### PR TITLE
update earthscope realtime seedlink server address

### DIFF
--- a/obspy/clients/seedlink/tests/example_SL_RTTrace.py
+++ b/obspy/clients/seedlink/tests/example_SL_RTTrace.py
@@ -113,7 +113,7 @@ def main():
     # slClient.slconn.set_sl_address("discovery.rm.ingv.it:39962")
     # slClient.multiselect = ("IV_MGAB:BHZ")
     #
-    # slClient.slconn.set_sl_address("rtserve.iris.washington.edu:18000")
+    # slClient.slconn.set_sl_address("rtserve.earthscope.org:18000")
     # slClient.multiselect = ("AT_TTA:BHZ")
     #
     # set a time window from 2 min in the past to 5 sec in the future

--- a/obspy/clients/seedlink/tests/test_slclient.py
+++ b/obspy/clients/seedlink/tests/test_slclient.py
@@ -52,7 +52,7 @@ class TestSLClient():
         __name__ != '__main__', reason='test must be started manually')
     def test_issue708(self):
         sl_client = SLClient()
-        sl_client.slconn.set_sl_address("rtserve.iris.washington.edu:18000")
+        sl_client.slconn.set_sl_address("rtserve.earthscope.org:18000")
         sl_client.multiselect = ("G_FDFM:00BHZ, G_SSB:00BHZ")
         # set a time window from 2 min - 1 min in the past
         dt = UTCDateTime()


### PR DESCRIPTION
### What does this PR do?

Change two occurrences in the tests connecting to old IRIS seedlink server with new Earthscope address. See https://groups.google.com/a/earthscope.org/g/data-announcements/c/F-1w-B9f96k

That test that is skipped by default passes when run locally.

### Links to other Issues?

--

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: ~~Added new tests for any new features or fixed regressions~~ No code changes
- [x] **Changelog**: ~~Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)~~ Not needed as it only affects some testing code
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
