### PR TITLE
Fix: EarthScope Syngine doesn't have the "test" model anymore

### DIFF
--- a/obspy/clients/syngine/__init__.py
+++ b/obspy/clients/syngine/__init__.py
@@ -29,9 +29,9 @@ Then request some data.
 ...                           eventid="GCMT:C201002270634A")
 >>> print(st)  # doctest: +ELLIPSIS
 3 Trace(s) in Stream:
-IU.ANMO.SE.MXZ | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
-IU.ANMO.SE.MXN | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
-IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+IU.ANMO.SE.MXZ | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
+IU.ANMO.SE.MXN | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
+IU.ANMO.SE.MXE | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
 >>> st.plot()  # doctest: +SKIP
 
 .. plot::
@@ -81,12 +81,12 @@ requests seismograms for all of these.
 ...     bulk=bulk, starttime="P-10", endtime="P+20")
 >>> print(st)  # doctest: +ELLIPSIS
 6 Trace(s) in Stream:
-XX.AA.SE.MXZ | 2010-02-27T06:48:11... - ... | 4.0 Hz, 120 samples
-XX.AA.SE.MXN | 2010-02-27T06:48:11... - ... | 4.0 Hz, 120 samples
-XX.AA.SE.MXE | 2010-02-27T06:48:11... - ... | 4.0 Hz, 120 samples
-XX.BB.SE.MXZ | 2010-02-27T06:48:15... - ... | 4.0 Hz, 120 samples
-XX.BB.SE.MXN | 2010-02-27T06:48:15... - ... | 4.0 Hz, 120 samples
-XX.BB.SE.MXE | 2010-02-27T06:48:15... - ... | 4.0 Hz, 120 samples
+XX.AA.SE.MXZ | 2010-02-27T06:48:10... - ... | 4.0 Hz, 120 samples
+XX.AA.SE.MXN | 2010-02-27T06:48:10... - ... | 4.0 Hz, 120 samples
+XX.AA.SE.MXE | 2010-02-27T06:48:10... - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXZ | 2010-02-27T06:48:14... - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXN | 2010-02-27T06:48:14... - ... | 4.0 Hz, 120 samples
+XX.BB.SE.MXE | 2010-02-27T06:48:14... - ... | 4.0 Hz, 120 samples
 
 
 Other Useful Methods

--- a/obspy/clients/syngine/client.py
+++ b/obspy/clients/syngine/client.py
@@ -223,9 +223,9 @@ class Client(WaveformClient, HTTPClient):
         ...                           eventid="GCMT:C201002270634A")
         >>> print(st)  # doctest: +ELLIPSIS
         3 Trace(s) in Stream:
-        IU.ANMO.SE.MXZ | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
-        IU.ANMO.SE.MXN | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
-        IU.ANMO.SE.MXE | 2010-02-27T06:35:14... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXZ | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXN | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
+        IU.ANMO.SE.MXE | 2010-02-27T06:35:13... - ... | 4.0 Hz, 15520 samples
 
         :param model: Specify the model.
         :type model: str
@@ -421,7 +421,7 @@ class Client(WaveformClient, HTTPClient):
         IU.ANMO.SE.MXZ  | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
         IU.ANTO.SE.MXZ  | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
         XX.S0001.SE.MXZ | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
-        XX.S0002.SE.MXZ | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
+        XX.S0003.SE.MXZ | 1900-01-01T00:00:00... - ... | 4.0 Hz, 15520 samples
 
         :param model: Specify the model.
         :type model: str

--- a/obspy/clients/syngine/tests/test_client.py
+++ b/obspy/clients/syngine/tests/test_client.py
@@ -58,12 +58,12 @@ class TestClient():
         """
         Actual test for the get_model_info() method.
         """
-        info = self.c.get_model_info("test")
+        info = self.c.get_model_info("ak135f_5s")
 
         assert isinstance(info, obspy.core.AttribDict)
         # Check two random keys.
         assert info.dump_type == "displ_only"
-        assert info.time_scheme == "newmark2"
+        assert info.time_scheme == "symplec4"
         # Check that both arrays have been converted to numpy arrays.
         assert isinstance(info.slip, np.ndarray)
         assert isinstance(info.sliprate, np.ndarray)
@@ -193,13 +193,13 @@ class TestClient():
     def test_error_handling_arguments(self):
         # Floating points value
         with pytest.raises(ValueError):
-            self.c.get_waveforms(model="test", receiverlatitude="a")
+            self.c.get_waveforms(model="ak135f_5s", receiverlatitude="a")
         # Int.
         with pytest.raises(ValueError):
-            self.c.get_waveforms(model="test", kernelwidth="a")
+            self.c.get_waveforms(model="ak135f_5s", kernelwidth="a")
         # Time.
         with pytest.raises(TypeError):
-            self.c.get_waveforms(model="test", origintime="a")
+            self.c.get_waveforms(model="ak135f_5s", origintime="a")
 
     def test_source_mechanisms_mock(self):
         r = RequestsMockResponse()
@@ -250,7 +250,7 @@ class TestClient():
         syngine and rely on the service for the error detection.
         """
         # Wrong components.
-        msg = re.compile("HTTP code 400 when.*Unrecognized component",
+        msg = re.compile("HTTP code 422 when.*String should match pattern",
                          re.DOTALL)
         with pytest.raises(ClientHTTPException, match=msg):
             self.c.get_waveforms(
@@ -341,41 +341,44 @@ class TestClient():
         Use the 'test' model which does not produce useful seismograms but
         is quick to test.
         """
