### PR TITLE
Cleanup/Ruff: Use identity comparison for type/class checks (E721, E712)

### DIFF
--- a/obspy/clients/fdsn/tests/test_client.py
+++ b/obspy/clients/fdsn/tests/test_client.py
@@ -199,7 +199,7 @@ class TestClient():
         assert minradius["doc_title"] == (
             "Specify minimum distance from the geographic point defined by "
             "latitude and longitude")
-        assert minradius["type"] == float
+        assert minradius["type"] is float
         assert minradius["options"] == []
 
     def test_iris_event_catalog_availability(self):

--- a/obspy/clients/fdsn/tests/test_wadl_parser.py
+++ b/obspy/clients/fdsn/tests/test_wadl_parser.py
@@ -57,10 +57,10 @@ class TestWADLParser():
         assert params["endtime"]["type"] == UTCDateTime
         assert params["endtime"]["required"]
 
-        assert params["network"]["type"] == str
-        assert params["station"]["type"] == str
-        assert params["location"]["type"] == str
-        assert params["channel"]["type"] == str
+        assert params["network"]["type"] is str
+        assert params["station"]["type"] is str
+        assert params["location"]["type"] is str
+        assert params["channel"]["type"] is str
 
         assert sorted(params["quality"]["options"]) == \
             sorted(["D", "R", "Q", "M", "B"])
@@ -173,21 +173,21 @@ class TestWADLParser():
         assert params["startafter"]["type"] == UTCDateTime
         assert params["endbefore"]["type"] == UTCDateTime
         assert params["endafter"]["type"] == UTCDateTime
-        assert params["network"]["type"] == str
-        assert params["station"]["type"] == str
-        assert params["location"]["type"] == str
-        assert params["channel"]["type"] == str
-        assert params["minlatitude"]["type"] == float
-        assert params["maxlatitude"]["type"] == float
-        assert params["latitude"]["type"] == float
-        assert params["minlongitude"]["type"] == float
-        assert params["maxlongitude"]["type"] == float
-        assert params["longitude"]["type"] == float
-        assert params["minradius"]["type"] == float
-        assert params["maxradius"]["type"] == float
-        assert params["level"]["type"] == str
-        assert params["includerestricted"]["type"] == bool
-        assert params["includeavailability"]["type"] == bool
+        assert params["network"]["type"] is str
+        assert params["station"]["type"] is str
+        assert params["location"]["type"] is str
+        assert params["channel"]["type"] is str
+        assert params["minlatitude"]["type"] is float
+        assert params["maxlatitude"]["type"] is float
+        assert params["latitude"]["type"] is float
+        assert params["minlongitude"]["type"] is float
+        assert params["maxlongitude"]["type"] is float
+        assert params["longitude"]["type"] is float
+        assert params["minradius"]["type"] is float
+        assert params["maxradius"]["type"] is float
+        assert params["level"]["type"] is str
+        assert params["includerestricted"]["type"] is bool
+        assert params["includeavailability"]["type"] is bool
         assert params["updatedafter"]["type"] == UTCDateTime
 
         # Now read a dataselect file with no types.
@@ -199,13 +199,13 @@ class TestWADLParser():
         # Assert that types have been assigned.
         assert params["starttime"]["type"] == UTCDateTime
         assert params["endtime"]["type"] == UTCDateTime
