### PR TITLE
Docs: add a link to the installation instructions on the main page

### DIFF
--- a/misc/docs/source/index.rst
+++ b/misc/docs/source/index.rst
@@ -24,6 +24,7 @@ Getting Started
 
 Install instructions are available on the `wiki <https://github.com/obspy/obspy/wiki/#installation>`_.
 
+
 .. hlist::
 
     * `Tutorial <tutorial/index.html>`_

--- a/misc/docs/source/index.rst
+++ b/misc/docs/source/index.rst
@@ -22,6 +22,8 @@ for seismology**.
 Getting Started
 ---------------
 
+Install instructions are available on the `wiki <https://github.com/obspy/obspy/wiki/#installation>`_.
+
 .. hlist::
 
     * `Tutorial <tutorial/index.html>`_


### PR DESCRIPTION
adds a link to the installation instructions on the main page of the docs 