### PR TITLE
react to new Numpy 2.5 deprecation warnings

### DIFF
--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -891,7 +891,7 @@ class WaveformPlotting(object):
 
         # Create array for min/max values. Use masked arrays to handle gaps.
         extreme_values = np.ma.empty((noi, self.width, 2))
-        trace.data.shape = (noi, spi)
+        data = trace.data.reshape((noi, spi))
 
         ispp = int(spp)
         fspp = spp % 1.0
@@ -903,11 +903,11 @@ class WaveformPlotting(object):
         # Loop over each interval to avoid larger errors towards the end.
         for _i in range(noi):
             if delta:
-                cur_interval = trace.data[_i][:-delta]
-                rest = trace.data[_i][-delta:]
+                cur_interval = data[_i][:-delta]
+                rest = data[_i][-delta:]
             else:
-                cur_interval = trace.data[_i]
-            cur_interval.shape = (self.width, ispp)
+                cur_interval = data[_i]
+            cur_interval = cur_interval.reshape((self.width, ispp))
             extreme_values[_i, :, 0] = cur_interval.min(axis=1)
             extreme_values[_i, :, 1] = cur_interval.max(axis=1)
             # Add the rest.

--- a/obspy/io/mseed/util.py
+++ b/obspy/io/mseed/util.py
@@ -1598,7 +1598,7 @@ def shift_time_of_file(input_file, output_file, timeshift):
         is_time_correction_applied = bool(activity_flags & 2)
 
         current_time_shift = current_record[40:44]
-        current_time_shift.dtype = np.int32
+        current_time_shift = current_time_shift.view(dtype=np.int32)
         if do_swap:
             current_time_shift = current_time_shift.byteswap(False)
         current_time_shift = current_time_shift[0]
@@ -1630,9 +1630,9 @@ def shift_time_of_file(input_file, output_file, timeshift):
             second = time[6:7]
             msecs = time[8:10]
             # Change dtype of multibyte values.
-            year.dtype = np.uint16
-            julday.dtype = np.uint16
-            msecs.dtype = np.uint16
+            year = year.view(dtype=np.uint16)
+            julday = julday.view(dtype=np.uint16)
+            msecs = msecs.view(dtype=np.uint16)
             if do_swap:
                 year = year.byteswap(False)
                 julday = julday.byteswap(False)
@@ -1653,9 +1653,9 @@ def shift_time_of_file(input_file, output_file, timeshift):
                 julday = julday.byteswap(False)
                 msecs = msecs.byteswap(False)
             # Change dtypes back.
-            year.dtype = np.uint8
-            julday.dtype = np.uint8
-            msecs.dtype = np.uint8
+            year = year.view(dtype=np.uint8)
+            julday = julday.view(dtype=np.uint8)
+            msecs = msecs.view(dtype=np.uint8)
             # Write to current record.
             time[0:2] = year[:]
             time[2:4] = julday[:]
@@ -1670,7 +1670,7 @@ def shift_time_of_file(input_file, output_file, timeshift):
         current_time_shift = np.array([current_time_shift], np.int32)
         if do_swap:
             current_time_shift = current_time_shift.byteswap(False)
-        current_time_shift.dtype = np.uint8
+        current_time_shift = current_time_shift.view(dtype=np.uint8)
         current_record[40:44] = current_time_shift[:]
 
     # Write to the output file.
@@ -1770,7 +1770,7 @@ def spread_time_over_file(input_file, output_file, timeshift):
         is_time_correction_applied = bool(activity_flags & 2)
 
         current_time_shift = current_record[40:44]
-        current_time_shift.dtype = np.int32
+        current_time_shift = current_time_shift.view(dtype=np.int32)
         if do_swap:
             current_time_shift = current_time_shift.byteswap(False)
         current_time_shift = current_time_shift[0]
@@ -1802,9 +1802,9 @@ def spread_time_over_file(input_file, output_file, timeshift):
             second = time[6:7]
             msecs = time[8:10]
             # Change dtype of multibyte values.
-            year.dtype = np.uint16
-            julday.dtype = np.uint16
-            msecs.dtype = np.uint16
+            year = year.view(dtype=np.uint16)
+            julday = julday.view(dtype=np.uint16)
+            msecs = msecs.view(dtype=np.uint16)
             if do_swap:
                 year = year.byteswap(False)
                 julday = julday.byteswap(False)