-        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+        st = self.c.get_waveforms(model="ak135f_5s", network="IU",
+                                  station="ANMO",
                                   eventid="GCMT:C201002270634A",
                                   components="Z")
         assert len(st) == 1
         # Download exactly the same with a bulk request and check the result
         # is the same!
         st_bulk = self.c.get_waveforms_bulk(
-            model="test", bulk=[("IU", "ANMO")],
+            model="ak135f_5s", bulk=[("IU", "ANMO")],
             eventid="GCMT:C201002270634A", components="Z")
         assert len(st_bulk) == 1
         assert st == st_bulk
 
         # Test phase relative times. This tests that everything is correctly
         # encoded and what not.
-        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+        st = self.c.get_waveforms(model="ak135f_5s", network="IU",
+                                  station="ANMO",
                                   eventid="GCMT:C201002270634A",
                                   starttime="P-10", endtime="P+20",
                                   components="Z")
         assert len(st) == 1
         st_bulk = self.c.get_waveforms_bulk(
-            model="test", bulk=[("IU", "ANMO")],
+            model="ak135f_5s", bulk=[("IU", "ANMO")],
             starttime="P-10", endtime="P+20",
             eventid="GCMT:C201002270634A", components="Z")
         assert len(st_bulk) == 1
         assert st == st_bulk
 
         # One to test a source mechanism
-        st = self.c.get_waveforms(model="test", network="IU", station="ANMO",
+        st = self.c.get_waveforms(model="ak135f_5s", network="IU",
+                                  station="ANMO",
                                   sourcemomenttensor=[1, 2, 3, 4, 5, 6],
                                   sourcelatitude=10, sourcelongitude=20,
                                   sourcedepthinmeters=100,
                                   components="Z")
         assert len(st) == 1
         st_bulk = self.c.get_waveforms_bulk(
-            model="test", bulk=[("IU", "ANMO")],
+            model="ak135f_5s", bulk=[("IU", "ANMO")],
             sourcemomenttensor=[1, 2, 3, 4, 5, 6],
             sourcelatitude=10, sourcelongitude=20,
             sourcedepthinmeters=100,
@@ -385,7 +388,7 @@ class TestClient():
 
         # One more to test actual time values.
         st = self.c.get_waveforms(
-            model="test", network="IU", station="ANMO",
+            model="ak135f_5s", network="IU", station="ANMO",
             origintime=obspy.UTCDateTime(2015, 1, 2, 3, 0, 5),
             starttime=obspy.UTCDateTime(2015, 1, 2, 3, 4, 5),
             endtime=obspy.UTCDateTime(2015, 1, 2, 3, 10, 5),
@@ -395,7 +398,7 @@ class TestClient():
             components="Z")
         assert len(st) == 1
         st_bulk = self.c.get_waveforms_bulk(
-            model="test", bulk=[("IU", "ANMO")],
+            model="ak135f_5s", bulk=[("IU", "ANMO")],
             origintime=obspy.UTCDateTime(2015, 1, 2, 3, 0, 5),
             starttime=obspy.UTCDateTime(2015, 1, 2, 3, 4, 5),
             endtime=obspy.UTCDateTime(2015, 1, 2, 3, 10, 5),
@@ -411,7 +414,7 @@ class TestClient():
         with NamedTemporaryFile() as tf:
             filename = tf.name
             st = self.c.get_waveforms(
-                model="test", network="IU", station="ANMO",
+                model="ak135f_5s", network="IU", station="ANMO",
                 eventid="GCMT:C201002270634A", starttime="P-10",
                 endtime="P+10", components="Z", filename=tf)
             # No return value.
@@ -423,7 +426,7 @@ class TestClient():
         # Save to an open file-like object.
         with io.BytesIO() as buf:
             st = self.c.get_waveforms(
-                model="test", network="IU", station="ANMO",
+                model="ak135f_5s", network="IU", station="ANMO",
                 eventid="GCMT:C201002270634A", starttime="P-10",
                 endtime="P+10", components="Z", filename=buf)
             # No return value.
@@ -434,20 +437,16 @@ class TestClient():
             assert len(st) == 1
 
     def test_reading_saczip_files(self):
-        with pytest.warns(UserWarning,
-                          match="Sample spacing read from SAC"):
-            st = self.c.get_waveforms(
-                model="test", network="IU", station="ANMO",
-                eventid="GCMT:C201002270634A", starttime="P-10",
-                endtime="P+10", components="Z", format="saczip")
+        st = self.c.get_waveforms(
+            model="ak135f_5s", network="IU", station="ANMO",
+            eventid="GCMT:C201002270634A", starttime="P-10",
+            endtime="P+10", components="Z", format="saczip")
         assert len(st) == 1
         # Same with bulk request.
-        with pytest.warns(UserWarning,
-                          match="Sample spacing read from SAC"):
-            st_bulk = self.c.get_waveforms_bulk(
-                model="test", bulk=[("IU", "ANMO")],
-                eventid="GCMT:C201002270634A", starttime="P-10",
-                endtime="P+10", components="Z", format="saczip")
+        st_bulk = self.c.get_waveforms_bulk(
+            model="ak135f_5s", bulk=[("IU", "ANMO")],
+            eventid="GCMT:C201002270634A", starttime="P-10",
+            endtime="P+10", components="Z", format="saczip")
         assert len(st_bulk) == 1
 
         assert st == st_bulk


### PR DESCRIPTION
https://service.earthscope.org/irisws/syngine/1/models lists all models available and "test" is no longer there. Adapted the test cases to use another model, and check the returned error messages etc. Tests pass locally.

For some reason, the tests don't warn anymore for SACZ

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
