### PR TITLE
Fix NDK format autodetection for negative hypocenter depth (fixes #2823)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,11 @@ master
 ======
 
 Changes:
- - ...
+ - obspy.io.ndk:
+   * fix format autodetection (_is_ndk) for NDK files whose hypocenter depth is
+     negative; depths are in kilometres and may be negative (e.g. events above
+     sea level), but the check assumed metres and rejected negative values
+     (see #2823)
 
 maintenance_1.5.x
 =================

--- a/obspy/io/ndk/core.py
+++ b/obspy/io/ndk/core.py
@@ -126,9 +126,13 @@ def _is_ndk(filename):
     except ValueError:
         return False
 
+    # The depth is given in kilometres and, according to the NDK format
+    # documentation, may be negative (e.g. for events located above sea
+    # level). The previous check assumed metres and rejected negative depths,
+    # so some valid NDK files failed format autodetection (see #2823).
     if (-90.0 <= latitude <= 90.0) and \
             (-180.0 <= longitude <= 180.0) and \
-            (0 <= depth <= 800000):
+            (-10 <= depth <= 800):
         return True
     return False
 

--- a/obspy/io/ndk/tests/test_ndk.py
+++ b/obspy/io/ndk/tests/test_ndk.py
@@ -77,6 +77,21 @@ class TestNDK():
         for filename in invalid_files:
             assert not _is_ndk(filename)
 
+    def test_is_ndk_negative_depth(self, testdata):
+        """
+        _is_ndk() must accept files whose hypocenter depth is negative.
+
+        Depths in NDK files are given in kilometres and may be negative (e.g.
+        for events located above sea level), see #2823. The depth field of the
+        first record occupies columns 42:47 of the header line.
+        """
+        with open(testdata['C200604092050A.ndk'], "rt") as fh:
+            content = fh.read()
+        first_line, _, rest = content.partition("\n")
+        # original depth is " 34.6"; replace it with a negative depth
+        modified = first_line[:42] + " -1.1" + first_line[47:] + "\n" + rest
+        assert _is_ndk(io.StringIO(modified))
+
     def test_reading_using_obspy_plugin(self, testdata):
         """
         Checks that reading with the read_events() function works correctly.


### PR DESCRIPTION
## What

Fixes #2823.

`read_events()` fails to autodetect the NDK format for some valid GCMT events (it raises `Unknown format for file`), even though reading works fine when the format is specified explicitly.

`obspy.io.ndk.core._is_ndk()` validates the first-record hypocenter depth with `(0 <= depth <= 800000)`. As @ThomasLecocq diagnosed in the issue, this assumes the depth is in **metres** and forbids negative values — but per the [NDK format documentation](https://www.ldeo.columbia.edu/~gcmt/projects/CMT/catalog/allorder.ndk_explained) the depth is in **kilometres** and may legitimately be negative (e.g. an event located above sea level). The reporter's file has a depth of `-1.1`, so autodetection rejected it while `_read_ndk()` parses it without any problem.

## Fix

Relax the check to `(-10 <= depth <= 800)` (depth in km), exactly as suggested by the maintainer in the issue and confirmed by the reporter.

## Tests

Added `test_is_ndk_negative_depth`, which builds a record with a negative depth and asserts `_is_ndk()` accepts it. It fails on `master` and passes with the fix. The full `test_ndk.py` suite (20 tests) passes; flake8 clean; CHANGELOG updated.

Credit to @ThomasLecocq for diagnosing the root cause and proposing the bound.