-        assert params["network"]["type"] == str
-        assert params["station"]["type"] == str
-        assert params["location"]["type"] == str
-        assert params["channel"]["type"] == str
-        assert params["quality"]["type"] == str
-        assert params["minimumlength"]["type"] == float
-        assert params["longestonly"]["type"] == bool
+        assert params["network"]["type"] is str
+        assert params["station"]["type"] is str
+        assert params["location"]["type"] is str
+        assert params["channel"]["type"] is str
+        assert params["quality"]["type"] is str
+        assert params["minimumlength"]["type"] is float
+        assert params["longestonly"]["type"] is bool
 
     def test_usgs_event_wadl_parsing(self, testdata):
         """

--- a/obspy/clients/fdsn/wadl_parser.py
+++ b/obspy/clients/fdsn/wadl_parser.py
@@ -172,7 +172,7 @@ class WADLParser(object):
 
         default_value = param_doc.get("default")
         if default_value is not None:
-            if param_type == bool:
+            if param_type is bool:
                 default_value = self._convert_boolean(default_value)
             else:
                 default_value = param_type(default_value)

--- a/obspy/core/tests/test_trace.py
+++ b/obspy/core/tests/test_trace.py
@@ -1359,7 +1359,7 @@ class TestTrace:
             warnings.simplefilter("always", UserWarning)
             tr.taper(max_percentage=None, side="left")
         assert len(w) == 1
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
 
         assert tr.data[:5].sum() < 5.
         assert tr.data[6:].sum() == 5.
@@ -1372,7 +1372,7 @@ class TestTrace:
             warnings.simplefilter("always", UserWarning)
             tr.taper(max_percentage=None, side="right")
         assert len(w) == 1
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
 
         assert tr.data[:5].sum() == 5.
         assert tr.data[6:].sum() < 5.
@@ -1389,7 +1389,7 @@ class TestTrace:
             warnings.simplefilter("always", UserWarning)
             tr.taper(max_percentage=0.7, max_length=int(npts / 2) + 1)
         assert len(w) == 1
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
 
         data = np.ones(npts)
         tr = Trace(data=data, header={'sampling': 1.})
@@ -1772,7 +1772,7 @@ class TestTrace:
             warnings.simplefilter("always", UserWarning)
             tr.remove_response(inventory=inv)
         assert len(w) == 1
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
 
     def test_processing_info_remove_response_and_sensitivity(self):
         """
@@ -2371,7 +2371,7 @@ class TestTrace:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tr.normalize()
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
         msg = "Attempting to normalize by dividing through zero."
         assert msg in w[0].message.args[0]
         np.testing.assert_allclose(tr.data, np.array([-0.0, 0.0, 0.0, -0.0]))
@@ -2387,7 +2387,7 @@ class TestTrace:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tr.normalize(norm=0)
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
         msg = "Attempting to normalize by dividing through zero."
         assert msg in w[0].message.args[0]
         np.testing.assert_allclose(tr.data, np.array([10.0, 10.0, 0.0, 0.0]))
@@ -2399,7 +2399,7 @@ class TestTrace:
             warnings.simplefilter("always")
             tr.normalize(norm=-2)
 
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
         msg = "Normalizing with negative values is forbidden."
         assert msg in w[0].message.args[0]
 
@@ -2716,7 +2716,7 @@ class TestTrace:
             tr.resample(30)
 
         assert len(w) == 1
-        assert w[0].category == UserWarning
+        assert w[0].category is UserWarning
 
         assert tr.stats.sampling_rate == 30
         assert tr.data.shape[0] == 1

--- a/obspy/io/mseed/tests/test_mseed_special_issues.py
+++ b/obspy/io/mseed/tests/test_mseed_special_issues.py
@@ -298,7 +298,7 @@ class TestMSEEDSpecialIssue():
             # invalid reclen
             read(file, reclen=111)
             assert 'Invalid record length' in str(w[0].message)
-            assert w[0].category == UserWarning
+            assert w[0].category is UserWarning
             # wrong reclen - raises and also displays a warning
             with pytest.raises(Exception):
                 read(file, reclen=4096)

--- a/obspy/io/quakeml/core.py
+++ b/obspy/io/quakeml/core.py
@@ -167,7 +167,7 @@ class Unpickler(object):
         text = q[0].text
         if text is None or text == '':
             return None
-        if convert_to == bool:
+        if convert_to is bool:
             if text.lower() in ["true", "1"]:
                 return True
             elif text.lower() in ["false", "0"]:
@@ -309,7 +309,7 @@ class Unpickler(object):
         confidence_level = self._xpath2obj('confidenceLevel', el, float)
         if confidence_level is not None:
             error.confidence_level = confidence_level
