### PR TITLE
codecov CI: ignore some files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -35,3 +35,8 @@ flags:
     carryforward: true
   unittests_network:
     carryforward: true
+
+# ignore some files that codecov thinks is code
+ignore:
+  - "obspy/io/ah/tests/data/ah1.*"
+  - "obspy/io/ah/tests/data/ah2.*"


### PR DESCRIPTION
### What does this PR do?

Make codecov ignore some files it thinks are C code

```
warning - 2026-06-30 10:29:54,648 -- There was an issue decoding: obspy/io/ah/tests/data/ah1.c, file fixes were not applied to this file.
warning - 2026-06-30 10:29:54,648 -- There was an issue decoding: obspy/io/ah/tests/data/ah2.c, file fixes were not applied to this file.
```


### Links to other Issues?

--

### AI used?

--

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
