### PR TITLE
Fix seedlink server for EPOSFR (doctests & tests)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changes:
      connection no timeout is used, which in practice leads to a default 2min
      timeout even if user sets a shorter timeout when establishing the client
      (see #3767)
+   * fix seedlink for EPOSFR to rtserve.resif.fr (see #3793)
  - obspy.imaging:
    * fix a bug in dayplot when data is only available for part of the time
      window (see #3780)

--- a/obspy/clients/seedlink/basic_client.py
+++ b/obspy/clients/seedlink/basic_client.py
@@ -31,7 +31,7 @@ class Client(object):
 
     :type server: str
     :param server: Server name or IP address to connect to (e.g.
-        "localhost", "rtserver.ipgp.fr")
+        "localhost", "rtserve.resif.fr")
     :type port: int
     :param port: Port at which the seedlink server is operating (default is
         `18000`).
@@ -74,7 +74,7 @@ class Client(object):
         Request waveform data from the seedlink server.
 
         >>> from obspy import UTCDateTime
-        >>> client = Client('rtserver.ipgp.fr')
+        >>> client = Client('rtserve.resif.fr')
         >>> t = UTCDateTime() - 1500
         >>> st = client.get_waveforms("G", "FDFM", "10", "BHZ", t, t + 5)
         >>> print(st)  # doctest: +ELLIPSIS
@@ -204,7 +204,7 @@ class Client(object):
         Supports ``fnmatch`` wildcards, e.g. ``*`` and ``?``, in ``network``,
         ``station``, ``location`` and ``channel``.
 
-        >>> client = Client('rtserver.ipgp.fr')
+        >>> client = Client('rtserve.resif.fr')
         >>> info = client.get_info(station="FDFM")
         >>> print(info)
         [('G', 'FDFM')]

--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -14,7 +14,7 @@ from obspy.clients.seedlink.basic_client import Client
 class TestClient():
 
     def init_client(self):
-        self.client = Client("rtserver.ipgp.fr")
+        self.client = Client("rtserve.resif.fr")
 
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):


### PR DESCRIPTION

### AI used?

njet

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [ ] **Tests**: Added new tests for any new features or fixed regressions
- [ ] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [ ] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**

Rare actions items:

- [ ] First time contributors: Feel free to add your name to `CONTRIBUTORS.txt`
- [ ] New modules: add the module to `CODEOWNERS` with your github handle

### Issue labels

The PR can be flagged with the following "issue labels" to alter CI runs:
- `no_ci` to skip CI builds while work-in-progress
- `build_docs` to trigger automatic docs build to [see how docs render for the PR](https://docs.obspy.org/pr/)
- `test_network` to include "networked" tests if the PR touches any tests marked as "network"
- `upload_images` to attach plots generated in tests as artifacts to the CI run
