### PR TITLE
FDSN: change default base_url to new "EARTHSCOPE+USGS"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,11 @@ Changes:
    * inventory: fix a bug that Latitude, Longitude and Distance did not accept
      'measurement_units' when being initialized (see #3623)
  - obspy.clients.fdsn:
+   * add new URL mapping 'EARTHSCOPE+USGS' and make it the default. This will
+     use EarthScope for dataselect and station web services and use USGS for
+     event web service. This is basically restoring the output users got before
+     IRIS-now-EarthScope discontinued serving an event web service which was a
+     mirror of USGS event web service (see #3784)
    * update URL endpoint for IGN to https (see #3744)
  - obspy.clients.filesystem:
    * tsindex: improve handling of sql sessions, less connections staying open

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,7 +15,7 @@ Changes:
      use EarthScope for dataselect and station web services and use USGS for
      event web service. This is basically restoring the output users got before
      IRIS-now-EarthScope discontinued serving an event web service which was a
-     mirror of USGS event web service (see #3784)
+     mirror of USGS event web service (see #3784).
    * update URL endpoint for IGN to https (see #3744)
  - obspy.clients.filesystem:
    * tsindex: improve handling of sql sessions, less connections staying open

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -154,10 +154,11 @@ class Client(object):
         else:
             return False
 
-    def __init__(self, base_url="EARTHSCOPE", major_versions=None, user=None,
-                 password=None, user_agent=DEFAULT_USER_AGENT, debug=False,
-                 timeout=120, service_mappings=None, force_redirect=False,
-                 eida_token=None, _discover_services=True, use_gzip=True):
+    def __init__(self, base_url="EARTHSCOPE+USGS", major_versions=None,
+                 user=None, password=None, user_agent=DEFAULT_USER_AGENT,
+                 debug=False, timeout=120, service_mappings=None,
+                 force_redirect=False, eida_token=None,
+                 _discover_services=True, use_gzip=True):
         """
         Initializes an FDSN Web Service client.
 
@@ -173,7 +174,14 @@ class Client(object):
         :type base_url: str
         :param base_url: Base URL of FDSN web service compatible server
             (e.g. "https://service.earthscope.org") or key string for
-            recognized server (one of %s).
+            recognized server (one of %s). To mimick the previous behavior of
+            former IRIS (now EarthScope) as default which used to mirror the
+            event web service of USGS but which since recently discontinued
+            their event web service mirror, we made the client by default (when
+            `base_url` is not explicitly specified otherwise) use EarthScope
+            for dataselect and station web services and use USGS for event web
+            service, indicated by a `base_url` URL mapping named
+            'EARTHSCOPE+USGS' (unless `service_mappings` is specified).
         :type major_versions: dict
         :param major_versions: Allows to specify custom major version numbers
             for individual services (e.g.
@@ -255,6 +263,9 @@ class Client(object):
             warnings.warn(msg, ObsPyDeprecationWarning)
 
         if base_url.upper() in URL_MAPPINGS:
+            if base_url.upper() == "EARTHSCOPE+USGS" and not service_mappings:
+                service_mappings = {
+                    'event': 'https://earthquake.usgs.gov/fdsnws/event/1'}
             url_mapping = base_url.upper()
             base_url = URL_MAPPINGS[url_mapping]
             url_subpath = URL_MAPPING_SUBPATHS.get(

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -105,6 +105,10 @@ URL_MAPPINGS = {
     "BGR": "https://eida.bgr.de",
     "BGS": 'https://eida.bgs.ac.uk',
     "EARTHSCOPE": "https://service.earthscope.org",
+    # the following will use USGS as endpoint for event web service.
+    # to keep things simple we just keep the base URL from earthscope here and
+    # simply set a custom event service mapping during Client init
+    "EARTHSCOPE+USGS": "https://service.earthscope.org",
     "EIDA": "http://eida-federator.ethz.ch",
     "EPOSFR": "https://seisdata.epos-france.fr",
     "ETH": "https://eida.ethz.ch",

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -1896,3 +1896,33 @@ class TestClientNoNetwork():
         msg = 'Timed Out'
         with pytest.raises(FDSNException, match=msg):
             raise_on_error(code, data)
+
+    @mock.patch('obspy.clients.fdsn.client.download_url')
+    def test_default_client_earthscope_and_usgs(self, download_mock):
+        """
+        Test that by default the client uses EarthScope for dataselect+station
+        and USGS for event
+        """
+        # just mock an empty response, we're just interested to see what
+        # URL was going to be downloaded
+        download_mock.return_value = (204, None)
+        t = UTCDateTime(2010, 1, 1)
+
+        client_default = Client(_discover_services=False)
+        client_explicit = Client('EARTHSCOPE+USGS', _discover_services=False)
+        for client in (client_default, client_explicit):
+            # check event endpoint
+            with pytest.raises(FDSNNoDataException):
+                client.get_events()
+            assert download_mock.call_args.args[0].startswith(
+                'https://earthquake.usgs.gov/fdsnws/event/')
+            # check dataselect endpoint
+            with pytest.raises(FDSNNoDataException):
+                client.get_waveforms('IU', 'ANMO', '', '*', t, t+1)
+            assert download_mock.call_args.args[0].startswith(
+                'https://service.earthscope.org/fdsnws/dataselect/')
+            # check station endpoint
+            with pytest.raises(FDSNNoDataException):
+                client.get_stations()
+            assert download_mock.call_args.args[0].startswith(
+                'https://service.earthscope.org/fdsnws/station/')


### PR DESCRIPTION
### What does this PR do?

Back in the day, former IRIS served events as a mirror of USGS, but this is now discontinued by now EarthScope, so that currently, the default FDSN client in obspy if not specifying a certain FDSN node or custom service mappings, currently does not serve events at all.

This PR implements strategy `1.` outlined by @chad-earthscope in https://github.com/obspy/obspy/issues/3768#issuecomment-4983950026 to mimic the old behavior of the default FDSN client instance of obspy.
This is the simplemost fix that does not add unwanted complexity and just uses the existing `base_url` and `service_mappings` concept already in place.

It's based on maintenance branch, since it to some extent can be seen as a "fix" (restore old behavior of default client) even though strictly it's a behavior change (the default client querying two separate FDSN nodes). Open to discussion if it rather should go into master.

### Links to other Issues?

closes #3768 
supersedes and closes #3769

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
