### PR TITLE
pytest: raise if '-m' command line option is used

### DIFF
--- a/obspy/conftest.py
+++ b/obspy/conftest.py
@@ -188,6 +188,13 @@ def pytest_configure(config):
     # Skip or select network options based on options
     network_selected = config.getoption('--network')
     all_selected = config.getoption('--all')
+    if getattr(config.option, "markexpr"):
+        msg = ('marker expressions (pytest option "-m") will be internally '
+               'overwritten in conftest.py and thus can not be used. '
+               'By default, tests marked as "network" will be excluded. This '
+               'behavior can be changed by custom options "--network" and '
+               '"--all".')
+        raise Exception(msg)
     if network_selected and not all_selected:
         setattr(config.option, 'markexpr', 'network')
     elif not network_selected and not all_selected:


### PR DESCRIPTION
### What does this PR do?

This makes pytest error out if CLI option `-m` is used, which can be confusing otherwise, since we overwrite it internally in `conftest.py` based on custom options `.

### Links to other Issues?

--

### AI used?

--


### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
