### PR TITLE
Fixes multiprocessing resourcetracker warning error on CI (and in general) - py version & OS safe.

### DIFF
--- a/obspy/conftest.py
+++ b/obspy/conftest.py
@@ -185,6 +185,21 @@ def pytest_configure(config):
     """
     Configure pytest with custom logic for ObsPy before test run.
     """
+    # obspy-runtests chdirs into ObsPy's package directory so that pytest
+    # collects the installed package. That directory contains sub-packages
+    # whose names shadow standard library modules (most notably
+    # ``obspy/signal``). Any helper interpreter that multiprocessing spawns
+    # with ``python -c`` under the ``spawn``/``forkserver`` start methods
+    # prepends the current working directory to ``sys.path`` and would then
+    # import ``obspy/signal`` in place of the stdlib ``signal`` module and
+    # crash on startup -- e.g. the multiprocessing ``resource_tracker`` on
+    # Python 3.14, where ``forkserver`` became the default start method on
+    # Linux. Exporting ``PYTHONSAFEPATH`` is inherited by those subprocesses
+    # and stops the unsafe ``sys.path`` prepend so the stdlib modules resolve
+    # correctly. It does not affect this already-running interpreter or test
+    # collection, and it is a no-op on Python < 3.11.
+    os.environ["PYTHONSAFEPATH"] = "1"
+
     # Skip or select network options based on options
     network_selected = config.getoption('--network')
     all_selected = config.getoption('--all')

--- a/obspy/core/tests/test_resource_identifier.py
+++ b/obspy/core/tests/test_resource_identifier.py
@@ -11,10 +11,10 @@ import copy
 import gc
 import io
 import itertools
-import multiprocessing.pool
 import pickle
 import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -499,11 +499,22 @@ class TestResourceIdentifier:
         Test that event-scoping of resource IDs still works when many
         threads are used to generate catalogs via various methods.
         """
-        pool = multiprocessing.pool.ThreadPool()
+        # Use a plain threading pool (concurrent.futures) rather than
+        # multiprocessing.pool.ThreadPool. Although ThreadPool runs the work
+        # in threads, its construction builds a multiprocessing SimpleQueue
+        # backed by a POSIX semaphore that registers with the
+        # multiprocessing.resource_tracker under any non-"fork" start method.
+        # Python 3.14 makes "forkserver" the default start method on Linux, so
+        # this registration now happens and can emit a "resource_tracker:
+        # process died unexpectedly" UserWarning during pool construction
+        # (i.e. outside the catch_warnings block below), which is escalated to
+        # an error when the suite runs with -W error. ThreadPoolExecutor is
+        # pure threading and never touches the resource_tracker.
         # currently it is not possible to avoid warnings with many threads
         with warnings.catch_warnings(record=True):
-            nested_catalogs = pool.map(make_diverse_catalog_list, range(5))
-        pool.close()
+            with ThreadPoolExecutor() as pool:
+                nested_catalogs = list(
+                    pool.map(make_diverse_catalog_list, range(5)))
         # get a flat list of catalogs
         catalogs = list(itertools.chain.from_iterable(nested_catalogs))
         # run catalogs through previous tests


### PR DESCRIPTION
Fixes https://github.com/obspy/obspy/actions/runs/32981814744/job/98220378824?pr=3570

```
=================================== FAILURES ===================================
______ TestResourceIdentifier.test_event_scoped_resource_id_many_threads _______
Traceback (most recent call last):
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 304, in _ensure_running_and_write
    self._write(to_send)
    ~~~~~~~~~~~^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 342, in _write
    nbytes = os.write(self._fd, msg)
BrokenPipeError: [Errno 32] Broken pipe

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/runner.py", line 361, in from_call
    result: TResult | None = func()
                             ~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/runner.py", line 250, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/logging.py", line 865, in pytest_runtest_call
    yield
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/skipping.py", line 268, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/runner.py", line 184, in pytest_runtest_call
    item.runtest()
    ~~~~~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/python.py", line 1707, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/_pytest/python.py", line 167, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/runner/miniconda3/envs/test/lib/python3.14/site-packages/obspy/core/tests/test_resource_identifier.py", line 502, in test_event_scoped_resource_id_many_threads
    pool = multiprocessing.pool.ThreadPool()
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/pool.py", line 930, in __init__
    Pool.__init__(self, processes, initializer, initargs)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/pool.py", line 196, in __init__
    self._change_notifier = self._ctx.SimpleQueue()
                            ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/context.py", line 113, in SimpleQueue
    return SimpleQueue(ctx=self.get_context())
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/queues.py", line 361, in __init__
    self._rlock = ctx.Lock()
                  ~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/context.py", line 68, in Lock
    return Lock(ctx=self.get_context())
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/synchronize.py", line 176, in __init__
    SemLock.__init__(self, SEMAPHORE, 1, 1, ctx=ctx)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/synchronize.py", line 79, in __init__
    register(self._semlock.name, "semaphore")
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 335, in register
    self._send('REGISTER', name, rtype)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 352, in _send
    self._ensure_running_and_write(msg)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 306, in _ensure_running_and_write
    self._teardown_dead_process()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/runner/miniconda3/envs/test/lib/python3.14/multiprocessing/resource_tracker.py", line 233, in _teardown_dead_process
    warnings.warn('resource_tracker: process died unexpectedly, '
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  'relaunching.  Some resources might leak.')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UserWarning: resource_tracker: process died unexpectedly, relaunching.  Some resources might leak.
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.14.7-final-0 ________________

Coverage XML written to file /home/runner/work/obspy/obspy/coverage.xml
=========================== short test summary info ============================
SKIPPED [17] ../_pytest/doctest.py:458: all tests skipped by +SKIP option
SKIPPED [1] geodetics/tests/test_util_geodetics.py:195: Geographiclib installed, not using calc_vincenty_inverse
SKIPPED [1] imaging/tests/test_mopad_script.py:186: Currently broken until further review.
SKIPPED [1] signal/tests/test_quality_control.py:847: Test requires the jsonschema module
FAILED core/tests/test_resource_identifier.py::TestResourceIdentifier::test_event_scoped_resource_id_many_threads - UserWarning: resource_tracker: process died unexpectedly, relaunching.  Some resources might leak.
==== 1 failed, 2325 passed, 20 skipped, 117 deselected in 128.91s (0:02:08) ====
Your test results have been reported and are available at: https://tests.obspy.org/160013/
```


### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
