### PR TITLE
adjust to a deprecation warning in pytest

### DIFF
--- a/obspy/core/tests/test_utcdatetime.py
+++ b/obspy/core/tests/test_utcdatetime.py
@@ -1526,7 +1526,7 @@ class TestUTCDateTime:
 
     @pytest.mark.parametrize(
         "path",
-        (Path(__file__).parent / "data" / "utc_pickles").glob("*.pkl")
+        tuple((Path(__file__).parent / "data" / "utc_pickles").glob("*.pkl"))
     )
     def test_read_old_pickles(self, path):
         """Load many old pickle files, ensure each can be unpickled."""


### PR DESCRIPTION
### What does this PR do?

Adjust to a deprecation warning in pytest, see https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize

### Links to other Issues?

--

### AI used?

--

### PR Checklist

- [ ] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
