### PR TITLE
FDSN/WADL parsing: skip non-query parameters and improve warnings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+maintenance_1.5.x
+=================
+
+Changes:
+ - obspy.clients.fdsn:
+   * skip non-query related parameters when parsing WADL files for now and
+     improve warning messages for these cases (see #3788)
+
 1.5.1rc2
 ========
 

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -123,9 +123,24 @@ class WADLParser(object):
             name = "maxlongitude"
 
         style = param_doc.get("style")
-        if style != "query":
-            msg = "Unknown parameter style '%s' in WADL" % style
+        if style == "query":
+            # this is what we are interested in here, query parameters
+            pass
+        elif style in ("header", "matrix", "template", "plain"):
+            # these additional styles are defined by the WADL schema, but here
+            # we do not currently parse them
+            msg = f"Ignoring non-query parameter of style '{style}' in WADL"
             warnings.warn(msg)
+            return
+        else:
+            # these are styles not defined by the WADL schema.
+            # we should add validation against the WADL XMLSchema to not rely
+            # on hard coding what could be acceptable or not (although WADL
+            # schema does not seem to change over time, considering as of 2026
+            # the schema has 2009 in the namespace)
+            msg = f"Ignoring unknown parameter style '{style}' in WADL"
+            warnings.warn(msg)
+            return
 
         required = self._convert_boolean(param_doc.get("required"))
         if required is None:


### PR DESCRIPTION
### What does this PR do?

Skip non-query parameters when parsing WADL files for now and improve warnings on unwanted or unexpected ones.

Ideally we should
 - add validation against WADL schema, to be able to faster tell if any problems are in the WADL or our side. 
 - parse these so-far-unencountered new styles properly (for the new authentication scheme)

### Links to other Issues?

see #3778

### AI used?

no

### PR Checklist

- [ ] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