-        if quantity_type != int:
+        if quantity_type is not int:
             uncertainty = self._xpath2obj('uncertainty', el, float)
             if uncertainty is not None:
                 error.uncertainty = uncertainty

--- a/obspy/io/sac/tests/test_sactrace.py
+++ b/obspy/io/sac/tests/test_sactrace.py
@@ -375,7 +375,7 @@ class TestSACTrace():
                 warnings.simplefilter('always', UserWarning)
                 setattr(sac, hdr, too_long)
                 assert len(w) == 1
-                assert w[0].category == UserWarning
+                assert w[0].category is UserWarning
                 assert 'Alphanumeric headers longer than 8' in str(w[0])
             assert sac._hs[_hd.STRHDRS.index(hdr)].decode() == too_long[:8]
             assert getattr(sac, hdr) == too_long[:8].strip()

--- a/obspy/io/scardec/tests/test_core.py
+++ b/obspy/io/scardec/tests/test_core.py
@@ -43,9 +43,9 @@ class TestScardec():
                 cat.write(temp_filename, format="SCARDEC")
 
                 assert len(w) == 2
-                assert w[0].category == UserWarning
+                assert w[0].category is UserWarning
                 assert 'No moment wave magnitude found' in str(w[0])
-                assert w[1].category == UserWarning
+                assert w[1].category is UserWarning
                 assert 'No derived origin attached' in str(w[1])
 
             with open(temp_filename, "rb") as fh:
@@ -92,9 +92,9 @@ class TestScardec():
                 new_data = tf.read()
 
                 assert len(w) == 2
-                assert w[0].category == UserWarning
+                assert w[0].category is UserWarning
                 assert 'No moment wave magnitude found' in str(w[0])
-                assert w[1].category == UserWarning
+                assert w[1].category is UserWarning
                 assert 'No derived origin attached' in str(w[1])
 
         # Test file header
@@ -138,9 +138,9 @@ class TestScardec():
                         new_data = buf2.read()
 
                 assert len(w) == 2
-                assert w[0].category == UserWarning
+                assert w[0].category is UserWarning
                 assert 'No moment wave magnitude found' in str(w[0])
-                assert w[1].category == UserWarning
+                assert w[1].category is UserWarning
                 assert 'No derived origin attached' in str(w[1])
 
         # Test file header

--- a/obspy/io/segy/tests/test_segy.py
+++ b/obspy/io/segy/tests/test_segy.py
@@ -195,7 +195,7 @@ class TestSEGY():
                 f.close()
                 # A relative tolerance of 1E-6 is considered good enough.
                 rms1 = rms(data, new_data)
-                assert True == (rms1 < 1E-6)
+                assert rms1 < 1E-6
 
     def test_pack_and_unpack_very_small_ibm_floats(self):
         """
@@ -225,7 +225,7 @@ class TestSEGY():
                 f.close()
                 # A relative tolerance of 1E-6 is considered good enough.
                 rms1 = rms(data, new_data)
-                assert True == (rms1 < 1E-6)
+                assert rms1 < 1E-6
 
     def test_pack_and_unpack_ibm_special_cases(self):
         """

--- a/obspy/taup/tests/test_taup_plotting.py
+++ b/obspy/taup/tests/test_taup_plotting.py
@@ -180,7 +180,7 @@ class TestTauPyPlotting:
                                        show=False)
             assert len(w) == 1
             assert str(w[0].message) == expected_message
-            assert w[0].category == UserWarning
+            assert w[0].category is UserWarning
         finally:
             plt.close(fig)
         # cartesian pot attempted in polar axes


### PR DESCRIPTION
Replace `==`/`!=` comparisons against type and class objects with `is`/`is not` across source and tests, and drop the redundant `True ==` in two SEGY roundtrip assertions.

The left operand in every case is already a type or class object (param_type, convert_to, quantity_type, parsed WADL parameter types, warning `.category` classes), so identity comparison is behaviour- preserving for these singletons while clearing ruff E721/E712.

No isinstance() conversion is used: it would change semantics by accepting subclasses, which none of these sites intend.

### AI used?

DJ Claude

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
