### PR TITLE
signal: fix dominant_period for single (1D) traces

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,10 @@ Changes:
    * fix a void return type in write mseed ctypes wrapper (see #3735)
    * fix reading in case when numpy.memmap is not implemented (see #3741)
    * Memory leak fixed in obspy-readbuffer.c (see #3714)
+ - obspy.signal:
+   * freqattributes.dominant_period no longer raises on a single (1D) trace
+     and now reads the dominant frequency from the amplitude spectrum instead
+     of the raw time-domain samples (see #2576)
  - obspy.taup:
    * fix an issue with obspy.taup not being usable with specific Python
      versions 3.13.10 and 3.14.1 (see #3650)

--- a/obspy/signal/freqattributes.py
+++ b/obspy/signal/freqattributes.py
@@ -244,9 +244,9 @@ def dominant_period(data, fs, smoothie, fk):
     freqaxis = np.linspace(0, fs, nfft + 1)
     dperiod = np.zeros(data.shape[0])
     f = fftpack.fft(data, nfft)
-    # f_sm = util.smooth(abs(f[:,0:nfft // 2]),1)
-    f_sm = f[:, 0:nfft // 2]
     if np.size(data.shape) > 1:
+        # f_sm = util.smooth(abs(f[:,0:nfft // 2]),1)
+        f_sm = f[:, 0:nfft // 2]
         i = 0
         for row in f_sm:
             [mdist_ind, _mindist] = max(enumerate(abs(row)), key=itemgetter(1))
@@ -268,7 +268,8 @@ def dominant_period(data, fs, smoothie, fk):
         ddperiod = util.smooth(ddperiod, smoothie)
         return dperiod, ddperiod
     else:
-        [mdist_ind, _mindist] = max(enumerate(abs(data)), key=itemgetter(1))
+        f_sm = f[0:nfft // 2]
+        [mdist_ind, _mindist] = max(enumerate(abs(f_sm)), key=itemgetter(1))
         dperiod = freqaxis[mdist_ind]
         return dperiod
 

--- a/obspy/signal/tests/test_freqattributes.py
+++ b/obspy/signal/tests/test_freqattributes.py
@@ -124,6 +124,26 @@ class TestFreqTrace():
                       np.sum(self.res[:, 15] ** 2))
         assert rms < 1.0e-5
 
+    def test_domper_1d(self):
+        """
+        Regression test for a single, non-windowed trace, see #2576.
+
+        This used to raise an IndexError because a 2D slice of the spectrum
+        was taken before the dimensionality check. The 1D branch also read
+        the raw time-domain samples instead of the amplitude spectrum, so the
+        returned value was meaningless.
+        """
+        fs = 100.0
+        f0 = 10.0
+        t = np.arange(2000) / fs
+        sine = np.sin(2 * pi * f0 * t)
+        dperiod = freqattributes.dominant_period(sine, fs, self.smoothie,
+                                                 self.fk)
+        # a single trace returns one value, not the (dperiod, ddperiod) tuple
+        assert np.ndim(dperiod) == 0
+        # the peak of the amplitude spectrum sits on the injected frequency
+        assert abs(dperiod - f0) < 0.2
+
     def test_logcep(self):
         """
         """


### PR DESCRIPTION
### What does this PR do?

This fixes `freqattributes.dominant_period`, which was broken for the normal single-trace case. The `f[:, 0:nfft // 2]` slice ran before the `data.shape` check, so a 1D input tried a 2D index and raised `IndexError: too many indices`. The 1D branch was also taking the max over the raw time-domain samples and then reading that index off the frequency axis, so even without the crash the returned "dominant period" didn't really mean anything. I moved the slice into the 2D branch and had the 1D branch read the amplitude spectrum, which is what the windowed path already does per row. Thanks to @ThomasLecocq for pinning down the exact lines in the issue.

I added a regression test that feeds a 1D sine at a known frequency and checks the result lands on that frequency's bin; the existing windowed test is unchanged and still passes.

### Links to other Issues?

fixes #2576

### AI used?

Yes. I used Claude Code to help find the offending lines and draft the fix and the test. I went through the change myself and confirmed it locally before opening this.

### PR Checklist

- [x] Correct **base branch** selected? (`maintenance_1.5.x`, this is a bug fix)
- [x] **Tests**: Added a regression test for the 1D case
- [x] **Changelog**: Added a short note in `CHANGELOG.txt`
