### PR TITLE
Fix: event: WaveformStreamID equality based on the referenced stream (#3658)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,10 @@ Changes:
  - obspy.signal:
    * spectral estimation: add getter functions for rotational noise models
      (see #3732)
+ - obspy.core:
+   * event: WaveformStreamID equality is now based on the stream it refers to,
+     so an unset (None) and an empty ("") code compare equal and a round-trip
+     through a seed string stays equal (see #3658)
 
 1.5.1 (doi: 10.5281/zenodo.22108563)
 ====================================
@@ -21,9 +25,6 @@ Changes:
  - obspy.core:
    * inventory: fix a bug that Latitude, Longitude and Distance did not accept
      'measurement_units' when being initialized (see #3623)
-   * event: WaveformStreamID equality is now based on the stream it refers to,
-     so an unset (None) and an empty ("") code compare equal and a round-trip
-     through a seed string stays equal (see #3658)
  - obspy.clients.fdsn:
    * add new URL mapping 'EARTHSCOPE+USGS' and make it the default. This will
      use EarthScope for dataselect and station web services and use USGS for

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,9 @@ Changes:
  - obspy.core:
    * inventory: fix a bug that Latitude, Longitude and Distance did not accept
      'measurement_units' when being initialized (see #3623)
+   * event: WaveformStreamID equality is now based on the stream it refers to,
+     so an unset (None) and an empty ("") code compare equal and a round-trip
+     through a seed string stays equal (see #3658)
  - obspy.clients.fdsn:
    * add new URL mapping 'EARTHSCOPE+USGS' and make it the default. This will
      use EarthScope for dataselect and station web services and use USGS for

--- a/obspy/core/event/base.py
+++ b/obspy/core/event/base.py
@@ -683,6 +683,16 @@ class WaveformStreamID(__WaveformStreamID):
             self.location_code if self.location_code else "",
             self.channel_code if self.channel_code else "")
 
+    def __eq__(self, other):
+        # Two ids describe the same stream if their SEED identifiers match. An
+        # unset (None) and an empty ("") code are equivalent here, just like in
+        # get_seed_string()/id, so that a round-trip through a seed string
+        # still compares equal (see #3658). Stored values are left untouched.
+        if not isinstance(other, WaveformStreamID):
+            return super().__eq__(other)
+        return (self.get_seed_string() == other.get_seed_string() and
+                self.resource_uri == other.resource_uri)
+
     id = property(get_seed_string)
 
 

--- a/obspy/core/tests/test_event.py
+++ b/obspy/core/tests/test_event.py
@@ -611,6 +611,40 @@ class TestWaveformStreamID:
         waveform_id = WaveformStreamID(seed_string="BW.FUR.01.EHZ")
         assert waveform_id.id == waveform_id.get_seed_string()
 
+    def test_equality(self):
+        """
+        Equality is based on the stream the id refers to, so an unset (None)
+        and an empty ("") code compare equal - a round-trip through a seed
+        string in particular stays equal (see #3658).
+        """
+        by_parts = WaveformStreamID(network_code="VN", station_code="TDVB",
+                                    channel_code="HHL")
+        assert by_parts.location_code is None
+        # round-trip through the seed string sets location_code to ""
+        round_trip = WaveformStreamID(seed_string=by_parts.get_seed_string())
+        assert round_trip.location_code == ""
+        assert by_parts == round_trip
+        assert not (by_parts != round_trip)
+        # explicit empty location is also equal to the unset one
+        empty = WaveformStreamID(network_code="VN", station_code="TDVB",
+                                 location_code="", channel_code="HHL")
+        assert by_parts == empty
+        # genuinely different streams are not equal
+        assert by_parts != WaveformStreamID(network_code="VN",
+                                            station_code="TDVB",
+                                            channel_code="HHZ")
+        assert by_parts != WaveformStreamID(network_code="VN",
+                                            station_code="TDVB",
+                                            location_code="00",
+                                            channel_code="HHL")
+        # a differing resource_uri still distinguishes two ids
+        with_uri = WaveformStreamID(
+            network_code="VN", station_code="TDVB", channel_code="HHL",
+            resource_uri=ResourceIdentifier("smi:local/x"))
+        assert by_parts != with_uri
+        # comparison with an unrelated type is False, not an error
+        assert by_parts != "VN.TDVB..HHL"
+
 
 class TestBase:
     """


### PR DESCRIPTION
Comparing two WaveformStreamID objects used to compare each code field directly, so an unset location (None) and an empty one ('') made otherwise identical ids unequal - in particular a round-trip through a seed string (which parses the empty location to '') no longer compared equal to the by-parts object it came from.

Add a content-based `__eq__` that compares the seed string (where None and '' are already equivalent) plus the resource_uri. Stored values are untouched, so QuakeML serialization is unchanged (None still omits locationCode, '' still emits locationCode='').

Fixes #3658 

### AI used?

Da Claudy

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
