### PR TITLE
Fix Vidale "adaptative" computation (fixes 3725)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,9 @@ Changes:
    * fix a void return type in write mseed ctypes wrapper (see #3735)
    * fix reading in case when numpy.memmap is not implemented (see #3741)
    * Memory leak fixed in obspy-readbuffer.c (see #3714)
+ - obspy.signal.polarization:
+   * fix a wrong calculation of the covariance matrix in the adaptative
+     vidale method (see #3787)
  - obspy.taup:
    * fix an issue with obspy.taup not being usable with specific Python
      versions 3.13.10 and 3.14.1 (see #3650)

--- a/obspy/signal/polarization.py
+++ b/obspy/signal/polarization.py
@@ -260,19 +260,18 @@ def vidale_adapt(stream, noise_thres, fs, flow, fhigh, spoint, stime, etime,
                 int(spoint[1] + offset + adapt / 2)]
         ex = ea[int(spoint[0] + offset - adapt / 2):
                 int(spoint[0] + offset + adapt / 2)]
-        zx -= zx.mean()
-        nx -= nx.mean()
-        ex -= ex.mean()
+        zx = zx - zx.mean()
+        nx = nx - nx.mean()
+        ex = ex - ex.mean()
 
-        mask = (stream[0][:] ** 2 + stream[1][:] ** 2 + stream[2][:] ** 2) > \
-            noise_thres
-        xx = np.zeros((3, mask.sum()), dtype=np.complex128)
-        # East
-        xx[0, :] = ea
-        # North
-        xx[1, :] = na
-        # Z
-        xx[2, :] = za
+        # exclude low-energy samples *inside the analysis window* that fall
+        # within the noise sphere of radius sqrt(noise_thres) (Vidale 1986)
+        power = np.abs(ex) ** 2 + np.abs(nx) ** 2 + np.abs(zx) ** 2
+        mask = power > noise_thres
+        if mask.sum() < 2:
+            mask = np.ones_like(mask)
+        # build the 3xN data matrix from the *windowed* analytic signals
+        xx = np.vstack([ex[mask], nx[mask], zx[mask]])
 
         covmat = np.cov(xx)
         eigvec, eigenval, v = np.linalg.svd(covmat)

--- a/obspy/signal/tests/test_polarization.py
+++ b/obspy/signal/tests/test_polarization.py
@@ -41,6 +41,42 @@ def _create_test_data():
     return sz
 
 
+def _create_rotating_test_data(fs=20.0, npts=2048, f0=3.0, az1=20.0, az2=70.0,
+                               inc1=30.0, inc2=75.0):
+    """
+    Synthetic, rectilinearly polarized 3C signal whose polarization *axis*
+    rotates along the trace: the horizontal azimuth ramps linearly from
+    ``az1`` to ``az2`` while the incidence angle (measured from the vertical)
+    ramps from ``inc1`` to ``inc2`` (the vertical amplitude ``cos(inc)`` thus
+    varies too). All three components stay non-zero.
+
+    A correct adaptive-window Vidale analysis must recover both the *time
+    varying* azimuth and incidence. Used by the regression test for
+    :issue:`3725`, where the covariance was computed from the whole trace
+    (collapsing every window onto the trace-averaged direction) instead of
+    from the current analysis window.
+    """
+    t = np.arange(npts) / fs
+    carrier = np.cos(2.0 * np.pi * f0 * t)
+    theta = np.deg2rad(np.linspace(az1, az2, npts))    # rotating azimuth
+    phi = np.deg2rad(np.linspace(inc1, inc2, npts))    # rotating incidence
+    data_e = carrier * np.sin(theta) * np.sin(phi)
+    data_n = carrier * np.cos(theta) * np.sin(phi)
+    data_z = carrier * np.cos(phi)
+
+    st = obspy.Stream()
+    for data, chan in [(data_z, 'HHZ'), (data_n, 'HHN'), (data_e, 'HHE')]:
+        tr = obspy.Trace(data=np.ascontiguousarray(data, dtype=np.float64))
+        tr.stats.sampling_rate = fs
+        tr.stats.starttime = obspy.UTCDateTime('2014-03-01T00:00')
+        tr.stats.network = 'XX'
+        tr.stats.station = 'POLR'
+        tr.stats.channel = chan
+        st.append(tr)
+    st.sort(reverse=True)
+    return st
+
+
 class TestPolarization():
     """
     Test cases for polarization analysis
@@ -195,3 +231,70 @@ class TestPolarization():
             assert np.allclose(got / got[0], np.ones_like(got), rtol=1e-4)
         assert np.allclose(out["timestamp"] - out["timestamp"][0],
                            np.arange(0, 97.85, 0.05), rtol=1e-5)
+
+    def test_polarization_vidale_windowed_covariance(self):
+        """
+        Regression test for :issue:`3725`.
+
+        The adaptive-window Vidale analysis must build the covariance matrix
+        from the current analysis window, not from the full trace. For a
+        source whose azimuth rotates 20 -> 70 degrees and incidence rotates
+        30 -> 75 degrees, the recovered azimuth and incidence must follow
+        those rotations; using the full trace instead collapses every window
+        onto the trace-averaged direction (azimuth ~45 degrees, incidence
+        ~52 degrees, each with a peak-to-peak spread of about 1 degree) and
+        smears the rectilinearity down to ~0.7.
+        """
+        st = _create_rotating_test_data(az1=20.0, az2=70.0, inc1=30.0,
+                                        inc2=75.0)
+        t = st[0].stats.starttime
+        e = st[0].stats.endtime
+
+        out = polarization.polarization_analysis(
+            st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
+            verbose=False, stime=t, etime=e, method="vidale", var_noise=0.0)
+
+        azimuth = out["azimuth"]
+        # azimuth must vary across the trace (the full-trace covariance bug
+        # yields a near-constant azimuth) and track the imposed rotation
+        assert np.ptp(azimuth) > 30.0
+        assert abs(azimuth[:20].mean() - 20.0) < 5.0
+        assert abs(azimuth[-20:].mean() - 70.0) < 5.0
+        # incidence must likewise track its rotation, not collapse to the
+        # trace-averaged value (~52 degrees)
+        incidence = out["incidence"]
+        assert np.ptp(incidence) > 30.0
+        assert abs(incidence[:20].mean() - 30.0) < 6.0
+        assert abs(incidence[-20:].mean() - 75.0) < 6.0
+        # the per-window motion stays rectilinear; the full-trace covariance
+        # bug smears energy over the rotating directions and drops this to ~0.7
+        assert np.all(out["rectilinearity"] > 0.95)
+
+    def test_polarization_vidale_noise_threshold(self):
+        """
+        Regression test for :issue:`3725`.
+
+        With a non-zero noise threshold (``var_noise > 0``) the Vidale
+        covariance estimation must exclude low-energy samples inside the
+        window instead of attempting to broadcast the full-length signal into
+        a shortened array, which previously raised a ``ValueError``.
+        """
+        st = _create_test_data()
+        t = st[0].stats.starttime
+        e = st[0].stats.endtime
+
+        out = polarization.polarization_analysis(
+            st, win_len=10.0, win_frac=0.1, frqlow=1.0, frqhigh=5.0,
+            verbose=False, stime=t, etime=e, method="vidale", var_noise=0.5)
+
+        # must run to completion and return finite results ...
+        for key in ["azimuth", "incidence", "rectilinearity", "planarity",
+                    "ellipticity"]:
+            assert np.all(np.isfinite(out[key]))
+        # ... the perfectly rectilinear input must stay rectilinear ...
+        assert np.allclose(out["rectilinearity"], 1.0, atol=1e-4)
+        assert np.allclose(out["planarity"], 1.0, atol=1e-4)
+        # ... and excluding low-energy samples must not shift the recovered
+        # orientation away from the known (noise-free) reference values
+        assert np.allclose(out["azimuth"], 26.56505117707799, atol=1e-4)
+        assert np.allclose(out["incidence"], 65.905157447889309, atol=1e-4)


### PR DESCRIPTION
Fixes #3725 . When using the adaptative method for Vidale polarization, the covariances are actually not computed on the windowed data but on the full trace, leading to averaging of the azimuth for all windows. There is also a problem with some array size.

This PR creates a new synthetic stream with known polarization parameters, and adds regression tests, then finally corrects the bug. This plot illustrates the before/after:

This bug was introduced in #2570 somehow.

It related to #2821

## Before:

<img width="1667" height="1757" alt="image" src="https://github.com/user-attachments/assets/f38d89dd-39d7-4989-b535-081837c60bd3" />


## After:

<img width="1412" height="1517" alt="image" src="https://github.com/user-attachments/assets/1f9537ce-cace-4799-8f89-0abfd38ef649" />


### AI used?

Yes. To generate the input test stream, visual plots of the checks and proposed patches.

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
