### PR TITLE
FDSN Client accepts a list of base_url entries and merges endpoints.  Default changed to "EARTHSCOPE","USGS"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,10 @@ Changes:
      'measurement_units' when being initialized (see #3623)
  - obspy.clients.fdsn:
    * update URL endpoint for IGN to https (see #3744)
+   * FDSN Client `base_url` can be a list of datacenter shortcuts/URLs;
+     services missing from earlier entries are filled in from later ones
+     without overwriting. Default is now `["EARTHSCOPE", "USGS"]` so
+     event queries work after EarthScope dropped its event service.
  - obspy.clients.filesystem:
    * tsindex: improve handling of sql sessions, less connections staying open
      (see #3736)
@@ -42,7 +46,7 @@ Changes:
      mindepversion tests
    * Minimum Dependencies: numpy 1.21 (was 1.20) (see #3639)
  - obspy.core:
-   * response: tweaks to allow sane processing of PolynomialResponseStage 
+   * response: tweaks to allow sane processing of PolynomialResponseStage
      responses if they have 2 coefficients or less (see #3632)
    * response: allow recalculating overall sensitivity even if unit type is not
      one of VEL/ACC/DISP (see #3235), add method for calculating the normalization

--- a/misc/docs/source/coding_style.rst
+++ b/misc/docs/source/coding_style.rst
@@ -48,9 +48,9 @@ manner:
 .. _matplotlib: http://matplotlib.org/
 
 Import statements in source code are grouped by standard library imports,
-followed by third party packages and finally obspy imports. Inside blocks
-``from ...`` imports come after ``import ...`` statements, and both should be
-sorted alphabetically:
+followed by third party packages and finally obspy imports, with a blank line
+in between these groups. Inside blocks ``from ...`` imports come after
+``import ...`` statements, and both should be sorted alphabetically:
 
 .. code-block:: python
 

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -154,10 +154,52 @@ class Client(object):
         else:
             return False
 
-    def __init__(self, base_url="EARTHSCOPE", major_versions=None, user=None,
-                 password=None, user_agent=DEFAULT_USER_AGENT, debug=False,
-                 timeout=120, service_mappings=None, force_redirect=False,
-                 eida_token=None, _discover_services=True, use_gzip=True):
+    @classmethod
+    def _resolve_base_url(cls, base_url):
+        """
+        Resolve a single short name or raw URL to a ``(base_url,
+        url_subpath)`` tuple.
+
+        Raises a :class:`ValueError` for an unrecognized all-alpha
+        shortcut or an invalid URL.
+        """
+        if base_url.upper() == 'IRIS':
+            base_url = 'EARTHSCOPE'
+            msg = ("IRIS is now EarthScope, please consider changing the "
+                   "FDSN client short URL to 'EARTHSCOPE'.")
+            warnings.warn(msg, ObsPyDeprecationWarning)
+
+        if base_url.upper() == 'RESIF':
+            msg = ("RESIF is now EPOSFR. Webservices and client will be "
+                   "shutdown in 2026. Please consider changing the FDSN "
+                   "client short URL to 'EPOSFR'.")
+            warnings.warn(msg, ObsPyDeprecationWarning)
+
+        if base_url.upper() in URL_MAPPINGS:
+            url_mapping = base_url.upper()
+            base_url = URL_MAPPINGS[url_mapping]
+            url_subpath = URL_MAPPING_SUBPATHS.get(
+                url_mapping, URL_DEFAULT_SUBPATH)
+        else:
+            if base_url.isalpha():
+                msg = "The FDSN service shortcut `{}` is unknown."\
+                      .format(base_url)
+                raise ValueError(msg)
+            url_subpath = URL_DEFAULT_SUBPATH
+        # Make sure the base_url does not end with a slash.
+        base_url = base_url.strip("/")
+        # Catch invalid URLs to avoid confusing error messages
+        if not cls._validate_base_url(base_url):
+            msg = "The FDSN service base URL `{}` is not a valid URL."\
+                  .format(base_url)
+            raise ValueError(msg)
+        return base_url, url_subpath
+
+    def __init__(self, base_url=["EARTHSCOPE", "USGS"], major_versions=None,
+                 user=None, password=None, user_agent=DEFAULT_USER_AGENT,
+                 debug=False, timeout=120, service_mappings=None,
+                 force_redirect=False, eida_token=None,
+                 _discover_services=True, use_gzip=True):
         """
         Initializes an FDSN Web Service client.
 
@@ -170,10 +212,18 @@ class Client(object):
         or client.help() for parameter description of
         all webservices.
 
-        :type base_url: str
+        :type base_url: str or list of str
         :param base_url: Base URL of FDSN web service compatible server
             (e.g. "https://service.earthscope.org") or key string for
-            recognized server (one of %s).
+            recognized server (one of %s). Multiple datacenters may be
+            combined by passing a list, e.g.
+            ``["EARTHSCOPE", "USGS"]`` (the default): the service map
+            (dataselect/station/event) is built from the first datacenter,
+            and any service it does not provide is filled in from the next
+            listed datacenter that does provide it (without overwriting
+            services already resolved by an earlier one). This is the
+            default because EarthScope no longer provides an event service,
+            so it is filled in from USGS.
         :type major_versions: dict
         :param major_versions: Allows to specify custom major version numbers
             for individual services (e.g.
@@ -242,39 +292,23 @@ class Client(object):
         # the client more convenient.
         self.__version_cache = {}
 
-        if base_url.upper() == 'IRIS':
-            base_url = 'EARTHSCOPE'
-            msg = ("IRIS is now EarthScope, please consider changing the FDSN "
-                   "client short URL to 'EARTHSCOPE'.")
-            warnings.warn(msg, ObsPyDeprecationWarning)
-
-        if base_url.upper() == 'RESIF':
-            msg = ("RESIF is now EPOSFR. Webservices and client will be "
-                   "shutdown in 2026. Please consider changing the FDSN "
-                   "client short URL to 'EPOSFR'.")
-            warnings.warn(msg, ObsPyDeprecationWarning)
-
-        if base_url.upper() in URL_MAPPINGS:
-            url_mapping = base_url.upper()
-            base_url = URL_MAPPINGS[url_mapping]
-            url_subpath = URL_MAPPING_SUBPATHS.get(
-                url_mapping, URL_DEFAULT_SUBPATH)
+        # A list/tuple of designations (e.g. ["EARTHSCOPE", "USGS"]) lists
+        # more than one datacenter to be merged into a single service map;
+        # a plain string is a single datacenter as before.
+        if isinstance(base_url, (list, tuple)):
+            tokens = [t.strip() for t in base_url if t and t.strip()]
         else:
-            if base_url.isalpha():
-                msg = "The FDSN service shortcut `{}` is unknown."\
-                      .format(base_url)
-                raise ValueError(msg)
-            url_subpath = URL_DEFAULT_SUBPATH
-        # Make sure the base_url does not end with a slash.
-        base_url = base_url.strip("/")
-        # Catch invalid URLs to avoid confusing error messages
-        if not self._validate_base_url(base_url):
+            tokens = [base_url]
+        if not tokens:
             msg = "The FDSN service base URL `{}` is not a valid URL."\
                   .format(base_url)
             raise ValueError(msg)
 
-        self.base_url = base_url
-        self.url_subpath = url_subpath
+        self._combined_datacenters = [
+            self._resolve_base_url(token) for token in tokens]
+        self._is_combined = len(self._combined_datacenters) > 1
+
+        self.base_url, self.url_subpath = self._combined_datacenters[0]
 
         self._set_opener(user, password)
 
@@ -299,7 +333,15 @@ class Client(object):
                     print("\t%s: '%s'" % (key, value))
             print("Request Headers: %s" % str(self.request_headers))
 
-        if _discover_services:
+        if self._is_combined:
+            if not _discover_services:
+                msg = ("Service discovery cannot be disabled when "
+                       "combining multiple datacenters in the base_url "
+                       "designation; discovery will be performed "
+                       "regardless.")
+                warnings.warn(msg)
+            self._discover_combined_services()
+        elif _discover_services:
             self._discover_services()
         else:
             self.services = DEFAULT_SERVICES.copy()
@@ -1647,6 +1689,75 @@ class Client(object):
             print("Storing discovered services in cache.")
         self.__service_discovery_cache[url_hash] = \
             copy.deepcopy(self.services)
+
+    def _discover_combined_services(self):
+        """
+        Discover and merge services for a list-combined base_url.
+
+        Each listed datacenter (``self._combined_datacenters``) is probed
+        independently, reusing :meth:`_discover_services` (and its
+        caching). For every service the earlier datacenters do not
+        provide, the first later datacenter that does provide it is used
+        to fill it in - services already resolved by an earlier
+        datacenter are never overwritten. Any user supplied
+        ``service_mappings`` (custom URLs or ``None`` deactivations)
+        always take precedence over this combined result.
+
+        A datacenter that offers none of the candidate services (e.g. an
+        outage or a misconfigured/incompatible server) causes
+        :meth:`_discover_services` to raise for that datacenter, which
+        propagates from here - combining datacenters does not silently
+        skip an unreachable/empty one.
+        """
+        user_mappings = self._service_mappings
+        saved_base_url, saved_subpath = self.base_url, self.url_subpath
+
+        # Probe every listed datacenter independently (ignoring any user
+        # supplied service_mappings, which only apply to the final,
+        # merged client) to find out which of the candidate services each
+        # one actually offers.
+        per_dc_services = []
+        try:
+            for base_url, url_subpath in self._combined_datacenters:
+                self.base_url = base_url
+                self.url_subpath = url_subpath
+                self._service_mappings = {}
+                self._discover_services()
+                per_dc_services.append(self.services)
+        finally:
+            self.base_url, self.url_subpath = saved_base_url, saved_subpath
+            self._service_mappings = user_mappings
+
+        # Primary-first fill: the first datacenter to offer a service
+        # claims it; later datacenters only fill in gaps.
+        claimed = set()
+        combined_mappings = {}
+        for i, ((base_url, url_subpath), dc_services) in enumerate(
+                zip(self._combined_datacenters, per_dc_services)):
+            is_primary = (i == 0)
+            for service in FDSNWS:
+                if service in claimed or service in user_mappings \
+                        or service not in dc_services:
+                    continue
+                claimed.add(service)
+                # The primary datacenter's own services resolve directly
+                # through self.base_url/self.url_subpath, so only
+                # non-primary fill-ins need an explicit mapping.
+                if not is_primary:
+                    combined_mappings[service] = "/".join((
+                        base_url, url_subpath.lstrip("/"), service,
+                        str(self.major_versions[service])))
+
+        # The user's explicit mappings (including custom URLs and
+        # ``None`` deactivations) always win over the combined result.
+        combined_mappings.update(user_mappings)
+
+        # Do the real, final discovery against the primary datacenter
+        # plus the merged service mappings. This reuses the same WADL
+        # parsing, event catalog/contributor discovery, and EIDA-auth
+        # detection as a normal single-datacenter client.
+        self._service_mappings = combined_mappings
+        self._discover_services()
 
     def get_webservice_version(self, service):
         """

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1654,6 +1654,232 @@ class TestClientNoNetwork():
         assert base_url_event in download_url_mock.call_args_list[0][0][0]
 
     @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_fills_in_missing_service(
+            self, download_url_mock, testdata):
+        """
+        Tests that ``[DC1, DC2]`` combines two datacenters: services
+        provided by the first (primary) datacenter are used as-is, and any
+        service it lacks is filled in from the next datacenter that
+        provides it.
+        """
+        base_url_a = "http://dc-a1.example.com"
+        base_url_b = "http://dc-b1.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if "application.wadl" not in url:
+                return 404, None
+            if base_url_a in url and "dataselect" in url:
+                with open(testdata["2014-01-07_iris_dataselect.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_a in url and "station" in url:
+                with open(testdata["2014-01-07_iris_station.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_b in url and "event" in url:
+                with open(testdata["usgs_event.wadl"], "rb") as fh:
+                    return 200, fh.read()
+            # dc-a has no event service, dc-b has no dataselect/station.
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_b]
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            c = Client(base_url=combined_url, user_agent=USER_AGENT)
+
+        # dataselect/station resolve through the primary's own base_url.
+        assert c.base_url == base_url_a
+        assert set(c.services).issuperset({"dataselect", "event",
+                                          "station"})
+        # Only the filled-in service gets an explicit mapping.
+        assert c._service_mappings == {
+            "event": "%s/fdsnws/event/1" % base_url_b}
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_first_datacenter_wins(
+            self, download_url_mock, testdata):
+        """
+        Tests that when both datacenters in a combined base_url provide
+        the same service, the earlier (primary) one is used and the
+        later one's version of that service is not.
+        """
+        base_url_a = "http://dc-a2.example.com"
+        base_url_b = "http://dc-b2.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if "application.wadl" not in url or "station" not in url:
+                return 404, None
+            if base_url_a in url:
+                with open(testdata["2014-01-07_iris_station.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_b in url:
+                with open(testdata["2014-01-07_ncedc_station.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_b]
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            c = Client(base_url=combined_url, user_agent=USER_AGENT)
+
+        assert c.base_url == base_url_a
+        assert "station" not in c._service_mappings
+        assert list(c.services) == ["station"]
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_user_service_mappings_win(
+            self, download_url_mock, testdata):
+        """
+        Tests that explicit ``service_mappings`` always take precedence
+        over a combined base_url's own fill-in logic, including manually
+        deactivating a service with ``None``.
+        """
+        base_url_a = "http://dc-a3.example.com"
+        base_url_b = "http://dc-b3.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if "application.wadl" not in url:
+                return 404, None
+            if base_url_a in url and "dataselect" in url:
+                with open(testdata["2014-01-07_iris_dataselect.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_b in url and "event" in url:
+                with open(testdata["usgs_event.wadl"], "rb") as fh:
+                    return 200, fh.read()
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_b]
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            c = Client(base_url=combined_url, user_agent=USER_AGENT,
+                       service_mappings={"event": None})
+
+        assert "event" not in c.services
+        # The explicit ``None`` deactivation is carried through verbatim,
+        # same as for a plain, single-datacenter client.
+        assert c._service_mappings.get("event") is None
+        assert "dc-b3" not in str(c._service_mappings)
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_three_datacenters(
+            self, download_url_mock, testdata):
+        """
+        Tests combining three datacenters, each providing exactly one of
+        the three services.
+        """
+        base_url_a = "http://dc-a4.example.com"
+        base_url_b = "http://dc-b4.example.com"
+        base_url_c = "http://dc-c4.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if "application.wadl" not in url:
+                return 404, None
+            if base_url_a in url and "dataselect" in url:
+                with open(testdata["2014-01-07_iris_dataselect.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_b in url and "station" in url:
+                with open(testdata["2014-01-07_iris_station.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_c in url and "event" in url:
+                with open(testdata["usgs_event.wadl"], "rb") as fh:
+                    return 200, fh.read()
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_b, base_url_c]
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            c = Client(base_url=combined_url, user_agent=USER_AGENT)
+
+        assert c.base_url == base_url_a
+        assert set(c.services).issuperset({"dataselect", "station",
+                                          "event"})
+        assert c._service_mappings == {
+            "station": "%s/fdsnws/station/1" % base_url_b,
+            "event": "%s/fdsnws/event/1" % base_url_c,
+        }
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_dead_datacenter_fails_hard(
+            self, download_url_mock, testdata):
+        """
+        Tests that if any datacenter in a combined base_url offers no
+        services at all, client instantiation raises rather than
+        silently continuing with the remaining ones.
+        """
+        base_url_a = "http://dc-a5.example.com"
+        base_url_dead = "http://dc-dead5.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if base_url_a in url and "application.wadl" in url \
+                    and "dataselect" in url:
+                with open(testdata["2014-01-07_iris_dataselect.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            # dc-dead never returns a usable WADL for any service.
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_dead]
+        with pytest.raises(FDSNNoServiceException):
+            Client(base_url=combined_url, user_agent=USER_AGENT)
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
+    def test_combined_base_url_discover_services_false_warns(
+            self, download_url_mock, testdata):
+        """
+        Tests that passing ``_discover_services=False`` together with a
+        combined base_url warns that discovery cannot be disabled (it is
+        required to know what each datacenter offers) and that discovery
+        is performed anyway.
+        """
+        base_url_a = "http://dc-a6.example.com"
+        base_url_b = "http://dc-b6.example.com"
+
+        def side_effect(*args, **kwargs):
+            url = args[0]
+            if "application.wadl" not in url:
+                return 404, None
+            if base_url_a in url and "dataselect" in url:
+                with open(testdata["2014-01-07_iris_dataselect.wadl"],
+                          "rb") as fh:
+                    return 200, fh.read()
+            if base_url_b in url and "event" in url:
+                with open(testdata["usgs_event.wadl"], "rb") as fh:
+                    return 200, fh.read()
+            return 404, None
+
+        download_url_mock.side_effect = side_effect
+
+        combined_url = [base_url_a, base_url_b]
+        with CatchAndAssertWarnings(
+                expected=[(UserWarning,
+                          "Service discovery cannot be disabled")]):
+            c = Client(base_url=combined_url, user_agent=USER_AGENT,
+                       _discover_services=False)
+
+        # Discovery still happened despite _discover_services=False.
+        assert set(c.services).issuperset({"dataselect", "event"})
+
+    @mock.patch("obspy.clients.fdsn.client.download_url")
     def test_no_data_exception(self, download_url_mock):
         """
         Verify that a request returning no data raises an identifiable


### PR DESCRIPTION
### What this PR does

The `base_url` kwarg accepts a list of data center IDs and/or base URLs.  Discovery is conducted on each, and service URLs are merged together prioritizing the first entry for each service.  For example with `base_url = ["EARTHSCOPE", "ISC"]`, the `dataselect` and `station` services are discovered from EarthScope (but no `event` service), and the `event` service from ISC is discovered and added to the service mapping.

The default for `base_url` is also changed to `["EARTHSCOPE", "USGS"]`.

The motivation for this is the changed user experience now that EarthScope does not offer an `event` service.  Scripts that used to work now fail, and a default client that can get metadata, waveforms, and events is the experience this is trying to partially restore.

This is effectively an easier, and more dynamic, path to something like this:
```python
from obspy.clients.fdsn import Client
client = Client("EARTHSCOPE", service_mappings={
    "event": "https://earthquake.usgs.gov/fdsnws/event/1"})
```
It is also less explicit.

I'm not convinced this is the right approach, please treat as food for thought

### Links to other Issues

See https://github.com/obspy/obspy/issues/3768

### AI used

AI was used for review

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