@@ -1825,9 +1825,9 @@ def spread_time_over_file(input_file, output_file, timeshift):
                 julday = julday.byteswap(False)
                 msecs = msecs.byteswap(False)
             # Change dtypes back.
-            year.dtype = np.uint8
-            julday.dtype = np.uint8
-            msecs.dtype = np.uint8
+            year = year.view(dtype=np.uint8)
+            julday = julday.view(dtype=np.uint8)
+            msecs = msecs.view(dtype=np.uint8)
             # Write to current record.
             time[0:2] = year[:]
             time[2:4] = julday[:]
@@ -1843,7 +1843,7 @@ def spread_time_over_file(input_file, output_file, timeshift):
             current_time_shift = np.array([current_time_shift], np.int32)
             if do_swap:
                 current_time_shift = current_time_shift.byteswap(False)
-            current_time_shift.dtype = np.uint8
+            current_time_shift = current_time_shift.view(dtype=np.uint8)
             current_record[40:44] = current_time_shift[:]
 
     # Write to the output file.

--- a/obspy/io/segy/pack.py
+++ b/obspy/io/segy/pack.py
@@ -111,7 +111,7 @@ def pack_4byte_ibm(file, data, endian='>'):
     else:
         raise Exception
     # Write the zeros again.
-    new_data.dtype = np.uint32
+    new_data = new_data.view(dtype=np.uint32)
     new_data[zeros] = 0
     # Write to file.
     file.write(new_data.tobytes())

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -129,10 +129,9 @@ class TestSEGY():
 
                 # Test all other parts of the packed data. Set dtype to int32
                 # to get 4 byte numbers.
-                packed_data_copy = packed_data.copy()
-                new_packed_data_copy = new_packed_data.copy()
-                packed_data_copy.dtype = np.int32
-                new_packed_data_copy.dtype = np.int32
+                packed_data_copy = packed_data.view(dtype=np.int32).copy()
+                new_packed_data_copy = new_packed_data.view(
+                    dtype=np.int32).copy()
                 # Equalize the non normalized parts.
                 packed_data_copy[non_normalized] = \
                     new_packed_data_copy[non_normalized]
@@ -143,7 +142,7 @@ class TestSEGY():
                 # same.
                 data = data[non_normalized]
                 # Unpack the data again.
-                new_packed_data.dtype = np.int32
+                new_packed_data = new_packed_data.view(dtype=np.int32)
                 new_packed_data = new_packed_data[non_normalized]
                 length = len(new_packed_data)
                 f = io.BytesIO()
@@ -152,7 +151,7 @@ class TestSEGY():
                 new_data = DATA_SAMPLE_FORMAT_UNPACK_FUNCTIONS[1](
                     f, length, endian)
                 f.close()
-                packed_data.dtype = np.int32
+                packed_data = packed_data.view(dtype=np.int32)
                 packed_data = packed_data[non_normalized]
                 length = len(packed_data)
                 f = io.BytesIO()

--- a/obspy/signal/util.py
+++ b/obspy/signal/util.py
@@ -139,7 +139,7 @@ def enframe(x, win, inc):
     else:
         # length = next_pow_2(nwin)
         length = nwin
-    nf = int(np.fix((nx - length + inc) // inc))
+    nf = int(np.trunc((nx - length + inc) // inc))
     # f = np.zeros((nf, length))
     indf = inc * np.arange(nf)
     inds = np.arange(length) + 1
@@ -217,7 +217,7 @@ def rdct(x, n=0):
     if (n == 0):
         n = m
         a = np.sqrt(2 * n)
-        x = np.append([x[0:n:2, :]], [x[2 * int(np.fix(n / 2)):0:-2, :]],
+        x = np.append([x[0:n:2, :]], [x[2 * int(np.trunc(n / 2)):0:-2, :]],
                       axis=1)
         x = x[0, :, :]
         z = np.append(np.sqrt(2.), 2. * np.exp((-0.5j * float(np.pi / n)) *


### PR DESCRIPTION
### What does this PR do?

Adjusts to multiple new deprecation warnings that numpy 2.5 started issuing. See https://numpy.org/devdocs/release/2.5.0-notes.html#deprecations

 - setting `ndarray.shape` is deprecated
 - setting `ndarray.dtype` is deprecated
 - `np.fix` is deprecated

### Links to other Issues?

--

### AI used?

--

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
