### PR TITLE
FDSNWS auth tests: use credentials from environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,10 @@ jobs:
     # Ensure network tests dont fail build.
     continue-on-error: ${{ contains(matrix.options, 'network') || contains(matrix.options, 'warnings') }}
     env:
+      # set environment variables for FSNWS authenticated tests at EarthScope
+      OBSPY_TESTS_USER_AGENT: ${{ secrets.OBSPY_TESTS_USER_AGENT }}
+      OBSPY_TESTS_EARTHSCOPE_AUTH_USER: ${{ secrets.OBSPY_TESTS_EARTHSCOPE_AUTH_USER }}
+      OBSPY_TESTS_EARTHSCOPE_AUTH_PASSWORD: ${{ secrets.OBSPY_TESTS_EARTHSCOPE_AUTH_PASSWORD }}
       # set path of test environment for caching
       prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\test' }}
       # set individual cache key

--- a/obspy/clients/fdsn/tests/data/station_helpstring.txt
+++ b/obspy/clients/fdsn/tests/data/station_helpstring.txt
@@ -19,15 +19,9 @@ The service offers the following optional standard parameters:
         Specify minimum distance from the geographic point defined by latitude
         and longitude
     includerestricted (bool), Default value: True
-    includeavailability (bool)
-        Specify if results should include information about time series data
-        availability.
     updatedafter (UTCDateTime)
         Limit to metadata updated after specified date; updates are data center
         specific
