### PR TITLE
Keep stream unchanged when ->ZNE rotation fails (fixes #2692)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,11 @@ master
 ======
 
 Changes:
- - ...
+ - obspy.core:
+   * Stream.rotate(method="->ZNE", ...) no longer modifies the stream in place
+     when the rotation fails (e.g. because orientation metadata is missing from
+     the inventory); the original traces are now kept until the rotation has
+     fully succeeded (see #2692)
 
 maintenance_1.5.x
 =================

--- a/obspy/core/stream.py
+++ b/obspy/core/stream.py
@@ -3606,9 +3606,12 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         st = self.select(network=network, station=station, location=location)
         st = (st.select(channel=channels[0]) + st.select(channel=channels[1]) +
               st.select(channel=channels[2]))
-        # remove the original unrotated traces from the stream
-        for tr in st.traces:
-            self.remove(tr)
+        # Remember the original traces but do not modify the stream yet: a
+        # failing rotation must leave the input stream unchanged (see #2692).
+        # All work is therefore done on a copy and only committed back to the
+        # stream once the rotation has fully succeeded.
+        original_traces = list(st.traces)
+        st = st.copy()
         # cut data so that we end up with a set of matching pieces for the tree
         # components (i.e. cut away any parts where one of the three components
         # has no data)
@@ -3623,6 +3626,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
                    "report on github.")
             raise NotImplementedError(msg)
         num_pieces = int(len(st) / 3)
+        rotated_traces = []
         for i in range(num_pieces):
             # three consecutive traces are always the ones that combine for one
             # rotation run
@@ -3642,7 +3646,12 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
             for tr, new_data, component in zip(traces, zne, "ZNE"):
                 tr.data = new_data
                 tr.stats.channel = tr.stats.channel[:-1] + component
-            self.traces += traces
+            rotated_traces += traces
+        # The rotation succeeded for all pieces, so it is now safe to replace
+        # the original (unrotated) traces with the rotated ones.
+        for tr in original_traces:
+            self.remove(tr)
+        self.traces += rotated_traces
         return self
 
     def newbyteorder(self, byteorder='native'):

--- a/obspy/core/tests/test_stream.py
+++ b/obspy/core/tests/test_stream.py
@@ -2724,6 +2724,34 @@ class TestStream:
         # check that rotation to ZNE worked..
         assert set(tr.stats.channel[-1] for tr in result) == set('ZNE')
 
+    def test_rotate_to_zne_failure_keeps_stream_unchanged(self):
+        """
+        A failing ``->ZNE`` rotation must not modify the stream in place.
+
+        See #2692: the rotation used to remove (and trim) the original traces
+        before the metadata lookup, so a failure (e.g. metadata missing from
+        the inventory) left the stream corrupted or empty.
+        """
+        traces = []
+        for component in "12Z":
+            tr = Trace(np.arange(100, dtype=np.float64))
+            tr.stats.network = "BW"
+            tr.stats.station = "FFB1"
+            tr.stats.location = ""
+            tr.stats.channel = "HH" + component
+            tr.stats.starttime = UTCDateTime(0)
+            tr.stats.sampling_rate = 100.0
+            traces.append(tr)
+        st = Stream(traces)
+        st_before = st.copy()
+        # an empty inventory has no orientation metadata, so the rotation fails
+        inv = Inventory(networks=[], source="test")
+        with pytest.raises(Exception):
+            st.rotate("->ZNE", inventory=inv)
+        # the stream must be completely unchanged
+        assert len(st) == 3
+        assert st == st_before
+
     def test_write_empty_stream(self):
         """
         Tests error message when trying to write an empty stream


### PR DESCRIPTION
## What

Fixes #2692.

`Stream.rotate(method="->ZNE", inventory=...)` modifies the stream in place *before* the rotation can fail. In `_rotate_specific_channels_to_zne()` the original traces are removed from the stream (and `_trim_common_channels()` trims them in place) up front, but the metadata lookup (`metadata_getter`) and `rotate2zne()` happen afterwards. If any of those fails — most commonly because the inventory has no orientation metadata for one of the channels — the traces have already been removed/trimmed, leaving the stream **corrupted or completely empty**.

### Reproduce

```python
import numpy as np
from obspy import Trace, Stream, UTCDateTime
from obspy.core.inventory import Inventory

st = Stream([Trace(np.arange(100.), header={
    'network': 'BW', 'station': 'FFB1', 'location': '',
    'channel': 'HH' + c, 'sampling_rate': 100.0,
    'starttime': UTCDateTime(0)}) for c in '12Z'])

inv = Inventory(networks=[], source='test')  # no metadata -> rotation fails
try:
    st.rotate('->ZNE', inventory=inv)
except Exception:
    pass
print(len(st))   # master: 0  (stream wiped!)  -> expected: 3
```

## Fix

Do all of the work (trim, sort, metadata lookup, rotation) on a **copy**, and only commit the result back to the stream — removing the original traces and appending the rotated ones — once the rotation has fully succeeded.

## Backwards compatibility

The successful path is unchanged: verified against the existing `->ZNE` test data (`ffbx_unrotated_gaps.mseed` + `ffbx.stationxml`), which still rotates BH1/BH2/BHZ and HH1/HH2/HHZ (with gaps) to ZNE exactly as before. All existing rotation tests pass (`test_stream.py` + `test_rotate.py`).

## Tests

Added `test_rotate_to_zne_failure_keeps_stream_unchanged`, which asserts the stream is intact after a failed rotation. It fails on `master` (stream becomes empty) and passes with the fix. flake8 clean; CHANGELOG updated.