### PR TITLE
Fix freqattributes.spectrum to honour n1/n2 sub-window (fixes #3491)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,12 @@ master
 ======
 
 Changes:
- - ...
+ - obspy.signal:
+   * freqattributes.spectrum now honours the n1/n2 sub-window arguments (they
+     were previously ignored), which also fixes freqattributes.welch so that it
+     averages periodograms of distinct, correctly-sized sections instead of
+     repeatedly spectrum-ing the whole array (or raising a broadcasting error
+     for section lengths shorter than the data) (see #3491)
 
 maintenance_1.5.x
 =================

--- a/obspy/signal/freqattributes.py
+++ b/obspy/signal/freqattributes.py
@@ -48,7 +48,7 @@ def spectrum(data, win, nfft, n1=0, n2=0):
         n2 = len(data)
     n = n2 - n1
     u = pow(np.linalg.norm([win]), 2) / n
-    xw = data * win
+    xw = data[n1:n2] * win
     px = pow(abs(fftpack.fft(xw, nfft)), 2) / (n * u)
     px[0] = px[1]
     return px
@@ -76,15 +76,16 @@ def welch(data, win, nfft, l=0, over=0):  # NOQA
     """
     if (l == 0):  # NOQA
         l = len(data)  # NOQA
-    n1 = 0
-    n2 = l
-    n0 = (1. - float(over)) * l
-    nsect = 1 + int(np.floor((len(data) - l) / (n0)))
+    # Hop between successive (possibly overlapping) sections. Each section has
+    # exactly ``l`` samples so it matches the length of ``win``.
+    step = int(round((1. - float(over)) * l))
+    if step < 1:
+        step = 1
+    nsect = 1 + (len(data) - l) // step
     px = 0
     for _i in range(nsect):
-        px = px + spectrum(data, win, nfft, n1, n2) / nsect
-        n1 = n1 + n0
-        n2 = n2 + n0
+        n1 = _i * step
+        px = px + spectrum(data, win, nfft, n1, n1 + l) / nsect
     return px
 
 

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -139,6 +139,63 @@ class TestFreqTrace():
                       np.sum(self.res[:, 13] ** 2))
         assert rms < 1.0e-5
 
+    def test_spectrum_respects_n1_n2(self):
+        """spectrum() must use the n1:n2 sub-window, not the whole array.
+
+        See #3491: previously n1 and n2 only affected the normalisation
+        scalar while the FFT was always computed on the full ``data``, so
+        changing them did not change the result.
+        """
+        rng = np.random.default_rng(42)
+        n = 1024
+        nfft = 256
+        data = rng.standard_normal(n)
+        win = signal.windows.hamming(n // 2)
+        # Selecting the first half must equal computing on the sliced data.
+        sub = freqattributes.spectrum(data, win, nfft, 0, n // 2)
+        manual = freqattributes.spectrum(data[0:n // 2], win, nfft, 0, n // 2)
+        np.testing.assert_allclose(sub, manual)
+        # The first and second halves of the signal must give different
+        # spectra (they did not before the fix).
+        second = freqattributes.spectrum(data, win, nfft, n // 2, n)
+        assert not np.allclose(sub, second)
+        # Default arguments still return the periodogram of the whole array.
+        full_win = signal.windows.hamming(n)
+        np.testing.assert_allclose(
+            freqattributes.spectrum(data, full_win, nfft),
+            freqattributes.spectrum(data, full_win, nfft, 0, n))
+
+    def test_welch_averages_distinct_sections(self):
+        """welch() must average periodograms of distinct sliding sections.
+
+        See #3491: because spectrum() ignored n1/n2, welch() effectively
+        averaged the spectrum of the whole array with itself, and using a
+        section length shorter than the data raised a broadcasting error.
+        """
+        rng = np.random.default_rng(7)
+        n = 1024
+        nfft = 256
+        data = rng.standard_normal(n)
+        section = n // 4
+        over = 0.5
+        win = signal.windows.hamming(section)
+        px = freqattributes.welch(data, win, nfft, l=section, over=over)
+        # Reproduce the expected average of length-``section`` sliding windows.
+        step = int(round((1.0 - over) * section))
+        nsect = 1 + (n - section) // step
+        ref = 0
+        for i in range(nsect):
+            ref = ref + freqattributes.spectrum(
+                data, win, nfft, i * step, i * step + section) / nsect
+        np.testing.assert_allclose(px, ref)
+        assert nsect > 1
+        # A full-length window collapses to a single section equal to
+        # spectrum() of the whole array (unchanged legacy behaviour).
+        full_win = signal.windows.hamming(n)
+        np.testing.assert_allclose(
+            freqattributes.welch(data, full_win, nfft),
+            freqattributes.spectrum(data, full_win, nfft, 0, n))
+
     def test_pgm(self):
         """
         """


### PR DESCRIPTION
## What

Fixes #3491.

`obspy.signal.freqattributes.spectrum(data, win, nfft, n1, n2)` documents `n1`/`n2` as start/end indices into the input series (*"If n1 and n2 are not specified the periodogram of the entire sequence is returned"*), but they were only used to form the normalisation scalar `n = n2 - n1` — the FFT was always taken over the **whole** `data` array (`xw = data * win`). So changing `n1`/`n2` had no effect on the output.

As a direct consequence, `welch()` — which advances `n1`/`n2` to average periodograms of sliding sections — actually averaged the spectrum of the whole array with itself (returning the single-section result), and raised `ValueError: operands could not be broadcast together` whenever the section length `l` was shorter than the data, because the (float) section indices were never applied to `data`.

## Fix

- `spectrum()`: compute the FFT on the requested sub-window, `xw = data[n1:n2] * win`.
- `welch()`: rewrite the loop to step over fixed-length, integer-indexed sections (`step = round((1 - over) * l)`, guarding `step >= 1` so `over = 1` no longer divides by zero), so each section is exactly `l` samples and matches `win`.

## Backwards compatibility

Default behaviour is unchanged:
- `spectrum(data, win, nfft)` → `n1 = 0, n2 = len(data)` → periodogram of the whole array (identical to before).
- A full-length window collapses `welch()` to a single section equal to `spectrum()` of the whole array — this is exactly how `welch()` is used internally by `central_frequency_unwindowed`, so that path is unaffected.

Only previously-broken cases change: passing non-default `n1`/`n2`, or `welch()` with a section shorter than the data (which used to raise).

## Note on scaling

The issue also notes that `spectrum()`/`welch()` are not scaled to a true PSD/ESD. That is a separate, output-magnitude-changing concern with backwards-compatibility implications, so it is intentionally left out of this PR, which targets the indexing bug.

## Tests

Existing `test_freqattributes.py` passes unchanged. Added two regression tests (`test_spectrum_respects_n1_n2`, `test_welch_averages_distinct_sections`) that fail on `master` and pass with the fix. flake8 clean; CHANGELOG updated.