### PR TITLE
Fix: unwrap response list phase before interpolation (#3585)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,10 @@ Changes:
  - obspy.signal:
    * spectral estimation: add getter functions for rotational noise models
      (see #3732)
+ - obspy.core:
+   * inventory: unwrap the phase of a response list (FAP) stage before
+     interpolating it, so a cubic spline no longer oscillates across +/-180
+     degree phase wraps (see #3585)
 
 1.5.1 (doi: 10.5281/zenodo.22108563)
 ====================================
@@ -21,9 +25,6 @@ Changes:
  - obspy.core:
    * inventory: fix a bug that Latitude, Longitude and Distance did not accept
      'measurement_units' when being initialized (see #3623)
-   * inventory: unwrap the phase of a response list (FAP) stage before
-     interpolating it, so a cubic spline no longer oscillates across +/-180
-     degree phase wraps (see #3585)
  - obspy.clients.fdsn:
    * add new URL mapping 'EARTHSCOPE+USGS' and make it the default. This will
      use EarthScope for dataselect and station web services and use USGS for

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,9 @@ Changes:
  - obspy.core:
    * inventory: fix a bug that Latitude, Longitude and Distance did not accept
      'measurement_units' when being initialized (see #3623)
+   * inventory: unwrap the phase of a response list (FAP) stage before
+     interpolating it, so a cubic spline no longer oscillates across +/-180
+     degree phase wraps (see #3585)
  - obspy.clients.fdsn:
    * add new URL mapping 'EARTHSCOPE+USGS' and make it the default. This will
      use EarthScope for dataselect and station web services and use USGS for

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1532,8 +1532,13 @@ class Response(ComparingObject):
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
                     f, amp, k=3)(frequencies)
+                # Interpolate the *unwrapped* phase and wrap the result back to
+                # (-180, 180]. Splining the raw wrapped phase makes the spline
+                # oscillate wildly across +/-180 deg wraps (see #3585).
+                phase = np.unwrap(phase, period=360.0)
                 phase = scipy.interpolate.InterpolatedUnivariateSpline(
                     f, phase, k=3)(frequencies)
+                phase = (phase + 180.0) % 360.0 - 180.0
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -259,6 +259,36 @@ class TestResponse:
         np.testing.assert_allclose(amp, exp_amp, rtol=1E-3)
         np.testing.assert_allclose(phase, exp_ph, rtol=1E-3)
 
+    def test_response_list_stage_phase_wrapping(self):
+        """
+        Phase of a response list stage must be unwrapped before interpolation,
+        otherwise a cubic spline oscillates wildly across +/-180 deg wraps
+        (see #3585).
+        """
+        # true phase: smooth ramp 0 -> -540 deg (three wraps) over 0.1-50 Hz
+        f = np.logspace(-1, np.log10(50), 20)
+        span = np.log10(f[-1]) - np.log10(f[0])
+        true_unwrapped = -540.0 * (np.log10(f) - np.log10(f[0])) / span
+        wrapped = (true_unwrapped + 180) % 360 - 180
+        elems = [ResponseListElement(float(fr), 1.0, float(p))
+                 for fr, p in zip(f, wrapped)]
+        resp = Response(
+            instrument_sensitivity=InstrumentSensitivity(1.0, 1.0, "M/S", "V"),
+            response_stages=[ResponseListResponseStage(
+                1, 1.0, 1.0, "M/S", "V", response_list_elements=elems)])
+
+        freqs = np.logspace(-1, np.log10(50), 500)
+        with CatchAndAssertWarnings():
+            cpx = resp.get_evalresp_response_for_frequencies(freqs,
+                                                             output="VEL")
+        out = np.degrees(np.unwrap(np.angle(cpx)))
+        # the interpolated (unwrapped) phase must stay within the tabulated
+        # envelope and remain monotonic - the old cubic-on-wrapped spline
+        # overshoots the +/-180 wraps and violates both.
+        assert out.min() >= true_unwrapped.min() - 15.0
+        assert out.max() <= true_unwrapped.max() + 15.0
+        assert np.max(np.diff(out)) < 5.0
+
     def test_response_with_no_units_in_stage_1(self, testdata):
         """
         ObsPy has some heuristics to deal with this particular degenerate case.


### PR DESCRIPTION
A ResponseListResponseStage (frequency/amplitude/phase triplets) interpolated its phase with a cubic spline directly on the wrapped values. Across +/-180 degree phase wraps the spline overshoots wildly (Gibbs-like oscillation), producing spurious spikes in the response phase (and amplitude notches after evalresp) - clearly visible on real legacy FAP responses such as a Willmore Mk3 from a SEISAN file.

Unwrap the phase before the spline and wrap the result back to (-180, 180]. The interpolant now follows the physical continuous phase and stays exact at the tabulated nodes. Amplitude interpolation is unchanged.

<img width="1210" height="440" alt="image" src="https://github.com/user-attachments/assets/60528278-b587-4ad3-a869-355e0e5f5e70" />


Impact is minimal: only ResponseListResponseStage is affected (a rare stage type), and np.unwrap is a no-op unless adjacent phase samples jump by more than 180 degrees. FAP responses without wraps are bit-identical (verified on the bundled IM_IL31 response, whose existing full-evalresp test passes unchanged); only responses with genuine +/-180 wraps change, and only in the between-node regions that were previously wrong. Amplitude never changes.

Regression test added (fails on master, passes here).


Fixes #3585 

### AI used?

Claudydude

### PR Checklist

- [x] Correct **base branch** selected? [`master` for new features, `maintenance_?.?.x` for bug fixes](https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model)
- [x] **Tests**: Added new tests for any new features or fixed regressions
- [x] **Changelog**: Added a short note in `CHANGELOG.txt` (only obsolete if fixing a bug introduced *after* the last release)
- [x] Add the yellow `ready for review` label when you the PR is **ready to be reviewed**
