### PR TITLE
Fix tsindex connection pool leak on repeated queries (#3430, follow-up to #3736)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,14 @@ Changes:
  - General:
    * adjusted minimum dependency versions to Python >=3.12, numpy >=2.2,
      scipy >=1.15 and matplotlib >=3.9 (see #3570)
+ - obspy.clients.filesystem:
+   * tsindex: fix a remaining connection pool leak that could exhaust the pool
+     with a "QueuePool limit ... reached" error. The session refactor in #3736
+     wrapped the index/summary row queries in a session context manager but
+     closed it before the lazily evaluated query was iterated, so iteration
+     re-opened a connection on the already-closed session that was never
+     returned to the pool. The query is now consumed inside the session
+     context (see #3430, follow-up to #3736)
  - obspy.signal:
    * spectral estimation: add getter functions for rotational noise models
      (see #3732)

--- a/obspy/clients/filesystem/tests/test_tsindex.py
+++ b/obspy/clients/filesystem/tests/test_tsindex.py
@@ -552,6 +552,28 @@ class TestClient():
         assert not client.has_data(starttime=UTCDateTime(1970, 12, 31),
                                    endtime=UTCDateTime(2013, 1, 7))
 
+    def test_no_connection_pool_leak(self, client):
+        """
+        Repeated queries must not leak connections from the pool (#3430).
+
+        The index/summary row queries are lazily evaluated. The session
+        refactor in #3736 wrapped them in a ``with self.session()`` context
+        manager but closed it before iterating the query, so iteration
+        re-opened a connection on the already-closed session that was never
+        returned to the pool. After enough queries this exhausted the pool
+        with a ``QueuePool limit ... reached`` ``ValueError``.
+        """
+        pool = client.request_handler.engine.pool
+        # run comfortably more queries than the pool can ever hold at once
+        n_iter = pool.size() + pool._max_overflow + 10
+        for _ in range(n_iter):
+            client.has_data(network="*", station="*", location="*",
+                            channel="*")
+            client.get_availability(network="*", station="*", location="*",
+                                    channel="*")
+        # all connections must have been returned to the pool
+        assert pool.checkedout() == 0
+
 
 def purge(dir, pattern):
     """

--- a/obspy/clients/filesystem/tsindex.py
+++ b/obspy/clients/filesystem/tsindex.py
@@ -1475,33 +1475,38 @@ class TSIndexDatabaseHandler(object):
             except Exception as err:
                 raise ValueError(str(err))
 
-        index_rows = []
-        try:
-            for rt in result:
-                # convert to a named tuple
-                NamedRow = namedtuple('NamedRow',
-                                      ['network', 'station', 'location',
-                                       'channel', 'quality', 'version',
-                                       'starttime', 'endtime', 'samplerate',
-                                       'filename', 'byteoffset', 'bytes',
-                                       'hash', 'timeindex', 'timespans',
-                                       'timerates', 'format', 'filemodtime',
-                                       'updated', 'scanned', 'requeststart',
-                                       'requestend'])
-                row, requeststart, requestend = rt
-                nrow = NamedRow(
-                        row.network, row.station, row.location,
-                        row.channel, row.quality, row.version,
-                        row.starttime, row.endtime, row.samplerate,
-                        row.filename, row.byteoffset, row.bytes,
-                        row.hash, row.timeindex, row.timespans,
-                        row.timerates, row.format, row.filemodtime,
-                        row.updated, row.scanned,
-                        requeststart, requestend
-                       )
-                index_rows.append(nrow)
-        except ResourceClosedError:
-            pass  # query returned no results
+            # NOTE: ``result`` is a lazily evaluated query. It must be
+            # consumed *inside* the ``with self.session()`` block, otherwise
+            # iterating it re-opens a connection on the already-closed session
+            # that is never returned to the pool, eventually exhausting it
+            # (see #3430).
+            index_rows = []
+            NamedRow = namedtuple('NamedRow',
+                                  ['network', 'station', 'location',
+                                   'channel', 'quality', 'version',
+                                   'starttime', 'endtime', 'samplerate',
+                                   'filename', 'byteoffset', 'bytes',
+                                   'hash', 'timeindex', 'timespans',
+                                   'timerates', 'format', 'filemodtime',
+                                   'updated', 'scanned', 'requeststart',
+                                   'requestend'])
+            try:
+                for rt in result:
+                    # convert to a named tuple
+                    row, requeststart, requestend = rt
+                    nrow = NamedRow(
+                            row.network, row.station, row.location,
+                            row.channel, row.quality, row.version,
+                            row.starttime, row.endtime, row.samplerate,
+                            row.filename, row.byteoffset, row.bytes,
+                            row.hash, row.timeindex, row.timespans,
+                            row.timerates, row.format, row.filemodtime,
+                            row.updated, row.scanned,
+                            requeststart, requestend
+                           )
+                    index_rows.append(nrow)
+            except ResourceClosedError:
+                pass  # query returned no results
         logger.debug("Fetched %d index rows" % len(index_rows))
         return index_rows
 
@@ -1586,16 +1591,21 @@ class TSIndexDatabaseHandler(object):
             except Exception as err:
                 raise ValueError(str(err))
 
-        # Map raw tuples to named tuples for clear referencing
-        NamedRow = namedtuple('NamedRow',
-                              ['network', 'station', 'location', 'channel',
-                               'earliest', 'latest', 'updated'])
-        summary_rows = []
-        try:
-            for row in result:
-                summary_rows.append(NamedRow(*row))
-        except ResourceClosedError:
-            pass  # query returned no results
+            # Map raw tuples to named tuples for clear referencing.
+            # NOTE: ``result`` is a lazily evaluated query and must be
+            # consumed *inside* the ``with self.session()`` block, otherwise
+            # iterating it re-opens a connection on the already-closed session
+            # that is never returned to the pool, eventually exhausting it
+            # (see #3430).
+            NamedRow = namedtuple('NamedRow',
+                                  ['network', 'station', 'location', 'channel',
+                                   'earliest', 'latest', 'updated'])
+            summary_rows = []
+            try:
+                for row in result:
+                    summary_rows.append(NamedRow(*row))
+            except ResourceClosedError:
+                pass  # query returned no results
         logger.debug("Fetched %d summary rows" % len(summary_rows))
         return summary_rows
 


### PR DESCRIPTION
Follow-up to #3736. In `_fetch_index_rows`/`_fetch_summary_rows` the `with self.session()` block closes before the lazy query is iterated, so iteration reopens a connection on the closed session that's never returned to the pool → `QueuePool limit ... reached`. Moved the iteration inside the session context.

Added a regression test (fails on master, passes here).

### AI used?

yep, da Claudy

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
