### PR TITLE
deprecate Earthscope flinnengdahl web service

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,10 @@ Changes:
  - obspy.clients.filesystem:
    * tsindex: improve handling of sql sessions, less connections staying open
      (see #3736)
+ - obspy.clients.iris:
+   * deprecate flinnengdahl web service, which EarthScope announced will be
+     retired in July 2026. Users should use obspy.geodetics instead.
+     (see #3756)
  - obspy.io.mseed:
    * fix the type of exception raised when trying to read an empty file
      (see #3709)

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 import numpy as np
 
 from obspy import Stream, UTCDateTime, __version__, read
+from obspy.core.util.decorator import deprecated
 from obspy.core.util import NamedTemporaryFile
 
 
@@ -606,6 +607,10 @@ class Client(object):
         results['azimuth'] = float(data.azimuth)
         return results
 
+    @deprecated(
+        'EarthScope has announced the retirement of its Flinn-Engdahl web '
+        'service on or after July 6th 2026. Try using '
+        'obspy.geodetics.flinnengdahl instead.')
     def flinnengdahl(self, lat, lon, rtype="both"):
         """
         Low-level interface for `flinnengdahl` Web service of EarthScope
@@ -631,14 +636,17 @@ class Client(object):
 
         >>> from obspy.clients.iris import Client
         >>> client = Client()
-        >>> client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")
+        >>> client.flinnengdahl(
+        ...     lat=-20.5, lon=-100.6, rtype="code")  # doctest: +SKIP
         683
 
-        >>> print(client.flinnengdahl(lat=42, lon=-122.24, rtype="region"))
+        >>> print(client.flinnengdahl(
+        ...     lat=42, lon=-122.24, rtype="region"))  # doctest: +SKIP
         OREGON
 
-        >>> code, region = client.flinnengdahl(lat=-20.5, lon=-100.6)
-        >>> print(code, region)
+        >>> code, region = client.flinnengdahl(
+        ...     lat=-20.5, lon=-100.6)  # doctest: +SKIP
+        >>> print(code, region)  # doctest: +SKIP
         683 SOUTHEAST CENTRAL PACIFIC OCEAN
         """
         service = 'flinnengdahl'

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -4,14 +4,15 @@ The obspy.clients.iris.client test suite.
 """
 import numpy as np
 import pytest
+from unittest import mock
 
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
+from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.clients.iris import Client
 
-pytestmark = pytest.mark.network
 
-
+@pytest.mark.network
 class TestClient():
     """
     Test cases for obspy.clients.iris.client.Client.
@@ -75,47 +76,6 @@ class TestClient():
             client.distaz(stalat=1.1, stalon=1.2)
         with pytest.raises(Exception):
             client.distaz(1.1, 1.2)
-
-    def test_flinnengdahl(self):
-        """
-        Tests calculation of Flinn-Engdahl region code or name.
-        """
-        client = Client()
-        # code
-        result = client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")
-        assert result == 683
-        assert isinstance(result, int)
-        # w/o kwargs
-        result = client.flinnengdahl(-20.5, -100.6, "code")
-        assert result == 683
-        # region
-        result = client.flinnengdahl(lat=42, lon=-122.24, rtype="region")
-        assert result == 'OREGON'
-        assert isinstance(result, str)
-        # w/o kwargs
-        result = client.flinnengdahl(42, -122.24, "region")
-        assert result == 'OREGON'
-        # both
-        result = client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="both")
-        assert result == (683, 'SOUTHEAST CENTRAL PACIFIC OCEAN')
-        assert isinstance(result[0], int)
-        assert isinstance(result[1], str)
-        # w/o kwargs
-        result = client.flinnengdahl(-20.5, -100.6, "both")
-        assert result == (683, 'SOUTHEAST CENTRAL PACIFIC OCEAN')
-        # default rtype
-        result = client.flinnengdahl(lat=42, lon=-122.24)
-        assert result == (32, 'OREGON')
-        # w/o kwargs
-        # outside boundaries
-        with pytest.raises(Exception):
-            client.flinnengdahl(lat=-90.1, lon=0)
-        with pytest.raises(Exception):
-            client.flinnengdahl(lat=90.1, lon=0)
-        with pytest.raises(Exception):
-            client.flinnengdahl(lat=0, lon=-180.1)
-        with pytest.raises(Exception):
-            client.flinnengdahl(lat=0, lon=180.1)
 
     def test_traveltime(self):
         """
@@ -274,3 +234,13 @@ class TestClient():
         assert st1[0].stats.endtime == st2[0].stats.endtime
         assert st1[0].data[0] == 24
         assert round(abs(st2[0].data[0]--2.8373747e-06), 7) == 0
+
+
+def test_flinnengdahl_deprecation_warning():
+    with mock.patch('obspy.clients.iris.Client._fetch'):
+        client = Client()
+        msg = ('EarthScope has announced the retirement of its Flinn-Engdahl '
+               'web service on or after July 6th 2026. Try using '
+               'obspy.geodetics.flinnengdahl instead')
+        with pytest.warns(ObsPyDeprecationWarning, match=msg):
+            client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")


### PR DESCRIPTION

### What does this PR do?

Deprecates flinn-engdahl endpoint in our EarthScope web service client. Earthscope announced it will be retired on or after July 6th 2026, so it will stop working at that point. Also show a message mentioning geodetics module which has similar functions anyway.
Also already delete tests since they will stop working soon anyway.

### Links to other Issues?


--


### AI used?

--

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