-    matchtimeseries (bool)
-        Specify that the availabilities line up with available data. This is an
-        IRIS extension to the FDSN specification
     format (str), Default value: xml, Choices: xml, text
         Specify output format. This is an IRIS extension to the FDSN
         specification

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -10,6 +10,7 @@ The obspy.clients.fdsn.client test suite.
     (https://www.gnu.org/copyleft/lesser.html)
 """
 import io
+import os
 import re
 import socket
 import sys
@@ -55,7 +56,26 @@ from obspy.core.inventory import Response
 from obspy.geodetics import locations2degrees
 
 
-USER_AGENT = "ObsPy (test suite) " + " ".join(DEFAULT_USER_AGENT.split())
+# Custom user agent for running the test suite can be set using environment
+# variable OBSPY_TESTS_USER_AGENT, e.g. to let affected servers know what
+# traffic is coming from our CI runs. If not set has a still semi useful
+# default.
+USER_AGENT = (
+    os.environ.get("OBSPY_TESTS_USER_AGENT", "ObsPy (test suite)") +
+    " " + " ".join(DEFAULT_USER_AGENT.split()))
+# fetch credentials to be used when testing against EarthScope authenticated
+# FDSNWS ("queryauth" endpoints) from environment variables (which in CI will
+# be set through github actions secrets). Skip respective tests if not set.
+EARTHSCOPE_AUTH_USER = os.environ.get("OBSPY_TESTS_EARTHSCOPE_AUTH_USER")
+EARTHSCOPE_AUTH_PASSWORD = os.environ.get(
+    "OBSPY_TESTS_EARTHSCOPE_AUTH_PASSWORD")
+if EARTHSCOPE_AUTH_USER and EARTHSCOPE_AUTH_PASSWORD:
+    EARTHSCOPE_CREDENTIALS = True
+else:
+    EARTHSCOPE_CREDENTIALS = False
+MSG_NO_EARTHSCOPE_CREDENTIALS = (
+    "No credentials for EarthScope authentication set (via environment "
+    "variables)")
 
 
 def _normalize_stats(obj):
@@ -111,9 +131,13 @@ class TestClient():
     def setup_class(cls):
         cls.client = Client(base_url="EARTHSCOPE", user_agent=USER_AGENT)
         cls.client_ISC = Client(base_url="ISC", user_agent=USER_AGENT)
-        cls.client_auth = \
-            Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
-                   user="nobody@iris.edu", password="anonymous")
+        if EARTHSCOPE_AUTH_USER and EARTHSCOPE_AUTH_PASSWORD:
+            cls.client_auth = \
+                Client(base_url="EARTHSCOPE", user_agent=USER_AGENT,
+                       user=EARTHSCOPE_AUTH_USER,
+                       password=EARTHSCOPE_AUTH_PASSWORD)
+        else:
+            cls.client_auth = None
 
     # @pytest.mark.skip(reason='data no longer available')
     def test_trim_stream_after_get_waveform(self):
@@ -375,6 +399,8 @@ class TestClient():
             assert got == expected, \
                 "Dataselect failed for query %s" % repr(query)
 
+    @pytest.mark.skipif(
+        not EARTHSCOPE_CREDENTIALS, reason=MSG_NO_EARTHSCOPE_CREDENTIALS)
     def test_authentication(self, testdata):
         """
         Test dataselect with authentication.
@@ -645,7 +671,10 @@ class TestClient():
         authenticated bulk request.
         """
         if auth:
-            client = self.client_auth
+            if EARTHSCOPE_CREDENTIALS:
+                client = self.client_auth
+            else:
+                pytest.skip(MSG_NO_EARTHSCOPE_CREDENTIALS)
         else:
             client = self.client
 
@@ -719,7 +748,8 @@ class TestClient():
             del tr.stats._fdsnws_dataselect_url
         assert got == expected, failmsg(got, expected)
 
-    def test_station_bulk(self):
+    @pytest.mark.parametrize('auth', (True, False))
+    def test_station_bulk(self, auth):
         """
         Test bulk station requests, POSTing data to server. Also tests
         authenticated bulk request.
@@ -728,7 +758,14 @@ class TestClient():
         input types are tested with the waveform bulk downloader and thus
         should work just fine.
         """
-        clients = [self.client, self.client_auth]
+        if auth:
+            if EARTHSCOPE_CREDENTIALS:
+                client = self.client_auth
+            else:
+                pytest.skip(MSG_NO_EARTHSCOPE_CREDENTIALS)
+        else:
+            client = self.client
+
         # test cases for providing lists of lists
         starttime = UTCDateTime(1990, 1, 1)
         endtime = UTCDateTime(1990, 1, 1) + 10
@@ -738,46 +775,44 @@ class TestClient():
             ["IU", "COR", "", "UHZ", starttime, endtime],
             ["IU", "HRV", "", "LHN", starttime, endtime],
         ]
-        for client in clients:
-            # Test with station level.
-            inv = client.get_stations_bulk(bulk, level="station")
-            # Test with output to file.
-            with NamedTemporaryFile() as tf:
-                client.get_stations_bulk(
-                    bulk, filename=tf.name, level="station")
-                inv2 = read_inventory(tf.name, format="stationxml")
+        # Test with station level.
+        inv = client.get_stations_bulk(bulk, level="station")
+        # Test with output to file.
+        with NamedTemporaryFile() as tf:
+            client.get_stations_bulk(
+                bulk, filename=tf.name, level="station")
+            inv2 = read_inventory(tf.name, format="stationxml")
 
-            assert inv.networks == inv2.networks
-            assert len(inv.networks) == 1
-            assert inv[0].code == "IU"
-            assert len(inv.networks[0].stations) == 4
-            assert sorted([_i.code for _i in inv.networks[0].stations]) == \
-                sorted(["ANMO", "CCM", "COR", "HRV"])
+        assert inv.networks == inv2.networks
+        assert len(inv.networks) == 1
+        assert inv[0].code == "IU"
+        assert len(inv.networks[0].stations) == 4
+        assert sorted([_i.code for _i in inv.networks[0].stations]) == \
+            sorted(["ANMO", "CCM", "COR", "HRV"])
 
-            # Test with channel level.
-            inv = client.get_stations_bulk(bulk, level="channel")
-            # Test with output to file.
-            with NamedTemporaryFile() as tf:
-                client.get_stations_bulk(
-                    bulk, filename=tf.name, level="channel")
-                inv2 = read_inventory(tf.name, format="stationxml")
+        # Test with channel level.
+        inv = client.get_stations_bulk(bulk, level="channel")
+        # Test with output to file.
+        with NamedTemporaryFile() as tf:
+            client.get_stations_bulk(
+                bulk, filename=tf.name, level="channel")
+            inv2 = read_inventory(tf.name, format="stationxml")
 
-            assert inv.networks == inv2.networks
-            assert len(inv.networks) == 1
-            assert inv[0].code == "IU"
-            assert len(inv.networks[0].stations) == 4
-            assert sorted([_i.code for _i in inv.networks[0].stations]) == \
-                sorted(["ANMO", "CCM", "COR", "HRV"])
-            channels = []
-            for station in inv[0]:
-                for channel in station:
-                    channels.append("IU.%s.%s.%s" % (
-                        station.code, channel.location_code,
-                        channel.code))
-            assert sorted(channels) == \
-                sorted(["IU.ANMO..BHE", "IU.CCM..BHZ", "IU.COR..UHZ",
-                        "IU.HRV..LHN"])
-        return
+        assert inv.networks == inv2.networks
+        assert len(inv.networks) == 1
+        assert inv[0].code == "IU"
+        assert len(inv.networks[0].stations) == 4
+        assert sorted([_i.code for _i in inv.networks[0].stations]) == \
+            sorted(["ANMO", "CCM", "COR", "HRV"])
+        channels = []
+        for station in inv[0]:
+            for channel in station:
+                channels.append("IU.%s.%s.%s" % (
+                    station.code, channel.location_code,
+                    channel.code))
+        assert sorted(channels) == \
+            sorted(["IU.ANMO..BHE", "IU.CCM..BHZ", "IU.COR..UHZ",
+                    "IU.HRV..LHN"])
 
     def test_get_waveform_attach_response(self):
         """
@@ -1007,6 +1042,8 @@ class TestClient():
         # Just make sure something is being downloaded.
         assert bool(len(inv.networks))
 
+    @pytest.mark.skipif(
+        not EARTHSCOPE_CREDENTIALS, reason=MSG_NO_EARTHSCOPE_CREDENTIALS)
     def test_redirection_auth(self):
         """
         Tests the redirection of GET and POST requests using authentication.
@@ -1037,8 +1074,8 @@ class TestClient():
                        user_agent=USER_AGENT)
             # The force_redirect flag overwrites that behaviour.
             c_auth = Client("EARTHSCOPE", service_mappings=service_mappings,
-                            user="nobody@earthscope.org",
-                            password="anonymous",
+                            user=EARTHSCOPE_AUTH_USER,
+                            password=EARTHSCOPE_AUTH_PASSWORD,
                             user_agent=USER_AGENT, force_redirect=True)
         st = c_auth.get_waveforms(
             network="IU", station="ANMO", location="00", channel="BHZ",

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -180,7 +180,7 @@ class TestClient():
              "channel", "minlatitude", "maxlatitude", "minlongitude",
              "maxlongitude", "latitude", "longitude", "minradius",
              "maxradius", "level", "includerestricted", "format",
-             "includeavailability", "updatedafter", "matchtimeseries"}
+             "updatedafter"}
         assert {*client_ISC.services["event"].keys()} == \
             {"starttime", "endtime", "minlatitude", "maxlatitude",
              "minlongitude", "maxlongitude", "latitude", "longitude",

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1091,12 +1091,6 @@ class TestClient():
         # Just make sure something is being downloaded.
         assert bool(len(inv.networks))
 
-        cat = c_auth.get_events(starttime=UTCDateTime("2001-01-07T01:00:00"),
-                                endtime=UTCDateTime("2001-01-07T01:05:00"),
-                                catalog="ISC")
-        # Just make sure something is being downloaded.
-        assert bool(len(cat))
-
         # Also test the bulk requests which are done using POST requests.
         bulk = (("TA", "A25A", "", "BHZ",
                  UTCDateTime("2010-03-25T00:00:00"),


### PR DESCRIPTION
### What does this PR do?

Fixes authenticated FDSNWS tests. We had old "anonymous" credentials that presumably worked on old IRIS servers at some point, but nowadays with these dummy credentials we just get authentication errors back.

I made an account at Earthscope dedicated to only be used for authenticated requests during CI tests and put the credentials in github secrets for the repository which will then be picked up from environment variables during the test runs.

### Links to other Issues?

--

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
