### PR TITLE
MSEED: fallback from np.memmap to np.frombuffer in case memmap is not implemented

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changes:
    * fix the type of exception raised when trying to read an empty file
      (see #3709)
    * fix a void return type in write mseed ctypes wrapper (see #3735)
+   * fix reading in case when numpy.memmap is not implemented (see #3741)
  - obspy.clients:
    * SDS client: fix handling of empty files (see #3709)
  - obspy.taup:

--- a/obspy/io/mseed/core.py
+++ b/obspy/io/mseed/core.py
@@ -449,7 +449,11 @@ def _read_mseed(mseed_object, starttime=None, endtime=None, headonly=False,
         if os.path.getsize(mseed_object) == 0:
             bfr_np = np.array([], dtype=np.int8)
         else:
-            bfr_np = np.memmap(mseed_object, dtype=np.int8, mode="c")
+            try:
+                bfr_np = np.memmap(mseed_object, dtype=np.int8, mode="c")
+            except (AttributeError, OSError, NotImplementedError):
+                with open(mseed_object, "rb") as f:
+                    bfr_np = from_buffer(f.read(), dtype=np.int8)
 
     elif hasattr(mseed_object, 'read'):
         bfr_np = from_buffer(mseed_object.read(), dtype=np.int8)

--- a/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
+++ b/obspy/io/mseed/tests/test_mseed_reading_and_writing.py
@@ -405,6 +405,20 @@ class TestMSEEDReadingAndWriting():
             assert stream[0].stats.get('channel') == 'LHE'
             assert np.all(stream[0].data[0:5] ==
                           [-1134, -962, -293, -161, -587])
+        # Test whether fallback from np.memorymap to np.frombuffer works
+        with mock.patch("numpy.memmap",
+                        side_effect=OSError("memmap not supported")):
+            stream = _read_mseed(testdata["CH.BALST..LHE.D.2025.314"])
+            stream.verify()
+            assert len(stream) == 1
+            assert stream[0].stats.network == 'CH'
+            assert stream[0].stats['station'] == 'BALST'
+            assert stream[0].stats.get('location') == ''
+            assert stream[0].stats.npts == 86343
+            assert stream[0].stats['sampling_rate'] == 1.0
+            assert stream[0].stats.get('channel') == 'LHE'
+            assert np.all(stream[0].data[0:5] ==
+                          [-1134, -962, -293, -161, -587])
 
     def test_read_partial_time_window_from_file(self, testdata):
         """


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue that reading of miniseed files fails in case numpy.memmap is not implemented. In this case, the code will now read the file into a buffer the classic way. Also, the tests are updated to include a test of the fallback solution.

### Links to other Issues?

See #3731

### AI used?

No

### PR Checklist

- [X] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [X] **Tests**: Added new tests for any new features or fixed regressions
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
