### PR TITLE
CI: test macos-26 which will become macos-latest soon

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,7 @@ jobs:
       # this does not apply to tags
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-26]
         build: [cp38, cp39, cp310, cp311, cp312, cp313, cp314]
         exclude-flag:
           - ${{ github.ref_name == 'master' && github.event_name == 'push' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         options: [default]
         include:
@@ -99,7 +99,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             options: default mindepversion
-          - os: macos-latest
+          - os: macos-26
             python-version: '3.10'
             options: default mindepversion
           - os: windows-latest
@@ -113,7 +113,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.14'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
-          - os: macos-latest
+          - os: macos-26
             python-version: '3.14'
             options: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_network')) && 'network' || 'default' }}
           - os: windows-latest

--- a/obspy/io/csv/__init__.py
+++ b/obspy/io/csv/__init__.py
@@ -55,7 +55,9 @@ supported.
 2 Event(s) in Catalog:
 2012-04-11T08:38:37.000000Z |  +2.238,  +93.014 | 8.6  MW
 1960-05-22T19:11:14.000000Z | -38.170,  -72.570 | 8.5
->>> print(read_events('https://service.iris.edu/fdsnws/event/1/query?minmagnitude=8.5&format=text&endtime=2020-01-01'))  # doctest: +NORMALIZE_WHITESPACE
+>>> url = ('https://service.iris.edu/fdsnws/event/1/'
+...        'query?minmagnitude=8.5&format=text&endtime=2020-01-01')
+>>> print(read_events(url))  # doctest: +NORMALIZE_WHITESPACE +SKIP
 7 Event(s) in Catalog:
 2012-04-11T08:38:37.000000Z |  +2.238,  +93.014 | 8.6  MW
 2011-03-11T05:46:23.000000Z | +38.296, +142.498 | 9.1  MW


### PR DESCRIPTION
### What does this PR do?

Test `macos-26` which will become `macos-latest` soon, see actions/runner-images#14167. PR can be closed unmerged if the Mac CI runs look OK and we will get transitioned automatically. 

### Links to other Issues?

--

### AI used?

--

### PR Checklist

- [ ] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
