### PR TITLE
EarthScope: Add proper deprecation warnings for all their custom web

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,8 @@ Changes:
    * deprecate flinnengdahl web service, which EarthScope announced will be
      retired in July 2026. Users should use obspy.geodetics instead.
      (see #3756)
+   * deprecate all services except the evalresp service. Services get retired
+     throughout August 2026 (see #3791)
  - obspy.clients.neic:
    * change of IP address and domain to 137.227.252.145 and cwbp2.usgs.gov
      (see #3792).

--- a/obspy/clients/fdsn/client.py
+++ b/obspy/clients/fdsn/client.py
@@ -256,6 +256,13 @@ class Client(object):
                    "client short URL to 'EARTHSCOPE'.")
             warnings.warn(msg, ObsPyDeprecationWarning)
 
+        if base_url.upper() == 'IRISPH5':
+            msg = ("EarthScope PH5 WS will get retired on Sept. 1st 2026. See "
+                   "https://www.earthscope.org/news/mailing-lists/ for more "
+                   "information. The short URL 'IRISPH5' will get removed in "
+                   "a future obspy release so please adjust accordingly.")
+            warnings.warn(msg, ObsPyDeprecationWarning)
+
         if base_url.upper() == 'RESIF':
             msg = ("RESIF is now EPOSFR. Webservices and client will be "
                    "shutdown in 2026. Please consider changing the FDSN "

--- a/obspy/clients/fdsn/header.py
+++ b/obspy/clients/fdsn/header.py
@@ -143,6 +143,8 @@ URL_MAPPINGS = {
     "USGS": "https://earthquake.usgs.gov",
     "USP": "https://sismo.iag.usp.br"
 }
+# Earthscope PH5 WS will get removed Sept 1 2026, we start showing a warning
+# with 1.5.1, so get rid of it completely with 1.6.0 or 1.7.0
 URL_MAPPING_SUBPATHS = {
     "IRISPH5": "/ph5ws",
 }

--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -274,7 +274,9 @@ class TestClient():
         Tests the IRISPH5 URL mapping, which is special due to its custom
         subpath.
         """
-        client = Client('IRISPH5')
+        with pytest.warns(ObsPyDeprecationWarning,
+                          match="EarthScope PH5 WS will get retired"):
+            client = Client('IRISPH5')
 
         # Event id query.
         cat = client.get_events(catalog='8A')
@@ -825,10 +827,12 @@ class TestClient():
         for tr in st:
             assert isinstance(tr.stats.get("response"), Response)
 
-        st = client.get_waveforms("IU", "ANMO", "00", "BHZ",
-                                  UTCDateTime("2000-02-27T06:00:00.000"),
-                                  UTCDateTime("2000-02-27T06:00:05.000"),
-                                  attach_response=True)
+        with pytest.warns(ObsPyDeprecationWarning,
+                          match="attach_response is deprecated"):
+            st = client.get_waveforms("IU", "ANMO", "00", "BHZ",
+                                      UTCDateTime("2000-02-27T06:00:00.000"),
+                                      UTCDateTime("2000-02-27T06:00:05.000"),
+                                      attach_response=True)
         for tr in st:
             assert isinstance(tr.stats.get("response"), Response)
 

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -65,14 +65,10 @@ class Client(object):
 
     >>> from obspy.clients.iris import Client
     >>> client = Client()
-    >>> result = client.distaz(stalat=1.1, stalon=1.2, evtlat=3.2,
-    ...                        evtlon=1.4)
-    >>> print(result['distance'])
-    2.10256
-    >>> print(result['backazimuth'])
-    5.46944
-    >>> print(result['azimuth'])
-    185.47695
+    >>> dt = UTCDateTime("2005-01-01")
+    >>> data = client.evalresp("IU", "ANMO", "00", "BHZ", dt, output='fap')
+    >>> data[0]  # frequency, amplitude, phase of first point
+    array([  1.00000000e-05,   1.05593400e+04,   1.79200700e+02])
     """
     def __init__(self, base_url="https://service.earthscope.org/irisws",
                  user="", password="", timeout=20, debug=False,
@@ -303,20 +299,6 @@ class Client(object):
 
         :rtype: :class:`~obspy.core.stream.Stream` or ``None``
         :return: ObsPy Stream object if no ``filename`` is given.
-
-        .. rubric:: Example
-
-        >>> from obspy.clients.iris import Client
-        >>> from obspy import UTCDateTime
-        >>> dt = UTCDateTime("2005-01-01T00:00:00")
-        >>> client = Client()
-        >>> st = client.timeseries("IU", "ANMO", "00", "BHZ", dt, dt+10)
-        >>> print(st[0].data)  # doctest: +ELLIPSIS
-        [  24   20   19   19   19   15   10    4   -4  -11 ...
-        >>> st = client.timeseries("IU", "ANMO", "00", "BHZ", dt, dt+10,
-        ...     filter=["correct", "demean", "lp=2.0"])
-        >>> print(st[0].data)  # doctest: +ELLIPSIS
-        [ -1.57498380e-06  -1.26325779e-06  -7.84855445e-07 ...
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -402,23 +384,6 @@ class Client(object):
             nothing will be returned. Default is ``None``.
         :rtype: str or ``None``
         :return: SEED RESP file as string if no ``filename`` is given..
-
-        .. rubric:: Example
-
-        >>> from obspy.clients.iris import Client
-        >>> from obspy import UTCDateTime
-        >>> client = Client()
-        >>> dt = UTCDateTime("2010-02-27T06:30:00.000")
-        >>> data = client.resp("IU", "ANMO", "00", "BHZ", dt)
-        >>> print(data.decode())  # doctest: +ELLIPSIS
-        #
-        ####################################################################...
-        #
-        B050F03     Station:     ANMO
-        B050F16     Network:     IU
-        B052F03     Location:    00
-        B052F04     Channel:     BHZ
-        ...
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -492,45 +457,6 @@ class Client(object):
         :rtype: str or ``None``
         :return: String with SAC poles and zeros information if no ``filename``
             is given.
-
-        .. rubric:: Example
-
-        >>> from obspy.clients.iris import Client
-        >>> from obspy import UTCDateTime
-        >>> client = Client()
-        >>> dt = UTCDateTime("2005-01-01")
-        >>> sacpz = client.sacpz("IU", "ANMO", "00", "BHZ", dt)
-        >>> print(sacpz.decode())  # doctest: +SKIP
-        * **********************************
-        * NETWORK   (KNETWK): IU
-        * STATION    (KSTNM): ANMO
-        * LOCATION   (KHOLE): 00
-        * CHANNEL   (KCMPNM): BHZ
-        * CREATED           : ...
-        * START             : 2002-11-19T21:07:00
-        * END               : 2008-06-30T00:00:00
-        * DESCRIPTION       : Albuquerque, New Mexico, USA
-        * LATITUDE          : 34.945981
-        * LONGITUDE         : -106.457133
-        * ELEVATION         : 1671.0
-        * DEPTH             : 145.0
-        * DIP               : 0.0
-        * AZIMUTH           : 0.0
-        * SAMPLE RATE       : 20.0
-        * INPUT UNIT        : M
-        * OUTPUT UNIT       : COUNTS
-        * INSTTYPE          : Geotech KS-54000 Borehole Seismometer
-        * INSTGAIN          : 1.935000e+03 (M/S)
-        * ...
-        * **********************************
-        ZEROS      3
-           +0.000000e+00   +0.000000e+00
-           +0.000000e+00   +0.000000e+00
-           +0.000000e+00   +0.000000e+00
-        POLES      5 ...
-        CONSTANT   6.985619e+13
-        <BLANKLINE>
-        ...
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -596,23 +522,6 @@ class Client(object):
 
         The ``distance`` (in degrees) and ``distancemeters`` are the distance
         between the two points on the spheroid.
-
-        .. rubric:: Example
-
-        >>> from obspy.clients.iris import Client
-        >>> client = Client()
-        >>> result = client.distaz(stalat=1.1, stalon=1.2, evtlat=3.2,
-        ...                        evtlon=1.4)
-        >>> print(result['distance'])
-        2.10256
-        >>> print(result['distancemeters'])
-        233272.79028
-        >>> print(result['backazimuth'])
-        5.46944
-        >>> print(result['azimuth'])
-        185.47695
-        >>> print(result['ellipsoidname'])
-        WGS84
         """
         # build up query
         try:
@@ -655,23 +564,6 @@ class Client(object):
         :rtype: int, str, or tuple
         :returns: Returns Flinn-Engdahl region code or name or both, depending
             on the request type parameter ``rtype``.
-
-        .. rubric:: Examples
-
-        >>> from obspy.clients.iris import Client
-        >>> client = Client()
-        >>> client.flinnengdahl(
-        ...     lat=-20.5, lon=-100.6, rtype="code")  # doctest: +SKIP
-        683
-
-        >>> print(client.flinnengdahl(
-        ...     lat=42, lon=-122.24, rtype="region"))  # doctest: +SKIP
-        OREGON
-
-        >>> code, region = client.flinnengdahl(
-        ...     lat=-20.5, lon=-100.6)  # doctest: +SKIP
-        >>> print(code, region)  # doctest: +SKIP
-        683 SOUTHEAST CENTRAL PACIFIC OCEAN
         """
         service = 'flinnengdahl'
         # check rtype
@@ -788,21 +680,6 @@ class Client(object):
             nothing will be returned. Default is ``None``.
         :rtype: str or ``None``
         :return: ASCII travel time table if no ``filename`` is given.
-
-        .. rubric:: Example
-
-        >>> from obspy.clients.iris import Client
-        >>> client = Client()
-        >>> result = client.traveltime(evloc=(-36.122,-72.898),
-        ...     staloc=[(-33.45,-70.67),(47.61,-122.33),(35.69,139.69)],
-        ...     evdepth=22.9)
-        >>> print(result.decode())  # doctest: +ELLIPSIS  +NORMALIZE_WHITESPACE
-        Model: iasp91
-        Distance   Depth   Phase   Travel    Ray Param  Takeoff  Incident ...
-          (deg)     (km)   Name    Time (s)  p (s/deg)   (deg)    (deg)   ...
-        ------------------------------------------------------------------...
-            3.24    22.9   P         49.39    13.750     53.77    45.82   ...
-            3.24    22.9   Pn        49.40    13.754     53.80    45.84   ...
         """
         kwargs = {}
         kwargs['model'] = str(model)

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -161,144 +161,17 @@ class Client(object):
                 fh.close()
 
     # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
-    @deprecated(
-        'EarthScope has announced the retirement of its "irisws-timeseries" '
-        'web service for August 26, 2026. For details see '
-        'https://www.earthscope.org/news/mailing-lists/. This method will '
-        'be removed in a future obspy release, so please adjust accordingly.')
+    @deprecated()
     def timeseries(self, network, station, location, channel,
                    starttime, endtime, filter=[], filename=None,
                    output='miniseed', **kwargs):
         """
-        Low-level interface for `timeseries` Web service of EarthScope
-        (https://service.earthscope.org/irisws/timeseries/)- release 1.3.5
-        (2012-06-07).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method fetches segments of seismic data and returns data formatted
-        in either MiniSEED, ASCII or SAC. It can optionally filter the data.
-
-        **Channel and temporal constraints (required)**
-
-        The four SCNL parameters (Station - Channel - Network - Location) are
-        used to determine the channel of interest, and are all required.
-        Wildcards are not accepted.
-
-        :type network: str
-        :param network: Network code, e.g. ``'IU'``.
-        :type station: str
-        :param station: Station code, e.g. ``'ANMO'``.
-        :type location: str
-        :param location: Location code, e.g. ``'00'``
-        :type channel: str
-        :param channel: Channel code, e.g. ``'BHZ'``.
-        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`
-        :param starttime: Start date and time.
-        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`
-        :param endtime: End date and time.
-
-        **Filter Options**
-
-        The following parameters act as filters upon the time series.
-
-        :type filter: list[str], optional
-        :param filter: Filter list.  List order matters because each filter
-            operation is performed in the order given. For example
-            ``filter=["demean", "lp=2.0"]`` will demean and then apply a
-            low-pass filter, while ``filter=["lp=2.0", "demean"]`` will apply
-            the low-pass filter first, and then demean.
-
-            ``"taper=WIDTH,TYPE"``
-                Apply a time domain symmetric tapering function to the
-                time series data. The width is specified as a fraction of the
-                trace length from 0 to 0.5. The window types HANNING (default),
-                HAMMING, or COSINE may be optionally followed, e.g.
-                ``"taper=0.25"`` or ``"taper=0.5,COSINE"``.
-            ``"envelope=true"``
-                Calculate the envelope of the time series. This calculation
-                uses a Hilbert transform approximated by a time domain filter.
-            ``"lp=FREQ"``
-                Low-pass filter the time-series using an IIR 4th order filter,
-                using this value (in Hertz) as the cutoff, e.g. ``"lp=1.0"``.
-            ``"hp=FREQ"``
-                High-pass filter the time-series using an IIR 4th order filter,
-                using this value (in Hertz) as the cutoff, e.g. ``"hp=3.0"``.
-            ``"bp=FREQ1,FREQ2"``
-                Band pass frequencies, in Hz, e.g. ``"bp=0.1,1.0"``.
-            ``"demean"``
-                Remove mean value from data.
-            ``"scale"``
-                Scale data samples by specified factor, e.g. ``"scale=2.0"``
-                If ``"scale=AUTO"``, the data will be scaled by the stage-zero
-                gain. Cannot specify both ``scale`` and ``divscale``.
-                Cannot specify both ``correct`` and ``scale=AUTO``.
-            ``"divscale"``
-                Scale data samples by the inverse of the specified factor, e.g
-                ``"divscale=2.0"``. You cannot specify both ``scale`` and
-                ``divscale``.
-            ``"correct"``
-                Apply instrument correction to convert to earth units. Uses
-                either deconvolution or polynomial response correction. Cannot
-                specify both ``correct`` and ``scale=AUTO``. Correction
-                on > 10^7 samples will result in an error. At a sample rate of
-                20 Hz, 10^7 samples is approximately 5.8 days.
-            ``"freqlimits=FREQ1,FREQ2,FREQ3,FREQ4"``
-                Specify an envelope for a spectrum taper for deconvolution,
-                e.g. ``"freqlimits=0.0033,0.004,0.05,0.06"``. Frequencies are
-                specified in Hertz. This cosine taper scales the spectrum from
-                0 to 1 between FREQ1 and FREQ2 and from 1 to 0 between FREQ3
-                and FREQ4. Can only be used with the correct option. Cannot be
-                used in combination with the ``autolimits`` option.
-            ``"autolimits=X,Y"``
-                Automatically determine frequency limits for deconvolution,
-                e.g. ``"autolimits=3.0,3.0"``. A pass band is determined for
-                all frequencies with the lower and upper corner cutoffs defined
-                in terms of dB down from the maximum amplitude. This algorithm
-                is designed to work with flat responses, i.e. a response in
-                velocity for an instrument which is flat to velocity. Other
-                combinations will likely result in unsatisfactory results.
-                Cannot be used in combination with the ``freqlimits`` option.
-            ``"units=UNIT"``
-                Specify output units. Can be DIS, VEL, ACC or DEF, where DEF
-                results in no unit conversion, e.g. ``"units=VEL"``. Option
-                ``units`` can only be used with ``correct``.
-            ``"diff"``
-                Differentiate using 2 point (uncentered) method
-            ``"int"``
-                Integrate using trapezoidal (midpoint) method
-            ``"decimate=SAMPLERATE"``
-                Specify the sample-rate to decimate to, e.g.
-                ``"decimate=2.0"``. The sample-rate of the source divided by
-                the given sample-rate must be factorable by 2,3,4,7.
-
-        **Miscelleneous options**
-
-        :type filename: str, optional
-        :param filename: Name of a output file. If this parameter is given
-            nothing will be returned. Default is ``None``.
-        :type output: str, optional
-        :param output: Output format if parameter ``filename`` is used.
-
-            ``'ascii'``
-                Data format, 1 column (values)
-            ``'ascii2'``
-                ASCII data format, 2 columns (time, value)
-            ``'ascii'``
-                Same as ascii2
-            ``'audio'``
-                audio WAV file
-            ``'miniseed'``
-                MiniSEED format
-            ``'plot'``
-                A simple plot of the time series
-            ``'saca'``
-                SAC, ASCII format
-            ``'sacbb'``
-                SAC, binary big-endian format
-            ``'sacbl'``
-                SAC, binary little-endian format
-
-        :rtype: :class:`~obspy.core.stream.Stream` or ``None``
-        :return: ObsPy Stream object if no ``filename`` is given.
+        EarthScope has announced the retirement of its "irisws-timeseries" web
+        service for August 26, 2026. For details see
+        https://www.earthscope.org/news/mailing-lists/. This method will be
+        removed in a future obspy release, so please adjust accordingly.
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -337,53 +210,16 @@ class Client(object):
         return stream
 
     # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
-    @deprecated(
-        'EarthScope has announced the retirement of its "irisws-resp" web '
-        'service for August 31, 2026. For details see '
-        'https://www.earthscope.org/news/mailing-lists/. This method will '
-        'be removed in a future obspy release, so please adjust accordingly.')
+    @deprecated()
     def resp(self, network, station, location="*", channel="*",
              starttime=None, endtime=None, filename=None, **kwargs):
         """
-        Low-level interface for `resp` Web service of EarthScope
-        (https://service.earthscope.org/irisws/resp/) - 1.4.1 (2011-04-14).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method provides access to channel response information in the SEED
-        `RESP <https://ds.iris.edu/ds/nodes/dmc/kb/questions/60>`_
-        format (as used by evalresp). Users can query for channel response by
-        network, station, channel, location and time.
-
-        :type network: str
-        :param network: Network code, e.g. ``'IU'``.
-        :type station: str
-        :param station: Station code, e.g. ``'ANMO'``.
-        :type location: str, optional
-        :param location: Location code, e.g. ``'00'``, wildcards allowed.
-            Defaults to ``'*'``.
-        :type channel: str, optional
-        :param channel: Channel code, e.g. ``'BHZ'``, wildcards allowed.
-            Defaults to ``'*'``.
-
-        **Temporal constraints**
-
-        The following three parameters impose time constraints on the query.
-        Time may be requested through the use of either time OR the start and
-        end times. If no time is specified, then the current time is assumed.
-
-        :type time: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
-        :param time: Find the response for the given time. Time cannot be used
-            with ``starttime`` or ``endtime`` parameters
-        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
-        :param starttime: Start time, may be used in conjunction with
-            ``endtime``.
-        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
-        :param endtime: End time, may be used in conjunction with
-            ``starttime``.
-        :type filename: str, optional
-        :param filename: Name of a output file. If this parameter is given
-            nothing will be returned. Default is ``None``.
-        :rtype: str or ``None``
-        :return: SEED RESP file as string if no ``filename`` is given..
+        EarthScope has announced the retirement of its "irisws-resp" web
+        service for August 31, 2026. For details see
+        https://www.earthscope.org/news/mailing-lists/. This method will
+        be removed in a future obspy release, so please adjust accordingly.
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -420,43 +256,16 @@ class Client(object):
         return self._to_file_or_data(filename, data)
 
     # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
-    @deprecated(
-        'EarthScope has announced the retirement of its "irisws-sacpz" web '
-        'service for August 31, 2026. For details see '
-        'https://www.earthscope.org/news/mailing-lists/. This method will '
-        'be removed in a future obspy release, so please adjust accordingly.')
+    @deprecated()
     def sacpz(self, network, station, location="*", channel="*",
               starttime=None, endtime=None, filename=None, **kwargs):
         """
-        Low-level interface for `sacpz` Web service of EarthScope
-        (https://service.earthscope.org/irisws/sacpz/)
-        release 1.1.1 (2012-1-9).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method provides access to instrument response information
-        (per-channel) as poles and zeros in the ASCII format used by SAC and
-        other programs. Users can query for channel response by network,
-        station, channel, location and time.
-
-        :type network: str
-        :param network: Network code, e.g. ``'IU'``.
-        :type station: str
-        :param station: Station code, e.g. ``'ANMO'``.
-        :type location: str, optional
-        :param location: Location code, e.g. ``'00'``, wildcards allowed.
-            Defaults to ``'*'``.
-        :type channel: str, optional
-        :param channel: Channel code, e.g. ``'BHZ'``, wildcards allowed.
-            Defaults to ``'*'``.
-        :type starttime: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
-        :param starttime: Start date and time.
-        :type endtime: :class:`~obspy.core.utcdatetime.UTCDateTime`, optional
-        :param endtime: End date and time. Requires ``starttime`` parameter.
-        :type filename: str, optional
-        :param filename: Name of a output file. If this parameter is given
-            nothing will be returned. Default is ``None``.
-        :rtype: str or ``None``
-        :return: String with SAC poles and zeros information if no ``filename``
-            is given.
+        EarthScope has announced the retirement of its "irisws-sacpz" web
+        service for August 31, 2026. For details see
+        https://www.earthscope.org/news/mailing-lists/. This method will
+        be removed in a future obspy release, so please adjust accordingly.
         """
         kwargs['network'] = str(network)
         kwargs['station'] = str(station)
@@ -487,41 +296,15 @@ class Client(object):
         return self._to_file_or_data(filename, data)
 
     # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
-    @deprecated(
-        'EarthScope has announced the retirement of its "irisws-distaz" '
-        'web service for August 27, 2026. For details see '
-        'https://www.earthscope.org/news/mailing-lists/. This method will '
-        'be removed in a future obspy release, so please adjust accordingly.')
+    @deprecated()
     def distaz(self, stalat, stalon, evtlat, evtlon):
         """
-        Low-level interface for `distaz` Web service of EarthScope
-        (https://service.earthscope.org/irisws/distaz/) - release 1.0.3 (2016).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method will calculate the great-circle angular distance, azimuth,
-        and backazimuth between two geographic coordinate pairs. All results
-        are reported in degrees, with azimuth and backazimuth measured
-        clockwise from North.
-
-        :type stalat: float
-        :param stalat: Station latitude.
-        :type stalon: float
-        :param stalon: Station longitude.
-        :type evtlat: float
-        :param evtlat: Event latitude.
-        :type evtlon: float
-        :param evtlon: Event longitude.
-        :rtype: dict
-        :return: Dictionary containing values for azimuth, backazimuth and
-            distance.
-
-        The ``azimuth`` is the angle from the station to the event, while the
-        ``backazimuth`` is the angle from the event to the station.
-
-        Latitudes are converted to geocentric latitudes using the WGS84
-        spheroid to correct for ellipticity.
-
-        The ``distance`` (in degrees) and ``distancemeters`` are the distance
-        between the two points on the spheroid.
+        EarthScope has announced the retirement of its "irisws-distaz"
+        web service for August 27, 2026. For details see
+        https://www.earthscope.org/news/mailing-lists/. This method will
+        be removed in a future obspy release, so please adjust accordingly.
         """
         # build up query
         try:
@@ -540,30 +323,14 @@ class Client(object):
         results['azimuth'] = float(data.azimuth)
         return results
 
-    @deprecated(
-        'EarthScope has announced the retirement of its Flinn-Engdahl web '
-        'service on or after July 6th 2026. Try using '
-        'obspy.geodetics.flinnengdahl instead.')
+    @deprecated()
     def flinnengdahl(self, lat, lon, rtype="both"):
         """
-        Low-level interface for `flinnengdahl` Web service of EarthScope
-        (https://service.earthscope.org/irisws/flinnengdahl/) - release 1.1
-        (2011-06-08).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method converts a latitude, longitude pair into either a
-        `Flinn-Engdahl <https://en.wikipedia.org/wiki/Flinn-Engdahl_regions>`_
-        seismic region code or region name.
-
-        :type lat: float
-        :param lat: Latitude of interest.
-        :type lon: float
-        :param lon: Longitude of interest.
-        :type rtype: str, optional
-        :param rtype: Return type. Can be one of ``'code'``, ``'region'`` or
-            ``'both'``. Defaults to ``'both'``.
-        :rtype: int, str, or tuple
-        :returns: Returns Flinn-Engdahl region code or name or both, depending
-            on the request type parameter ``rtype``.
+        EarthScope has announced the retirement of its Flinn-Engdahl web
+        service on or after July 6th 2026. Try using
+        obspy.geodetics.flinnengdahl instead.
         """
         service = 'flinnengdahl'
         # check rtype
@@ -591,95 +358,18 @@ class Client(object):
             raise Exception(msg)
 
     # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
-    @deprecated(
-        'EarthScope has announced the retirement of its "irisws-traveltime" '
-        'web service for August 27, 2026. For details see '
-        'https://www.earthscope.org/news/mailing-lists/. This method will '
-        'be removed in a future obspy release, so please adjust accordingly.')
+    @deprecated()
     def traveltime(self, model='iasp91', phases=DEFAULT_PHASES, evdepth=0.0,
                    distdeg=None, distkm=None, evloc=None, staloc=None,
                    noheader=False, traveltimeonly=False, rayparamonly=False,
                    mintimeonly=False, filename=None):
         """
-        Low-level interface for `traveltime` Web service of EarthScope
-        (https://service.earthscope.org/irisws/traveltime/) - release 1.1.1
-        (2012-05-15).
+        DEPRECATED as of 1.5.1 - will be removed in future release
 
-        This method will calculates travel-times for seismic phases using a 1-D
-        spherical earth model.
-
-        :type model: str, optional
-        :param model: Name of 1-D earth velocity model to be used. Available
-            models include:
-
-            * ``'iasp91'`` (default) - by Int'l Assoc of Seismology and
-              Physics of the Earth's Interior
-            * ``'prem'`` - Preliminary Reference Earth Model
-            * ``'ak135'``
-
-        :type phases: list[str], optional
-        :param phases: Comma separated list of phases. The default is as
-            follows::
-
-                ['p','s','P','S','Pn','Sn','PcP','ScS','Pdiff','Sdiff',
-                 'PKP','SKS','PKiKP','SKiKS','PKIKP','SKIKS']
-
-            Invalid phases will be ignored. Valid arbitrary phases can be made
-            up e.g. sSKJKP. See
-            `TauP documentation <http://www.seis.sc.edu/TauP/>`_ for more
-            information.
-        :type evdepth: float, optional
-        :param evdepth: The depth of the event, in kilometers. Default is ``0``
-            km.
-
-        **Geographical Parameters - required**
-
-        The travel time web service requires a great-circle distance between an
-        event and station be specified. There are three methods of specifying
-        this distance:
-
-        * Specify a great-circle distance in degrees, using ``distdeg``
-        * Specify a great-circle distance in kilometers, using ``distkm``
-        * Specify an event location and one or more station locations,
-          using ``evloc`` and ``staloc``
-
-        :type distdeg: float or list[float], optional
-        :param evtlon: Great-circle distance from source to station, in decimal
-            degrees. Multiple distances may be specified as a list.
-        :type distkm: float or list[float], optional
-        :param distkm: Distance between the source and station, in kilometers.
-            Multiple distances may be specified as a list.
-        :type evloc: tuple(float, float), optional
-        :param evloc: The Event location (lat,lon) using decimal degrees.
-        :type staloc: tuple(float, float) or list[tuple(float, float)],
-            optional
-        :param staloc: Station locations for which the phases will be listed.
-            The general format is (lat,lon). Specify multiple station locations
-            with a list, e.g. ``[(lat1,lon1),(lat2,lon2),...,(latn,lonn)]``.
-
-        **Output Parameters**
-
-        :type noheader: bool, optional
-        :param noheader: Specifying noheader will strip the header from the
-            resulting table. Defaults to ``False``.
-        :type traveltimeonly: bool, optional
-        :param traveltimeonly: Returns a space-separated list of travel
-            times, in seconds. Defaults to ``False``.
-
-            .. note:: Travel times are produced in ascending order regardless
-                of the order in which the phases are specified
-
-        :type rayparamonly: bool, optional
-        :param rayparamonly: Returns a space-separated list of ray parameters,
-            in sec/deg.. Defaults to ``False``.
-        :type mintimeonly: bool, optional
-        :param mintimeonly: Returns only the first arrival of each phase for
-            each distance. Defaults to ``False``.
-        :type filename: str, optional
-        :param filename: Name of a output file. If this parameter is given
-            nothing will be returned. Default is ``None``.
-        :rtype: str or ``None``
-        :return: ASCII travel time table if no ``filename`` is given.
+        EarthScope has announced the retirement of its "irisws-traveltime"
+        web service for August 27, 2026. For details see
+        https://www.earthscope.org/news/mailing-lists/. This method will
+        be removed in a future obspy release, so please adjust accordingly.
         """
         kwargs = {}
         kwargs['model'] = str(model)

--- a/obspy/clients/iris/client.py
+++ b/obspy/clients/iris/client.py
@@ -164,6 +164,12 @@ class Client(object):
             if file_opened is True:
                 fh.close()
 
+    # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
+    @deprecated(
+        'EarthScope has announced the retirement of its "irisws-timeseries" '
+        'web service for August 26, 2026. For details see '
+        'https://www.earthscope.org/news/mailing-lists/. This method will '
+        'be removed in a future obspy release, so please adjust accordingly.')
     def timeseries(self, network, station, location, channel,
                    starttime, endtime, filter=[], filename=None,
                    output='miniseed', **kwargs):
@@ -348,6 +354,12 @@ class Client(object):
                 stream = Stream()
         return stream
 
+    # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
+    @deprecated(
+        'EarthScope has announced the retirement of its "irisws-resp" web '
+        'service for August 31, 2026. For details see '
+        'https://www.earthscope.org/news/mailing-lists/. This method will '
+        'be removed in a future obspy release, so please adjust accordingly.')
     def resp(self, network, station, location="*", channel="*",
              starttime=None, endtime=None, filename=None, **kwargs):
         """
@@ -442,6 +454,12 @@ class Client(object):
             raise Exception(msg)
         return self._to_file_or_data(filename, data)
 
+    # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
+    @deprecated(
+        'EarthScope has announced the retirement of its "irisws-sacpz" web '
+        'service for August 31, 2026. For details see '
+        'https://www.earthscope.org/news/mailing-lists/. This method will '
+        'be removed in a future obspy release, so please adjust accordingly.')
     def sacpz(self, network, station, location="*", channel="*",
               starttime=None, endtime=None, filename=None, **kwargs):
         """
@@ -542,6 +560,12 @@ class Client(object):
         data = self._fetch("sacpz", **kwargs)
         return self._to_file_or_data(filename, data)
 
+    # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
+    @deprecated(
+        'EarthScope has announced the retirement of its "irisws-distaz" '
+        'web service for August 27, 2026. For details see '
+        'https://www.earthscope.org/news/mailing-lists/. This method will '
+        'be removed in a future obspy release, so please adjust accordingly.')
     def distaz(self, stalat, stalon, evtlat, evtlon):
         """
         Low-level interface for `distaz` Web service of EarthScope
@@ -674,6 +698,12 @@ class Client(object):
             msg = msg % (e.__class__.__name__, e)
             raise Exception(msg)
 
+    # new deprecation in 1.5.1, remove in 1.6.0 or 1.7.0
+    @deprecated(
+        'EarthScope has announced the retirement of its "irisws-traveltime" '
+        'web service for August 27, 2026. For details see '
+        'https://www.earthscope.org/news/mailing-lists/. This method will '
+        'be removed in a future obspy release, so please adjust accordingly.')
     def traveltime(self, model='iasp91', phases=DEFAULT_PHASES, evdepth=0.0,
                    distdeg=None, distkm=None, evloc=None, staloc=None,
                    noheader=False, traveltimeonly=False, rayparamonly=False,

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -242,9 +242,7 @@ class TestClient():
 def test_flinnengdahl_deprecation_warning():
     with mock.patch('obspy.clients.iris.Client._fetch'):
         client = Client()
-        msg = ('EarthScope has announced the retirement of its Flinn-Engdahl '
-               'web service on or after July 6th 2026. Try using '
-               'obspy.geodetics.flinnengdahl instead')
+        msg = ('EarthScope has announced the retirement')
         with pytest.warns(ObsPyDeprecationWarning, match=msg):
             with pytest.raises(Exception, match="410: Gone"):
                 client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -4,7 +4,6 @@ The obspy.clients.iris.client test suite.
 """
 import numpy as np
 import pytest
-from unittest import mock
 
 from obspy.core.utcdatetime import UTCDateTime
 from obspy.core.util import NamedTemporaryFile
@@ -238,9 +237,7 @@ class TestClient():
                 client.timeseries("IU", "ANMO", "00", "BHZ", t1, t2,
                                   filter=["correct"])
 
-
-def test_flinnengdahl_deprecation_warning():
-    with mock.patch('obspy.clients.iris.Client._fetch'):
+    def test_flinnengdahl_deprecation_warning(self):
         client = Client()
         msg = ('EarthScope has announced the retirement')
         with pytest.warns(ObsPyDeprecationWarning, match=msg):

--- a/obspy/clients/iris/tests/test_client.py
+++ b/obspy/clients/iris/tests/test_client.py
@@ -12,6 +12,9 @@ from obspy.core.util.deprecation_helpers import ObsPyDeprecationWarning
 from obspy.clients.iris import Client
 
 
+MSG = "EarthScope has announced the retirement"
+
+
 @pytest.mark.network
 class TestClient():
     """
@@ -25,23 +28,28 @@ class TestClient():
         # 1
         t1 = UTCDateTime("2005-01-01")
         t2 = UTCDateTime("2008-01-01")
-        result = client.sacpz("IU", "ANMO", "00", "BHZ", t1, t2)
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.sacpz("IU", "ANMO", "00", "BHZ", t1, t2)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
         # drop lines with creation date (current time during request)
-        result = result.splitlines()
-        with open(testdata['IU.ANMO.00.BHZ.sacpz'], 'rb') as fp:
-            expected = fp.read().splitlines()
-        result.pop(5)
-        expected.pop(5)
-        assert result == expected
         # 2 - empty location code
         dt = UTCDateTime("2002-11-01")
-        result = client.sacpz('UW', 'LON', '', 'BHZ', dt)
-        assert b"* STATION    (KSTNM): LON" in result
-        assert b"* LOCATION   (KHOLE):" in result
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.sacpz('UW', 'LON', '', 'BHZ', dt)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
         # 3 - empty location code via '--'
-        result = client.sacpz('UW', 'LON', '--', 'BHZ', dt)
-        assert b"* STATION    (KSTNM): LON" in result
-        assert b"* LOCATION   (KHOLE):" in result
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.sacpz('UW', 'LON', '--', 'BHZ', dt)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
 
     def test_distaz(self):
         """
@@ -49,47 +57,40 @@ class TestClient():
         """
         client = Client()
         # normal request
-        result = client.distaz(stalat=1.1, stalon=1.2, evtlat=3.2, evtlon=1.4)
-        assert round(abs(result['distance']-2.10256), 7) == 0
-        assert round(abs(result['distancemeters']-233272.79028), 7) == 0
-        assert round(abs(result['backazimuth']-5.46944), 7) == 0
-        assert round(abs(result['azimuth']-185.47695), 7) == 0
-        assert result['ellipsoidname'] == 'WGS84'
-        assert isinstance(result['distance'], float)
-        assert isinstance(result['distancemeters'], float)
-        assert isinstance(result['backazimuth'], float)
-        assert isinstance(result['azimuth'], float)
-        assert isinstance(result['ellipsoidname'], str)
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.distaz(stalat=1.1, stalon=1.2, evtlat=3.2, evtlon=1.4)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
         # w/o kwargs
-        result = client.distaz(1.1, 1.2, 3.2, 1.4)
-        assert round(abs(result['distance']-2.10256), 7) == 0
-        assert round(abs(result['distancemeters']-233272.79028), 7) == 0
-        assert round(abs(result['backazimuth']-5.46944), 7) == 0
-        assert round(abs(result['azimuth']-185.47695), 7) == 0
-        assert result['ellipsoidname'] == 'WGS84'
-        # missing parameters
-        with pytest.raises(Exception):
-            client.distaz(stalat=1.1)
-        with pytest.raises(Exception):
-            client.distaz(1.1)
-        with pytest.raises(Exception):
-            client.distaz(stalat=1.1, stalon=1.2)
-        with pytest.raises(Exception):
-            client.distaz(1.1, 1.2)
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.distaz(1.1, 1.2, 3.2, 1.4)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
 
     def test_traveltime(self):
         """
         Tests calculation of travel-times for seismic phases.
         """
         client = Client()
-        result = client.traveltime(
-            evloc=(-36.122, -72.898), evdepth=22.9,
-            staloc=[(-33.45, -70.67), (47.61, -122.33), (35.69, 139.69)])
-        assert result.startswith(b'Model: iasp91')
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.traveltime(
+                    evloc=(-36.122, -72.898), evdepth=22.9,
+                    staloc=[(-33.45, -70.67), (47.61, -122.33),
+                            (35.69, 139.69)])
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
 
     def test_evalresp(self):
         """
         Tests evaluating instrument response information.
+
+        This is the only custom irisws endpoint that will stay for now.
         """
         client = Client()
         dt = UTCDateTime("2005-01-01")
@@ -193,25 +194,28 @@ class TestClient():
         # 1
         t1 = UTCDateTime("2005-001T00:00:00")
         t2 = UTCDateTime("2008-001T00:00:00")
-        result = client.resp("IU", "ANMO", "00", "BHZ", t1, t2)
-        assert b'B050F03     Station:     ANMO' in result
-        # Exception: No response data available
-        # 2 - empty location code
-        # result = client.resp("UW", "LON", "", "EHZ")
-        # self.assertIn(b'B050F03     Station:     LON', result)
-        # self.assertIn(b'B052F03     Location:    ??', result)
-        # 3 - empty location code via '--'
-        # result = client.resp("UW", "LON", "--", "EHZ")
-        # self.assertIn(b'B050F03     Station:     LON', result)
-        # self.assertIn(b'B052F03     Location:    ??', result)
-        # 4
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.resp("IU", "ANMO", "00", "BHZ", t1, t2)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
+
         dt = UTCDateTime("2010-02-27T06:30:00.000")
-        result = client.resp("IU", "ANMO", "*", "*", dt)
-        assert b'B050F03     Station:     ANMO' in result
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.resp("IU", "ANMO", "*", "*", dt)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
 
         dt = UTCDateTime("2005-001T00:00:00")
-        result = client.resp("AK", "RIDG", "--", "LH?", dt)
-        assert b'B050F03     Station:     RIDG' in result
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            try:
+                client.resp("AK", "RIDG", "--", "LH?", dt)
+            except Exception as e:
+                # expected to start failing soon
+                assert 'HTTP Error 410: Gone' in str(e)
 
     def test_timeseries(self):
         """
@@ -225,15 +229,14 @@ class TestClient():
         t1 = UTCDateTime("2005-001T00:00:00")
         t2 = UTCDateTime("2005-001T00:01:00")
         # no filter
-        st1 = client.timeseries("IU", "ANMO", "00", "BHZ", t1, t2)
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            with pytest.raises(Exception, match="410: Gone"):
+                client.timeseries("IU", "ANMO", "00", "BHZ", t1, t2)
         # instrument corrected
-        st2 = client.timeseries("IU", "ANMO", "00", "BHZ", t1, t2,
-                                filter=["correct"])
-        # compare results
-        assert st1[0].stats.starttime == st2[0].stats.starttime
-        assert st1[0].stats.endtime == st2[0].stats.endtime
-        assert st1[0].data[0] == 24
-        assert round(abs(st2[0].data[0]--2.8373747e-06), 7) == 0
+        with pytest.warns(ObsPyDeprecationWarning, match=MSG):
+            with pytest.raises(Exception, match="410: Gone"):
+                client.timeseries("IU", "ANMO", "00", "BHZ", t1, t2,
+                                  filter=["correct"])
 
 
 def test_flinnengdahl_deprecation_warning():
@@ -243,4 +246,5 @@ def test_flinnengdahl_deprecation_warning():
                'web service on or after July 6th 2026. Try using '
                'obspy.geodetics.flinnengdahl instead')
         with pytest.warns(ObsPyDeprecationWarning, match=msg):
-            client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")
+            with pytest.raises(Exception, match="410: Gone"):
+                client.flinnengdahl(lat=-20.5, lon=-100.6, rtype="code")


### PR DESCRIPTION
### What does this PR do?

Show proper deprecation warnings for web service calls that go to Earthscope custom endpoints that get retired mid 2026, so that a proper warning shows up when these calls will start failing soon.

### Links to other Issues?

--

### AI used?

no

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
