### PR TITLE
Fix neic ip & domain

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,9 @@ Changes:
    * deprecate flinnengdahl web service, which EarthScope announced will be
      retired in July 2026. Users should use obspy.geodetics instead.
      (see #3756)
+ - obspy.clients.neic:
+   * change of IP address and domain to 137.227.252.145 and cwbp2.usgs.gov
+     (see #3792).
  - obspy.clients.seedlink:
    * respect user specified timeout also in making the initial socket
      connection. Currently, when establishing the initial low-level socket

--- a/obspy/clients/neic/README.txt
+++ b/obspy/clients/neic/README.txt
@@ -15,7 +15,7 @@ NEIC CWB Query service client for ObsPy.
 
 The obspy.clients.neic package contains a client for the QueryServer software
 run at the National Earthquake Information Center (NEIC) in Golden, CO USA.
-This service is run publicly at cwbpub.cr.usgs.gov on port 2061.  This server
+This service is run publicly at cwbp2.usgs.gov on port 2061.  This server
 returns data based on a query command string as a series of binary MiniSEED
 blocks.  The data are not necessarily in order and may have gaps, overlaps and
 possibly duplicate blocks.  The client (this software) has to deal with these

--- a/obspy/clients/neic/__init__.py
+++ b/obspy/clients/neic/__init__.py
@@ -3,7 +3,7 @@
 obspy.clients.neic - CWB query module for ObsPy
 ===============================================
 The obspy.clients.neic package contains a client for the NEIC CWB Query server.
-A public server is at 137.227.230.97" for cwbpub.usgs.gov on port 2061.
+A public server is at 137.227.252.145 for cwbp2.usgs.gov on port 2061.
 
 :copyright:
     The ObsPy Development Team (devs@obspy.org)

--- a/obspy/clients/neic/client.py
+++ b/obspy/clients/neic/client.py
@@ -24,7 +24,7 @@ class Client(object):
 
     :type host: str, optional
     :param host: The IP address or DNS name of the server
-        (default is "137.227.230.97" for cwbpub.usgs.gov)
+        (default is "137.227.252.145" for cwbp2.usgs.gov)
     :type port: int, optional
     :param port: The port of the QueryServer (default is ``2061``)
     :type timeout: int, optional
@@ -51,7 +51,7 @@ class Client(object):
     IU.ANMO.00.BH... | 40.0 Hz, 401 samples
     IU.ANMO.00.BH... | 40.0 Hz, 401 samples
     """
-    def __init__(self, host="137.227.230.97", port=2061, timeout=30,
+    def __init__(self, host="137.227.252.145", port=2061, timeout=30,
                  debug=False):
         """
         Initializes access to a CWB QueryServer


### PR DESCRIPTION

### What does this PR do?

The host cwbp2.usgs.gov (IP address 137.227.252.145) is the updated server replacing the older cwbpub.cr.usgs.gov (137.227.224.97) used by the [USGS National Earthquake Information Center](https://www.usgs.gov/programs/earthquake-hazards/national-earthquake-information-center-neic) for seismic data services.

Somehow linked to #3590 but never got it right, my bad it seems.

### AI used?

no 

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
