### PR TITLE
Fix: Raise explicit exceptions instead of misplaced bare raise (E0704)

### DIFF
--- a/obspy/clients/seedlink/tests/test_basic_client.py
+++ b/obspy/clients/seedlink/tests/test_basic_client.py
@@ -36,15 +36,17 @@ class TestClient():
         # getting a result depends on two things.. how long backwards the ring
         # buffer stores data and how close to realtime the data is available,
         # so check some different offsets and see if we get some data
+        last_exc = None
         for offset in (3600, 2000, 1000, 500):
             try:
                 _test_offset_from_realtime(offset)
-            except AssertionError:
+            except AssertionError as exc:
+                last_exc = exc
                 continue
             else:
                 break
         else:
-            raise
+            raise last_exc
 
     def test_get_info(self):
         """
@@ -100,15 +102,17 @@ class TestClient():
         # getting a result depends on two things.. how long backwards the ring
         # buffer stores data and how close to realtime the data is available,
         # so check some different offsets and see if we get some data
+        last_exc = None
         for offset in (3600, 2000, 1000, 500):
             try:
                 _test_offset_from_realtime(offset)
-            except AssertionError:
+            except AssertionError as exc:
+                last_exc = exc
                 continue
             else:
                 break
         else:
-            raise
+            raise last_exc
 
 
 @mock.patch("obspy.clients.seedlink.basic_client.Client._multiselect_request")

--- a/obspy/io/csv/core.py
+++ b/obspy/io/csv/core.py
@@ -187,7 +187,7 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                 else:
                     dep = float(row['dep']) * 1000
                 if math.isnan(dep):
-                    raise
+                    raise ValueError('depth is NaN')
             except Exception:
                 dep = None
             author = _string(row, 'author')
@@ -207,14 +207,14 @@ def _read_csv(fname, skipheader=0, default=None, names=None,
                 # add zero to eliminate negative zeros in magnitudes
                 mag = float(row['mag']) + 0
                 if math.isnan(mag):
-                    raise
+                    raise ValueError('magnitude is NaN')
             except Exception:
                 magnitudes = []
             else:
                 try:
                     magtype = row['magtype']
                     if magtype.lower() in ('', 'none', 'null', 'nan'):
-                        raise
+                        raise ValueError('invalid magnitude type')
                 except Exception:
                     magtype = default.get('magtype')
                 magauthor = _string(row, 'magauthor')


### PR DESCRIPTION
A bare `raise` outside an active exception handler raises `RuntimeError: No active exception to re-raise`, not the intended exception.

io/csv/core.py: three bare `raise` statements sit inside `try` blocks (not their `except`) and were relied on to drop into the surrounding `except Exception`. They only worked because the RuntimeError they actually raised is itself an Exception. Raise an explicit ValueError for the NaN / invalid-value cases instead; still caught by the same handler, but no longer dependent on that accident.

clients/seedlink/tests/test_basic_client.py: the `for/else` bare `raise` was meant to surface the AssertionError from the failed offsets, but runs after the `except` has exited via `continue`, so no exception is active. Capture the AssertionError and re-raise it.

### AI used?

Claudyboy

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
