### PR TITLE
work around behavior change of numpy.linalg.eig with numpy 2.5

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,11 @@ maintenance_1.5.x
 =================
 
 Changes:
+ - General:
+   * add helper function that wraps around `numpy.linalg.eig` but always
+     mimicks the behavior of numpy <2.5, which is to downcast results to real
+     valued arrays when possible. Replacing all `numpy.linalg.eig` calls in the
+     code base with this wrapper (see #3760)
  - obspy.clients.fdsn:
    * update URL endpoint for IGN to https (see #3744)
  - obspy.clients.filesystem:

--- a/obspy/core/tests/test_util_misc.py
+++ b/obspy/core/tests/test_util_misc.py
@@ -4,12 +4,13 @@ import tempfile
 import warnings
 from unittest import mock
 
+import numpy as np
 import pytest
 
 from obspy import UTCDateTime, read
 from obspy.core.event import ResourceIdentifier as ResId
 from obspy.core.util.misc import CatchOutput, get_window_times, \
-    _ENTRY_POINT_CACHE, _yield_obj_parent_attr
+    _ENTRY_POINT_CACHE, _yield_obj_parent_attr, eig
 from obspy.core.util.base import CatchAndAssertWarnings
 
 
@@ -317,3 +318,26 @@ class TestUtilMisc:
 
         assert len(w) == 1
         assert 'something bad' in str(w[0].message)
+
+    def test_eig(self):
+        """
+        Test helper routine :func:`obspy.core.util.misc.eig` which is a drop in
+        replacement for :func:`numpy.linalg.eig` but mimicking the behavior of
+        numpy <2.5.
+        """
+        # test a matrix that will have real valued eigenvalues/-vectors
+        a = np.diag((1, 2, 3))
+        d_np, v_np = np.linalg.eig(a)
+        d, v = eig(a)
+        np.testing.assert_array_equal(d, d_np)
+        np.testing.assert_array_equal(v, v_np)
+        assert d.dtype == float
+        assert v.dtype == float
+        # test a matrix that will have complex valued eigenvalues/-vectors
+        a = np.array([[1, -1, 2], [4, -2, 1], [-2, 3, 4]])
+        d_np, v_np = np.linalg.eig(a)
+        d, v = eig(a)
+        np.testing.assert_array_equal(d, d_np)
+        np.testing.assert_array_equal(v, v_np)
+        assert d.dtype == complex
+        assert v.dtype == complex

--- a/obspy/core/util/misc.py
+++ b/obspy/core/util/misc.py
@@ -752,6 +752,31 @@ def ptp(a, *args, **kwargs):
     return np.ptp(a, *args, **kwargs)
 
 
+def eig(*args, **kwargs):
+    """
+    Drop in for :func:`numpy.linalg.eig()` which slightly changed behavior in
+    numpy 2.5, such that real valued outputs will not be returned downcast to
+    float anymore but left as complex with all imaginary parts zero. This might
+    not be accounted for in places where it is used across the code base.
+    In some cases it failed further down already because other numpy functions
+    refused to work on complex.
+    See #3760.
+    See `Numpy 2.5 release notes <np25notes>`_.
+
+    .. _np25notes: https://numpy.org/devdocs/release/2.5.0-notes.html#linalg-eig-and-linalg-eigvals-now-always-return-complex-arrays  # NOQA
+    """
+    d, v = np.linalg.eig(*args, **kwargs)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action='ignore', message='Casting complex values to real '
+            'discards the imaginary part')
+        if np.all(np.isreal(d)):
+            d = d.astype(float)
+        if np.all(np.isreal(v)):
+            v = v.astype(float)
+    return d, v
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(exclude_empty=True)

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -855,6 +855,16 @@ def mt2plane(mt):
     written by Andy Michael, Chen Ji and Oliver Boyd.
     """
     (d, v) = np.linalg.eig(mt.mt)
+    # numpy 2.5 changed behavior of eig which used to return real values
+    # when possible. so cast to float here
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action='ignore', message='Casting complex values to real '
+            'discards the imaginary part')
+        if np.all(np.isreal(d)):
+            d = d.astype(float)
+        if np.all(np.isreal(v)):
+            v = v.astype(float)
     d = np.array([d[1], d[0], d[2]])
     v = np.array([[v[1, 1], -v[1, 0], -v[1, 2]],
                  [v[2, 1], -v[2, 0], -v[2, 2]],

--- a/obspy/imaging/beachball.py
+++ b/obspy/imaging/beachball.py
@@ -31,6 +31,7 @@ import warnings
 import numpy as np
 from decorator import decorator
 
+from obspy.core.util.misc import eig
 
 D2R = np.pi / 180
 R2D = 180 / np.pi
@@ -854,17 +855,7 @@ def mt2plane(mt):
     `bb.m <http://www.ceri.memphis.edu/people/olboyd/Software/Software.html>`_
     written by Andy Michael, Chen Ji and Oliver Boyd.
     """
-    (d, v) = np.linalg.eig(mt.mt)
-    # numpy 2.5 changed behavior of eig which used to return real values
-    # when possible. so cast to float here
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            action='ignore', message='Casting complex values to real '
-            'discards the imaginary part')
-        if np.all(np.isreal(d)):
-            d = d.astype(float)
-        if np.all(np.isreal(v)):
-            v = v.astype(float)
+    (d, v) = eig(mt.mt)
     d = np.array([d[1], d[0], d[2]])
     v = np.array([[v[1, 1], -v[1, 0], -v[1, 2]],
                  [v[2, 1], -v[2, 0], -v[2, 2]],

--- a/obspy/imaging/scripts/mopad.py
+++ b/obspy/imaging/scripts/mopad.py
@@ -78,6 +78,7 @@ import sys
 import numpy as np
 
 from obspy import __version__
+from obspy.core.util.misc import eig
 
 
 MOPAD_VERSION = 0.7
@@ -343,10 +344,10 @@ class MomentTensor:
         self._deviatoric = M_devi
 
         # eigenvalues and -vectors
-        eigenwtot, eigenvtot = np.linalg.eig(M)
+        eigenwtot, eigenvtot = eig(M)
 
         # eigenvalues and -vectors of the deviatoric part
-        eigenw1, eigenv1 = np.linalg.eig(M_devi)
+        eigenw1, eigenv1 = eig(M_devi)
 
         # eigenvalues in ascending order:
         eigenw = np.real(np.take(eigenw1, np.argsort(abs(eigenwtot))))
@@ -421,7 +422,7 @@ class MomentTensor:
         self._deviatoric = M_devi
 
         # eigenvalues and -vectors of the deviatoric part
-        eigenw1, eigenv1 = np.linalg.eig(M_devi)
+        eigenw1, eigenv1 = eig(M_devi)
 
         # eigenvalues in ascending order of their absolute values:
         eigenw = np.real(np.take(eigenw1, np.argsort(abs(eigenw1))))
@@ -486,11 +487,11 @@ class MomentTensor:
         self._deviatoric = M_devi
 
         # eigenvalues and -vectors of the deviatoric part
-        eigenw1, eigenv1 = np.linalg.eig(M_devi)
+        eigenw1, eigenv1 = eig(M_devi)
         M0_devi = max(abs(eigenw1))
 
         # eigenvalues and -vectors of the full M !!!!!!!!
-        eigenw1, eigenv1 = np.linalg.eig(M)
+        eigenw1, eigenv1 = eig(M)
 
         # eigenvalues in ascending order of their absolute values:
         eigenw = np.real(np.take(eigenw1, np.argsort(abs(eigenw1))))

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -87,6 +87,18 @@ class Ellipse:
         if _almost_good_cov(cov):
             cov = _fix_cov(cov)
         evals, evecs = np.linalg.eig(cov)
+        # numpy 2.5 changed behavior of eig which used to return real values
+        # when possible. so cast to float here
+        with warnings.catch_warnings():
+            # numpy shows a warning about the cast, even if all imaginary parts
+            # are zero, which we test for here
+            warnings.filterwarnings(
+                action='ignore', message='Casting complex values to real '
+                'discards the imaginary part')
+            if np.all(np.isreal(evals)):
+                evals = evals.astype(float)
+            if np.all(np.isreal(evecs)):
+                evecs = evecs.astype(float)
         if np.any(evals < 0):
             cov_factor = cov[0][1]
             cov_base = cov/cov_factor

--- a/obspy/io/nordic/ellipse.py
+++ b/obspy/io/nordic/ellipse.py
@@ -20,6 +20,8 @@ import copy
 import io
 import warnings
 
+from obspy.core.util.misc import eig
+
 
 class Ellipse:
     def __init__(self, a, b, theta=0, center=(0, 0)):
@@ -86,19 +88,7 @@ class Ellipse:
         cov = np.array(cov)
         if _almost_good_cov(cov):
             cov = _fix_cov(cov)
-        evals, evecs = np.linalg.eig(cov)
-        # numpy 2.5 changed behavior of eig which used to return real values
-        # when possible. so cast to float here
-        with warnings.catch_warnings():
-            # numpy shows a warning about the cast, even if all imaginary parts
-            # are zero, which we test for here
-            warnings.filterwarnings(
-                action='ignore', message='Casting complex values to real '
-                'discards the imaginary part')
-            if np.all(np.isreal(evals)):
-                evals = evals.astype(float)
-            if np.all(np.isreal(evecs)):
-                evecs = evecs.astype(float)
+        evals, evecs = eig(cov)
         if np.any(evals < 0):
             cov_factor = cov[0][1]
             cov_base = cov/cov_factor

--- a/obspy/signal/array_analysis.py
+++ b/obspy/signal/array_analysis.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy.integrate import cumulative_trapezoid
 
 from obspy.core import Stream
+from obspy.core.util.misc import eig
 from obspy.signal.headers import clibsignal
 from obspy.signal.invsim import cosine_taper
 from obspy.signal.util import next_pow_2, util_geo_km
@@ -538,13 +539,13 @@ def array_rotation_strain(subarray, ts1, ts2, ts3, vp, vs, array_coords,
         # 9/14/92.ii.4, 7/21/06.ii.2(5)
 
         # eigvecs are principal axes, eigvals are principal strains
-        [eigvals, _eigvecs] = np.linalg.eig(gammah)
+        [eigvals, _eigvecs] = eig(gammah)
         # max shear strain, from Fung (1965, p71, eqn (8)
         ts_sh[itime] = .5 * (max(eigvals) - min(eigvals))
 
         # calculate max of total shear strain, not just horizontal strain
         # eigvecs are principal axes, eigvals are principal strains
-        [eigvalt, _eigvect] = np.linalg.eig(e)
+        [eigvalt, _eigvect] = eig(e)
         # max shear strain, from Fung (1965, p71, eqn (8)
         ts_s[itime] = .5 * (max(eigvalt) - min(eigvalt))
         #


### PR DESCRIPTION
### What does this PR do?

Replaces all use of `numpy.linalg.eig` in the code base with a helper function that calls it but will try to cast the results to float if possible. This is what numpy <2.5 did. We see some errors with new numpy because the results of numpy `eig` are used like real valued arrays which then results in errors since they now always were of complex type.

see [Numpy 2.5 release notes](https://numpy.org/devdocs/release/2.5.0-notes.html#linalg-eig-and-linalg-eigvals-now-always-return-complex-arrays)

### Links to other Issues?

--

### AI used?

--

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
