### PR TITLE
Fix dayplot right-hand cutoff at some widths (Fixes #3466)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,12 @@ Changes:
  - obspy.signal:
    * spectral estimation: add getter functions for rotational noise models
      (see #3732)
+ - obspy.imaging:
+   * dayplot: fix the right-hand side of each interval being cut off / squashed
+     into the last pixel at plot widths where the samples per interval are not
+     an integer multiple of the pixel width. Samples are now distributed evenly
+     across pixels instead of folding the remainder into the last one
+     (see #3466)
 
 1.5.1 (doi: 10.5281/zenodo.22108563)
 ====================================
@@ -53,11 +59,6 @@ Changes:
  - obspy.imaging:
    * fix a bug in dayplot when data is only available for part of the time
      window (see #3780)
-   * dayplot: fix the right-hand side of each interval being cut off / squashed
-     into the last pixel at plot widths where the samples per interval are not
-     an integer multiple of the pixel width. Samples are now distributed evenly
-     across pixels instead of folding the remainder into the last one
-     (see #3466)
  - obspy.io.mseed:
    * fix the type of exception raised when trying to read an empty file
      (see #3709)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,11 @@ Changes:
  - obspy.imaging:
    * fix a bug in dayplot when data is only available for part of the time
      window (see #3780)
+   * dayplot: fix the right-hand side of each interval being cut off / squashed
+     into the last pixel at plot widths where the samples per interval are not
+     an integer multiple of the pixel width. Samples are now distributed evenly
+     across pixels instead of folding the remainder into the last one
+     (see #3466)
  - obspy.io.mseed:
    * fix the type of exception raised when trying to read an empty file
      (see #3709)

--- a/obspy/imaging/tests/test_waveform.py
+++ b/obspy/imaging/tests/test_waveform.py
@@ -445,6 +445,43 @@ class TestWaveformPlot:
             '.' not in label.get_text() for label in ax.get_xticklabels()]
         assert all(labels_are_integers) == expected_all_integer_labels
 
+    @pytest.mark.parametrize('width', [4000, 4050, 4800, 3999, 6000])
+    def test_plot_day_plot_no_right_cutoff(self, width):
+        """
+        A spike at a known fraction of each interval must render at that same
+        fraction of the axis width, for any plot width (see #3466).
+        """
+        sr = 40.0
+        interval_min = 15
+        spike_frac = 0.92
+        start = UTCDateTime(0)
+        spi = int(interval_min * 60 * sr)
+        n = 24 * 3600 * int(sr)
+        data = np.zeros(n, dtype=np.float32)
+        data[np.arange(0, n, spi) + int(spike_frac * spi)] = 1.0
+        tr = Trace(data)
+        tr.stats.sampling_rate = sr
+        tr.stats.starttime = start
+        fig = Stream([tr]).plot(type='dayplot', interval=interval_min,
+                                size=(width, 800), handle=True)
+        ax = fig.axes[0]
+        # each interval is drawn as a Line2D with x = repeat(arange(width), 2)
+        found = 0
+        for line in ax.lines:
+            xdata = np.asarray(line.get_xdata())
+            ydata = np.asarray(line.get_ydata())
+            if xdata.size != 2 * width:
+                continue
+            deviation = np.abs(ydata - np.median(ydata))
+            if deviation.max() < 1e-6:
+                continue  # interval without the spike (e.g. padded tail)
+            spike_x = xdata[np.argmax(deviation)]
+            assert abs(spike_x / width - spike_frac) < 1.5 / width, \
+                f"spike at {spike_x / width:.3f} of width, expected " \
+                f"{spike_frac} (width={width})"
+            found += 1
+        assert found > 0
+
     def test_plot_day_plot_explicit_event(self, image_path):
         """
         Plots day plot, starting Jan 1970, with several events.

--- a/obspy/imaging/waveform.py
+++ b/obspy/imaging/waveform.py
@@ -899,29 +899,26 @@ class WaveformPlotting(object):
         extreme_values = np.ma.empty((noi, self.width, 2))
         data = trace.data.reshape((noi, spi))
 
-        ispp = int(spp)
-        fspp = spp % 1.0
-        if fspp == 0.0:
-            delta = None
-        else:
-            delta = spi - ispp * self.width
+        # Bin the samples of each interval evenly into self.width pixels. Using
+        # a fixed int(spp) samples per pixel and dumping the remainder into the
+        # last pixel used to cut off the right-hand side of the plot, see #3466
+        edges = np.linspace(0, spi, self.width + 1).astype(np.intp)
+        starts = edges[:-1]
 
         # Loop over each interval to avoid larger errors towards the end.
         for _i in range(noi):
-            if delta:
-                cur_interval = data[_i][:-delta]
-                rest = data[_i][-delta:]
+            row = data[_i]
+            if np.ma.isMaskedArray(row):
+                # ignore masked (gap) samples in the min/max
+                mins = np.minimum.reduceat(np.ma.filled(row, np.inf), starts)
+                maxs = np.maximum.reduceat(np.ma.filled(row, -np.inf), starts)
+                empty = np.add.reduceat(
+                    (~np.ma.getmaskarray(row)).astype(np.intp), starts) == 0
+                extreme_values[_i, :, 0] = np.ma.array(mins, mask=empty)
+                extreme_values[_i, :, 1] = np.ma.array(maxs, mask=empty)
             else:
-                cur_interval = data[_i]
-            cur_interval = cur_interval.reshape((self.width, ispp))
-            extreme_values[_i, :, 0] = cur_interval.min(axis=1)
-            extreme_values[_i, :, 1] = cur_interval.max(axis=1)
-            # Add the rest.
-            if delta:
-                extreme_values[_i, -1, 0] = min(extreme_values[_i, -1, 0],
-                                                rest.min())
-                extreme_values[_i, -1, 1] = max(extreme_values[_i, -1, 0],
-                                                rest.max())
+                extreme_values[_i, :, 0] = np.minimum.reduceat(row, starts)
+                extreme_values[_i, :, 1] = np.maximum.reduceat(row, starts)
         # Set class variable.
         self.extreme_values = extreme_values
 


### PR DESCRIPTION
dayplot binned each interval into int(spp) samples per pixel and dumped the leftover into the last pixel, squashing up to ~1/int(spp) of every row's tail into the right-most pixel when spi is not a multiple of the width. Bin evenly via reduceat instead. Regression test added.

Before-after view:

<img width="1320" height="550" alt="image" src="https://github.com/user-attachments/assets/8e6e1d3e-44ac-4599-80d3-01e24f06cbf2" />

Fixes #3466

### AI used?

Claudy & proofread by a human

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
