### PR TITLE
seedlink client: fix seedlink client not respecting user set timeout

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,12 @@ Changes:
    * deprecate flinnengdahl web service, which EarthScope announced will be
      retired in July 2026. Users should use obspy.geodetics instead.
      (see #3756)
+ - obspy.clients.seedlink:
+   * respect user specified timeout also in making the initial socket
+     connection. Currently, when establishing the initial low-level socket
+     connection no timeout is used, which in practice leads to a default 2min
+     timeout even if user sets a shorter timeout when establishing the client
+     (see #3767)
  - obspy.imaging:
    * fix a bug in dayplot when data is only available for part of the time
      window (see #3780)

--- a/obspy/clients/seedlink/client/seedlinkconnection.py
+++ b/obspy/clients/seedlink/client/seedlinkconnection.py
@@ -1028,8 +1028,6 @@ class SeedLinkConnection(object):
             server.
         :raise IOError: if an I/O error occurs.
         """
-        timeout = 4.0
-
         try:
             host_name = self.sladdr[0:self.sladdr.find(':')]
             nport = int(self.sladdr[self.sladdr.find(':') + 1:])
@@ -1040,6 +1038,7 @@ class SeedLinkConnection(object):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 65536)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            sock.settimeout(self.timeout)
             # print("DEBUG: sock.connect:", self.sladdr, host_name, nport)
             sock.connect((host_name, nport))
             # print("DEBUG: sock.connect: sock:", sock)
@@ -1048,8 +1047,8 @@ class SeedLinkConnection(object):
             self.socket = sock
 
             # Check if socket is connected
-            if not self.is_connected(timeout):
-                msg = "socket connect time-out %ss" % (timeout)
+            if not self.is_connected(self.timeout):
+                msg = f"socket connect time-out {self.timeout}s"
                 try:
                     self.socket.close()
                 except Exception:


### PR DESCRIPTION
### What does this PR do?

Currently when making the initial low-level socket connection for the seedlink client, no timeout is set, even if the client has a 20s default timeout and users can specify an even shorter one on `Client()` initialization. This leads to socket connection in some cases (unreachable server, wrong address, ...) timing out with a presumable default, which I found to be around 120s.
Fix this by also setting the client's stored timeout during the socket connection, so that shorter timeout on bad connections can be achieved.

Also remove a hard coded timeout inside the routine, which looks like it never did anything (since the blocking call is above it anyway) and replace it with the client's timeout (probably doesn't change anything, but for good measure..).

Not really sure how to properly test this, so no new tests for this were added.
The timeout happens in `socket.socket.connect()` which also includes DNS lookup and all kinds of things. In any case this change fixes the issue for me when trying to connect to a known seedlink server internet address which has a connection issue (meaning DNS lookup is likely working and done but the located IP address is not answering).


### Links to other Issues?

--

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
